### PR TITLE
fix(dive-detail): stop the profile chart flashing once on first open

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -1661,6 +1661,13 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   }
 
   Widget _buildProfileSection(BuildContext context, WidgetRef ref, Dive dive) {
+    // Every async chart input below is read through the built-in
+    // AsyncValue.value, which keeps the previous value while a provider
+    // reloads. The valueOrNull polyfill returns null during a reload, and
+    // these providers reload behind any detail change tick (the first-view
+    // safety review write included): the chart would drop its overlays and
+    // estimated pressure series for a frame, then draw them again.
+    //
     // Get profile analysis (async to avoid blocking UI with Buhlmann computation)
     final analysis = ref
         .watch(
@@ -1669,7 +1676,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
             sourceId: ref.watch(activeDiveSourceProvider(dive.id)),
           )),
         )
-        .valueOrNull;
+        .value;
 
     // Get marker settings
     final showMaxDepthMarker = ref.watch(showMaxDepthMarkerProvider);
@@ -1682,11 +1689,11 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
 
     // Get per-tank pressure data for multi-tank visualization
     final tankPressuresAsync = ref.watch(tankPressuresProvider(dive.id));
-    final tankPressures = tankPressuresAsync.valueOrNull;
+    final tankPressures = tankPressuresAsync.value;
     // Chart-only: real pressures augmented with linear estimates (#197).
     final estimatedTankPressures = ref
         .watch(estimatedTankPressuresProvider(dive.id))
-        .valueOrNull;
+        .value;
 
     // Get playback state
     final playbackState = ref.watch(playbackProvider(dive.id));
@@ -1697,10 +1704,10 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     // Profiles grouped by owning data source, plus the active-source and
     // overlay view state driving the whole page.
     final sourceProfiles =
-        ref.watch(sourceProfilesProvider(dive.id)).valueOrNull ??
+        ref.watch(sourceProfilesProvider(dive.id)).value ??
         const <String, SourceProfile>{};
     final dataSources =
-        ref.watch(diveDataSourcesProvider(dive.id)).valueOrNull ?? const [];
+        ref.watch(diveDataSourcesProvider(dive.id)).value ?? const [];
     final computerNames = _computerDisplayNames(context, dataSources);
     final labels = _sourceNameLabels(context);
     final isMultiSource = dataSources.length >= 2;
@@ -1788,7 +1795,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     );
 
     final photoMedia =
-        ref.watch(mediaForDiveProvider(dive.id)).valueOrNull ?? const [];
+        ref.watch(mediaForDiveProvider(dive.id)).value ?? const [];
     final photoMarkers = chartProfile.isEmpty
         ? const <PhotoChartMarker>[]
         : photoMarkersFromMedia(
@@ -1804,7 +1811,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     // ghosted next to the actual logged profile.
     final plannedOverlay = ref
         .watch(plannedProfileOverlayProvider(dive.id))
-        .valueOrNull;
+        .value;
     final overlays = <ChartSourceOverlay>[
       for (final id in overlayIds)
         if (id != activeSource?.id &&
@@ -2044,14 +2051,13 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                             estimatedTankPressures?.pressures ?? tankPressures,
                         estimatedTankIds:
                             estimatedTankPressures?.estimatedTankIds,
-                        gasSwitches: gasSwitchesAsync.valueOrNull,
+                        gasSwitches: gasSwitchesAsync.value,
                         gasSegments:
                             (dive.tanks.isEmpty || chartProfile.isEmpty)
                             ? null
                             : buildGasUsageSegments(
                                 tanks: dive.tanks,
-                                gasSwitches:
-                                    gasSwitchesAsync.valueOrNull ?? const [],
+                                gasSwitches: gasSwitchesAsync.value ?? const [],
                                 diveDurationSeconds:
                                     chartProfile.last.timestamp,
                                 firstSampleSeconds:

--- a/lib/features/dive_log/presentation/widgets/dive_profile_panel.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_panel.dart
@@ -240,19 +240,13 @@ class _DiveProfilePanelContentState
   }
 
   Widget _buildProfileContent(BuildContext context, Dive dive) {
-    final analysis = ref
-        .watch(profileAnalysisProvider(widget.diveId))
-        .valueOrNull;
-    final gasSwitches = ref
-        .watch(gasSwitchesProvider(widget.diveId))
-        .valueOrNull;
-    final tankPressures = ref
-        .watch(tankPressuresProvider(widget.diveId))
-        .valueOrNull;
+    final analysis = ref.watch(profileAnalysisProvider(widget.diveId)).value;
+    final gasSwitches = ref.watch(gasSwitchesProvider(widget.diveId)).value;
+    final tankPressures = ref.watch(tankPressuresProvider(widget.diveId)).value;
     // Chart-only: real pressures augmented with linear estimates (#197).
     final estimatedTankPressures = ref
         .watch(estimatedTankPressuresProvider(widget.diveId))
-        .valueOrNull;
+        .value;
     final settings = ref.watch(settingsProvider);
     final units = UnitFormatter(settings);
     final colorScheme = Theme.of(context).colorScheme;

--- a/test/features/dive_log/presentation/pages/dive_detail_profile_section_reload_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_profile_section_reload_test.dart
@@ -1,0 +1,208 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Regression cover for the one-time profile chart flash on first open.
+///
+/// Opening a dive for the first time computes and persists its safety
+/// review. That write ticks `watchDiveDetailChanges` about 300ms after the
+/// chart has painted, which refreshes `diveProvider`. Providers that watch
+/// `diveProvider`'s future (`estimatedTankPressuresProvider`) go through a
+/// RELOAD behind it, and the same happens to the analysis chain whenever one
+/// of its inputs refreshes. The profile section read every chart input
+/// through the `valueOrNull` polyfill, which returns null during a reload, so
+/// the chart dropped the series for a frame and then drew it again.
+///
+/// The built-in `AsyncValue.value` keeps the previous value across a reload;
+/// these tests pin that the chart is fed from it.
+void main() {
+  Dive diveWithProfileAndTank() => createTestDiveWithBottomTime().copyWith(
+    profile: List.generate(
+      6,
+      (i) => DiveProfilePoint(
+        timestamp: i * 60,
+        depth: (i < 3 ? i * 8.0 : (5 - i) * 8.0),
+      ),
+    ),
+    // Start/end pressures but no transmitter samples: exactly the shape the
+    // estimated pressure synthesizer fills in.
+    tanks: const [
+      DiveTank(id: 'tank-1', volume: 11.1, startPressure: 200, endPressure: 60),
+    ],
+  );
+
+  ProfileAnalysis analysisWithCeiling() => ProfileAnalysis.empty().copyWith(
+    ceilingCurve: List<double>.filled(6, 0.0),
+  );
+
+  Future<ProviderContainer> pumpDetail(
+    WidgetTester tester, {
+    required Dive dive,
+    required Override diveOverride,
+    required Override analysisOverride,
+  }) async {
+    final base = await getBaseOverrides();
+    // The detail page overflows the fixed test viewport; that is not what
+    // these tests assert.
+    final originalOnError = FlutterError.onError;
+    addTearDown(() => FlutterError.onError = originalOnError);
+    FlutterError.onError = (d) {
+      if (d.toString().contains('overflowed')) return;
+      originalOnError?.call(d);
+    };
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          diveOverride,
+          analysisOverride,
+          diveDataSourcesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <DiveDataSource>[]),
+          gasSwitchesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+          // No real samples, so estimatedTankPressuresProvider (deliberately
+          // NOT overridden) synthesizes a series for tank-1.
+          tankPressuresProvider(
+            dive.id,
+          ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
+          sourceProfilesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <String, SourceProfile>{}),
+          weeklyOtuProvider(dive.id).overrideWith((ref) async => 0.0),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DiveDetailPage(diveId: dive.id, embedded: true),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    return ProviderScope.containerOf(
+      tester.element(find.byType(DiveDetailPage)),
+    );
+  }
+
+  DiveProfileChart chart(WidgetTester tester) =>
+      tester.widget<DiveProfileChart>(find.byType(DiveProfileChart));
+
+  testWidgets(
+    'keeps the estimated pressure series while the dive provider refreshes',
+    (tester) async {
+      final dive = diveWithProfileAndTank();
+      // Held open once the refresh starts so the reload window spans a frame.
+      Completer<void>? diveGate;
+      final container = await pumpDetail(
+        tester,
+        dive: dive,
+        diveOverride: diveProvider(dive.id).overrideWith((ref) async {
+          final gate = diveGate;
+          if (gate != null) await gate.future;
+          return dive;
+        }),
+        analysisOverride: profileAnalysisProvider(
+          dive.id,
+        ).overrideWith((ref) async => analysisWithCeiling()),
+      );
+
+      expect(chart(tester).estimatedTankIds, contains('tank-1'));
+      expect(chart(tester).tankPressures?['tank-1'], isNotEmpty);
+
+      // The detail change tick: diveProvider refreshes and, behind it,
+      // estimatedTankPressuresProvider reloads.
+      diveGate = Completer<void>();
+      container.invalidate(diveProvider(dive.id));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(
+        container.read(estimatedTankPressuresProvider(dive.id)).isReloading,
+        isTrue,
+        reason: 'precondition: the estimate must be mid-reload',
+      );
+      expect(
+        chart(tester).estimatedTankIds,
+        contains('tank-1'),
+        reason:
+            'a reload of the estimate must not drop the series from the '
+            'chart; the previous value is still available',
+      );
+      expect(chart(tester).tankPressures?['tank-1'], isNotEmpty);
+
+      diveGate.complete();
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      expect(chart(tester).estimatedTankIds, contains('tank-1'));
+    },
+  );
+
+  testWidgets('keeps the analysis overlays while the analysis reloads', (
+    tester,
+  ) async {
+    final dive = diveWithProfileAndTank();
+    final analysis = analysisWithCeiling();
+    // Flipping the trigger reloads the analysis; the gate holds that reload
+    // open so it spans a frame.
+    final trigger = StateProvider<int>((ref) => 0);
+    Completer<ProfileAnalysis?>? analysisGate;
+    final container = await pumpDetail(
+      tester,
+      dive: dive,
+      diveOverride: diveProvider(dive.id).overrideWith((ref) async => dive),
+      analysisOverride: profileAnalysisProvider(dive.id).overrideWith((
+        ref,
+      ) async {
+        if (ref.watch(trigger) == 0) return analysis;
+        return analysisGate!.future;
+      }),
+    );
+
+    expect(chart(tester).ceilingCurve, isNotNull);
+
+    analysisGate = Completer<ProfileAnalysis?>();
+    container.read(trigger.notifier).state = 1;
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      container
+          .read(
+            sourceProfileAnalysisProvider((diveId: dive.id, sourceId: null)),
+          )
+          .isLoading,
+      isTrue,
+      reason: 'precondition: the analysis must be mid-reload',
+    );
+    expect(
+      chart(tester).ceilingCurve,
+      isNotNull,
+      reason:
+          'a reload of the analysis must not strip the overlays from the '
+          'chart; the previous analysis is still available',
+    );
+
+    analysisGate.complete(analysis);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(chart(tester).ceilingCurve, isNotNull);
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_detail_profile_section_reload_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_profile_section_reload_test.dart
@@ -16,6 +16,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_c
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_until.dart';
 
 /// Regression cover for the one-time profile chart flash on first open.
 ///
@@ -129,13 +130,13 @@ void main() {
       // estimatedTankPressuresProvider reloads.
       diveGate = Completer<void>();
       container.invalidate(diveProvider(dive.id));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
-
-      expect(
-        container.read(estimatedTankPressuresProvider(dive.id)).isReloading,
-        isTrue,
-        reason: 'precondition: the estimate must be mid-reload',
+      // Pump until the reload window is actually open rather than assuming
+      // a frame count; the gate holds it open until this test closes it.
+      await pumpUntil(
+        tester,
+        () =>
+            container.read(estimatedTankPressuresProvider(dive.id)).isReloading,
+        reason: 'the estimate must be mid-reload',
       );
       expect(
         chart(tester).estimatedTankIds,
@@ -178,17 +179,16 @@ void main() {
 
     analysisGate = Completer<ProfileAnalysis?>();
     container.read(trigger.notifier).state = 1;
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 50));
-
-    expect(
-      container
+    // Pump until the reload window is actually open rather than assuming
+    // a frame count; the gate holds it open until this test closes it.
+    await pumpUntil(
+      tester,
+      () => container
           .read(
             sourceProfileAnalysisProvider((diveId: dive.id, sourceId: null)),
           )
           .isReloading,
-      isTrue,
-      reason: 'precondition: the analysis must be mid-reload',
+      reason: 'the analysis must be mid-reload',
     );
     expect(
       chart(tester).ceilingCurve,

--- a/test/features/dive_log/presentation/widgets/dive_profile_panel_reload_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_panel_reload_test.dart
@@ -16,6 +16,7 @@ import 'package:submersion/features/divers/presentation/providers/diver_provider
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_until.dart';
 import '../../../../helpers/test_app.dart';
 
 /// The table-mode side panel hosts the same chart as the detail page and
@@ -112,13 +113,13 @@ void main() {
 
       diveGate = Completer<void>();
       container.invalidate(diveProvider(diveId));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
-
-      expect(
-        container.read(estimatedTankPressuresProvider(diveId)).isReloading,
-        isTrue,
-        reason: 'precondition: the estimate must be mid-reload',
+      // Pump until the reload window is actually open rather than assuming
+      // a frame count; the gate holds it open until this test closes it.
+      await pumpUntil(
+        tester,
+        () =>
+            container.read(estimatedTankPressuresProvider(diveId)).isReloading,
+        reason: 'the estimate must be mid-reload',
       );
       expect(
         chart(tester).estimatedTankIds,
@@ -158,13 +159,12 @@ void main() {
 
     analysisGate = Completer<ProfileAnalysis?>();
     container.read(trigger.notifier).state = 1;
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 50));
-
-    expect(
-      container.read(profileAnalysisProvider(diveId)).isReloading,
-      isTrue,
-      reason: 'precondition: the analysis must be mid-reload',
+    // Pump until the reload window is actually open rather than assuming
+    // a frame count; the gate holds it open until this test closes it.
+    await pumpUntil(
+      tester,
+      () => container.read(profileAnalysisProvider(diveId)).isReloading,
+      reason: 'the analysis must be mid-reload',
     );
     expect(
       chart(tester).ceilingCurve,

--- a/test/features/dive_log/presentation/widgets/dive_profile_panel_reload_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_panel_reload_test.dart
@@ -1,102 +1,90 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:submersion/core/providers/provider.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
-import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
-import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
-import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/highlight_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
-import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_panel.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_app.dart';
 
-/// Regression cover for the one-time profile chart flash on first open.
-///
-/// Opening a dive for the first time computes and persists its safety
-/// review. That write ticks `watchDiveDetailChanges` about 300ms after the
-/// chart has painted, which refreshes `diveProvider`. Providers that watch
-/// `diveProvider`'s future (`estimatedTankPressuresProvider`) go through a
-/// RELOAD behind it, and the same happens to the analysis chain whenever one
-/// of its inputs refreshes. The profile section read every chart input
-/// through the `valueOrNull` polyfill, which returns null during a reload, so
-/// the chart dropped the series for a frame and then drew it again.
-///
-/// The built-in `AsyncValue.value` keeps the previous value across a reload;
-/// these tests pin that the chart is fed from it.
+/// The table-mode side panel hosts the same chart as the detail page and
+/// reads the same providers, so it is exposed to the same reload window:
+/// a detail change tick refreshes diveProvider, estimatedTankPressuresProvider
+/// reloads behind it, and a read through the valueOrNull polyfill would drop
+/// the estimated series for a frame. See
+/// dive_detail_profile_section_reload_test.dart for the detail page side.
 void main() {
-  Dive diveWithProfileAndTank() => createTestDiveWithBottomTime().copyWith(
-    profile: List.generate(
-      6,
-      (i) => DiveProfilePoint(
-        timestamp: i * 60,
-        depth: (i < 3 ? i * 8.0 : (5 - i) * 8.0),
-      ),
-    ),
-    // Start/end pressures but no transmitter samples: exactly the shape the
-    // estimated pressure synthesizer fills in.
-    tanks: const [
-      DiveTank(id: 'tank-1', volume: 11.1, startPressure: 200, endPressure: 60),
-    ],
-  );
+  const diveId = 'panel-dive-1';
+
+  Dive diveWithProfileAndTank() =>
+      createTestDiveWithBottomTime(id: diveId).copyWith(
+        profile: List.generate(
+          6,
+          (i) => DiveProfilePoint(
+            timestamp: i * 60,
+            depth: (i < 3 ? i * 8.0 : (5 - i) * 8.0),
+          ),
+        ),
+        tanks: const [
+          DiveTank(
+            id: 'tank-1',
+            volume: 11.1,
+            startPressure: 200,
+            endPressure: 60,
+          ),
+        ],
+      );
 
   ProfileAnalysis analysisWithCeiling() => ProfileAnalysis.empty().copyWith(
     ceilingCurve: List<double>.filled(6, 0.0),
   );
 
-  Future<ProviderContainer> pumpDetail(
+  Future<ProviderContainer> pumpPanel(
     WidgetTester tester, {
-    required Dive dive,
     required Override diveOverride,
     required Override analysisOverride,
   }) async {
-    final base = await getBaseOverrides();
-    // A desktop-sized surface so the page lays out without overflowing the
-    // default 800x600 test viewport.
-    tester.view.physicalSize = const Size(1600, 4000);
-    tester.view.devicePixelRatio = 1.0;
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
-
     await tester.pumpWidget(
-      ProviderScope(
+      testApp(
         overrides: [
-          ...base,
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+          currentDiverIdProvider.overrideWith(
+            (ref) => MockCurrentDiverIdNotifier(),
+          ),
+          highlightedDiveIdProvider.overrideWith((ref) => diveId),
           diveOverride,
           analysisOverride,
-          diveDataSourcesProvider(
-            dive.id,
-          ).overrideWith((ref) async => <DiveDataSource>[]),
           gasSwitchesProvider(
-            dive.id,
+            diveId,
           ).overrideWith((ref) async => <GasSwitchWithTank>[]),
           // No real samples, so estimatedTankPressuresProvider (deliberately
           // NOT overridden) synthesizes a series for tank-1.
           tankPressuresProvider(
-            dive.id,
+            diveId,
           ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
-          sourceProfilesProvider(
-            dive.id,
-          ).overrideWith((ref) async => <String, SourceProfile>{}),
-          weeklyOtuProvider(dive.id).overrideWith((ref) async => 0.0),
         ],
-        child: MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: DiveDetailPage(diveId: dive.id, embedded: true),
+        child: const SizedBox(
+          height: 350,
+          width: 600,
+          child: DiveProfilePanel(),
         ),
       ),
     );
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     return ProviderScope.containerOf(
-      tester.element(find.byType(DiveDetailPage)),
+      tester.element(find.byType(DiveProfilePanel)),
     );
   }
 
@@ -107,33 +95,28 @@ void main() {
     'keeps the estimated pressure series while the dive provider refreshes',
     (tester) async {
       final dive = diveWithProfileAndTank();
-      // Held open once the refresh starts so the reload window spans a frame.
       Completer<void>? diveGate;
-      final container = await pumpDetail(
+      final container = await pumpPanel(
         tester,
-        dive: dive,
-        diveOverride: diveProvider(dive.id).overrideWith((ref) async {
+        diveOverride: diveProvider(diveId).overrideWith((ref) async {
           final gate = diveGate;
           if (gate != null) await gate.future;
           return dive;
         }),
         analysisOverride: profileAnalysisProvider(
-          dive.id,
+          diveId,
         ).overrideWith((ref) async => analysisWithCeiling()),
       );
 
       expect(chart(tester).estimatedTankIds, contains('tank-1'));
-      expect(chart(tester).tankPressures?['tank-1'], isNotEmpty);
 
-      // The detail change tick: diveProvider refreshes and, behind it,
-      // estimatedTankPressuresProvider reloads.
       diveGate = Completer<void>();
-      container.invalidate(diveProvider(dive.id));
+      container.invalidate(diveProvider(diveId));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 50));
 
       expect(
-        container.read(estimatedTankPressuresProvider(dive.id)).isReloading,
+        container.read(estimatedTankPressuresProvider(diveId)).isReloading,
         isTrue,
         reason: 'precondition: the estimate must be mid-reload',
       );
@@ -142,7 +125,7 @@ void main() {
         contains('tank-1'),
         reason:
             'a reload of the estimate must not drop the series from the '
-            'chart; the previous value is still available',
+            'panel chart; the previous value is still available',
       );
       expect(chart(tester).tankPressures?['tank-1'], isNotEmpty);
 
@@ -158,15 +141,12 @@ void main() {
   ) async {
     final dive = diveWithProfileAndTank();
     final analysis = analysisWithCeiling();
-    // Flipping the trigger reloads the analysis; the gate holds that reload
-    // open so it spans a frame.
     final trigger = StateProvider<int>((ref) => 0);
     Completer<ProfileAnalysis?>? analysisGate;
-    final container = await pumpDetail(
+    final container = await pumpPanel(
       tester,
-      dive: dive,
-      diveOverride: diveProvider(dive.id).overrideWith((ref) async => dive),
-      analysisOverride: profileAnalysisProvider(dive.id).overrideWith((
+      diveOverride: diveProvider(diveId).overrideWith((ref) async => dive),
+      analysisOverride: profileAnalysisProvider(diveId).overrideWith((
         ref,
       ) async {
         if (ref.watch(trigger) == 0) return analysis;
@@ -182,11 +162,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
 
     expect(
-      container
-          .read(
-            sourceProfileAnalysisProvider((diveId: dive.id, sourceId: null)),
-          )
-          .isReloading,
+      container.read(profileAnalysisProvider(diveId)).isReloading,
       isTrue,
       reason: 'precondition: the analysis must be mid-reload',
     );
@@ -195,7 +171,7 @@ void main() {
       isNotNull,
       reason:
           'a reload of the analysis must not strip the overlays from the '
-          'chart; the previous analysis is still available',
+          'panel chart; the previous analysis is still available',
     );
 
     analysisGate.complete(analysis);

--- a/test/helpers/pump_until.dart
+++ b/test/helpers/pump_until.dart
@@ -10,6 +10,9 @@ import 'package:flutter_test/flutter_test.dart';
 /// Fails the test if [condition] is still false after [maxFrames], so a state
 /// that is never reached surfaces as an explicit failure rather than an
 /// assertion that passes for the wrong reason.
+///
+/// [maxFrames] must be at least 1: one frame is always pumped, so a smaller
+/// budget could not be honoured.
 Future<void> pumpUntil(
   WidgetTester tester,
   bool Function() condition, {
@@ -17,6 +20,10 @@ Future<void> pumpUntil(
   Duration interval = const Duration(milliseconds: 10),
   String? reason,
 }) async {
+  assert(
+    maxFrames >= 1,
+    'pumpUntil always pumps one frame; maxFrames must be >= 1',
+  );
   // Always pump at least one frame before believing [condition]. A provider
   // state such as `isReloading` becomes true the instant the reload is
   // scheduled, before the widgets that read it have rebuilt: returning then

--- a/test/helpers/pump_until.dart
+++ b/test/helpers/pump_until.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pumps frames until [condition] returns true, then returns.
+///
+/// The widget-test analogue of `waitUntil`: inside `testWidgets` the clock is
+/// fake, so a real `Future.delayed` never advances and a fixed-duration pump
+/// hard-codes an assumption about how many frames the work takes. Polling the
+/// condition states that assumption instead of guessing at it.
+///
+/// Fails the test if [condition] is still false after [maxFrames], so a state
+/// that is never reached surfaces as an explicit failure rather than an
+/// assertion that passes for the wrong reason.
+Future<void> pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  int maxFrames = 100,
+  Duration interval = const Duration(milliseconds: 10),
+  String? reason,
+}) async {
+  // Always pump at least one frame before believing [condition]. A provider
+  // state such as `isReloading` becomes true the instant the reload is
+  // scheduled, before the widgets that read it have rebuilt: returning then
+  // would leave the caller asserting on props left over from the previous
+  // frame, which passes whatever the widget does with the new state.
+  await tester.pump(interval);
+  for (var frame = 1; frame < maxFrames && !condition(); frame++) {
+    await tester.pump(interval);
+  }
+  if (!condition()) {
+    fail(
+      'pumpUntil: condition not met within $maxFrames frames'
+      '${reason == null ? '' : ' ($reason)'}',
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Selecting a dive from the dives list for the first time drew the profile chart, then flashed it once before settling.

**Trigger.** The first view of a dive computes and persists its safety review (`safetyReviewProvider` -> `saveReview`). That write lands on `dive_safety_reviews` / `dive_safety_findings`, both in `watchDiveDetailChanges`, so about 300ms after the chart has painted the detail tick fires and `diveProvider` refreshes. The second view finds a stored review at the current engine version and never writes, which is why it only happened once per dive.

**Mechanism.** `estimatedTankPressuresProvider` watches `diveProvider`'s future, so it goes through a *reload* behind that refresh. The profile section read every async chart input through the repo's `valueOrNull` polyfill, which is `when(loading: () => null)`: it keeps the value on a refresh but returns null during a reload. For that window the chart lost its estimated pressure series and the right axis with it, the plot insets changed, and the depth curve re-projected; then the reload completed and it snapped back. The analysis overlays (`sourceProfileAnalysisProvider`) had the same exposure on any analysis-input tick. Verified with a provider-level probe on a real in-memory database: after the safety save, only the detail stream ticks (the HLC stamp is a raw statement, so the analysis stream does not), `diveProvider` reports `isRefreshing` and keeps its value, and `estimatedTankPressuresProvider` reports `isReloading` with `valueOrNull == null` and `value != null`.

**Fix.** Read the profile section's chart inputs through the built-in `AsyncValue.value`, which keeps the previous value across a reload, in `dive_detail_page.dart`, and do the same in the table-mode `DiveProfilePanel`. The fullscreen profile page already read them this way. Same pattern as #429.

## Tests

- New `dive_detail_profile_section_reload_test.dart` (2 widget tests). Each holds a reload window open across a frame with a completer and asserts the chart keeps its estimated pressure series during a `diveProvider` refresh, and its analysis overlays during an analysis reload. Both failed at the mid-reload assertion before the fix.
- Detail page, side panel, chart series consistency, and fullscreen suites green (88 tests). `flutter analyze` clean.

## Not changed

The first-view safety review write itself, and the detail tick it causes, are left as they are. The write is needed for sync, and after this change a tick no longer has a visible effect on the chart.
