### PR TITLE
fix(dive-log): collapse a combined dive's halves into one display source

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -2604,6 +2604,27 @@ class DiveDataSources extends Table {
   /// time base", which is every source that was never consolidated.
   IntColumn get timeOffsetSeconds => integer().nullable()();
 
+  /// This row's position among its own original dive's data sources at the
+  /// moment a sequential Combine carried it here (issue #1451). Null on every
+  /// row a merge never carried, which is every row on an ordinary dive.
+  ///
+  /// `DiveMergeService.apply` copies each combined segment's
+  /// `dive_data_sources` rows onto the merged dive as provenance, because
+  /// each is the sole surviving copy of its half's rawData / rawFingerprint /
+  /// sourceUuid. Two halves of one physical dive therefore arrive as two
+  /// rows, and the display used to offer them as two switchable sources: the
+  /// chart then drew only the active half. The rows are the same strand seen
+  /// in two consecutive slices, not two competing recordings, so
+  /// `_canonicalDataSourceRows` collapses rows sharing a slot into one
+  /// display source. The rows themselves stay in the table untouched.
+  ///
+  /// A slot rather than a plain flag so a dive that was consolidated (two
+  /// computers, slots 0 and 1 in each segment) and only then combined still
+  /// shows one chip per computer instead of flattening both strands into one.
+  /// Segments whose sources carry no computerId have nothing else to
+  /// distinguish their strands by, which is exactly the case that was broken.
+  IntColumn get mergeSourceSlot => integer().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -3332,7 +3353,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 183;
+  static const int currentSchemaVersion = 184;
 
   /// The oldest schema whose reader can apply this build's sync payloads
   /// without loss or misinterpretation (the compatibility floor).
@@ -3765,6 +3786,11 @@ class AppDatabase extends _$AppDatabase {
     // a parallel branch's rung never ran ours and the beforeOpen backstop
     // only runs AFTER onUpgrade: by then the rows would be gone.
     183,
+    // v184 (issue #1451): dive_data_sources.merge_source_slot, the marker a
+    // sequential Combine stamps on the provenance rows it carries so the
+    // display can collapse the halves of one dive back into one source.
+    // Backfilled for dives combined before this rung shipped.
+    184,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -5962,6 +5988,90 @@ class AppDatabase extends _$AppDatabase {
         'ALTER TABLE dive_data_sources ADD COLUMN time_offset_seconds INTEGER',
       );
     }
+  }
+
+  /// Idempotent DDL for the v184 dive_data_sources.merge_source_slot column
+  /// (issue #1451). Same dual-call contract (onUpgrade + beforeOpen backstop)
+  /// as the other column-assert helpers. Nullable with no default, so every
+  /// pre-existing row reads back as "not carried by a merge".
+  Future<void> _assertDataSourceMergeSlotColumn() async {
+    final cols = await customSelect(
+      "PRAGMA table_info('dive_data_sources')",
+    ).get();
+    if (cols.isEmpty) return;
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    if (!names.contains('merge_source_slot')) {
+      await customStatement(
+        'ALTER TABLE dive_data_sources ADD COLUMN merge_source_slot INTEGER',
+      );
+    }
+  }
+
+  /// Stamp `merge_source_slot = 0` on the provenance rows of dives that were
+  /// combined before v184 shipped, so their halves collapse to one display
+  /// source the way a post-v184 combine does (issue #1451).
+  ///
+  /// Nothing recorded the marker at the time, so the rows have to be
+  /// recognized by shape. A dive qualifies only when all three hold:
+  ///
+  ///  - it has two or more `dive_data_sources` rows, and
+  ///  - none of them is primary. Every importer writes its own row with
+  ///    `is_primary = 1` (dive_import_service, uddf_entity_importer,
+  ///    saveComputerReading) and a consolidation leaves the target's primary
+  ///    row alone, so "no primary at all" is the signature of
+  ///    `DiveMergeService.apply`, which writes every carried row
+  ///    `isPrimary: false`, and
+  ///  - every row has an entry and an exit time, and no two of those spans
+  ///    overlap.
+  ///
+  /// The last test is what makes this safe. Combined halves are consecutive
+  /// slices of one timeline, so their spans are disjoint; two computers
+  /// recording one dive cover the same minutes, so theirs overlap. Without
+  /// it, a consolidation whose target row was never marked primary would
+  /// collapse to a single chip and the chart would go back to drawing the
+  /// interleaved union of both computers (issue #543). A dive whose rows
+  /// carry no entry/exit times cannot be classified either way and is left
+  /// alone: it keeps exactly today's behavior.
+  ///
+  /// Runs once on the v184 rung, not from the beforeOpen backstop: it writes
+  /// rows rather than asserting DDL, and every merge performed after the
+  /// upgrade stamps its own slots.
+  ///
+  /// Guarded on the columns it reads, like every other migration helper here.
+  /// A database whose `dive_data_sources` a parallel branch shaped without
+  /// entry/exit times must still open: the classification has no input there,
+  /// so skipping is the same answer as running.
+  Future<void> _backfillMergeSourceSlots() async {
+    final cols = await customSelect(
+      "PRAGMA table_info('dive_data_sources')",
+    ).get();
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    const required = {
+      'dive_id',
+      'is_primary',
+      'entry_time',
+      'exit_time',
+      'merge_source_slot',
+    };
+    if (!names.containsAll(required)) return;
+    await customStatement(
+      'UPDATE dive_data_sources SET merge_source_slot = 0 '
+      'WHERE merge_source_slot IS NULL '
+      'AND dive_id IN ('
+      '  SELECT dive_id FROM dive_data_sources'
+      '  GROUP BY dive_id'
+      '  HAVING COUNT(*) >= 2'
+      '     AND SUM(CASE WHEN is_primary THEN 1 ELSE 0 END) = 0'
+      '     AND SUM(CASE WHEN entry_time IS NULL OR exit_time IS NULL'
+      '                  THEN 1 ELSE 0 END) = 0'
+      ') '
+      'AND dive_id NOT IN ('
+      '  SELECT a.dive_id FROM dive_data_sources a'
+      '  JOIN dive_data_sources b'
+      '    ON b.dive_id = a.dive_id AND b.id <> a.id'
+      '  WHERE a.entry_time < b.exit_time AND b.entry_time < a.exit_time'
+      ')',
+    );
   }
 
   /// Site-level entry/exit method columns on dive_sites (issue #1104).
@@ -9770,6 +9880,14 @@ class AppDatabase extends _$AppDatabase {
           }
         }
         if (from < 183) await reportProgress();
+        // v184: the marker a sequential Combine stamps on the provenance
+        // rows it carries, plus a backfill for dives combined before it
+        // existed (issue #1451).
+        if (from < 184) {
+          await _assertDataSourceMergeSlotColumn();
+          await _backfillMergeSourceSlots();
+        }
+        if (from < 184) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -9948,6 +10066,12 @@ class AppDatabase extends _$AppDatabase {
         // (issue #1177; same parallel-branch version-collision self-heal).
         // Reading a consolidated dive's sources throws without it.
         await _assertDataSourceTimeOffsetColumn();
+
+        // v184 backstop: re-assert the merge provenance marker (issue
+        // #1451; same parallel-branch version-collision self-heal).
+        // Reading any dive's sources throws without it. Only the column is
+        // re-asserted here; the one-shot backfill belongs to the rung.
+        await _assertDataSourceMergeSlotColumn();
 
         // v160 backstop: re-assert service_kinds.default_category. A device
         // that reached 160 or higher through a parallel branch never enters

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -6022,9 +6022,10 @@ class AppDatabase extends _$AppDatabase {
   ///    `DiveMergeService.apply`, which writes every carried row
   ///    `isPrimary: false`, and
   ///  - every row has an entry and an exit time, and no two of those spans
-  ///    overlap.
+  ///    overlap, and
+  ///  - no row carries a non-zero `time_offset_seconds`.
   ///
-  /// The last test is what makes this safe. Combined halves are consecutive
+  /// The span test is what makes this safe. Combined halves are consecutive
   /// slices of one timeline, so their spans are disjoint; two computers
   /// recording one dive cover the same minutes, so theirs overlap. Without
   /// it, a consolidation whose target row was never marked primary would
@@ -6032,6 +6033,19 @@ class AppDatabase extends _$AppDatabase {
   /// interleaved union of both computers (issue #543). A dive whose rows
   /// carry no entry/exit times cannot be classified either way and is left
   /// alone: it keeps exactly today's behavior.
+  ///
+  /// The offset test closes the one hole in that reasoning.
+  /// `DiveConsolidationService` shifts a folded-in dive's SAMPLES by
+  /// `time_offset_seconds` but copies its `entry_time`/`exit_time` over
+  /// verbatim, so a secondary whose clock was badly out has a stored span
+  /// that misses the target's even though the two cover the same minutes.
+  /// The span test would read that as a Combine. A non-zero offset is the
+  /// trace consolidation leaves and a Combine never writes, so requiring
+  /// zero across the dive rules that shape out. It costs a few false
+  /// negatives -- a pre-v184 dive that was consolidated and then combined is
+  /// now skipped -- and a skipped dive simply keeps today's display, which
+  /// is the safe direction to be wrong in for a one-shot write over user
+  /// data.
   ///
   /// Runs once on the v184 rung, not from the beforeOpen backstop: it writes
   /// rows rather than asserting DDL, and every merge performed after the
@@ -6051,6 +6065,7 @@ class AppDatabase extends _$AppDatabase {
       'is_primary',
       'entry_time',
       'exit_time',
+      'time_offset_seconds',
       'merge_source_slot',
     };
     if (!names.containsAll(required)) return;
@@ -6063,6 +6078,8 @@ class AppDatabase extends _$AppDatabase {
       '  HAVING COUNT(*) >= 2'
       '     AND SUM(CASE WHEN is_primary THEN 1 ELSE 0 END) = 0'
       '     AND SUM(CASE WHEN entry_time IS NULL OR exit_time IS NULL'
+      '                  THEN 1 ELSE 0 END) = 0'
+      '     AND SUM(CASE WHEN COALESCE(time_offset_seconds, 0) <> 0'
       '                  THEN 1 ELSE 0 END) = 0'
       ') '
       'AND dive_id NOT IN ('

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -6223,7 +6223,7 @@ class DiveRepository {
       return (result.data['cnt'] as int) >= 2;
     } catch (e, stackTrace) {
       _log.error(
-        'Failed to check multiple computers for dive: $diveId',
+        'Failed to count data source strands for dive: $diveId',
         error: e,
         stackTrace: stackTrace,
       );

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -965,20 +965,31 @@ class DiveRepository {
   }
 
   /// Collapses [rows] so at most one dive_data_sources row survives per
-  /// non-null computerId, keeping the first row encountered -- since every
-  /// caller queries in `desc(isPrimary), asc(createdAt)` order, that's the
-  /// primary if one exists, else the earliest-created. Rows with a null
-  /// computerId (manual entries, edited profiles) are never deduped; there
-  /// is nothing to collide on.
+  /// strand, keeping the first row encountered -- since every caller queries
+  /// in `desc(isPrimary), asc(createdAt)` order, that's the primary if one
+  /// exists, else the earliest-created.
   ///
-  /// A same-computer sequential merge (DiveMergeService.apply, step 10)
-  /// carries over every original dive's data source row as provenance; when
-  /// both originals were logged by the same physical computer, that
-  /// produces two rows sharing one computerId on the merged dive. Without
-  /// this, getProfilesByDataSource's computerId -> sourceId lookup collides
-  /// and silently misroutes every profile point to whichever row is
-  /// iterated last, and getDataSources shows a second, empty, selectable
-  /// chip for the row that lost the collision.
+  /// A row's strand is its computerId when it has one, else its
+  /// mergeSourceSlot when a sequential Combine carried it here, else nothing
+  /// at all: a manual entry or an edited profile has neither, so there is
+  /// nothing for it to collide on and it always survives.
+  ///
+  /// A sequential merge (DiveMergeService.apply, step 10) carries over every
+  /// original dive's data source row as provenance, so a merged dive holds
+  /// one row per combined segment. When both originals were logged by the
+  /// same physical computer those rows share a computerId; without this,
+  /// getProfilesByDataSource's computerId -> sourceId lookup collides and
+  /// silently misroutes every profile point to whichever row is iterated
+  /// last, and getDataSources shows a second, empty, selectable chip for the
+  /// row that lost the collision.
+  ///
+  /// Segments imported from a file or a cloud service carry no computerId at
+  /// all, so before v184 nothing collapsed them: the merged dive reported two
+  /// sources, and the detail chart's multi-source branch drew only the active
+  /// half of the dive (issue #1451). mergeSourceSlot closes that gap. It is
+  /// the row's position among its own segment's sources, so two segments each
+  /// contributing one source share slot 0 and collapse, while a dive that was
+  /// consolidated before it was combined keeps one surviving row per computer.
   ///
   /// Canonicalizing on READ is deliberate, not a stopgap for a bad write
   /// (#1045): the row that loses here still owns the only copy of its half's
@@ -988,16 +999,19 @@ class DiveRepository {
   List<DiveDataSourcesData> _canonicalDataSourceRows(
     List<DiveDataSourcesData> rows,
   ) {
-    final seenComputers = <String>{};
+    final seenStrands = <String>{};
     final result = <DiveDataSourcesData>[];
     for (final row in rows) {
-      final computerId = row.computerId;
-      if (computerId == null) {
-        result.add(row);
-        continue;
-      }
-      if (!seenComputers.add(computerId)) continue;
-      result.add(row);
+      // Namespaced so a computer id can never be mistaken for a slot key.
+      // computerId wins when both are set: a merge-carried row still belongs
+      // to its computer's strand, and collapsing on it keeps a merged dive's
+      // rows in one chip with any later same-computer source.
+      final strand = switch ((row.computerId, row.mergeSourceSlot)) {
+        (final String id, _) => 'computer:$id',
+        (null, final int slot) => 'mergeSlot:$slot',
+        (null, null) => null,
+      };
+      if (strand == null || seenStrands.add(strand)) result.add(row);
     }
     return result;
   }
@@ -6180,18 +6194,22 @@ class DiveRepository {
     }
   }
 
-  /// Return true if a dive has readings from 2 or more computers.
+  /// Return true if a dive has readings from 2 or more sources.
   ///
-  /// Counts distinct canonical sources rather than raw rows -- two rows
-  /// sharing a computer_id (the shape a same-computer sequential merge
-  /// produces) collapse to one, matching [_canonicalDataSourceRows]. A row
-  /// with no computer_id is always its own canonical source, since [id] is
-  /// unique per row.
+  /// Counts distinct canonical strands rather than raw rows, by the same rule
+  /// [_canonicalDataSourceRows] applies: computer_id when there is one, else
+  /// merge_source_slot for a row a sequential Combine carried here, else the
+  /// row's own id (unique, so such a row is always its own strand). The two
+  /// rows a Combine leaves behind therefore count as one, whether or not the
+  /// segments came from a computer download (issue #1451).
   Future<bool> hasMultipleDataSources(String diveId) async {
     try {
       final result = await _db
           .customSelect(
-            'SELECT COUNT(DISTINCT COALESCE(computer_id, id)) as cnt '
+            'SELECT COUNT(DISTINCT COALESCE('
+            "'computer:' || computer_id, "
+            "'mergeSlot:' || merge_source_slot, "
+            "'row:' || id)) as cnt "
             'FROM dive_data_sources WHERE dive_id = ?',
             variables: [Variable(diveId)],
           )

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -14,6 +14,7 @@ import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_times_sql.dart';
 import 'package:submersion/features/dive_log/data/repositories/profile_series_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_series_repository.dart';
+import 'package:submersion/features/dive_log/data/services/data_source_strand.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_sample_point.dart';
 import 'package:submersion/features/dive_log/domain/entities/bulk_edit_request.dart'
     as domain;
@@ -1002,16 +1003,12 @@ class DiveRepository {
     final seenStrands = <String>{};
     final result = <DiveDataSourcesData>[];
     for (final row in rows) {
-      // Namespaced so a computer id can never be mistaken for a slot key.
-      // computerId wins when both are set: a merge-carried row still belongs
-      // to its computer's strand, and collapsing on it keeps a merged dive's
-      // rows in one chip with any later same-computer source.
-      final strand = switch ((row.computerId, row.mergeSourceSlot)) {
-        (final String id, _) => 'computer:$id',
-        (null, final int slot) => 'mergeSlot:$slot',
-        (null, null) => null,
-      };
-      if (strand == null || seenStrands.add(strand)) result.add(row);
+      final strand = dataSourceStrandKey(
+        rowId: row.id,
+        computerId: row.computerId,
+        mergeSourceSlot: row.mergeSourceSlot,
+      );
+      if (seenStrands.add(strand)) result.add(row);
     }
     return result;
   }
@@ -6196,12 +6193,21 @@ class DiveRepository {
 
   /// Return true if a dive has readings from 2 or more sources.
   ///
-  /// Counts distinct canonical strands rather than raw rows, by the same rule
-  /// [_canonicalDataSourceRows] applies: computer_id when there is one, else
+  /// Counts distinct canonical strands rather than raw rows, mirroring
+  /// [dataSourceStrandKey] in SQL: computer_id when there is one, else
   /// merge_source_slot for a row a sequential Combine carried here, else the
   /// row's own id (unique, so such a row is always its own strand). The two
   /// rows a Combine leaves behind therefore count as one, whether or not the
   /// segments came from a computer download (issue #1451).
+  ///
+  /// Deliberately the collapse rule alone, without the disjoint-span test the
+  /// profile surfaces add on top of it (`usesPerSourceRendering`). That test
+  /// exists because drawing one source on a 2D chart HIDES the others, which
+  /// is wrong for consecutive halves. This count's only caller is the 3D
+  /// page's dive/computers switcher, whose computers scene overlays every
+  /// strand at once, so nothing is hidden and two strands still have
+  /// something to compare -- two computers that each recorded half a dive
+  /// included.
   Future<bool> hasMultipleDataSources(String diveId) async {
     try {
       final result = await _db

--- a/lib/features/dive_log/data/services/data_source_strand.dart
+++ b/lib/features/dive_log/data/services/data_source_strand.dart
@@ -1,0 +1,32 @@
+/// The strand a `dive_data_sources` row belongs to for display purposes.
+///
+/// A dive can hold more provenance rows than it has sources to show. Combine
+/// carries every segment's row onto the merged dive because each one holds the
+/// only surviving copy of its half's rawData/rawFingerprint/sourceUuid, which
+/// reparse and the import duplicate checker read directly (issue #1451). Those
+/// rows collapse on read instead: rows sharing a strand key are one chip, and
+/// the first of them wins.
+///
+/// The key is total, so every row has one:
+///
+/// - `computerId` when the row has one. It wins over the slot: a carried row
+///   still belongs to its computer's strand, and collapsing on it keeps a
+///   merged dive's rows in one chip with any later same-computer source.
+/// - else `mergeSourceSlot`, the row's position among its own segment's
+///   strands, stamped by [DiveMergeService.apply]. This is what collapses the
+///   halves of a file or cloud import, which carry no computer.
+/// - else the row's own id, which is unique, so such a row is always its own
+///   strand and never collapses against anything.
+///
+/// Namespaced per kind so a computer id can never be mistaken for a slot.
+/// Mirrored in SQL by `DiveRepository.hasMultipleDataSources`; keep the two in
+/// step.
+String dataSourceStrandKey({
+  required String rowId,
+  required String? computerId,
+  required int? mergeSourceSlot,
+}) => switch ((computerId, mergeSourceSlot)) {
+  (final String id, _) => 'computer:$id',
+  (null, final int slot) => 'mergeSlot:$slot',
+  (null, null) => 'row:$rowId',
+};

--- a/lib/features/dive_log/data/services/dive_consolidation_service.dart
+++ b/lib/features/dive_log/data/services/dive_consolidation_service.dart
@@ -170,6 +170,21 @@ class DiveConsolidationService {
         (r) => r.diveId == targetDiveId,
       );
 
+      // Where a folded-in dive's own merge slots have to land so they do not
+      // collide with the target's (issue #1451). A slot names a strand
+      // WITHIN one dive, so two dives that were each combined from halves
+      // both carry slot 0, and copying those over verbatim would collapse
+      // all four rows into a single chip. Rebased past whatever the target
+      // already uses, the same way timeOffsetSeconds composes below.
+      // Secondaries with no slots of their own leave this untouched.
+      var nextMergeSlot =
+          1 +
+          snapshot.dataSourceRows
+              .where((r) => r.diveId == targetDiveId)
+              .map((r) => r.mergeSourceSlot)
+              .nonNulls
+              .fold<int>(-1, (a, b) => a > b ? a : b);
+
       for (final secondary in plan.secondaries) {
         final secRow = snapshot.diveRows.firstWhere(
           (r) => r.id == secondary.id,
@@ -233,9 +248,13 @@ class DiveConsolidationService {
                 ),
               );
         } else {
+          final slotBase = nextMergeSlot;
+          var highestSecSlot = -1;
           for (final row in secSources) {
             final copiedId = _uuid.v4();
             sourceIdMap[row.id] = copiedId;
+            final slot = row.mergeSourceSlot;
+            if (slot != null && slot > highestSecSlot) highestSecSlot = slot;
             await _db
                 .into(_db.diveDataSources)
                 .insert(
@@ -254,9 +273,13 @@ class DiveConsolidationService {
                         timeOffsetSeconds: Value(
                           (row.timeOffsetSeconds ?? 0) + offset,
                         ),
+                        mergeSourceSlot: Value(
+                          slot == null ? null : slot + slotBase,
+                        ),
                       ),
                 );
           }
+          nextMergeSlot = slotBase + highestSecSlot + 1;
           // A profile row whose sourceId names none of the copied rows (an
           // old row that never got attributed) still needs an owner on the
           // target, so fall back to the secondary's primary source.

--- a/lib/features/dive_log/data/services/dive_merge_service.dart
+++ b/lib/features/dive_log/data/services/dive_merge_service.dart
@@ -252,16 +252,17 @@ class DiveMergeService {
       // Overwrites any slot the row already carried: combining a dive that
       // was itself combined re-slots every row against THIS merge, which is
       // what keeps the result one dive rather than a growing chip per merge.
+      final rowsBySegment = <String, List<DiveDataSourcesData>>{};
+      for (final row in snapshot.dataSourceRows) {
+        (rowsBySegment[row.diveId] ??= <DiveDataSourcesData>[]).add(row);
+      }
       final mergeSlotByRowId = <String, int>{};
-      for (final segment
-          in snapshot.dataSourceRows.map((r) => r.diveId).toSet()) {
-        final rows =
-            snapshot.dataSourceRows.where((r) => r.diveId == segment).toList()
-              ..sort((a, b) {
-                if (a.isPrimary != b.isPrimary) return a.isPrimary ? -1 : 1;
-                final byCreated = a.createdAt.compareTo(b.createdAt);
-                return byCreated != 0 ? byCreated : a.id.compareTo(b.id);
-              });
+      for (final rows in rowsBySegment.values) {
+        rows.sort((a, b) {
+          if (a.isPrimary != b.isPrimary) return a.isPrimary ? -1 : 1;
+          final byCreated = a.createdAt.compareTo(b.createdAt);
+          return byCreated != 0 ? byCreated : a.id.compareTo(b.id);
+        });
         for (final (slot, row) in rows.indexed) {
           mergeSlotByRowId[row.id] = slot;
         }
@@ -281,13 +282,14 @@ class DiveMergeService {
             );
       }
 
+      // Reuses the grouping above, so the fallback owner is picked from a
+      // segment already in canonical order: with no primary row it lands on
+      // the oldest rather than on whatever order the snapshot query returned.
       String? mergedSourceIdFor(String diveId, String? sourceId) {
         final mapped = mergedSourceIds[sourceId];
         if (mapped != null) return mapped;
-        final segment = snapshot.dataSourceRows
-            .where((r) => r.diveId == diveId)
-            .toList();
-        if (segment.isEmpty) return null;
+        final segment = rowsBySegment[diveId];
+        if (segment == null || segment.isEmpty) return null;
         final owner = segment.firstWhere(
           (r) => r.isPrimary,
           orElse: () => segment.first,

--- a/lib/features/dive_log/data/services/dive_merge_service.dart
+++ b/lib/features/dive_log/data/services/dive_merge_service.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/repositories/profile_series_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_series_repository.dart';
+import 'package:submersion/features/dive_log/data/services/data_source_strand.dart';
 import 'package:submersion/features/dive_log/data/services/dive_merge_snapshot.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
 import 'package:submersion/features/dive_log/domain/services/unreadable_series_exception.dart';
@@ -240,18 +241,24 @@ class DiveMergeService {
       // its own id here and the copied samples point at it, so the strands
       // stay separable without a lossy write.
 
-      // Each carried row's slot among its OWN segment's sources (#1451).
+      // Each carried row's slot among its OWN segment's STRANDS (#1451).
       // Read-side canonicalization collapses rows sharing a slot into one
       // display source, so the two halves of one physical dive stop being
       // offered as switchable alternatives -- the state that made the chart
-      // draw only the active half. Ordered like every canonical read
-      // (primary first, then oldest), so a consolidated segment's primary
-      // computer always takes slot 0 and its folded-in computer slot 1, and
-      // the two segments' strands line up rather than crossing over.
+      // draw only the active half. Strands are ordered like every canonical
+      // read (primary first, then oldest), so a consolidated segment's
+      // primary computer always takes slot 0 and its folded-in computer slot
+      // 1, and the two segments' strands line up rather than crossing over.
       //
-      // Overwrites any slot the row already carried: combining a dive that
-      // was itself combined re-slots every row against THIS merge, which is
-      // what keeps the result one dive rather than a growing chip per merge.
+      // Numbered per strand rather than per row, because a segment can arrive
+      // already collapsed: combining A+B and then combining that result with
+      // C hands this pass a segment whose two rows deliberately share a slot.
+      // Indexing rows would split them to 0 and 1 while C took 0 again, so
+      // the dive would show two chips whose spans interleave -- #1451 again,
+      // one combine later, with the middle segment hidden behind a chip.
+      //
+      // Overwrites whatever slot a row already carried: the incoming slot
+      // names a strand within the OLD dive, and only its grouping survives.
       final rowsBySegment = <String, List<DiveDataSourcesData>>{};
       for (final row in snapshot.dataSourceRows) {
         (rowsBySegment[row.diveId] ??= <DiveDataSourcesData>[]).add(row);
@@ -263,8 +270,15 @@ class DiveMergeService {
           final byCreated = a.createdAt.compareTo(b.createdAt);
           return byCreated != 0 ? byCreated : a.id.compareTo(b.id);
         });
-        for (final (slot, row) in rows.indexed) {
-          mergeSlotByRowId[row.id] = slot;
+        final slotByStrand = <String, int>{};
+        for (final row in rows) {
+          final strand = dataSourceStrandKey(
+            rowId: row.id,
+            computerId: row.computerId,
+            mergeSourceSlot: row.mergeSourceSlot,
+          );
+          mergeSlotByRowId[row.id] = slotByStrand[strand] ??=
+              slotByStrand.length;
         }
       }
       for (final row in snapshot.dataSourceRows) {

--- a/lib/features/dive_log/data/services/dive_merge_service.dart
+++ b/lib/features/dive_log/data/services/dive_merge_service.dart
@@ -239,6 +239,33 @@ class DiveMergeService {
       // series row's sourceId closes that gap (#1149): each carried row keeps
       // its own id here and the copied samples point at it, so the strands
       // stay separable without a lossy write.
+
+      // Each carried row's slot among its OWN segment's sources (#1451).
+      // Read-side canonicalization collapses rows sharing a slot into one
+      // display source, so the two halves of one physical dive stop being
+      // offered as switchable alternatives -- the state that made the chart
+      // draw only the active half. Ordered like every canonical read
+      // (primary first, then oldest), so a consolidated segment's primary
+      // computer always takes slot 0 and its folded-in computer slot 1, and
+      // the two segments' strands line up rather than crossing over.
+      //
+      // Overwrites any slot the row already carried: combining a dive that
+      // was itself combined re-slots every row against THIS merge, which is
+      // what keeps the result one dive rather than a growing chip per merge.
+      final mergeSlotByRowId = <String, int>{};
+      for (final segment
+          in snapshot.dataSourceRows.map((r) => r.diveId).toSet()) {
+        final rows =
+            snapshot.dataSourceRows.where((r) => r.diveId == segment).toList()
+              ..sort((a, b) {
+                if (a.isPrimary != b.isPrimary) return a.isPrimary ? -1 : 1;
+                final byCreated = a.createdAt.compareTo(b.createdAt);
+                return byCreated != 0 ? byCreated : a.id.compareTo(b.id);
+              });
+        for (final (slot, row) in rows.indexed) {
+          mergeSlotByRowId[row.id] = slot;
+        }
+      }
       for (final row in snapshot.dataSourceRows) {
         await _db
             .into(_db.diveDataSources)
@@ -249,6 +276,7 @@ class DiveMergeService {
                     id: Value(mergedSourceIds[row.id]!),
                     diveId: Value(mergedId),
                     isPrimary: const Value(false),
+                    mergeSourceSlot: Value(mergeSlotByRowId[row.id]),
                   ),
             );
       }

--- a/lib/features/dive_log/domain/entities/source_profile.dart
+++ b/lib/features/dive_log/domain/entities/source_profile.dart
@@ -18,3 +18,38 @@ class SourceProfile {
   final bool isEdited;
   final List<DiveProfilePoint> points;
 }
+
+/// True when [profiles] read as consecutive segments of one timeline rather
+/// than competing recordings of the same minutes (issue #1451).
+///
+/// A dive gets per-source rendering -- one drawn series with the rest
+/// available as overlays -- because two computers recording the same dive
+/// disagree sample by sample, and interleaving them draws a sawtooth
+/// (issue #543). That reasoning does not hold for the halves of a dive a
+/// computer split in two and a Combine stitched back together: each half owns
+/// its own stretch of the timeline, so drawing one means hiding the rest of
+/// the dive. Those are told apart by whether the sources overlap in time, not
+/// by counting them.
+///
+/// Sources with no samples carry no span and are ignored; fewer than two
+/// spans is not a sequential arrangement, so the answer is false and callers
+/// keep whatever they do for an ordinary dive. Spans that merely touch at a
+/// boundary count as disjoint: a Combine's synthesized surface fill is
+/// appended to the segment before the gap, so the next segment starts exactly
+/// where it ended.
+bool sourceProfilesAreSequential(Iterable<SourceProfile> profiles) {
+  final spans = <(int, int)>[
+    for (final p in profiles)
+      if (p.points.isNotEmpty)
+        (p.points.first.timestamp, p.points.last.timestamp),
+  ]..sort((a, b) => a.$1.compareTo(b.$1));
+  if (spans.length < 2) return false;
+  // Compared against the furthest end seen so far, not just the previous
+  // span's: a span nested inside an earlier one starts later but overlaps it.
+  var reach = spans.first.$2;
+  for (final (start, end) in spans.skip(1)) {
+    if (start < reach) return false;
+    if (end > reach) reach = end;
+  }
+  return true;
+}

--- a/lib/features/dive_log/domain/entities/source_profile.dart
+++ b/lib/features/dive_log/domain/entities/source_profile.dart
@@ -1,4 +1,5 @@
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
 
 /// One data source's profile samples for a dive, keyed by the
 /// dive_data_sources row that owns them.
@@ -37,12 +38,26 @@ class SourceProfile {
 /// boundary count as disjoint: a Combine's synthesized surface fill is
 /// appended to the segment before the gap, so the next segment starts exactly
 /// where it ended.
+///
+/// Each span is the min and max of its points rather than the first and last.
+/// Sorted order is not an invariant of [SourceProfile.points]: mergeSeriesPoints
+/// sorts only when it has two or more series to interleave and returns a lone
+/// series' samples untouched, which is exactly the shape a source owning one
+/// series has. Reading the ends off an unsorted list would misjudge the span
+/// and pick the wrong rendering mode.
 bool sourceProfilesAreSequential(Iterable<SourceProfile> profiles) {
-  final spans = <(int, int)>[
-    for (final p in profiles)
-      if (p.points.isNotEmpty)
-        (p.points.first.timestamp, p.points.last.timestamp),
-  ]..sort((a, b) => a.$1.compareTo(b.$1));
+  final spans = <(int, int)>[];
+  for (final profile in profiles) {
+    if (profile.points.isEmpty) continue;
+    var start = profile.points.first.timestamp;
+    var end = start;
+    for (final point in profile.points) {
+      if (point.timestamp < start) start = point.timestamp;
+      if (point.timestamp > end) end = point.timestamp;
+    }
+    spans.add((start, end));
+  }
+  spans.sort((a, b) => a.$1.compareTo(b.$1));
   if (spans.length < 2) return false;
   // Compared against the furthest end seen so far, not just the previous
   // span's: a span nested inside an earlier one starts later but overlaps it.
@@ -53,3 +68,16 @@ bool sourceProfilesAreSequential(Iterable<SourceProfile> profiles) {
   }
   return true;
 }
+
+/// Whether a dive's chart draws one source at a time, with the others
+/// available as overlays, rather than the whole merged profile (issue #1451).
+///
+/// Two or more sources is a necessary condition but not a sufficient one: the
+/// halves of a dive a Combine stitched together arrive as several sources that
+/// never overlap in time, and drawing one of those hides the rest of the dive.
+/// Shared by every surface that renders a profile so the three of them cannot
+/// drift apart.
+bool usesPerSourceRendering(
+  List<DiveDataSource> sources,
+  Iterable<SourceProfile> profiles,
+) => sources.length >= 2 && !sourceProfilesAreSequential(profiles);

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -1704,15 +1704,14 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     final computerNames = _computerDisplayNames(context, dataSources);
     final labels = _sourceNameLabels(context);
     // Per-source rendering exists because two computers recording one dive
-    // disagree sample by sample (#543). Sources that never overlap in time
-    // are the halves of a split dive a Combine stitched together, and
-    // drawing one of those means hiding the rest of the dive (#1451), so
-    // they get the ordinary single-series treatment instead. Profiles that
-    // have not loaded yet carry no spans, so the sequential test answers
-    // false and the first build behaves exactly as it does today.
-    final isMultiSource =
-        dataSources.length >= 2 &&
-        !sourceProfilesAreSequential(sourceProfiles.values);
+    // disagree sample by sample (#543); the halves of a split dive a Combine
+    // stitched together are not that, and drawing one of those would hide the
+    // rest of the dive (#1451). Profiles that have not loaded yet carry no
+    // spans, so this stays true on the first build, exactly as it does today.
+    final isMultiSource = usesPerSourceRendering(
+      dataSources,
+      sourceProfiles.values,
+    );
 
     final activeSourceId = ref.watch(activeDiveSourceProvider(dive.id));
     final overlayIds = ref.watch(overlaySourcesProvider(dive.id));

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -1703,7 +1703,16 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         ref.watch(diveDataSourcesProvider(dive.id)).valueOrNull ?? const [];
     final computerNames = _computerDisplayNames(context, dataSources);
     final labels = _sourceNameLabels(context);
-    final isMultiSource = dataSources.length >= 2;
+    // Per-source rendering exists because two computers recording one dive
+    // disagree sample by sample (#543). Sources that never overlap in time
+    // are the halves of a split dive a Combine stitched together, and
+    // drawing one of those means hiding the rest of the dive (#1451), so
+    // they get the ordinary single-series treatment instead. Profiles that
+    // have not loaded yet carry no spans, so the sequential test answers
+    // false and the first build behaves exactly as it does today.
+    final isMultiSource =
+        dataSources.length >= 2 &&
+        !sourceProfilesAreSequential(sourceProfiles.values);
 
     final activeSourceId = ref.watch(activeDiveSourceProvider(dive.id));
     final overlayIds = ref.watch(overlaySourcesProvider(dive.id));

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -2143,6 +2143,13 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
             ),
             // Sources bar: tap a chip to make that source drive the whole
             // page; the eye overlays a source on the chart for comparison.
+            // Both of those are per-source RENDERING, which is why the bar
+            // follows usesPerSourceRendering rather than the source count:
+            // on a dive whose sources are consecutive halves there is no
+            // "other source" to switch to or overlay, only the rest of the
+            // same dive. Set primary and Split do not disappear with it --
+            // the Data Sources section carries its own copy of both, gated
+            // on the source count alone (data_sources_section.dart).
             if (isMultiSource)
               SourceBar(
                 sources: [

--- a/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+++ b/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
@@ -317,9 +317,10 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
     // Same rule as the detail page: sources that never overlap in time are
     // consecutive halves of one dive, not alternative recordings of it, so
     // they are drawn as one series rather than one-at-a-time (#1451).
-    final isMultiSource =
-        dataSources.length >= 2 &&
-        !sourceProfilesAreSequential(sourceProfiles.values);
+    final isMultiSource = usesPerSourceRendering(
+      dataSources,
+      sourceProfiles.values,
+    );
     // A metadata-only active source has an entry with no points; the chart
     // then renders its empty-profile placeholder instead of silently
     // falling back to the primary's profile (mixed attribution).

--- a/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+++ b/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
@@ -314,6 +314,12 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
     final activeProfile = activeSource == null
         ? null
         : sourceProfiles[activeSource.id];
+    // Same rule as the detail page: sources that never overlap in time are
+    // consecutive halves of one dive, not alternative recordings of it, so
+    // they are drawn as one series rather than one-at-a-time (#1451).
+    final isMultiSource =
+        dataSources.length >= 2 &&
+        !sourceProfilesAreSequential(sourceProfiles.values);
     // A metadata-only active source has an entry with no points; the chart
     // then renders its empty-profile placeholder instead of silently
     // falling back to the primary's profile (mixed attribution).
@@ -322,7 +328,7 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
     // from dive.profile: the merged series spans every source, so markers
     // computed against it can report a depth the drawn curve never reaches
     // and photo pins scaled to it drift off the visible span (#1167).
-    final chartProfile = (dataSources.length >= 2 && activeProfile != null)
+    final chartProfile = (isMultiSource && activeProfile != null)
         ? activeProfile.points
         : dive.profile;
 
@@ -563,7 +569,7 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
                 ),
                 // Source switching and overlay comparison, mirroring the
                 // detail page (management actions stay on the detail page).
-                if (dataSources.length >= 2)
+                if (isMultiSource)
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 12),
                     child: SourceBar(

--- a/lib/features/media/presentation/pages/media_viewer_page.dart
+++ b/lib/features/media/presentation/pages/media_viewer_page.dart
@@ -401,9 +401,10 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
             // one dive a Combine stitched together, not alternative
             // recordings of it: the face reads the whole dive, not the
             // active half (#1451). Mirrors the detail and fullscreen pages.
-            final isMultiSource =
-                dataSources.length >= 2 &&
-                !sourceProfilesAreSequential(sourceProfiles.values);
+            final isMultiSource = usesPerSourceRendering(
+              dataSources,
+              sourceProfiles.values,
+            );
             final perdixProfile = (isMultiSource && activeProfile != null)
                 ? activeProfile.points
                 : dive?.profile ?? const [];

--- a/lib/features/media/presentation/pages/media_viewer_page.dart
+++ b/lib/features/media/presentation/pages/media_viewer_page.dart
@@ -16,6 +16,7 @@ import 'package:submersion/core/router/section_navigation.dart';
 import 'package:submersion/core/services/lightroom/lightroom_api_client.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
 import 'package:submersion/features/dive_log/presentation/providers/active_source_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
@@ -396,8 +397,14 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
             final activeProfile = activeSource == null
                 ? null
                 : sourceProfiles[activeSource.id];
-            final perdixProfile =
-                (dataSources.length >= 2 && activeProfile != null)
+            // Sources that never overlap in time are consecutive halves of
+            // one dive a Combine stitched together, not alternative
+            // recordings of it: the face reads the whole dive, not the
+            // active half (#1451). Mirrors the detail and fullscreen pages.
+            final isMultiSource =
+                dataSources.length >= 2 &&
+                !sourceProfilesAreSequential(sourceProfiles.values);
+            final perdixProfile = (isMultiSource && activeProfile != null)
                 ? activeProfile.points
                 : dive?.profile ?? const [];
             // Rebuilt only on page-level setState (page swipes, toggles),

--- a/test/core/database/migration_v182_profile_series_test.dart
+++ b/test/core/database/migration_v182_profile_series_test.dart
@@ -157,7 +157,8 @@ void main() {
         final version = await second
             .customSelect('PRAGMA user_version')
             .getSingle();
-        expect(version.data.values.first, 183);
+        // The ladder ran to the end, whatever the end currently is.
+        expect(version.data.values.first, AppDatabase.currentSchemaVersion);
       },
     );
 

--- a/test/core/database/migration_v183_drop_legacy_tables_test.dart
+++ b/test/core/database/migration_v183_drop_legacy_tables_test.dart
@@ -148,7 +148,10 @@ void main() {
         scalar(raw, 'SELECT COUNT(*) AS n FROM tank_pressure_series'),
         greaterThan(0),
       );
-      expect(scalar(raw, 'PRAGMA user_version'), 183);
+      expect(
+        scalar(raw, 'PRAGMA user_version'),
+        AppDatabase.currentSchemaVersion,
+      );
 
       await db.close();
     },
@@ -208,7 +211,10 @@ void main() {
       ),
       isEmpty,
     );
-    expect(scalar(raw, 'PRAGMA user_version'), 183);
+    expect(
+      scalar(raw, 'PRAGMA user_version'),
+      AppDatabase.currentSchemaVersion,
+    );
   });
 
   test(
@@ -249,7 +255,10 @@ void main() {
         scalar(raw, 'SELECT SUM(sample_count) AS n FROM tank_pressure_series'),
         3,
       );
-      expect(scalar(raw, 'PRAGMA user_version'), 183);
+      expect(
+        scalar(raw, 'PRAGMA user_version'),
+        AppDatabase.currentSchemaVersion,
+      );
     },
   );
 
@@ -274,7 +283,10 @@ void main() {
     addTearDown(db.close);
     await expectLater(db.customSelect('SELECT 1').get(), completes);
 
-    expect(scalar(raw, 'PRAGMA user_version'), 183);
+    expect(
+      scalar(raw, 'PRAGMA user_version'),
+      AppDatabase.currentSchemaVersion,
+    );
     // Only dive_profiles is unpackable here. Its samples are still only in
     // the legacy table, so its drop is skipped rather than destroying them.
     // The pressures are packed per dive independently of it, which is the
@@ -328,7 +340,10 @@ void main() {
     );
     await first.customSelect('SELECT 1').get();
     await first.close();
-    expect(scalar(raw, 'PRAGMA user_version'), 183);
+    expect(
+      scalar(raw, 'PRAGMA user_version'),
+      AppDatabase.currentSchemaVersion,
+    );
     expect(scalar(raw, 'SELECT COUNT(*) AS n FROM dive_profiles'), 11);
 
     // The malformed series table is repaired (dropped, so the backstop's
@@ -380,7 +395,10 @@ void main() {
     addTearDown(db.close);
     await db.customSelect('SELECT 1').get();
 
-    expect(scalar(raw, 'PRAGMA user_version'), 183);
+    expect(
+      scalar(raw, 'PRAGMA user_version'),
+      AppDatabase.currentSchemaVersion,
+    );
     expect(
       raw.select(
         "SELECT name FROM sqlite_master WHERE type = 'table' "
@@ -420,7 +438,10 @@ void main() {
     addTearDown(db.close);
     await db.customSelect('SELECT 1').get();
 
-    expect(scalar(raw, 'PRAGMA user_version'), 183);
+    expect(
+      scalar(raw, 'PRAGMA user_version'),
+      AppDatabase.currentSchemaVersion,
+    );
     expect(
       raw.select(
         "SELECT name FROM sqlite_master WHERE type = 'table' "
@@ -501,7 +522,10 @@ void main() {
     addTearDown(db.close);
     await expectLater(db.customSelect('SELECT 1').get(), completes);
 
-    expect(scalar(raw, 'PRAGMA user_version'), 183);
+    expect(
+      scalar(raw, 'PRAGMA user_version'),
+      AppDatabase.currentSchemaVersion,
+    );
     expect(scalar(raw, 'SELECT COUNT(*) AS n FROM dive_profiles'), 1);
   });
 
@@ -539,7 +563,10 @@ void main() {
       raw.select("SELECT name FROM sqlite_master WHERE name = 'dive_profiles'"),
       isEmpty,
     );
-    expect(scalar(raw, 'PRAGMA user_version'), 183);
+    expect(
+      scalar(raw, 'PRAGMA user_version'),
+      AppDatabase.currentSchemaVersion,
+    );
   });
 
   test(
@@ -615,7 +642,10 @@ void main() {
   );
 
   test('v183 is present in the migration ladder', () {
-    expect(AppDatabase.currentSchemaVersion, 183);
+    // v183 is now a past migration; the latest-version tripwire lives in the
+    // newest migration's test (migration_v184_merge_source_slot_test.dart),
+    // so assert membership rather than equality.
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(183));
     expect(AppDatabase.migrationVersions, contains(183));
     // The wire compatibility floor lands on 183, not on the 182 rung that
     // replaced the two synced entities: no released build was ever stamped

--- a/test/core/database/migration_v183_rung_resilience_test.dart
+++ b/test/core/database/migration_v183_rung_resilience_test.dart
@@ -44,7 +44,10 @@ void main() {
         addTearDown(db.close);
 
         await expectLater(db.customSelect('SELECT 1').get(), completes);
-        expect(scalar(raw, 'PRAGMA user_version'), 183);
+        expect(
+          scalar(raw, 'PRAGMA user_version'),
+          AppDatabase.currentSchemaVersion,
+        );
         // The pack itself ran, so no samples are stranded by the failure.
         expect(scalar(raw, 'SELECT COUNT(*) AS n FROM dive_profile_series'), 4);
       },

--- a/test/core/database/migration_v184_merge_source_slot_test.dart
+++ b/test/core/database/migration_v184_merge_source_slot_test.dart
@@ -1,0 +1,246 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// v184 (issue #1451): `dive_data_sources.merge_source_slot`, the marker a
+/// sequential Combine stamps on the provenance rows it carries so the display
+/// collapses the halves of one dive back into a single source.
+///
+/// Dives combined before the marker existed have to be recognized by shape,
+/// and the shape has to exclude a two-computer consolidation: collapsing one
+/// of those would put the chart back to drawing the interleaved union of both
+/// computers, which is issue #543. The discriminator is time. Combined halves
+/// are consecutive slices of one timeline, so their entry/exit spans are
+/// disjoint; two computers recording one dive cover the same minutes.
+void main() {
+  // Stamped at 183 so ONLY the v184 step runs, isolating what is asserted.
+  NativeDatabase setupDb(void Function(dynamic rawDb) seed) {
+    return NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 183');
+        rawDb.execute('CREATE TABLE dives (id TEXT PRIMARY KEY)');
+        // The pre-v184 shape: every column the backfill reads, and no
+        // merge_source_slot. entry_time/exit_time are drift dateTime
+        // columns, stored as unix seconds.
+        rawDb.execute('''
+          CREATE TABLE dive_data_sources (
+            id TEXT NOT NULL PRIMARY KEY,
+            dive_id TEXT NOT NULL,
+            computer_id TEXT,
+            is_primary INTEGER NOT NULL DEFAULT 0,
+            imported_at INTEGER NOT NULL,
+            created_at INTEGER NOT NULL,
+            entry_time INTEGER,
+            exit_time INTEGER
+          )
+        ''');
+        seed(rawDb);
+      },
+    );
+  }
+
+  void insertSource(
+    dynamic rawDb,
+    String id,
+    String diveId, {
+    bool isPrimary = false,
+    String? computerId,
+    int? entry,
+    int? exit,
+  }) {
+    rawDb.execute(
+      'INSERT INTO dive_data_sources '
+      '(id, dive_id, computer_id, is_primary, imported_at, created_at, '
+      'entry_time, exit_time) VALUES (?, ?, ?, ?, 0, 0, ?, ?)',
+      [id, diveId, computerId, isPrimary ? 1 : 0, entry, exit],
+    );
+  }
+
+  Future<Map<String, int?>> slots(AppDatabase db) async {
+    final rows = await db
+        .customSelect(
+          'SELECT id, merge_source_slot FROM dive_data_sources ORDER BY id',
+        )
+        .get();
+    return {
+      for (final r in rows)
+        r.read<String>('id'): r.readNullable<int>('merge_source_slot'),
+    };
+  }
+
+  test('v184 is the current schema version and is in the ladder', () {
+    expect(AppDatabase.currentSchemaVersion, 184);
+    expect(AppDatabase.migrationVersions, contains(184));
+  });
+
+  test('adds merge_source_slot to dive_data_sources', () async {
+    final db = AppDatabase(setupDb((_) {}));
+    addTearDown(db.close);
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('dive_data_sources')")
+        .get();
+    expect(
+      cols.map((c) => c.read<String>('name')),
+      contains('merge_source_slot'),
+    );
+  });
+
+  test('marks the rows of a dive combined before the marker existed', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        rawDb.execute("INSERT INTO dives (id) VALUES ('combined')");
+        // Two file imports, no computer to collide on, consecutive spans,
+        // neither primary: exactly what DiveMergeService.apply left behind.
+        insertSource(rawDb, 'src-first', 'combined', entry: 0, exit: 1800);
+        insertSource(rawDb, 'src-second', 'combined', entry: 2100, exit: 3600);
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await slots(db), {'src-first': 0, 'src-second': 0});
+  });
+
+  test('leaves a two-computer consolidation alone (#543)', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        rawDb.execute("INSERT INTO dives (id) VALUES ('consolidated')");
+        // Overlapping spans: two recordings of the same minutes. Neither row
+        // is primary, so the primary test alone would have collapsed them
+        // and sent the chart back to drawing the union of both computers.
+        insertSource(
+          rawDb,
+          'src-a',
+          'consolidated',
+          computerId: 'dc-a',
+          entry: 0,
+          exit: 3600,
+        );
+        insertSource(
+          rawDb,
+          'src-b',
+          'consolidated',
+          computerId: 'dc-b',
+          entry: 60,
+          exit: 3500,
+        );
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await slots(db), {'src-a': null, 'src-b': null});
+  });
+
+  test('leaves a dive that still has a primary source alone', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        rawDb.execute("INSERT INTO dives (id) VALUES ('imported')");
+        insertSource(
+          rawDb,
+          'src-primary',
+          'imported',
+          isPrimary: true,
+          entry: 0,
+          exit: 1800,
+        );
+        insertSource(rawDb, 'src-extra', 'imported', entry: 2100, exit: 3600);
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await slots(db), {'src-extra': null, 'src-primary': null});
+  });
+
+  test('leaves an ordinary single-source dive alone', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        rawDb.execute("INSERT INTO dives (id) VALUES ('ordinary')");
+        insertSource(rawDb, 'src-only', 'ordinary', entry: 0, exit: 1800);
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await slots(db), {'src-only': null});
+  });
+
+  test('leaves rows that cannot be classified alone', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        rawDb.execute("INSERT INTO dives (id) VALUES ('untimed')");
+        // No entry/exit times: nothing says whether these halves are
+        // consecutive or competing, so they keep today's behavior.
+        insertSource(rawDb, 'src-x', 'untimed');
+        insertSource(rawDb, 'src-y', 'untimed', entry: 2100, exit: 3600);
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await slots(db), {'src-x': null, 'src-y': null});
+  });
+
+  test('marks a dive combined from three segments', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        rawDb.execute("INSERT INTO dives (id) VALUES ('triple')");
+        insertSource(rawDb, 'src-1', 'triple', entry: 0, exit: 600);
+        insertSource(rawDb, 'src-2', 'triple', entry: 700, exit: 1300);
+        insertSource(rawDb, 'src-3', 'triple', entry: 1400, exit: 2000);
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await slots(db), {'src-1': 0, 'src-2': 0, 'src-3': 0});
+  });
+
+  test('leaves a dive where any pair overlaps alone', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        rawDb.execute("INSERT INTO dives (id) VALUES ('mixed')");
+        // Two consecutive halves plus a third source covering the gap
+        // between them. One overlap is enough to say this is not a plain
+        // sequential combine, so nothing here is marked.
+        insertSource(rawDb, 'src-1', 'mixed', entry: 0, exit: 1800);
+        insertSource(rawDb, 'src-2', 'mixed', entry: 2100, exit: 3600);
+        insertSource(rawDb, 'src-3', 'mixed', entry: 1700, exit: 2200);
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await slots(db), {'src-1': null, 'src-2': null, 'src-3': null});
+  });
+
+  test('treats halves that touch at the boundary as consecutive', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        rawDb.execute("INSERT INTO dives (id) VALUES ('touching')");
+        insertSource(rawDb, 'src-1', 'touching', entry: 0, exit: 1800);
+        insertSource(rawDb, 'src-2', 'touching', entry: 1800, exit: 3600);
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await slots(db), {'src-1': 0, 'src-2': 0});
+  });
+
+  test('marks only the qualifying dive when several shapes coexist', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        for (final id in ['combined', 'consolidated']) {
+          rawDb.execute('INSERT INTO dives (id) VALUES (?)', [id]);
+        }
+        insertSource(rawDb, 'src-first', 'combined', entry: 0, exit: 1800);
+        insertSource(rawDb, 'src-second', 'combined', entry: 2100, exit: 3600);
+        insertSource(rawDb, 'src-a', 'consolidated', entry: 0, exit: 3600);
+        insertSource(rawDb, 'src-b', 'consolidated', entry: 60, exit: 3500);
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await slots(db), {
+      'src-a': null,
+      'src-b': null,
+      'src-first': 0,
+      'src-second': 0,
+    });
+  });
+}

--- a/test/core/database/migration_v184_merge_source_slot_test.dart
+++ b/test/core/database/migration_v184_merge_source_slot_test.dart
@@ -31,7 +31,8 @@ void main() {
             imported_at INTEGER NOT NULL,
             created_at INTEGER NOT NULL,
             entry_time INTEGER,
-            exit_time INTEGER
+            exit_time INTEGER,
+            time_offset_seconds INTEGER
           )
         ''');
         seed(rawDb);
@@ -47,12 +48,22 @@ void main() {
     String? computerId,
     int? entry,
     int? exit,
+    int? timeOffsetSeconds,
   }) {
     rawDb.execute(
       'INSERT INTO dive_data_sources '
       '(id, dive_id, computer_id, is_primary, imported_at, created_at, '
-      'entry_time, exit_time) VALUES (?, ?, ?, ?, 0, 0, ?, ?)',
-      [id, diveId, computerId, isPrimary ? 1 : 0, entry, exit],
+      'entry_time, exit_time, time_offset_seconds) '
+      'VALUES (?, ?, ?, ?, 0, 0, ?, ?, ?)',
+      [
+        id,
+        diveId,
+        computerId,
+        isPrimary ? 1 : 0,
+        entry,
+        exit,
+        timeOffsetSeconds,
+      ],
     );
   }
 
@@ -123,6 +134,32 @@ void main() {
           computerId: 'dc-b',
           entry: 60,
           exit: 3500,
+        );
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await slots(db), {'src-a': null, 'src-b': null});
+  });
+
+  test('leaves a consolidation whose clocks disagree alone (#543)', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        rawDb.execute("INSERT INTO dives (id) VALUES ('shifted')");
+        // Two recordings of the same dive, no computer to collide on, and a
+        // secondary whose clock was two hours out. Consolidation shifts the
+        // SAMPLES by time_offset_seconds but copies entry_time/exit_time
+        // verbatim, so the stored spans do not overlap even though the two
+        // rows cover the same minutes. The disjointness test alone would
+        // read that as a Combine and collapse both to one chip.
+        insertSource(rawDb, 'src-a', 'shifted', entry: 0, exit: 3600);
+        insertSource(
+          rawDb,
+          'src-b',
+          'shifted',
+          entry: 7200,
+          exit: 10800,
+          timeOffsetSeconds: -7200,
         );
       }),
     );

--- a/test/core/services/database_service_vacuum_test.dart
+++ b/test/core/services/database_service_vacuum_test.dart
@@ -160,19 +160,19 @@ void main() {
       );
       await DatabaseService.instance.close(strict: true);
 
-      expect(storedVersionOnDisk(), 183);
+      expect(storedVersionOnDisk(), AppDatabase.currentSchemaVersion);
       // Only VACUUM returns the dropped table's pages to the filesystem; a
       // plain DROP leaves them on the freelist.
       expect(freelistOnDisk(), 0);
     },
   );
 
-  test('a file stamped 183 whose legacy table the BACKSTOP drops is '
-      'VACUUMed', () async {
+  test('a file stamped at the current version whose legacy table the BACKSTOP '
+      'drops is VACUUMed', () async {
     // The v183 rung is explicitly allowed to skip its drop: its own pack
     // threw, the series table's foreign-key parents were absent, or the
-    // residue count found rows no series covered. The file is stamped 183
-    // either way, and the beforeOpen backstop drops the tables on the first
+    // residue count found rows no series covered. The file is stamped at the
+    // current version either way, and the beforeOpen backstop drops the tables on the first
     // later open whose pack succeeds. That open has no pending ladder, so a
     // reclamation keyed on the stored version never runs for it, and there
     // is no other VACUUM of the live database anywhere in the app: the
@@ -207,7 +207,7 @@ void main() {
       raw.execute('COMMIT');
       stmt.close();
       // Already at the current version, so there is no ladder to run.
-      raw.execute('PRAGMA user_version = 183');
+      raw.execute('PRAGMA user_version = ${AppDatabase.currentSchemaVersion}');
     });
 
     expect(freelistOnDisk(), 0);
@@ -225,7 +225,7 @@ void main() {
     );
   });
 
-  test('a file already at 183 is not VACUUMed', () async {
+  test('a file already at the current version is not VACUUMed', () async {
     await seedFile((raw) {
       // A freelist the open must leave alone: pages freed by a bulk delete
       // in a scratch table, with no pending migration to trigger the VACUUM.

--- a/test/features/dive_log/data/repositories/canonical_data_sources_test.dart
+++ b/test/features/dive_log/data/repositories/canonical_data_sources_test.dart
@@ -128,4 +128,97 @@ void main() {
       expect(sources.map((s) => s.id).toList(), ['src-a', 'src-b']);
     },
   );
+
+  // Issue #1451: a Combine of two file/cloud imports carries two provenance
+  // rows with no computerId to collide on. Before merge_source_slot existed
+  // they stayed two selectable sources, and the chart drew only one half of
+  // the dive.
+  test('getDataSources collapses merge provenance rows that share a slot, '
+      'even with no computerId', () async {
+    for (final (id, day) in [('src-first', 1), ('src-second', 2)]) {
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: Value(id),
+              diveId: const Value('dive-1'),
+              isPrimary: const Value(false),
+              mergeSourceSlot: const Value(0),
+              importedAt: Value(DateTime(2026, 1, day)),
+              createdAt: Value(DateTime(2026, 1, day)),
+            ),
+          );
+    }
+
+    final sources = await repository.getDataSources('dive-1');
+
+    expect(sources.map((s) => s.id).toList(), ['src-first']);
+    expect(await repository.hasMultipleDataSources('dive-1'), isFalse);
+  });
+
+  test('getDataSources keeps one source per slot, so a consolidated dive that '
+      'was then combined still shows both computers', () async {
+    // Two segments, each contributing a primary (slot 0) and a folded-in
+    // secondary (slot 1). Four rows, two strands.
+    var day = 1;
+    for (final slot in [0, 1, 0, 1]) {
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: Value('src-$day'),
+              diveId: const Value('dive-1'),
+              isPrimary: const Value(false),
+              mergeSourceSlot: Value(slot),
+              importedAt: Value(DateTime(2026, 1, day)),
+              createdAt: Value(DateTime(2026, 1, day)),
+            ),
+          );
+      day++;
+    }
+
+    final sources = await repository.getDataSources('dive-1');
+
+    expect(sources.map((s) => s.id).toList(), ['src-1', 'src-2']);
+    expect(await repository.hasMultipleDataSources('dive-1'), isTrue);
+  });
+
+  test(
+    'a slot never collapses a row against a source that has a computer',
+    () async {
+      // A merged dive later consolidated with a computer download: the carried
+      // halves are one strand, the download is its own.
+      for (final (id, day) in [('src-half-a', 1), ('src-half-b', 2)]) {
+        await db
+            .into(db.diveDataSources)
+            .insert(
+              DiveDataSourcesCompanion(
+                id: Value(id),
+                diveId: const Value('dive-1'),
+                isPrimary: const Value(false),
+                mergeSourceSlot: const Value(0),
+                importedAt: Value(DateTime(2026, 1, day)),
+                createdAt: Value(DateTime(2026, 1, day)),
+              ),
+            );
+      }
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-computer'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('dc-a'),
+              isPrimary: const Value(false),
+              importedAt: Value(DateTime(2026, 1, 3)),
+              createdAt: Value(DateTime(2026, 1, 3)),
+            ),
+          );
+
+      final sources = await repository.getDataSources('dive-1');
+
+      expect(sources.map((s) => s.id).toList(), ['src-half-a', 'src-computer']);
+      expect(await repository.hasMultipleDataSources('dive-1'), isTrue);
+    },
+  );
 }

--- a/test/features/dive_log/data/services/dive_consolidation_service_test.dart
+++ b/test/features/dive_log/data/services/dive_consolidation_service_test.dart
@@ -108,6 +108,7 @@ void main() {
     required String diveId,
     String? computerId,
     bool isPrimary = true,
+    int? mergeSourceSlot,
     Uint8List? rawData,
     Uint8List? rawFingerprint,
     String? descriptorVendor,
@@ -125,6 +126,7 @@ void main() {
           ).copyWith(
             isPrimary: Value(isPrimary),
             computerId: Value(computerId),
+            mergeSourceSlot: Value(mergeSourceSlot),
             rawData: Value(rawData),
             rawFingerprint: Value(rawFingerprint),
             descriptorVendor: Value(descriptorVendor),
@@ -1281,6 +1283,88 @@ void main() {
       // computerId (null means "the dive's primary source"); only tanks,
       // pressures and events get stamped with the primary computer.
       expect(await profileTimestamps(), [0, 60, 120]);
+    });
+  });
+
+  group('merge slots compose across consolidation (#1451)', () {
+    /// The shape DiveMergeService.apply leaves behind: the segments' own
+    /// provenance rows, none primary, all sharing slot 0. createDive mints a
+    /// primary source of its own, which a real combine would never leave on
+    /// the merged dive, so it goes first.
+    Future<void> seedCombinedDive(String id, {required DateTime entry}) async {
+      await seedDive(id, entry: entry);
+      await (db.delete(
+        db.diveDataSources,
+      )..where((t) => t.diveId.equals(id))).go();
+      for (final n in [1, 2]) {
+        await seedDataSource(
+          'src-$id$n',
+          diveId: id,
+          isPrimary: false,
+          mergeSourceSlot: 0,
+        );
+      }
+    }
+
+    test('a folded-in combined dive keeps its own strand', () async {
+      // Both dives were combined from halves before this consolidation, so
+      // both carry slot 0 on every row. Copied over verbatim, all four rows
+      // would read as one strand and the target would show a single chip.
+      await seedCombinedDive('t', entry: DateTime.utc(2026, 7, 1, 9));
+      await seedCombinedDive('s', entry: DateTime.utc(2026, 7, 1, 9));
+
+      await service.apply(targetDiveId: 't', secondaryDiveIds: ['s']);
+
+      final rows = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.diveId.equals('t'))).get();
+      // The target's own two rows keep slot 0; the folded-in dive's land on
+      // slot 1 instead of colliding with them.
+      expect(rows.map((r) => r.mergeSourceSlot).nonNulls.toList()..sort(), [
+        0,
+        0,
+        1,
+        1,
+      ]);
+      // Three chips: each lineage collapses to one, plus the primary row
+      // backfillPrimaryDataSource mints for a target that has none (a merged
+      // dive never has one). Without the rebase the two lineages would read
+      // as one strand and there would be two.
+      final canonical = await diveRepo.getDataSources('t');
+      expect(canonical, hasLength(3));
+      // One survivor per slot, plus the unmarked backfilled primary. Copied
+      // rows are minted with fresh ids, so identify them by slot.
+      final canonicalIds = canonical.map((c) => c.id).toSet();
+      expect(
+        rows
+            .where((r) => canonicalIds.contains(r.id))
+            .map((r) => r.mergeSourceSlot)
+            .toSet(),
+        {0, 1, null},
+      );
+    });
+
+    test('a secondary with no slots of its own is left alone', () async {
+      await seedCombinedDive('t', entry: DateTime.utc(2026, 7, 1, 9));
+      await seedDive('s', entry: DateTime.utc(2026, 7, 1, 9));
+      await (db.delete(
+        db.diveDataSources,
+      )..where((t) => t.diveId.equals('s'))).go();
+      await seedDataSource('src-s', diveId: 's', computerId: 'comp-s');
+
+      await service.apply(targetDiveId: 't', secondaryDiveIds: ['s']);
+
+      final rows = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.diveId.equals('t'))).get();
+      // A source that was never carried by a merge stays unmarked: the
+      // rebase only moves slots that exist.
+      expect(
+        rows.where((r) => r.computerId == 'comp-s').single.mergeSourceSlot,
+        isNull,
+      );
+      expect(rows.map((r) => r.mergeSourceSlot).nonNulls.toList(), [0, 0]);
+      expect(await diveRepo.getDataSources('t'), hasLength(3));
     });
   });
 }

--- a/test/features/dive_log/data/services/dive_merge_service_test.dart
+++ b/test/features/dive_log/data/services/dive_merge_service_test.dart
@@ -720,4 +720,73 @@ void main() {
       expect(result.profilesPreserved, 2);
     });
   });
+
+  group('imported provenance (#1451)', () {
+    test('carries both rows but marks them one strand, so the merged dive '
+        'reports a single source', () async {
+      // File and cloud imports have no computerId, so nothing collapsed
+      // these rows before merge_source_slot existed: the merged dive
+      // reported two sources and the chart drew only the active half.
+      await seedDive('a', entry: DateTime.utc(2026, 7, 1, 9));
+      await seedDive('b', entry: DateTime.utc(2026, 7, 1, 10));
+
+      final outcome = await service.apply(['a', 'b']);
+      final mergedId = outcome.mergedDive.id;
+
+      final rows = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.diveId.equals(mergedId))).get();
+      expect(rows, hasLength(2), reason: 'both halves keep their provenance');
+      expect(rows.every((r) => r.computerId == null), isTrue);
+      expect(rows.map((r) => r.mergeSourceSlot).toSet(), {0});
+
+      expect(await diveRepo.getDataSources(mergedId), hasLength(1));
+      expect(await diveRepo.hasMultipleDataSources(mergedId), isFalse);
+    });
+
+    test('the surviving source owns every segment\'s samples', () async {
+      await seedDive('a', entry: DateTime.utc(2026, 7, 1, 9));
+      await seedDive('b', entry: DateTime.utc(2026, 7, 1, 10));
+
+      final outcome = await service.apply(['a', 'b']);
+      final mergedId = outcome.mergedDive.id;
+
+      // The chart's multi-source branch draws the active source's own
+      // points. With one canonical source that has to be the whole dive,
+      // not the first half: samples owned by the row that lost the collapse
+      // fall back to the surviving row (getProfilesByDataSource).
+      final profiles = await diveRepo.getProfilesByDataSource(mergedId);
+      expect(profiles, hasLength(1));
+      final merged = await diveRepo.getDiveById(mergedId);
+      expect(
+        profiles.values.single.points.map((p) => p.timestamp).toList(),
+        merged!.profile.map((p) => p.timestamp).toList(),
+      );
+      expect(
+        profiles.values.single.points.last.timestamp,
+        greaterThan(30 * 60),
+        reason: 'runs past the end of the first segment',
+      );
+    });
+
+    test('re-slots against the new merge when a combined dive is combined '
+        'again', () async {
+      await seedDive('a', entry: DateTime.utc(2026, 7, 1, 9));
+      await seedDive('b', entry: DateTime.utc(2026, 7, 1, 10));
+      final first = await service.apply(['a', 'b']);
+
+      await seedDive('c', entry: DateTime.utc(2026, 7, 1, 12));
+      final second = await service.apply([first.mergedDive.id, 'c']);
+      final mergedId = second.mergedDive.id;
+
+      final rows = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.diveId.equals(mergedId))).get();
+      expect(rows, hasLength(3));
+      // Segment one contributed two rows; the primary-then-oldest ordering
+      // that decides their slots is the same one every canonical read uses.
+      expect(rows.map((r) => r.mergeSourceSlot).toList()..sort(), [0, 0, 1]);
+      expect(await diveRepo.getDataSources(mergedId), hasLength(2));
+    });
+  });
 }

--- a/test/features/dive_log/data/services/dive_merge_service_test.dart
+++ b/test/features/dive_log/data/services/dive_merge_service_test.dart
@@ -770,7 +770,7 @@ void main() {
     });
 
     test('re-slots against the new merge when a combined dive is combined '
-        'again', () async {
+        'again, without splitting the strand it arrives as', () async {
       await seedDive('a', entry: DateTime.utc(2026, 7, 1, 9));
       await seedDive('b', entry: DateTime.utc(2026, 7, 1, 10));
       final first = await service.apply(['a', 'b']);
@@ -782,11 +782,56 @@ void main() {
       final rows = await (db.select(
         db.diveDataSources,
       )..where((t) => t.diveId.equals(mergedId))).get();
-      expect(rows, hasLength(3));
-      // Segment one contributed two rows; the primary-then-oldest ordering
-      // that decides their slots is the same one every canonical read uses.
-      expect(rows.map((r) => r.mergeSourceSlot).toList()..sort(), [0, 0, 1]);
-      expect(await diveRepo.getDataSources(mergedId), hasLength(2));
+      expect(rows, hasLength(3), reason: 'every segment keeps its provenance');
+      // The first segment arrives already collapsed to ONE strand, so both
+      // of its rows have to take the same new slot. Numbering rows rather
+      // than strands would hand them slots 0 and 1 while the third segment
+      // took slot 0 again, splitting one dive back into two chips whose
+      // spans interleave -- #1451 all over again, one combine later.
+      expect(rows.map((r) => r.mergeSourceSlot).toSet(), {0});
+      expect(await diveRepo.getDataSources(mergedId), hasLength(1));
+      expect(await diveRepo.hasMultipleDataSources(mergedId), isFalse);
+
+      final profiles = await diveRepo.getProfilesByDataSource(mergedId);
+      expect(profiles, hasLength(1));
+      final merged = await diveRepo.getDiveById(mergedId);
+      expect(
+        profiles.values.single.points.map((p) => p.timestamp).toList(),
+        merged!.profile.map((p) => p.timestamp).toList(),
+        reason: 'the middle segment is not stranded behind a second chip',
+      );
     });
+
+    test(
+      'a segment that carries two computers keeps one strand per computer',
+      () async {
+        // Consolidate-then-combine: re-slotting by strand must not flatten two
+        // computers into one chip the way it collapses one computer's halves.
+        // seedDive's computerId stamps the profile series only, so the source
+        // rows are attributed here.
+        await seedDive('a', entry: DateTime.utc(2026, 7, 1, 9));
+        await seedDive('b', entry: DateTime.utc(2026, 7, 1, 10));
+        for (final (sourceId, computerId) in const [
+          ('src-a', 'comp-1'),
+          ('src-b', 'comp-2'),
+        ]) {
+          await (db.update(db.diveDataSources)
+                ..where((t) => t.id.equals(sourceId)))
+              .write(DiveDataSourcesCompanion(computerId: Value(computerId)));
+        }
+
+        final merged = (await service.apply(['a', 'b'])).mergedDive.id;
+
+        final rows = await (db.select(
+          db.diveDataSources,
+        )..where((t) => t.diveId.equals(merged))).get();
+        expect(rows.map((r) => r.computerId).toSet(), {'comp-1', 'comp-2'});
+        expect(
+          await diveRepo.getDataSources(merged),
+          hasLength(2),
+          reason: 'computerId still wins over the slot',
+        );
+      },
+    );
   });
 }

--- a/test/features/dive_log/domain/entities/source_profiles_sequential_test.dart
+++ b/test/features/dive_log/domain/entities/source_profiles_sequential_test.dart
@@ -85,6 +85,29 @@ void main() {
       );
     });
 
+    test('reads each span as min and max, not first and last', () {
+      // mergeSeriesPoints returns a lone series' samples untouched, so a
+      // source that owns one series can hand over points in any order. Taking
+      // the ends off the list would read the second source's span as
+      // (2100, 1500), an inverted interval that overlaps the first.
+      expect(
+        sourceProfilesAreSequential([
+          _source('first', [600, 0, 1200]),
+          _source('second', [2100, 2700, 1500]),
+        ]),
+        isTrue,
+      );
+      // The mirror case: genuinely overlapping sources stay overlapping when
+      // their points arrive out of order.
+      expect(
+        sourceProfilesAreSequential([
+          _source('a', [1200, 0, 600]),
+          _source('b', [1190, 10, 610]),
+        ]),
+        isFalse,
+      );
+    });
+
     test('answers on argument order, not iteration order', () {
       expect(
         sourceProfilesAreSequential([

--- a/test/features/dive_log/domain/entities/source_profiles_sequential_test.dart
+++ b/test/features/dive_log/domain/entities/source_profiles_sequential_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
+
+SourceProfile _source(String id, List<int> timestamps) => SourceProfile(
+  sourceId: id,
+  computerId: null,
+  isEdited: false,
+  points: [
+    for (final t in timestamps) DiveProfilePoint(timestamp: t, depth: 10),
+  ],
+);
+
+void main() {
+  group('sourceProfilesAreSequential', () {
+    test('is false for a single source', () {
+      expect(
+        sourceProfilesAreSequential([
+          _source('a', [0, 60, 120]),
+        ]),
+        isFalse,
+      );
+    });
+
+    test('is false when no source has samples', () {
+      expect(
+        sourceProfilesAreSequential([_source('a', []), _source('b', [])]),
+        isFalse,
+      );
+    });
+
+    test('is false when two computers cover the same minutes', () {
+      expect(
+        sourceProfilesAreSequential([
+          _source('a', [0, 600, 1200]),
+          _source('b', [10, 610, 1190]),
+        ]),
+        isFalse,
+      );
+    });
+
+    test('is false when one span is nested inside another', () {
+      // Guards the running-max: sorted by start, the nested span begins
+      // after the previous one but still overlaps it.
+      expect(
+        sourceProfilesAreSequential([
+          _source('a', [0, 3600]),
+          _source('b', [600, 1200]),
+          _source('c', [900, 1000]),
+        ]),
+        isFalse,
+      );
+    });
+
+    test('is true for the halves of a combined dive', () {
+      expect(
+        sourceProfilesAreSequential([
+          _source('first', [0, 600, 1200]),
+          _source('second', [1500, 2100, 2700]),
+        ]),
+        isTrue,
+      );
+    });
+
+    test('is true when the halves touch at the boundary', () {
+      // A Combine appends its synthesized surface fill to the segment before
+      // the gap, so the next segment can start exactly where it ended.
+      expect(
+        sourceProfilesAreSequential([
+          _source('first', [0, 600, 1200]),
+          _source('second', [1200, 1800]),
+        ]),
+        isTrue,
+      );
+    });
+
+    test('ignores a metadata-only source with no samples', () {
+      expect(
+        sourceProfilesAreSequential([
+          _source('first', [0, 600]),
+          _source('metadata-only', []),
+          _source('second', [900, 1500]),
+        ]),
+        isTrue,
+      );
+    });
+
+    test('answers on argument order, not iteration order', () {
+      expect(
+        sourceProfilesAreSequential([
+          _source('second', [1500, 2100]),
+          _source('first', [0, 600]),
+        ]),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_detail_combined_sources_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_combined_sources_test.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/source_bar.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Issue #1451: a dive a computer logged as two, stitched back together by
+/// Combine, must draw as one continuous profile. Its carried provenance rows
+/// are consecutive slices of one timeline, not alternative recordings, so the
+/// page must not offer them as switchable sources and draw only the active
+/// slice.
+void main() {
+  final now = DateTime(2026, 5, 7);
+
+  /// A descend-and-ascend segment of [count] samples, one a minute, starting
+  /// at [startSeconds].
+  List<DiveProfilePoint> segment(int count, {required int startSeconds}) {
+    return List.generate(
+      count,
+      (i) => DiveProfilePoint(
+        timestamp: startSeconds + i * 60,
+        depth: (i < count / 2 ? i : (count - 1 - i)) * 3.0,
+      ),
+    );
+  }
+
+  final firstHalf = segment(6, startSeconds: 0);
+  final secondHalf = segment(6, startSeconds: 900);
+
+  DiveDataSource carriedSource(String id) => DiveDataSource(
+    id: id,
+    diveId: 'test-dive-1',
+    // A file or cloud import has no computer to collapse the halves on;
+    // that is the case that reached the page as two selectable sources.
+    computerId: null,
+    isPrimary: false,
+    sourceFileFormat: 'uddf',
+    importedAt: now,
+    createdAt: now,
+  );
+
+  late Dive dive;
+  late List<DiveDataSource> sources;
+  late Map<String, SourceProfile> profiles;
+
+  setUp(() {
+    dive = createTestDiveWithBottomTime().copyWith(
+      profile: [...firstHalf, ...secondHalf],
+    );
+    sources = [carriedSource('src-first'), carriedSource('src-second')];
+    profiles = {
+      'src-first': SourceProfile(
+        sourceId: 'src-first',
+        computerId: null,
+        isEdited: false,
+        points: firstHalf,
+      ),
+      'src-second': SourceProfile(
+        sourceId: 'src-second',
+        computerId: null,
+        isEdited: false,
+        points: secondHalf,
+      ),
+    };
+  });
+
+  Future<void> pumpPage(WidgetTester tester) async {
+    final base = await getBaseOverrides();
+    final originalOnError = FlutterError.onError;
+    FlutterError.onError = (d) {
+      if (d.toString().contains('overflowed')) return;
+      originalOnError?.call(d);
+    };
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          diveProvider(dive.id).overrideWith((ref) async => dive),
+          diveDataSourcesProvider(dive.id).overrideWith((ref) async => sources),
+          sourceProfilesProvider(dive.id).overrideWith((ref) async => profiles),
+          gasSwitchesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+          tankPressuresProvider(
+            dive.id,
+          ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
+          computersForDiveProvider(dive.id).overrideWith((ref) async => []),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: DiveDetailPage(diveId: dive.id, embedded: true)),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    FlutterError.onError = originalOnError;
+  }
+
+  testWidgets('the chart draws the whole combined dive, not the first half', (
+    tester,
+  ) async {
+    await pumpPage(tester);
+
+    final chart = tester.widget<DiveProfileChart>(
+      find.byType(DiveProfileChart),
+    );
+    expect(chart.profile.length, dive.profile.length);
+    expect(chart.profile.last.timestamp, secondHalf.last.timestamp);
+  });
+
+  testWidgets('carried provenance is not offered as switchable sources', (
+    tester,
+  ) async {
+    await pumpPage(tester);
+
+    expect(find.byType(SourceBar), findsNothing);
+  });
+
+  testWidgets('two computers recording the same minutes still get the source '
+      'bar and per-source rendering', (tester) async {
+    // The counterpart the gate must not catch: overlapping spans mean two
+    // recordings of one dive, where drawing the union is the sawtooth of
+    // issue #543.
+    sources = [
+      DiveDataSource(
+        id: 'src-a',
+        diveId: dive.id,
+        computerId: 'dc-a',
+        isPrimary: true,
+        computerName: 'Perdix',
+        importedAt: now,
+        createdAt: now,
+      ),
+      DiveDataSource(
+        id: 'src-b',
+        diveId: dive.id,
+        computerId: 'dc-b',
+        isPrimary: false,
+        computerName: 'Teric',
+        importedAt: now,
+        createdAt: now,
+      ),
+    ];
+    profiles = {
+      'src-a': SourceProfile(
+        sourceId: 'src-a',
+        computerId: 'dc-a',
+        isEdited: false,
+        points: [...firstHalf, ...secondHalf],
+      ),
+      'src-b': SourceProfile(
+        sourceId: 'src-b',
+        computerId: 'dc-b',
+        isEdited: false,
+        points: segment(6, startSeconds: 60),
+      ),
+    };
+
+    await pumpPage(tester);
+
+    expect(find.byType(SourceBar), findsOneWidget);
+    final chart = tester.widget<DiveProfileChart>(
+      find.byType(DiveProfileChart),
+    );
+    expect(chart.profile.length, profiles['src-a']!.points.length);
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_detail_combined_sources_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_combined_sources_test.dart
@@ -38,17 +38,18 @@ void main() {
   final firstHalf = segment(6, startSeconds: 0);
   final secondHalf = segment(6, startSeconds: 900);
 
-  DiveDataSource carriedSource(String id) => DiveDataSource(
-    id: id,
-    diveId: 'test-dive-1',
-    // A file or cloud import has no computer to collapse the halves on;
-    // that is the case that reached the page as two selectable sources.
-    computerId: null,
-    isPrimary: false,
-    sourceFileFormat: 'uddf',
-    importedAt: now,
-    createdAt: now,
-  );
+  DiveDataSource carriedSource(String id, {required String diveId}) =>
+      DiveDataSource(
+        id: id,
+        diveId: diveId,
+        // A file or cloud import has no computer to collapse the halves on;
+        // that is the case that reached the page as two selectable sources.
+        computerId: null,
+        isPrimary: false,
+        sourceFileFormat: 'uddf',
+        importedAt: now,
+        createdAt: now,
+      );
 
   late Dive dive;
   late List<DiveDataSource> sources;
@@ -58,7 +59,10 @@ void main() {
     dive = createTestDiveWithBottomTime().copyWith(
       profile: [...firstHalf, ...secondHalf],
     );
-    sources = [carriedSource('src-first'), carriedSource('src-second')];
+    sources = [
+      carriedSource('src-first', diveId: dive.id),
+      carriedSource('src-second', diveId: dive.id),
+    ];
     profiles = {
       'src-first': SourceProfile(
         sourceId: 'src-first',


### PR DESCRIPTION
Fixes #1451.

## The bug

A dive computer that surfaces briefly logs one dive as two. **Combine** stitches
the halves correctly at the data layer, but the detail chart then drew only half
of the result.

`DiveMergeService.apply` carries every segment's `dive_data_sources` row onto the
merged dive as provenance, which is load-bearing: each row holds the only
surviving copy of its half's `rawData` / `rawFingerprint` / `sourceUuid`, which
reparse and the import duplicate checker read directly. Those rows are meant to
collapse to one chip on read, but `_canonicalDataSourceRows` keyed that collapse
on `computerId` alone. A file or cloud import has no `computerId`, so nothing
collapsed: the merged dive reported two sources, the chart's multi-source branch
switched to per-source rendering, and the user saw one half of their dive with
the other reachable only through the overlay eye. A direct download sets a real
`computerId` on both segments, they collapse, and the display is correct, which
is why this never showed up in testing.

## The fix

**`dive_data_sources.merge_source_slot` (schema v184).** `apply` stamps each
carried row with the position of its strand among its *own* segment's strands,
and the read side collapses rows that share one. The rows stay in the table
untouched; only the display collapses, which is the contract the `computerId`
collapse already documents.

Per strand rather than per row because a segment can arrive already collapsed:
combining A+B and then combining that result with C hands `apply` a segment
whose two rows deliberately share a slot, and numbering rows would split them
back apart while C reused slot 0.

A slot rather than a plain "is merge provenance" flag so the marker composes: a
dive that was consolidated (two computers) and only then combined keeps one chip
per computer instead of flattening both strands into one. For the same reason
`DiveConsolidationService` rebases a folded-in dive's slots past the target's,
the way it already composes `timeOffsetSeconds`.

The strand rule lives in one place, `dataSourceStrandKey`: `computerId` when the
row has one, else `merge_source_slot`, else the row's own id. The read-side
collapse, the merge stamping and the `hasMultipleDataSources` SQL all spell it
the same way.

**A one-shot backfill on the v184 rung**, since dives combined before the marker
existed carry nothing to recognize them by. A dive qualifies only when it has 2+
source rows, *none* of them primary (every importer writes `is_primary = 1`;
`apply` writes every carried row `false`), and every row's `[entry_time,
exit_time]` span is disjoint from the others'. The disjointness test is what
makes it safe: combined halves are consecutive slices of one timeline, while two
computers recording one dive cover the same minutes. Without it a consolidation
whose target row was never marked primary would collapse to a single chip and the
chart would go back to drawing the interleaved union of both computers (#543).
Rows that carry no entry/exit times cannot be classified and are left alone.

The span test needs one guard of its own. Consolidation shifts a folded-in
dive's *samples* by `time_offset_seconds` but copies its entry and exit times
over verbatim, so a secondary whose clock was badly out stores a span that
misses the target's while covering the same minutes. The backfill therefore also
requires `time_offset_seconds` to be zero across the dive, which is the trace
consolidation leaves and a Combine never writes. Strictly fewer dives qualify,
and a skipped dive keeps today's display: the safe direction to be wrong in for
a one-shot write over user data.

**The chart's multi-source branch now keys off time, not count.** Per-source
rendering exists because two computers disagree sample by sample (#543); that
reasoning does not apply to consecutive halves of one dive, where drawing one
source means hiding the rest. `sourceProfilesAreSequential` gates the branch on
the detail page, the fullscreen profile page and the media viewer's Perdix face,
so a sequential pair can never select per-source rendering even if it reaches a
page as two rows.

`hasMultipleDataSources` mirrors the collapse rule in SQL, so the 3D page counts
the same strands as everything else. Deliberately the collapse rule alone,
without the disjoint-span test: that test exists because drawing one source on a
2D chart hides the others, and this count's only caller is the 3D page's
dive/computers switcher, whose computers scene overlays every strand at once.

## Known follow-up

Collapsing the halves takes the Split affordance away from the dives this fixes
(#1504). `DataSourcesSection` gates Split on the canonical source count, which
is now 1 for a combined pair of imports, and merge undo is a 5 second snackbar,
so a Combine the user regrets later has no recovery path. Nothing is lost below
the UI: both provenance rows survive and `DiveSplitService.split` reads raw
rows, so a split would execute correctly if it were reachable. Left out of this
PR because "what does Split mean on a collapsed strand?" needs deciding first,
and that is a new verb rather than a gate change.

## Tests

- `migration_v184_merge_source_slot_test.dart`: the column, and every shape the
  backfill must and must not catch (combined halves, an overlapping-span
  consolidation, a clock-shifted consolidation whose stored spans do not
  overlap, a dive that still has a primary, a single-source dive, untimed rows,
  and a mixed database).
- `source_profiles_sequential_test.dart`: the span helper, including a span
  nested inside another and profiles arriving out of order.
- `canonical_data_sources_test.dart`: slot collapse with no `computerId`, one
  chip per slot on a consolidated-then-combined dive, and a slot never
  collapsing against a source that has a computer.
- `dive_merge_service_test.dart`: both rows survive with their own raw payloads
  while the read side reports one source, the surviving source owns every
  segment's samples, re-combining a combined dive re-slots against the new merge
  without splitting the strand it arrives as, and a segment carrying two
  computers still keeps one strand per computer.
- `dive_consolidation_service_test.dart`: slots compose across consolidation.
- `dive_detail_combined_sources_test.dart`: the page draws the whole combined
  dive with no source bar, and a genuine two-computer dive still gets both.

Nine assertions in the v182/v183 migration suites hardcoded `183` as "the ladder
finished"; they now compare against `AppDatabase.currentSchemaVersion`.


