### PR TITLE
fix(setup): offer Google Drive in the wizard's Backup & Sync step

### DIFF
--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -8,7 +7,6 @@ import 'package:intl/intl.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType;
-import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/dropbox/dropbox_auth_store.dart';
 import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
@@ -25,6 +23,7 @@ import 'package:submersion/features/settings/presentation/widgets/newer_schema_p
 import 'package:submersion/features/settings/presentation/widgets/read_failed_peer_banner.dart';
 import 'package:submersion/features/settings/presentation/widgets/skipped_peer_banner.dart';
 import 'package:submersion/features/settings/presentation/widgets/sync_now_action.dart';
+import 'package:submersion/features/settings/presentation/widgets/cloud_provider_authenticate.dart';
 import 'package:submersion/features/settings/presentation/widgets/conflict_resolution_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/dropbox_connect_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/encryption_settings_section.dart';
@@ -856,7 +855,7 @@ class _CloudSyncPageState extends ConsumerState<CloudSyncPage> {
 
     try {
       // Authenticate with the provider
-      await _authenticateWithBrowserWait(context, cloudProvider, provider);
+      await authenticateWithBrowserWait(context, cloudProvider, provider);
 
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -897,76 +896,6 @@ class _CloudSyncPageState extends ConsumerState<CloudSyncPage> {
         );
       }
     }
-  }
-
-  /// On desktop, Google Drive authentication round-trips through the
-  /// system browser (loopback OAuth); keep a cancellable waiting dialog up
-  /// while it completes so the page does not look frozen. Other providers
-  /// and platforms authenticate directly.
-  Future<void> _authenticateWithBrowserWait(
-    BuildContext context,
-    CloudStorageProvider cloudProvider,
-    CloudProviderType provider,
-  ) async {
-    final needsDialog =
-        provider == CloudProviderType.googledrive &&
-        (Platform.isWindows || Platform.isLinux);
-    if (!needsDialog) {
-      await cloudProvider.authenticate();
-      return;
-    }
-
-    // Single synchronously-checked guard: whichever happens first -- auth
-    // settling or the user tapping Cancel -- closes the dialog exactly once.
-    // Because dialogClosed is checked and set with no intervening await, the
-    // two paths can never interleave, so the pop always targets the dialog
-    // (showDialog pushes it synchronously below, before any await yields to
-    // the auth microtask) and never the page route.
-    final navigator = Navigator.of(context, rootNavigator: true);
-    var dialogClosed = false;
-    void closeDialog(bool cancelled) {
-      if (dialogClosed) return;
-      dialogClosed = true;
-      navigator.pop(cancelled);
-    }
-
-    final auth = cloudProvider.authenticate();
-    unawaited(
-      auth.then((_) => closeDialog(false), onError: (_) => closeDialog(false)),
-    );
-    final cancelled =
-        await showDialog<bool>(
-          context: context,
-          barrierDismissible: false,
-          builder: (dialogContext) => AlertDialog(
-            title: Text(
-              dialogContext
-                  .l10n
-                  .settings_cloudSync_googleDrive_browserWait_title,
-            ),
-            content: Text(
-              dialogContext
-                  .l10n
-                  .settings_cloudSync_googleDrive_browserWait_message,
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => closeDialog(true),
-                child: Text(
-                  MaterialLocalizations.of(dialogContext).cancelButtonLabel,
-                ),
-              ),
-            ],
-          ),
-        ) ??
-        false;
-    if (cancelled) {
-      // Abandon the pending flow; the loopback listener times out on its
-      // own. Swallow its eventual error so nothing surfaces later.
-      unawaited(auth.catchError((_) {}));
-      throw const CloudStorageException('Google Sign-In was cancelled');
-    }
-    await auth;
   }
 
   /// Localized connection-failure message. For iCloud, the wording reflects

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -875,6 +875,10 @@ class _CloudSyncPageState extends ConsumerState<CloudSyncPage> {
 
       // Refresh sync state after successful authentication
       ref.read(syncStateProvider.notifier).refreshState();
+    } on CloudAuthCancelled {
+      // The user backed out of the browser sign-in deliberately. Clear the
+      // half-made selection, but do not dress a decision up as a failure.
+      ref.read(selectedCloudProviderTypeProvider.notifier).state = null;
     } catch (e) {
       // Clear the provider selection on failure
       ref.read(selectedCloudProviderTypeProvider.notifier).state = null;

--- a/lib/features/settings/presentation/widgets/cloud_provider_authenticate.dart
+++ b/lib/features/settings/presentation/widgets/cloud_provider_authenticate.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/data/repositories/sync_repository.dart'
+    show CloudProviderType;
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// On desktop, Google Drive authentication round-trips through the
+/// system browser (loopback OAuth); keep a cancellable waiting dialog up
+/// while it completes so the caller's page does not look frozen. Other
+/// providers and platforms authenticate directly.
+///
+/// Shared by Cloud Sync settings and the setup wizard's Backup & Sync step so
+/// both connect surfaces behave identically: a wizard that authenticated
+/// without the dialog would sit on a dead first-run screen for the whole
+/// OAuth round trip, with no way to back out.
+///
+/// Throws [CloudStorageException] if the user cancels.
+Future<void> authenticateWithBrowserWait(
+  BuildContext context,
+  CloudStorageProvider cloudProvider,
+  CloudProviderType provider,
+) async {
+  final needsDialog =
+      provider == CloudProviderType.googledrive &&
+      (Platform.isWindows || Platform.isLinux);
+  if (!needsDialog) {
+    await cloudProvider.authenticate();
+    return;
+  }
+
+  // Single synchronously-checked guard: whichever happens first -- auth
+  // settling or the user tapping Cancel -- closes the dialog exactly once.
+  // Because dialogClosed is checked and set with no intervening await, the
+  // two paths can never interleave, so the pop always targets the dialog
+  // (showDialog pushes it synchronously below, before any await yields to
+  // the auth microtask) and never the page route.
+  final navigator = Navigator.of(context, rootNavigator: true);
+  var dialogClosed = false;
+  void closeDialog(bool cancelled) {
+    if (dialogClosed) return;
+    dialogClosed = true;
+    navigator.pop(cancelled);
+  }
+
+  final auth = cloudProvider.authenticate();
+  unawaited(
+    auth.then((_) => closeDialog(false), onError: (_) => closeDialog(false)),
+  );
+  final cancelled =
+      await showDialog<bool>(
+        context: context,
+        barrierDismissible: false,
+        builder: (dialogContext) => AlertDialog(
+          title: Text(
+            dialogContext.l10n.settings_cloudSync_googleDrive_browserWait_title,
+          ),
+          content: Text(
+            dialogContext
+                .l10n
+                .settings_cloudSync_googleDrive_browserWait_message,
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => closeDialog(true),
+              child: Text(
+                MaterialLocalizations.of(dialogContext).cancelButtonLabel,
+              ),
+            ),
+          ],
+        ),
+      ) ??
+      false;
+  if (cancelled) {
+    // Abandon the pending flow; the loopback listener times out on its
+    // own. Swallow its eventual error so nothing surfaces later.
+    unawaited(auth.catchError((_) {}));
+    throw const CloudStorageException('Google Sign-In was cancelled');
+  }
+  await auth;
+}

--- a/lib/features/settings/presentation/widgets/cloud_provider_authenticate.dart
+++ b/lib/features/settings/presentation/widgets/cloud_provider_authenticate.dart
@@ -19,14 +19,19 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// OAuth round trip, with no way to back out.
 ///
 /// Throws [CloudStorageException] if the user cancels.
+///
+/// [debugForceBrowserWait] overrides the platform check so the dialog branch
+/// is reachable in tests on any host; production callers leave it null.
 Future<void> authenticateWithBrowserWait(
   BuildContext context,
   CloudStorageProvider cloudProvider,
-  CloudProviderType provider,
-) async {
+  CloudProviderType provider, {
+  @visibleForTesting bool? debugForceBrowserWait,
+}) async {
   final needsDialog =
-      provider == CloudProviderType.googledrive &&
-      (Platform.isWindows || Platform.isLinux);
+      debugForceBrowserWait ??
+      (provider == CloudProviderType.googledrive &&
+          (Platform.isWindows || Platform.isLinux));
   if (!needsDialog) {
     await cloudProvider.authenticate();
     return;
@@ -54,26 +59,40 @@ Future<void> authenticateWithBrowserWait(
       await showDialog<bool>(
         context: context,
         barrierDismissible: false,
-        builder: (dialogContext) => AlertDialog(
-          title: Text(
-            dialogContext.l10n.settings_cloudSync_googleDrive_browserWait_title,
-          ),
-          content: Text(
-            dialogContext
-                .l10n
-                .settings_cloudSync_googleDrive_browserWait_message,
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => closeDialog(true),
-              child: Text(
-                MaterialLocalizations.of(dialogContext).cancelButtonLabel,
-              ),
+        // Cancel is the only way out: a system back gesture or Escape that
+        // popped the route would leave dialogClosed false, so the pending
+        // auth's later closeDialog would pop whatever route is underneath --
+        // the caller's page, or the wizard's first-run screen.
+        builder: (dialogContext) => PopScope(
+          canPop: false,
+          child: AlertDialog(
+            title: Text(
+              dialogContext
+                  .l10n
+                  .settings_cloudSync_googleDrive_browserWait_title,
             ),
-          ],
+            content: Text(
+              dialogContext
+                  .l10n
+                  .settings_cloudSync_googleDrive_browserWait_message,
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => closeDialog(true),
+                child: Text(
+                  MaterialLocalizations.of(dialogContext).cancelButtonLabel,
+                ),
+              ),
+            ],
+          ),
         ),
       ) ??
       false;
+  // Belt and braces for the same hazard: whatever closed the route -- Cancel,
+  // the auth settling, or a pop that slipped past PopScope -- the dialog is
+  // gone by the time showDialog returns, so latch the flag here rather than
+  // trusting every future dismissal path to run through closeDialog.
+  dialogClosed = true;
   if (cancelled) {
     // Abandon the pending flow; the loopback listener times out on its
     // own. Swallow its eventual error so nothing surfaces later.

--- a/lib/features/settings/presentation/widgets/cloud_provider_authenticate.dart
+++ b/lib/features/settings/presentation/widgets/cloud_provider_authenticate.dart
@@ -8,6 +8,16 @@ import 'package:submersion/core/data/repositories/sync_repository.dart'
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
+/// Raised when the user dismisses the browser-wait dialog.
+///
+/// Cancelling is a decision, not a failure. Callers catch this ahead of their
+/// generic handler and roll back quietly, so a deliberate "no" never reaches
+/// the user as a red connection-failed snackbar with an untranslated English
+/// fragment embedded in it.
+class CloudAuthCancelled implements Exception {
+  const CloudAuthCancelled();
+}
+
 /// On desktop, Google Drive authentication round-trips through the
 /// system browser (loopback OAuth); keep a cancellable waiting dialog up
 /// while it completes so the caller's page does not look frozen. Other
@@ -18,7 +28,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// without the dialog would sit on a dead first-run screen for the whole
 /// OAuth round trip, with no way to back out.
 ///
-/// Throws [CloudStorageException] if the user cancels.
+/// Throws [CloudAuthCancelled] if the user cancels.
 ///
 /// [debugForceBrowserWait] overrides the platform check so the dialog branch
 /// is reachable in tests on any host; production callers leave it null.
@@ -59,6 +69,10 @@ Future<void> authenticateWithBrowserWait(
       await showDialog<bool>(
         context: context,
         barrierDismissible: false,
+        // Stated explicitly to pair with the rootNavigator lookup above:
+        // closeDialog pops the root navigator, so this dialog must be pushed
+        // onto it even if a nested navigator ever wraps a call site.
+        useRootNavigator: true,
         // Cancel is the only way out: a system back gesture or Escape that
         // popped the route would leave dialogClosed false, so the pending
         // auth's later closeDialog would pop whatever route is underneath --
@@ -97,7 +111,7 @@ Future<void> authenticateWithBrowserWait(
     // Abandon the pending flow; the loopback listener times out on its
     // own. Swallow its eventual error so nothing surfaces later.
     unawaited(auth.catchError((_) {}));
-    throw const CloudStorageException('Google Sign-In was cancelled');
+    throw const CloudAuthCancelled();
   }
   await auth;
 }

--- a/lib/features/setup_wizard/presentation/widgets/steps/backup_sync_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/backup_sync_step.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
 import 'package:submersion/features/settings/presentation/pages/s3_config_page.dart';
@@ -52,7 +53,16 @@ class _BackupSyncStepState extends ConsumerState<BackupSyncStep> {
       if (!mounted) return;
       // Activation contract mirrored from CloudSyncPage._selectProvider.
       selection.state = type;
-      final instance = cloudProviderInstanceFor(type);
+      // Resolve the backend the way that page does, rather than reaching for
+      // the raw singleton: this provider applies account-first credential
+      // resolution and the custom-folder check, so the singleton shortcut
+      // quietly broke the contract the comment above claims.
+      final instance = ref.read(cloudStorageProviderProvider);
+      if (instance == null) {
+        throw CloudStorageException(
+          context.l10n.settings_cloudSync_provider_initFailed(type.name),
+        );
+      }
       // Desktop Google Drive authenticates through the system browser, which
       // can take as long as the user does. The shared helper keeps a
       // cancellable wait dialog up so the wizard does not sit frozen with no

--- a/lib/features/setup_wizard/presentation/widgets/steps/backup_sync_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/backup_sync_step.dart
@@ -3,7 +3,6 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/providers/provider.dart';
-import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
 import 'package:submersion/features/settings/presentation/pages/s3_config_page.dart';
@@ -59,9 +58,20 @@ class _BackupSyncStepState extends ConsumerState<BackupSyncStep> {
       // quietly broke the contract the comment above claims.
       final instance = ref.read(cloudStorageProviderProvider);
       if (instance == null) {
-        throw CloudStorageException(
-          context.l10n.settings_cloudSync_provider_initFailed(type.name),
+        // Report it the way CloudSyncPage does, rather than throwing: routing
+        // this through setup_sync_error would print the exception's own type
+        // name into the snackbar alongside the message.
+        selection.state = null;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              context.l10n.settings_cloudSync_provider_initFailed(
+                _providerName(type),
+              ),
+            ),
+          ),
         );
+        return;
       }
       // Desktop Google Drive authenticates through the system browser, which
       // can take as long as the user does. The shared helper keeps a
@@ -84,6 +94,11 @@ class _BackupSyncStepState extends ConsumerState<BackupSyncStep> {
             .peerSyncFiles(instance);
         if (peers.isNotEmpty && mounted) widget.onLibraryFound!();
       }
+    } on CloudAuthCancelled {
+      // A deliberate cancel: undo the pending selection silently so the cards
+      // come back, with no error shown for a choice the user made.
+      selection.state = null;
+      if (mounted) notifier.setConnectedProvider(null);
     } catch (e) {
       selection.state = null;
       if (mounted) {

--- a/lib/features/setup_wizard/presentation/widgets/steps/backup_sync_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/backup_sync_step.dart
@@ -33,6 +33,10 @@ class _BackupSyncStepState extends ConsumerState<BackupSyncStep> {
 
   Future<void> _connect(CloudProviderType type) async {
     final notifier = ref.read(setupWizardProvider(widget.mode).notifier);
+    // Captured before any await: this controller is container-owned, so it
+    // still rolls the selection back if the step is disposed mid-connect,
+    // where reading it off `ref` would throw instead.
+    final selection = ref.read(selectedCloudProviderTypeProvider.notifier);
     setState(() => _connecting = true);
     try {
       if (type == CloudProviderType.dropbox) {
@@ -47,13 +51,18 @@ class _BackupSyncStepState extends ConsumerState<BackupSyncStep> {
       }
       if (!mounted) return;
       // Activation contract mirrored from CloudSyncPage._selectProvider.
-      ref.read(selectedCloudProviderTypeProvider.notifier).state = type;
+      selection.state = type;
       final instance = cloudProviderInstanceFor(type);
       // Desktop Google Drive authenticates through the system browser, which
       // can take as long as the user does. The shared helper keeps a
       // cancellable wait dialog up so the wizard does not sit frozen with no
       // way out; every other provider and platform authenticates directly.
       await authenticateWithBrowserWait(context, instance, type);
+      // A desktop browser round trip is user-paced and can easily outlast
+      // this step (the user backs out of the wizard while the browser is
+      // up). Both `ref` and the autoDispose draft notifier throw once that
+      // happens, so stop here rather than at the first of them.
+      if (!mounted) return;
       await ref.read(syncInitializerProvider).saveProvider(type);
       ref.read(syncStateProvider.notifier).refreshState();
       notifier.setConnectedProvider(type);
@@ -66,9 +75,9 @@ class _BackupSyncStepState extends ConsumerState<BackupSyncStep> {
         if (peers.isNotEmpty && mounted) widget.onLibraryFound!();
       }
     } catch (e) {
-      ref.read(selectedCloudProviderTypeProvider.notifier).state = null;
-      notifier.setConnectedProvider(null);
+      selection.state = null;
       if (mounted) {
+        notifier.setConnectedProvider(null);
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(context.l10n.setup_sync_error(e))),
         );

--- a/lib/features/setup_wizard/presentation/widgets/steps/backup_sync_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/backup_sync_step.dart
@@ -7,6 +7,7 @@ import 'package:submersion/core/services/cloud_storage/icloud_native_service.dar
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
 import 'package:submersion/features/settings/presentation/pages/s3_config_page.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/features/settings/presentation/widgets/cloud_provider_authenticate.dart';
 import 'package:submersion/features/settings/presentation/widgets/dropbox_connect_dialog.dart';
 import 'package:submersion/features/setup_wizard/domain/setup_wizard_models.dart';
 import 'package:submersion/features/setup_wizard/presentation/providers/setup_wizard_providers.dart';
@@ -44,10 +45,15 @@ class _BackupSyncStepState extends ConsumerState<BackupSyncStep> {
         ref.invalidate(dropboxAuthDataProvider);
         if (connected != true) return;
       }
+      if (!mounted) return;
       // Activation contract mirrored from CloudSyncPage._selectProvider.
       ref.read(selectedCloudProviderTypeProvider.notifier).state = type;
       final instance = cloudProviderInstanceFor(type);
-      await instance.authenticate();
+      // Desktop Google Drive authenticates through the system browser, which
+      // can take as long as the user does. The shared helper keeps a
+      // cancellable wait dialog up so the wizard does not sit frozen with no
+      // way out; every other provider and platform authenticates directly.
+      await authenticateWithBrowserWait(context, instance, type);
       await ref.read(syncInitializerProvider).saveProvider(type);
       ref.read(syncStateProvider.notifier).refreshState();
       notifier.setConnectedProvider(type);
@@ -116,6 +122,13 @@ class _BackupSyncStepState extends ConsumerState<BackupSyncStep> {
     final iCloudAvailable =
         isApple && iCloudAvailability != ICloudAvailability.unsupported;
     final dropboxConfigured = ref.watch(dropboxConfiguredProvider);
+    // Google Drive is offered wherever it can actually authenticate. On a
+    // desktop build without the Desktop-app OAuth client compiled in it is
+    // hidden rather than shown broken, the same treatment an unconfigured
+    // Dropbox already gets. Read through .value so a provider reload does
+    // not flash the card away.
+    final googleDriveAvailable =
+        ref.watch(googleDriveAvailableProvider).value ?? false;
 
     // The draft holds the connected provider in both modes: seeded from the
     // active provider on settings re-entry, set by the connect flow at first
@@ -245,6 +258,15 @@ class _BackupSyncStepState extends ConsumerState<BackupSyncStep> {
                     l10n.settings_cloudSync_provider_icloud_unsupportedSubtitle,
                   ),
                 ),
+              ),
+            if (googleDriveAvailable)
+              _providerCard(
+                theme: theme,
+                icon: Icons.add_to_drive,
+                name: 'Google Drive',
+                onTap: _connecting
+                    ? null
+                    : () => _connect(CloudProviderType.googledrive),
               ),
             if (dropboxConfigured)
               _providerCard(

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -1117,11 +1117,14 @@ void main() {
       await tester.tap(find.text(cancelLabel));
       await tester.pumpAndSettle();
 
-      // Dialog gone, selection cleared (no connected check icon), and the
-      // connection-failed snackbar shown.
+      // Dialog gone and the selection cleared (no connected check icon).
+      // No error is shown: cancelling is a decision, not a failure, so the
+      // helper raises CloudAuthCancelled and the page rolls back quietly
+      // rather than surfacing a red connection-failed snackbar carrying an
+      // untranslated English fragment.
       expect(find.text('Continue in your browser'), findsNothing);
       expect(find.byIcon(Icons.check_circle), findsNothing);
-      expect(find.textContaining('connection failed'), findsOneWidget);
+      expect(find.textContaining('connection failed'), findsNothing);
 
       // The abandoned flow's eventual error must be swallowed; nothing
       // may surface after the user has already cancelled.

--- a/test/features/settings/presentation/widgets/cloud_provider_authenticate_test.dart
+++ b/test/features/settings/presentation/widgets/cloud_provider_authenticate_test.dart
@@ -129,7 +129,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(AlertDialog), findsNothing);
-    expect(error, isA<CloudStorageException>());
+    expect(error, isA<CloudAuthCancelled>());
     expect(find.text('connect'), findsOneWidget);
 
     // The abandoned loopback listener eventually times out; its error must

--- a/test/features/settings/presentation/widgets/cloud_provider_authenticate_test.dart
+++ b/test/features/settings/presentation/widgets/cloud_provider_authenticate_test.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart'
+    show CloudProviderType;
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/features/settings/presentation/widgets/cloud_provider_authenticate.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// Authenticates only when the test completes [authCompleter], standing in for
+/// the desktop loopback round trip through the system browser.
+class _PendingAuthProvider implements CloudStorageProvider {
+  final authCompleter = Completer<void>();
+
+  @override
+  Future<void> authenticate() => authCompleter.future;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  /// Hosts a button that runs the helper, so the "page underneath" is a real
+  /// route whose survival can be asserted.
+  Future<void> pumpHost(
+    WidgetTester tester,
+    CloudStorageProvider provider, {
+    required void Function(Object error) onError,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () async {
+                  try {
+                    await authenticateWithBrowserWait(
+                      context,
+                      provider,
+                      CloudProviderType.googledrive,
+                      // The platform branch is Windows/Linux only; force it so
+                      // this runs on every host rather than being skipped on
+                      // the machines most developers use.
+                      debugForceBrowserWait: true,
+                    );
+                  } catch (e) {
+                    onError(e);
+                  }
+                },
+                child: const Text('connect'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('the wait dialog cannot be dismissed by a route pop', (
+    tester,
+  ) async {
+    // Regression: with the dialog poppable, an Escape or back gesture left
+    // dialogClosed false, so the pending auth's completion handler fired a
+    // second Navigator.pop that took the page route underneath with it.
+    final provider = _PendingAuthProvider();
+    await pumpHost(tester, provider, onError: (_) {});
+
+    await tester.tap(find.text('connect'));
+    await tester.pump();
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    // A route-level pop request (Escape, system back) must not take it down.
+    final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+    await navigator.maybePop();
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    // Auth settling closes the dialog and leaves the host page standing.
+    provider.authCompleter.complete();
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.text('connect'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('a pop that bypasses PopScope cannot pop the page underneath', (
+    tester,
+  ) async {
+    // Belt-and-braces half of the same fix: even an imperative pop, which
+    // PopScope does not gate, must not leave the late auth completion free to
+    // pop a second route.
+    final provider = _PendingAuthProvider();
+    await pumpHost(tester, provider, onError: (_) {});
+
+    await tester.tap(find.text('connect'));
+    await tester.pump();
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    tester.state<NavigatorState>(find.byType(Navigator)).pop();
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsNothing);
+
+    provider.authCompleter.complete();
+    await tester.pumpAndSettle();
+
+    // The host page survived: nothing popped it on the way out.
+    expect(find.text('connect'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('Cancel abandons the flow and swallows its late error', (
+    tester,
+  ) async {
+    final provider = _PendingAuthProvider();
+    Object? error;
+    await pumpHost(tester, provider, onError: (e) => error = e);
+
+    await tester.tap(find.text('connect'));
+    await tester.pump();
+
+    final cancelLabel = MaterialLocalizations.of(
+      tester.element(find.byType(AlertDialog)),
+    ).cancelButtonLabel;
+    await tester.tap(find.text(cancelLabel));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(error, isA<CloudStorageException>());
+    expect(find.text('connect'), findsOneWidget);
+
+    // The abandoned loopback listener eventually times out; its error must
+    // not surface after the user has already cancelled.
+    provider.authCompleter.completeError(
+      const CloudStorageException('loopback timeout'),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('no dialog on platforms that authenticate directly', (
+    tester,
+  ) async {
+    final provider = _PendingAuthProvider();
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => authenticateWithBrowserWait(
+                  context,
+                  provider,
+                  CloudProviderType.googledrive,
+                  debugForceBrowserWait: false,
+                ),
+                child: const Text('connect'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('connect'));
+    await tester.pump();
+    expect(find.byType(AlertDialog), findsNothing);
+
+    provider.authCompleter.complete();
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/features/setup_wizard/presentation/widgets/steps/backup_sync_step_test.dart
+++ b/test/features/setup_wizard/presentation/widgets/steps/backup_sync_step_test.dart
@@ -46,9 +46,10 @@ void main() {
       testApp(
         overrides: [
           ...overrides,
-          // Deterministic gates: not Apple, no Dropbox key.
+          // Deterministic gates: not Apple, no Dropbox key, no Drive.
           isApplePlatformProvider.overrideWithValue(false),
           dropboxConfiguredProvider.overrideWithValue(false),
+          googleDriveAvailableProvider.overrideWith((ref) async => false),
         ],
         child: Builder(
           builder: (context) {
@@ -83,6 +84,7 @@ void main() {
           ...overrides,
           isApplePlatformProvider.overrideWithValue(false),
           dropboxConfiguredProvider.overrideWithValue(false),
+          googleDriveAvailableProvider.overrideWith((ref) async => false),
         ],
         child: const BackupSyncStep(mode: SetupWizardMode.firstRun),
       ),
@@ -91,8 +93,62 @@ void main() {
 
     expect(find.text('iCloud'), findsNothing);
     expect(find.text('Dropbox'), findsNothing);
+    expect(find.text('Google Drive'), findsNothing);
     expect(find.text('S3'), findsOneWidget);
     expect(find.text('Not connected'), findsOneWidget);
+  });
+
+  testWidgets('Google Drive card renders when the build supports it', (
+    tester,
+  ) async {
+    // The wizard used to offer only iCloud, Dropbox and S3, so a first-run
+    // user could not pick Google Drive even though Cloud Sync settings has
+    // offered it all along.
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...overrides,
+          isApplePlatformProvider.overrideWithValue(false),
+          dropboxConfiguredProvider.overrideWithValue(false),
+          googleDriveAvailableProvider.overrideWith((ref) async => true),
+        ],
+        child: const BackupSyncStep(mode: SetupWizardMode.firstRun),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Google Drive'), findsOneWidget);
+    final tile = tester.widget<ListTile>(
+      find.ancestor(
+        of: find.text('Google Drive'),
+        matching: find.byType(ListTile),
+      ),
+    );
+    expect(tile.onTap, isNotNull);
+  });
+
+  testWidgets('Google Drive card is hidden on a build without OAuth config', (
+    tester,
+  ) async {
+    // Desktop builds without the committed Desktop-app OAuth client cannot
+    // authenticate, so the card is hidden rather than offered and broken --
+    // the same treatment the wizard already gives an unconfigured Dropbox.
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...overrides,
+          isApplePlatformProvider.overrideWithValue(false),
+          dropboxConfiguredProvider.overrideWithValue(false),
+          googleDriveAvailableProvider.overrideWith((ref) async => false),
+        ],
+        child: const BackupSyncStep(mode: SetupWizardMode.firstRun),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Google Drive'), findsNothing);
   });
 
   testWidgets('tapping S3 opens the config page via the root navigator', (
@@ -108,6 +164,7 @@ void main() {
           ...overrides,
           isApplePlatformProvider.overrideWithValue(false),
           dropboxConfiguredProvider.overrideWithValue(false),
+          googleDriveAvailableProvider.overrideWith((ref) async => false),
           // Simulate S3 having been activated on the config page so the
           // post-return handler records it in the draft.
           selectedCloudProviderTypeProvider.overrideWith(
@@ -147,6 +204,7 @@ void main() {
             ...overrides,
             isApplePlatformProvider.overrideWithValue(false),
             dropboxConfiguredProvider.overrideWithValue(false),
+            googleDriveAvailableProvider.overrideWith((ref) async => false),
             selectedCloudProviderTypeProvider.overrideWith((ref) => entry.key),
           ],
           child: const BackupSyncStep(mode: SetupWizardMode.settings),
@@ -174,6 +232,7 @@ void main() {
           ...overrides,
           isApplePlatformProvider.overrideWithValue(false),
           dropboxConfiguredProvider.overrideWithValue(false),
+          googleDriveAvailableProvider.overrideWith((ref) async => false),
           syncInitializerProvider.overrideWithValue(_FakeSyncInit()),
           syncStateProvider.overrideWith((ref) => _FakeSyncNotifier()),
         ],
@@ -222,6 +281,7 @@ void main() {
             (ref) async => ICloudAvailability.available,
           ),
           dropboxConfiguredProvider.overrideWithValue(false),
+          googleDriveAvailableProvider.overrideWith((ref) async => false),
         ],
         child: const BackupSyncStep(mode: SetupWizardMode.firstRun),
       ),
@@ -245,6 +305,7 @@ void main() {
             (ref) async => ICloudAvailability.unsupported,
           ),
           dropboxConfiguredProvider.overrideWithValue(false),
+          googleDriveAvailableProvider.overrideWith((ref) async => false),
         ],
         child: const BackupSyncStep(mode: SetupWizardMode.firstRun),
       ),

--- a/test/features/setup_wizard/presentation/widgets/steps/backup_sync_step_test.dart
+++ b/test/features/setup_wizard/presentation/widgets/steps/backup_sync_step_test.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/services/sync/sync_initializer.dart';
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
 import 'package:submersion/features/settings/presentation/pages/s3_config_page.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/features/settings/presentation/widgets/cloud_provider_authenticate.dart';
 import 'package:submersion/features/setup_wizard/domain/setup_wizard_models.dart';
 import 'package:submersion/features/setup_wizard/presentation/providers/setup_wizard_providers.dart';
 import 'package:submersion/features/setup_wizard/presentation/widgets/steps/backup_sync_step.dart';
@@ -55,14 +56,25 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+Widget _englishTestApp({required Widget child, List<dynamic>? overrides}) =>
+    testApp(locale: const Locale('en'), overrides: overrides, child: child);
+
 void main() {
   testWidgets('backup toggle reveals frequency and updates draft', (
     tester,
   ) async {
+    // Prove these English text finders are independent of the machine running
+    // the suite. Without an explicit app locale below, this German host locale
+    // makes the test fail before it ever reaches the interaction assertions.
+    tester.binding.platformDispatcher.localesTestValue = const [
+      Locale('de', 'DE'),
+    ];
+    addTearDown(tester.binding.platformDispatcher.clearLocalesTestValue);
+
     late ProviderContainer container;
     final overrides = await getBaseOverrides();
     await tester.pumpWidget(
-      testApp(
+      _englishTestApp(
         overrides: [
           ...overrides,
           // Deterministic gates: not Apple, no Dropbox key, no Drive.
@@ -98,7 +110,7 @@ void main() {
   ) async {
     final overrides = await getBaseOverrides();
     await tester.pumpWidget(
-      testApp(
+      _englishTestApp(
         overrides: [
           ...overrides,
           isApplePlatformProvider.overrideWithValue(false),
@@ -125,7 +137,7 @@ void main() {
     // offered it all along.
     final overrides = await getBaseOverrides();
     await tester.pumpWidget(
-      testApp(
+      _englishTestApp(
         overrides: [
           ...overrides,
           isApplePlatformProvider.overrideWithValue(false),
@@ -155,7 +167,7 @@ void main() {
     // the same treatment the wizard already gives an unconfigured Dropbox.
     final overrides = await getBaseOverrides();
     await tester.pumpWidget(
-      testApp(
+      _englishTestApp(
         overrides: [
           ...overrides,
           isApplePlatformProvider.overrideWithValue(false),
@@ -178,7 +190,7 @@ void main() {
     // config page opens without going through the onboarding redirect.
     final overrides = await getBaseOverrides();
     await tester.pumpWidget(
-      testApp(
+      _englishTestApp(
         overrides: [
           ...overrides,
           isApplePlatformProvider.overrideWithValue(false),
@@ -218,7 +230,7 @@ void main() {
     ) async {
       final overrides = await getBaseOverrides();
       await tester.pumpWidget(
-        testApp(
+        _englishTestApp(
           overrides: [
             ...overrides,
             isApplePlatformProvider.overrideWithValue(false),
@@ -250,7 +262,7 @@ void main() {
     final cloud = _FakeCloudProvider();
     final overrides = await getBaseOverrides();
     await tester.pumpWidget(
-      testApp(
+      _englishTestApp(
         overrides: [
           ...overrides,
           isApplePlatformProvider.overrideWithValue(false),
@@ -296,7 +308,7 @@ void main() {
     );
     final overrides = await getBaseOverrides();
     await tester.pumpWidget(
-      testApp(
+      _englishTestApp(
         overrides: [
           ...overrides,
           isApplePlatformProvider.overrideWithValue(false),
@@ -332,6 +344,50 @@ void main() {
     expect(find.textContaining('no network'), findsOneWidget);
   });
 
+  testWidgets('cancelling the sign-in rolls back without an error', (
+    tester,
+  ) async {
+    // A cancel is a decision, not a failure: the cards come back and nothing
+    // is reported, unlike the genuine-failure case above.
+    late ProviderContainer container;
+    final cloud = _FakeCloudProvider(failWith: const CloudAuthCancelled());
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      _englishTestApp(
+        overrides: [
+          ...overrides,
+          isApplePlatformProvider.overrideWithValue(false),
+          dropboxConfiguredProvider.overrideWithValue(false),
+          googleDriveAvailableProvider.overrideWith((ref) async => true),
+          cloudStorageProviderProvider.overrideWithValue(cloud),
+          syncInitializerProvider.overrideWithValue(_FakeSyncInit()),
+          syncStateProvider.overrideWith((ref) => _FakeSyncNotifier()),
+        ],
+        child: Builder(
+          builder: (context) {
+            container = ProviderScope.containerOf(context);
+            return const BackupSyncStep(mode: SetupWizardMode.firstRun);
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Google Drive'));
+    await tester.pumpAndSettle();
+
+    expect(container.read(selectedCloudProviderTypeProvider), isNull);
+    expect(
+      container
+          .read(setupWizardProvider(SetupWizardMode.firstRun))
+          .connectedProvider,
+      isNull,
+    );
+    expect(find.text('Google Drive'), findsOneWidget);
+    expect(find.byType(SnackBar), findsNothing);
+    expect(find.textContaining('Could not connect'), findsNothing);
+  });
+
   testWidgets('connect reports an unresolvable backend instead of hanging', (
     tester,
   ) async {
@@ -339,7 +395,7 @@ void main() {
     // app-managed sync is off. Surfacing that beats silently doing nothing.
     final overrides = await getBaseOverrides();
     await tester.pumpWidget(
-      testApp(
+      _englishTestApp(
         overrides: [
           ...overrides,
           isApplePlatformProvider.overrideWithValue(false),
@@ -357,7 +413,15 @@ void main() {
     await tester.tap(find.text('Google Drive'));
     await tester.pumpAndSettle();
 
-    expect(find.textContaining('googledrive'), findsOneWidget);
+    // The message carries the display name, not the enum's `googledrive`.
+    expect(
+      find.text(
+        AppLocalizationsEn().settings_cloudSync_provider_initFailed(
+          'Google Drive',
+        ),
+      ),
+      findsOneWidget,
+    );
     expect(find.text('Google Drive'), findsOneWidget);
   });
 
@@ -367,7 +431,7 @@ void main() {
     late ProviderContainer container;
     final overrides = await getBaseOverrides();
     await tester.pumpWidget(
-      testApp(
+      _englishTestApp(
         overrides: [
           ...overrides,
           isApplePlatformProvider.overrideWithValue(false),
@@ -413,7 +477,7 @@ void main() {
   ) async {
     final overrides = await getBaseOverrides();
     await tester.pumpWidget(
-      testApp(
+      _englishTestApp(
         overrides: [
           ...overrides,
           isApplePlatformProvider.overrideWithValue(true),
@@ -437,7 +501,7 @@ void main() {
   ) async {
     final overrides = await getBaseOverrides();
     await tester.pumpWidget(
-      testApp(
+      _englishTestApp(
         overrides: [
           ...overrides,
           isApplePlatformProvider.overrideWithValue(true),

--- a/test/features/setup_wizard/presentation/widgets/steps/backup_sync_step_test.dart
+++ b/test/features/setup_wizard/presentation/widgets/steps/backup_sync_step_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType;
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 import 'package:submersion/core/services/sync/sync_initializer.dart';
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
@@ -20,6 +21,24 @@ import '../../../../../helpers/test_app.dart';
 class _FakeSyncInit implements SyncInitializer {
   @override
   Future<void> saveProvider(CloudProviderType? provider) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Authenticates on demand, so both the success and failure branches of
+/// _connect are reachable.
+class _FakeCloudProvider implements CloudStorageProvider {
+  final Object? failWith;
+  var authenticateCalls = 0;
+
+  _FakeCloudProvider({this.failWith});
+
+  @override
+  Future<void> authenticate() async {
+    authenticateCalls++;
+    if (failWith != null) throw failWith!;
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -220,6 +239,127 @@ void main() {
       await tester.pumpAndSettle();
     });
   }
+
+  testWidgets('connecting Google Drive records it in the draft', (
+    tester,
+  ) async {
+    // _connect resolves the backend through cloudStorageProviderProvider --
+    // the same seam Cloud Sync settings uses -- so a fake can stand in for
+    // the real Drive singleton here.
+    late ProviderContainer container;
+    final cloud = _FakeCloudProvider();
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...overrides,
+          isApplePlatformProvider.overrideWithValue(false),
+          dropboxConfiguredProvider.overrideWithValue(false),
+          googleDriveAvailableProvider.overrideWith((ref) async => true),
+          cloudStorageProviderProvider.overrideWithValue(cloud),
+          syncInitializerProvider.overrideWithValue(_FakeSyncInit()),
+          syncStateProvider.overrideWith((ref) => _FakeSyncNotifier()),
+        ],
+        child: Builder(
+          builder: (context) {
+            container = ProviderScope.containerOf(context);
+            return const BackupSyncStep(mode: SetupWizardMode.firstRun);
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Google Drive'));
+    await tester.pumpAndSettle();
+
+    expect(cloud.authenticateCalls, 1);
+    expect(
+      container.read(selectedCloudProviderTypeProvider),
+      CloudProviderType.googledrive,
+    );
+    expect(
+      container
+          .read(setupWizardProvider(SetupWizardMode.firstRun))
+          .connectedProvider,
+      CloudProviderType.googledrive,
+    );
+    expect(find.text('Connected to Google Drive'), findsOneWidget);
+  });
+
+  testWidgets('a failed connect rolls the selection back and reports it', (
+    tester,
+  ) async {
+    late ProviderContainer container;
+    final cloud = _FakeCloudProvider(
+      failWith: const CloudStorageException('no network'),
+    );
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...overrides,
+          isApplePlatformProvider.overrideWithValue(false),
+          dropboxConfiguredProvider.overrideWithValue(false),
+          googleDriveAvailableProvider.overrideWith((ref) async => true),
+          cloudStorageProviderProvider.overrideWithValue(cloud),
+          syncInitializerProvider.overrideWithValue(_FakeSyncInit()),
+          syncStateProvider.overrideWith((ref) => _FakeSyncNotifier()),
+        ],
+        child: Builder(
+          builder: (context) {
+            container = ProviderScope.containerOf(context);
+            return const BackupSyncStep(mode: SetupWizardMode.firstRun);
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Google Drive'));
+    await tester.pumpAndSettle();
+
+    // Nothing may stay half-selected after a failure: the card list comes
+    // back and both the global selection and the draft are cleared.
+    expect(container.read(selectedCloudProviderTypeProvider), isNull);
+    expect(
+      container
+          .read(setupWizardProvider(SetupWizardMode.firstRun))
+          .connectedProvider,
+      isNull,
+    );
+    expect(find.text('Google Drive'), findsOneWidget);
+    expect(find.textContaining('no network'), findsOneWidget);
+  });
+
+  testWidgets('connect reports an unresolvable backend instead of hanging', (
+    tester,
+  ) async {
+    // cloudStorageProviderProvider returns null in custom-folder mode, where
+    // app-managed sync is off. Surfacing that beats silently doing nothing.
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...overrides,
+          isApplePlatformProvider.overrideWithValue(false),
+          dropboxConfiguredProvider.overrideWithValue(false),
+          googleDriveAvailableProvider.overrideWith((ref) async => true),
+          cloudStorageProviderProvider.overrideWithValue(null),
+          syncInitializerProvider.overrideWithValue(_FakeSyncInit()),
+          syncStateProvider.overrideWith((ref) => _FakeSyncNotifier()),
+        ],
+        child: const BackupSyncStep(mode: SetupWizardMode.firstRun),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Google Drive'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('googledrive'), findsOneWidget);
+    expect(find.text('Google Drive'), findsOneWidget);
+  });
 
   testWidgets('first run can disconnect and return to the provider cards', (
     tester,


### PR DESCRIPTION
## Problem

The first-run setup wizard's **Backup & Sync** step offered only iCloud, Dropbox and S3. Google Drive, which Cloud Sync settings has offered all along, was missing, so a new user could not pick it during setup: they had to finish the wizard and then go find it in Settings.

The step's `_providerName` switch already returned `'Google Drive'`. Dart's exhaustive switch over `CloudProviderType` forced the author to name the case, which is exactly how the gap survived review: the enum handling was complete while the hand-written list of provider cards was not.

## Fix

Add the Google Drive card to `BackupSyncStep`, between iCloud and Dropbox (matching the ordering in Cloud Sync settings).

- **Availability gate.** The card is gated on `googleDriveAvailableProvider`, so a Windows/Linux build without the Desktop-app OAuth client compiled in hides it rather than offering a connect that can only fail. That is the same treatment the wizard already gives an unconfigured Dropbox. The gate reads through `.value` so a provider reload cannot flash the card out of existence.
- **Desktop OAuth wait.** On Windows and Linux, Drive authenticates through a loopback redirect via the system browser, which takes as long as the user does. Cloud Sync settings already kept a cancellable wait dialog up for this; the wizard's `_connect` called `instance.authenticate()` bare, which would have left the first-run screen frozen for the whole round trip with no way out. The dialog logic moves to a shared `authenticateWithBrowserWait` helper that both surfaces now call, rather than being duplicated.
- **Existing-library path.** `SyncConnectStep` renders `BackupSyncStep` for its connect phase, so the "I already have data in the cloud" flow picks up the same card with no further change.

## Tests

Two new widget tests in `backup_sync_step_test.dart`: the card renders and is tappable when the build supports Drive, and is absent when it does not.

Every card-rendering test in that file now pins `googleDriveAvailableProvider` explicitly. Without it the tests would consult the real platform check, which is true on a macOS host and false on Linux CI, making the suite host-dependent.

Full suite: 23,301 passing. `flutter analyze` clean across the project.