### PR TITLE
fix(dive-log): derive CCR ppN2/MOD/density curves from the loop (issue #579)

### DIFF
--- a/lib/features/dive_log/data/services/profile_analysis_service.dart
+++ b/lib/features/dive_log/data/services/profile_analysis_service.dart
@@ -1889,9 +1889,16 @@ class ProfileAnalysisService {
 
     for (int i = 0; i < depths.length; i++) {
       final diluent = _activeGasSegmentAtTimestamp(timestamps[i], gasSegments);
-      final diluentFN2 = diluent.fN2.clamp(0.0, 1.0);
-      final diluentFHe = diluent.fHe.clamp(0.0, 1.0);
-      final diluentInert = (diluentFN2 + diluentFHe).clamp(0.0, 1.0);
+      // Inert fractions summing past 1 (import noise) are scaled back to 1
+      // together so the recorded He:N2 ratio survives; the diluent then has
+      // no O2 left and its MOD reads as unavailable.
+      final rawFN2 = math.max(diluent.fN2, 0.0);
+      final rawFHe = math.max(diluent.fHe, 0.0);
+      final rawInert = rawFN2 + rawFHe;
+      final overFull = rawInert > 1.0;
+      final diluentFN2 = overFull ? rawFN2 / rawInert : rawFN2;
+      final diluentFHe = overFull ? rawFHe / rawInert : rawFHe;
+      final diluentInert = overFull ? 1.0 : rawInert;
       diluentO2Fractions.add(1.0 - diluentInert);
 
       final ambientPressure = 1.0 + (depths[i] / 10.0);

--- a/lib/features/dive_log/data/services/profile_analysis_service.dart
+++ b/lib/features/dive_log/data/services/profile_analysis_service.dart
@@ -759,10 +759,6 @@ class ProfileAnalysisService {
           )
         : null;
 
-    final pointO2Fractions = ocGasMetrics?.o2Fractions;
-    final pointN2Fractions = ocGasMetrics?.n2Fractions;
-    final pointHeFractions = ocGasMetrics?.heFractions;
-
     // A measured ppO2 curve (from O2 cells/setpoint) takes priority for
     // rebreather dives: it reflects the actual loop ppO2, unlike the setpoint
     // (which may be absent for imported dives) or the OC depth x FO2 fallback.
@@ -928,6 +924,36 @@ class ProfileAnalysisService {
       }
     }
 
+    // Per-sample breathed fractions for the gas display curves. OC: the
+    // recorded tank/switch schedule. CCR: the loop itself (issue #579), the
+    // same model the engine loads tissues with: inspired inert = ambient -
+    // loop ppO2, split by the diluent's He:N2 ratio. The loop ppO2 is the
+    // displayed ppO2 curve so the ppN2/density overlays agree with it. With
+    // no setpoint segments the loop cannot be modeled and the legacy
+    // first-tank fractions stand.
+    final ccrLoopFractions = diveMode == DiveMode.ccr && gasSegments != null
+        ? _calculateCcrLoopFractions(
+            depths: depths,
+            timestamps: timestamps,
+            gasSegments: gasSegments,
+            loopPpO2Curve: ppO2Curve,
+          )
+        : null;
+    final pointO2Fractions =
+        ocGasMetrics?.o2Fractions ?? ccrLoopFractions?.o2Fractions;
+    final pointN2Fractions =
+        ocGasMetrics?.n2Fractions ?? ccrLoopFractions?.n2Fractions;
+    final pointHeFractions =
+        ocGasMetrics?.heFractions ?? ccrLoopFractions?.heFractions;
+    // MOD is a property of the gas, not of depth, and the chart draws it as a
+    // flat reference that moves only on a gas switch. On a CCR that gas is the
+    // diluent (the mix the diver can flush to or bail out on), not the
+    // depth-varying effective loop fraction.
+    final modO2Fractions =
+        ocGasMetrics?.o2Fractions ??
+        ccrLoopFractions?.diluentO2Fractions ??
+        List.filled(depths.length, o2Fraction);
+
     // Calculate additional gas/deco curves
     final ppN2Curve = pointN2Fractions != null
         ? _calculatePpCurve(depths, pointN2Fractions)
@@ -939,9 +965,7 @@ class ProfileAnalysisService {
         : heFraction > 0
         ? _calculatePpCurve(depths, List.filled(depths.length, heFraction))
         : null;
-    final modCurve = _calculateModCurve(
-      pointO2Fractions ?? List.filled(depths.length, o2Fraction),
-    );
+    final modCurve = _calculateModCurve(modO2Fractions);
     final densityCurve = _calculateDensityCurve(
       depths: depths,
       o2Fractions: pointO2Fractions ?? List.filled(depths.length, o2Fraction),
@@ -1834,6 +1858,64 @@ class ProfileAnalysisService {
       ),
       cnsCurve: cnsCurve,
       otuCurve: otuCurve,
+    );
+  }
+
+  /// Effective breathed fractions on a CCR loop at each sample, plus the
+  /// diluent O2 fraction for the MOD line.
+  ///
+  /// Mirrors the engine's `ClosedCircuit.inspiredAt` without the water-vapor
+  /// term, so the curves stay on the same ambient-pressure basis as the OC
+  /// partial pressures and the displayed loop ppO2. The loop ppO2 clamps to
+  /// ambient (the loop cannot exceed it near the surface) and a sample with no
+  /// loop ppO2 information falls back to breathing the diluent open-circuit
+  /// rather than reporting a hypoxic loop.
+  ({
+    List<double> o2Fractions,
+    List<double> n2Fractions,
+    List<double> heFractions,
+    List<double> diluentO2Fractions,
+  })
+  _calculateCcrLoopFractions({
+    required List<double> depths,
+    required List<int> timestamps,
+    required List<ProfileGasSegment> gasSegments,
+    required List<double> loopPpO2Curve,
+  }) {
+    final o2Fractions = <double>[];
+    final n2Fractions = <double>[];
+    final heFractions = <double>[];
+    final diluentO2Fractions = <double>[];
+
+    for (int i = 0; i < depths.length; i++) {
+      final diluent = _activeGasSegmentAtTimestamp(timestamps[i], gasSegments);
+      final diluentFN2 = diluent.fN2.clamp(0.0, 1.0);
+      final diluentFHe = diluent.fHe.clamp(0.0, 1.0);
+      final diluentInert = (diluentFN2 + diluentFHe).clamp(0.0, 1.0);
+      diluentO2Fractions.add(1.0 - diluentInert);
+
+      final ambientPressure = 1.0 + (depths[i] / 10.0);
+      final loopPpO2 = i < loopPpO2Curve.length ? loopPpO2Curve[i] : 0.0;
+      if (loopPpO2 <= 0 || diluentInert <= 0) {
+        o2Fractions.add(1.0 - diluentInert);
+        n2Fractions.add(diluentFN2);
+        heFractions.add(diluentFHe);
+        continue;
+      }
+
+      final pO2 = math.min(loopPpO2, ambientPressure);
+      final inertFraction = (ambientPressure - pO2) / ambientPressure;
+      final n2Share = diluentFN2 / diluentInert;
+      o2Fractions.add(pO2 / ambientPressure);
+      n2Fractions.add(inertFraction * n2Share);
+      heFractions.add(inertFraction * (1.0 - n2Share));
+    }
+
+    return (
+      o2Fractions: o2Fractions,
+      n2Fractions: n2Fractions,
+      heFractions: heFractions,
+      diluentO2Fractions: diluentO2Fractions,
     );
   }
 

--- a/test/features/dive_log/data/services/profile_analysis_service_test.dart
+++ b/test/features/dive_log/data/services/profile_analysis_service_test.dart
@@ -1068,6 +1068,27 @@ void main() {
       expect(analysis.modCurve![3], closeTo(67.778, 0.01));
     });
 
+    test('an over-full diluent is renormalized, keeping its He:N2 ratio', () {
+      // Import noise can hand us inert fractions summing past 1. The split
+      // must still follow the recorded He:N2 ratio (0.8:0.4) rather than the
+      // clipped one, and the diluent has no O2 left for a MOD.
+      final analysis = analyzeLoop(
+        gasSegments: const [
+          ProfileGasSegment(
+            startTimestamp: 0,
+            fN2: 0.8,
+            fHe: 0.4,
+            setpoint: 1.3,
+          ),
+        ],
+        ppO2Curve: List<double>.filled(depths.length, 1.3),
+      );
+      // 4.1 bar inert split 2:1.
+      expect(analysis.ppN2Curve![2], closeTo(4.1 * 2 / 3, 0.001));
+      expect(analysis.ppHeCurve![2], closeTo(4.1 / 3, 0.001));
+      expect(analysis.modCurve![2], 0.0);
+    });
+
     test('no loop information keeps the legacy first-tank curves', () {
       final analysis = analyzeLoop(gasSegments: null);
       // No setpoint segments and no measured ppO2: the loop cannot be

--- a/test/features/dive_log/data/services/profile_analysis_service_test.dart
+++ b/test/features/dive_log/data/services/profile_analysis_service_test.dart
@@ -946,4 +946,134 @@ void main() {
       },
     );
   });
+
+  group('CCR display curves come from the loop (issue #579)', () {
+    // Same dive as #455: 44 m on an air-diluent loop at setpoint 1.3 with an
+    // EAN40 first tank. At 44 m (5.4 bar) the loop's inspired inert gas is
+    // 5.4 - 1.3 = 4.1 bar, all nitrogen for an air diluent.
+    const depths = [0.0, 44.0, 44.0, 44.0, 44.0, 0.0];
+    const timestamps = [0, 180, 900, 1800, 2400, 2700];
+    const airDiluent = [
+      ProfileGasSegment(startTimestamp: 0, fN2: 0.79, setpoint: 1.3),
+    ];
+
+    ProfileAnalysis analyzeLoop({
+      List<ProfileGasSegment>? gasSegments = airDiluent,
+      List<double>? ppO2Curve,
+      double o2Fraction = 0.40,
+      double heFraction = 0.0,
+    }) {
+      return ProfileAnalysisService(gfLow: 0.45, gfHigh: 0.75).analyze(
+        diveId: 'ccr-display',
+        depths: depths,
+        timestamps: timestamps,
+        o2Fraction: o2Fraction,
+        heFraction: heFraction,
+        diveMode: DiveMode.ccr,
+        setpointHigh: 1.3,
+        gasSegments: gasSegments,
+        rebreatherPpO2Curve: ppO2Curve,
+      );
+    }
+
+    test('ppN2 is ambient minus loop ppO2, not first-tank fN2 x ambient', () {
+      final analysis = analyzeLoop(
+        ppO2Curve: List<double>.filled(depths.length, 1.3),
+      );
+      // Loop: 5.4 - 1.3 = 4.1 bar. First-tank EAN40 would give 5.4 x 0.60.
+      expect(analysis.ppN2Curve![2], closeTo(4.1, 0.001));
+    });
+
+    test('ppN2 follows the measured loop ppO2, not the segment setpoint', () {
+      final analysis = analyzeLoop(
+        ppO2Curve: List<double>.filled(depths.length, 1.1),
+      );
+      expect(analysis.ppN2Curve![2], closeTo(4.3, 0.001));
+    });
+
+    test('ppN2 uses the setpoint when no loop ppO2 was measured', () {
+      final analysis = analyzeLoop();
+      expect(analysis.ppN2Curve![2], closeTo(4.1, 0.001));
+    });
+
+    test('ppN2 is zero at the surface when the setpoint exceeds ambient', () {
+      final analysis = analyzeLoop(
+        ppO2Curve: List<double>.filled(depths.length, 1.3),
+      );
+      // The loop cannot hold 1.3 bar at 1.0 bar ambient: ppO2 clamps to
+      // ambient and no inert gas is inspired.
+      expect(analysis.ppN2Curve![0], closeTo(0.0, 0.001));
+    });
+
+    test('gas density weighs the loop partial pressures', () {
+      final analysis = analyzeLoop(
+        ppO2Curve: List<double>.filled(depths.length, 1.3),
+      );
+      // (1.3 x 32 + 4.1 x 28) / 24.04 g/L at 44 m.
+      expect(analysis.densityCurve![2], closeTo(6.506, 0.001));
+      // Pure O2 loop at the surface: 32 / 24.04.
+      expect(analysis.densityCurve![0], closeTo(1.331, 0.001));
+    });
+
+    test('MOD is the diluent MOD, not the first tank MOD', () {
+      final analysis = analyzeLoop(
+        ppO2Curve: List<double>.filled(depths.length, 1.3),
+      );
+      // Air diluent at ppO2 1.4: (1.4 / 0.21 - 1) x 10. EAN40 would be 25 m.
+      expect(analysis.modCurve![2], closeTo(56.667, 0.01));
+      expect(analysis.modCurve![0], closeTo(56.667, 0.01));
+    });
+
+    test('trimix diluent splits the inert gas by its He:N2 ratio', () {
+      final analysis = analyzeLoop(
+        gasSegments: const [
+          ProfileGasSegment(
+            startTimestamp: 0,
+            fN2: 0.37,
+            fHe: 0.45,
+            setpoint: 1.3,
+          ),
+        ],
+        ppO2Curve: List<double>.filled(depths.length, 1.3),
+        o2Fraction: 0.18,
+        heFraction: 0.45,
+      );
+      // 4.1 bar inert split 0.37:0.45.
+      expect(analysis.ppN2Curve![2], closeTo(1.85, 0.001));
+      expect(analysis.ppHeCurve![2], closeTo(2.25, 0.001));
+      // (1.3 x 32 + 1.85 x 28 + 2.25 x 4) / 24.04 g/L.
+      expect(analysis.densityCurve![2], closeTo(4.260, 0.001));
+      // Diluent 18/45 MOD at ppO2 1.4.
+      expect(analysis.modCurve![2], closeTo(67.778, 0.01));
+    });
+
+    test('a diluent switch moves the MOD and inert split at the switch', () {
+      final analysis = analyzeLoop(
+        gasSegments: const [
+          ProfileGasSegment(startTimestamp: 0, fN2: 0.79, setpoint: 1.3),
+          ProfileGasSegment(
+            startTimestamp: 1800,
+            fN2: 0.37,
+            fHe: 0.45,
+            setpoint: 1.3,
+          ),
+        ],
+        ppO2Curve: List<double>.filled(depths.length, 1.3),
+      );
+      expect(analysis.ppN2Curve![2], closeTo(4.1, 0.001));
+      expect(analysis.ppHeCurve![2], closeTo(0.0, 0.001));
+      expect(analysis.modCurve![2], closeTo(56.667, 0.01));
+      expect(analysis.ppN2Curve![3], closeTo(1.85, 0.001));
+      expect(analysis.ppHeCurve![3], closeTo(2.25, 0.001));
+      expect(analysis.modCurve![3], closeTo(67.778, 0.01));
+    });
+
+    test('no loop information keeps the legacy first-tank curves', () {
+      final analysis = analyzeLoop(gasSegments: null);
+      // No setpoint segments and no measured ppO2: the loop cannot be
+      // modeled, so the display falls back to the first tank as before.
+      expect(analysis.ppN2Curve![2], closeTo(5.4 * 0.60, 0.001));
+      expect(analysis.modCurve![2], closeTo(25.0, 0.01));
+    });
+  });
 }

--- a/test/features/dive_log/data/services/profile_analysis_service_test.dart
+++ b/test/features/dive_log/data/services/profile_analysis_service_test.dart
@@ -1089,6 +1089,19 @@ void main() {
       expect(analysis.modCurve![2], 0.0);
     });
 
+    test('a sample with no loop ppO2 breathes the diluent open-circuit', () {
+      // A zero in the resolved curve means the loop ppO2 is unknown at that
+      // sample. Treating it as a real 0 bar would report a hypoxic loop with
+      // all of ambient as inert gas; instead the sample falls back to the
+      // diluent's open-circuit fractions.
+      final ppO2Curve = List<double>.filled(depths.length, 1.3)..[2] = 0.0;
+      final analysis = analyzeLoop(ppO2Curve: ppO2Curve);
+      // Air diluent at 44 m: 5.4 x 0.79.
+      expect(analysis.ppN2Curve![2], closeTo(5.4 * 0.79, 0.001));
+      // The neighbouring samples still follow the loop.
+      expect(analysis.ppN2Curve![3], closeTo(4.1, 0.001));
+    });
+
     test('no loop information keeps the legacy first-tank curves', () {
       final analysis = analyzeLoop(gasSegments: null);
       // No setpoint segments and no measured ppO2: the loop cannot be


### PR DESCRIPTION
## Summary

Fixes #579. Follow-up to #455 / PR #571.

The profile chart's gas-derived display overlays for CCR dives (ppN2, ppHe, MOD, gas density) still came from the first tank's fixed fractions. For dive 003 (first tank EAN40, air diluent, setpoint 1.3) the ppN2 and density curves were systematically off at depth, and the MOD line showed 25 m under a 44 m dive.

`ProfileAnalysisService.analyze` now builds per-sample breathed fractions for CCR dives from the loop, using the same model the engine has loaded tissues with since #571: inspired inert = ambient - loop ppO2, split by the diluent's He:N2 ratio, with the diluent taken from the active setpoint segment. The loop ppO2 used is the already-resolved display curve (`resolveRebreatherPpO2`: computer ppO2, cell average, or setpoint), so the ppN2/ppHe/density overlays always agree with the displayed ppO2 curve.

## Changes

- New `_calculateCcrLoopFractions` in `profile_analysis_service.dart`: walks the samples, picks the active diluent segment, clamps the loop ppO2 to ambient (the loop cannot exceed it near the surface), and returns effective O2/N2/He fractions plus the diluent O2 fraction.
- ppN2, ppHe and gas density for CCR dives now use those loop fractions instead of the caller's first-tank scalars. Density therefore weighs the loop partial pressures (at 44 m on air diluent / SP 1.3: 6.51 g/L, previously 6.65 g/L from EAN40).
- **MOD on a CCR is the diluent's MOD.** The chart draws MOD as a flat gas property that only moves on a gas switch, and on a rebreather the gas the diver can flush to or bail out on is the diluent. A depth-varying "effective loop fraction" MOD would be a moving target with no physiological meaning. Dive 003 now shows 56.7 m (air diluent) instead of 25 m (EAN40).
- The loop partitioning deliberately omits the engine's alveolar water-vapor term so the curves stay on the same ambient-pressure basis as the OC partial pressures and the displayed loop ppO2.
- Dives with no loop information (no setpoint segments, no measured ppO2) keep the legacy first-tank curves, matching the deco behaviour chosen in #571.

Out of scope, as the issue notes: SCR display curves (depend on the SCR loop model).

## Test Plan

- [x] `flutter test` passes (new group `CCR display curves come from the loop (issue #579)` with 9 cases: measured ppO2 vs setpoint, surface clamp, trimix diluent split, diluent switch mid-dive, density weighting, diluent MOD, legacy fallback; `test/core/deco`, `test/features/dive_log/data` and `test/features/dive_log/presentation/providers` all green, 1589 tests)
- [x] `flutter analyze` passes
- [x] `dart format .` clean
- [x] Manual testing on: not yet run in the app
