### PR TITLE
feat(import): decode MacDive ZSAMPLES profiles for every dive

### DIFF
--- a/docs/import-formats/macdive-zsamples.md
+++ b/docs/import-formats/macdive-zsamples.md
@@ -1,15 +1,15 @@
 # MacDive `ZDIVE.ZSAMPLES` / `ZDIVE.ZRAWDATA` Binary Format — Investigation Findings
 
-**Status:** `ZRAWDATA` is **SOLVED** — see "Update 2026-08-09" at the end of this document. It is the raw Shearwater download stream stored *still compressed*; decompressing it with libdivecomputer's own two passes yields Petrel Native Format, and 266/267 dives in the reference corpus decode against ground truth. MacDive SQLite profile import works for Shearwater dives as of that date.
+**Status:** BOTH COLUMNS SOLVED. `ZRAWDATA` since 2026-08-09 (see "Update 2026-08-09"); `ZSAMPLES` since 2026-09-02 (see "Update 2026-09-02: ZSAMPLES solved" at the end). `ZSAMPLES` is TEA in ECB mode under a key fixed in the MacDive binary, not AES under a per-dive key, and every one of the 350 blobs in the reference library decodes sample-for-sample against MacDive's own exports. MacDive SQLite profile import now covers every dive MacDive itself drew a profile for, on every platform, with `ZRAWDATA` still preferred where it parses because it carries more channels.
 
-`ZSAMPLES` remains NO-GO (AES-encrypted with a per-dive key, documented below) but is now moot: every Shearwater dive that has `ZSAMPLES` also has `ZRAWDATA`.
+The "`ZSAMPLES` remains NO-GO (AES-encrypted with a per-dive key)" conclusion that stood here from 2026-04-23 to 2026-09-02 was wrong; the sections that reached it are retained below, unedited, as a record of how a fixed-key ECB cipher was misread as per-dive AES.
 
 **Second correction (see "Update 2026-09-01" below):** the per-model tables both earlier updates produced are gone. `ZCOMPUTER` is now resolved against libdivecomputer's own descriptor list, so any model it supports is attempted and the result is sanity-checked rather than trusted. Read that section before adding anything model-specific here.
 
 **Correction (see "Update 2026-08-29" below):** the claim in the previous paragraph that "non-Shearwater dives have neither [`ZSAMPLES` nor `ZRAWDATA`] and still need MacDive's XML export" was never actually tested against Suunto computers — the investigation corpus contained none. It turns out at least three Suunto models (EON Steel, EON Steel Black, Cobra) do populate `ZRAWDATA`, and unlike Shearwater's, theirs needs no decompression at all.
 
 The 2026-04-24 "ZRAWDATA pivot invalidated" section below is **historically inaccurate** and is retained only to show how the wrong conclusion was reached.
-**Date:** 2026-04-23 (initial), 2026-04-24 (ZRAWDATA invalidation), 2026-08-09 (ZRAWDATA solved), 2026-08-29 (Suunto ZRAWDATA confirmed), 2026-09-01 (model allowlist removed)
+**Date:** 2026-04-23 (initial), 2026-04-24 (ZRAWDATA invalidation), 2026-08-09 (ZRAWDATA solved), 2026-08-29 (Suunto ZRAWDATA confirmed), 2026-09-01 (model allowlist removed), 2026-09-02 (ZSAMPLES solved)
 **Author:** Eric Griffin
 **Spec:** `docs/superpowers/specs/2026-04-23-macdive-sqlite-profile-decoding-design.md`
 **Plan:** `docs/superpowers/plans/2026-04-23-macdive-zsamples-phase-1-spike.md`
@@ -624,3 +624,138 @@ bytes (`shearwater_raw_decompressor_test.dart` pins the Dart port against a
 blob generated from the 540-dive corpus). A contributor with a real Suunto
 database can close that gap by following the recipe above; it needs data, not
 a design change.
+
+## Update 2026-09-02: ZSAMPLES solved
+
+The per-dive AES conclusion above was wrong, and it was wrong for a reason
+worth recording: every piece of evidence in the spike was read through the
+assumption that CommonCrypto was the codec. The `CCCryptorCreate` imports the
+spike found belong to minizip's zip-password support (the same symbol table
+carries `createZipFileAtPath:...password:AES:`), and the functions around them
+are minizip's `mz_crypt_apple.c` verbatim, error codes included. The sample
+codec never touches CommonCrypto.
+
+### Where the codec lives
+
+MacDive 2.16.3 keeps it in an Objective-C class, `MDSampleUtils`:
+
+| Selector | Role |
+|---|---|
+| `sampleDataForArrayOfSamples:withOptions:` | encoder |
+| `sampleArrayFromData:` | dispatcher on the version word |
+| `sampleArrayFromDataV2:` | decoder for versions 2 to 4 |
+| `sampleArrayFromDataV1:` | decoder for version 1 |
+| `optionsFromData:` | reads the options word |
+
+`-[MDDive sampleOptions]` supplies the options word from the dive, and
+`-[MDDive samples]` runs the blob through `sampleArrayFromData:` and caches
+the result in an `NSCache`. Two small C functions next to the class do the
+cipher work. Their round function is
+`((v << 4) + k0) ^ (v + sum) ^ ((v >> 5) + k1)` with `sum` stepping by
+`0x9E3779B9` for 32 rounds: classic TEA, not XTEA (XTEA indexes the key by
+`sum`; this does not). The key is four 32-bit words in `__TEXT,__const`:
+
+```
+k0 = 0x00000086   k1 = 0x00000016   k2 = 0x00000080   k3 = 0x00000060
+```
+
+That the cipher is TEA also explains every "structural" observation the spike
+made. TEA has 64-bit blocks, so the "8-byte semi-constant markers" were ECB
+blocks whose plaintext repeated; the 28-byte record does not divide by 8, so
+block alignment alternated between odd and even samples and produced the
+"alternating sync word"; and the dominant `84b90aa09fbb1ecc` body prefix is
+nothing more than the encryption of `(time 0.0, depth 0.0)`, the first record
+of every dive that starts at the surface. The markers did not "transfer across
+dives" because the spike compared depth *buckets*, and identical 8-byte
+plaintext blocks (which need identical float bit patterns across two fields)
+are rare between different dives.
+
+### The format
+
+```text
+offset  size  meaning
+0       4     u32le version: 1, or 2..4 (every blob seen in the wild says 4)
+4       4     u32le options bitmask (versions 2..4 only)
+8       n*8   TEA-ECB ciphertext, a whole number of 8-byte blocks
+```
+
+Decrypt the body under the key above, little-endian words. The plaintext is:
+
+```text
+[records][zero padding to an 8-byte boundary][one more 8-byte block]
+```
+
+and the **last four bytes of the plaintext hold the byte length of the record
+run**. MacDive's encoder allocates `((len + 7) / 8 + 1)` blocks, copies the
+packed records in, stores `len` in the final word, and encrypts; its decoder
+decrypts everything, then reads that word to know where the records stop.
+
+Records are fixed width for a given options word: `time` and `depth` as
+32-bit floats, then one 4-byte field per set option bit, **in this order**
+(which is the encoder's emission order, not bit order):
+
+| Order | Bit | Field | Type | Unit as stored |
+|---:|---:|---|---|---|
+| 1 | 0 | pressure | f32 | diver's display unit (psi or bar) |
+| 2 | 5 | pressure2 (second transmitter) | f32 | same as pressure |
+| 3 | 1 | heart rate | i32 | bpm |
+| 4 | 2 | NDT | i32 | minutes |
+| 5 | 3 | ppO2 | f32 | bar |
+| 6 | 4 | temperature | f32 | Celsius |
+| 7 | 6 | next stop depth | f32 | metres |
+| 8 | 7 | TTS | i32 | minutes |
+
+Only bits 0 to 7 are consulted. The stride is therefore `8 + 4 * popcount(options & 0xFF)`,
+which is exactly the 12/16/20/24/28 ladder the spike measured: the five
+options words in the reference library are 16, 24, 25, 156 and 157.
+
+Depth and temperature are SI like every other Core Data column of that kind;
+pressure follows the display unit like `ZTANKANDGAS.ZAIRSTART` does, so the
+same `MacDiveUnitConverter.coreData` handles both. A zero pressure, ppO2 or
+heart rate is MacDive's "no reading".
+
+Version 1 has no options word and no encryption: after the 4-byte version
+come 24-byte records of time, depth, pressure (f32), NDT (i32), ppO2 (f32)
+and temperature (f32). No version 1 blob exists in the reference library; the
+decoder supports it because the MacDive binary still does.
+
+### Verification
+
+Against the 540-dive reference library and MacDive's own exports of it:
+
+- All 350 `ZSAMPLES` blobs decode; the length trailer and stride checks pass
+  on every one. Two blobs are the 16-byte header-plus-length-block form of an
+  empty sample array.
+- Depth and time match the UDDF export sample-for-sample on all 348 non-empty
+  dives once the export's own additions are discounted: MacDive's UDDF writer
+  prepends a synthetic `(0 s, 0 m)` point when a dive's first sample is below
+  the surface and appends one after the last sample when the dive ends below
+  it. That accounts for exactly the 1-2 extra waypoints on 268 dives.
+- Temperature matches the UDDF Kelvin values (as Celsius) on every dive that
+  carries it; pressure matches the XML export's psi on all 257 dives with bit
+  0; NDT matches the XML export's minutes on all 268 dives with bit 2; ppO2
+  matches on all 340 dives with bit 3.
+- An independent Python encoder built from the disassembly reproduces real
+  ciphertext byte for byte; the Dart decoder's fixtures come from it.
+
+TTS, heart rate, second-transmitter pressure and next-stop depth appear in no
+export MacDive produces, so their units are read from the decoder's setter
+types and value ranges (TTS 0 to 9 on recreational dives, so minutes) rather
+than cross-checked against ground truth.
+
+### Where it landed
+
+- `lib/features/universal_import/data/services/tea_block_cipher.dart`
+- `lib/features/universal_import/data/services/macdive_samples_decoder.dart`
+- `lib/features/universal_import/data/services/macdive_sqlite_sample.dart`
+- `MacDiveDiveMapper._attachSamples`, the fallback behind the `ZRAWDATA`
+  path. The raw download keeps precedence because libdivecomputer yields
+  channels `ZSAMPLES` never carries (per-cell ppO2, deco settings, events);
+  the samples cover every dive without usable raw bytes and every platform
+  without the native channel. The "MacDive format Submersion cannot read"
+  warning is gone; only a dive with unreadable bytes in both columns is
+  reported.
+
+The ratio of the two columns in the reference library: 267 dives have both,
+83 have only `ZSAMPLES`, and 190 have neither. Those 83 were the entire
+"needs the XML export" population and no longer are.

--- a/docs/import-formats/macdive-zsamples.md
+++ b/docs/import-formats/macdive-zsamples.md
@@ -714,6 +714,34 @@ pressure follows the display unit like `ZTANKANDGAS.ZAIRSTART` does, so the
 same `MacDiveUnitConverter.coreData` handles both. A zero pressure, ppO2 or
 heart rate is MacDive's "no reading".
 
+Following the display unit means these pressures inherit #912 whole: a library
+with no `SystemOfUnits` row resolves by inference, and a library that also
+records no cylinders used to give the inference nothing to work with, so psi
+passed through as bar. The sample pressures are themselves a strong witness
+(the same 600 ceiling separates 200-300 bar from 2400-3500 psi), so
+`MacDiveUnitInference` reads them as its last tier, after the cylinder columns
+that cost nothing to look at. Decoding costs a TEA pass per dive, so the scan
+stops at `sampleScanDiveLimit` dives or at the first reading that can only be
+psi. That bound leaves `unknown` reachable for a library whose only pressures
+sit past it, and there `_samplePoint` drops the pressure channel rather than
+charting a number it cannot place - the dive keeps every other channel, and
+before ZSAMPLES were readable it had none of them.
+
+### Failing closed
+
+The structural checks (version word in range, body a whole number of cipher
+blocks, a length trailer inside the buffer and divisible by the stride) do not
+prove the stride itself is right. A future record layout stamped with a
+version this decoder claims, or an options bit above the low byte that a newer
+encoder emits a field for, would misalign every read while still dividing the
+run. Fields read at the wrong offset are floats built from unrelated bytes, so
+the decoder also holds each record's time and depth to the bounds
+`RawProfileSanityCheck` applies on the raw path (-3 to 350 m, 0 to 24 h) and
+returns null for the whole blob otherwise. The upper bound on time does double
+duty: Dart's `double.round()` saturates at the int64 limit instead of throwing,
+so an unbounded huge time would multiply out into a negative `Duration` rather
+than an obviously wrong one.
+
 Version 1 has no options word and no encryption: after the 4-byte version
 come 24-byte records of time, depth, pressure (f32), NDT (i32), ppO2 (f32)
 and temperature (f32). No version 1 blob exists in the reference library; the
@@ -755,6 +783,14 @@ than cross-checked against ground truth.
   without the native channel. The "MacDive format Submersion cannot read"
   warning is gone; only a dive with unreadable bytes in both columns is
   reported.
+
+  It reports a `_SamplesOutcome` rather than a bool because an empty sample
+  array is MacDive saying it drew no profile, which is the whole story only
+  when `ZSAMPLES` was the dive's only source. A dive whose raw parse was
+  rejected and whose `ZSAMPLES` is empty still lost a profile, and it is
+  counted: toward the platform warning when the native channel was never
+  reachable (an XML export cannot rescue what MacDive never drew), toward the
+  XML-export warning otherwise.
 
 The ratio of the two columns in the reference library: 267 dives have both,
 83 have only `ZSAMPLES`, and 190 have neither. Those 83 were the entire

--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -11,6 +11,8 @@ import 'package:submersion/features/universal_import/data/models/import_payload.
 import 'package:submersion/features/universal_import/data/models/import_warning.dart';
 import 'package:submersion/features/universal_import/data/services/dive_computer_descriptor_index.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_raw_types.dart';
+import 'package:submersion/features/universal_import/data/services/macdive_samples_decoder.dart';
+import 'package:submersion/features/universal_import/data/services/macdive_sqlite_sample.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_unit_converter.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_unit_inference.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_value_mapper.dart';
@@ -71,9 +73,14 @@ typedef MacDiveRawPrePass = Uint8List? Function(Uint8List raw);
 ///
 /// Not every dive has `ZRAWDATA` at all: presence tracks how the dive entered
 /// MacDive (a native download versus manual entry or a file import) rather
-/// than the vendor. `ZSAMPLES` is AES-encrypted with a per-dive key and
-/// remains undecodable, but where a dive has both columns the `ZRAWDATA` one
-/// is the readable one.
+/// than the vendor. Every dive MacDive ever drew a profile for does have
+/// `ZSAMPLES`, its own copy of that profile, which [MacDiveSamplesDecoder]
+/// reads without the platform channel. It carries fewer channels than the raw
+/// download (no per-cell ppO2, no deco settings, no events), so it is the
+/// fallback rather than the first choice: a dive lands on it when it has no
+/// `ZRAWDATA`, when the raw parse is rejected, or when this platform cannot
+/// reach libdivecomputer at all. Only a dive with profile bytes in neither
+/// readable form counts toward the aggregated warning.
 class MacDiveDiveMapper {
   const MacDiveDiveMapper._();
 
@@ -152,71 +159,44 @@ class MacDiveDiveMapper {
         converter,
         multiDiver: diverNames.length > 1,
       );
+      var attached = false;
       if (ffiAvailable && _hasRawProfile(d)) {
         try {
-          if (!await _attachProfile(d, map, parse, descriptors)) undecoded++;
+          attached = await _attachProfile(d, map, parse, descriptors);
         } on MissingPluginException {
           ffiAvailable = false;
         } on PlatformException catch (e) {
           if (e.code == 'UNSUPPORTED' || e.code == 'channel-error') {
             ffiAvailable = false;
-          } else {
-            undecoded++;
           }
         } catch (_) {
           // A single corrupt blob must not abort a 500-dive import.
-          undecoded++;
         }
-      } else if (_hasRawProfile(d)) {
-        undecoded++;
       }
+      // Whatever kept the raw download from producing a profile, MacDive's
+      // own copy of the samples is still there to read.
+      if (!attached) attached = _attachSamples(d, map, converter);
+      if (!attached && _hasProfileBytes(d)) undecoded++;
       diveMaps.add(map);
     }
 
-    // Aggregated warnings, one per cause, so a 500-dive import does not
-    // produce 500 identical summary lines.
-    if (!ffiAvailable) {
-      warnings.add(
-        const ImportWarning(
-          severity: ImportWarningSeverity.info,
-          message:
-              'Dive profiles could not be decoded on this platform. Dive '
-              'details were imported without depth profiles.',
-          entityType: ImportEntityType.dives,
-        ),
-      );
-    } else if (undecoded > 0) {
+    // One aggregated warning, so a 500-dive import does not produce 500
+    // identical summary lines. Its wording depends on why: with no platform
+    // channel the raw downloads were never tried, whereas with one they were
+    // tried and rejected, and then MacDive's own samples could not be read
+    // either, which is the case the XML export can still rescue.
+    if (undecoded > 0) {
       warnings.add(
         ImportWarning(
           severity: ImportWarningSeverity.info,
-          message:
-              '$undecoded dive(s) had profile data Submersion could not '
-              'decode. To import those profiles, export from MacDive as XML '
-              '(File > Export > MacDive XML) and import that file instead.',
-          entityType: ImportEntityType.dives,
-        ),
-      );
-    }
-
-    // Dives that MacDive did not download itself - manual entries and file
-    // imports - keep their samples only in the encrypted ZSAMPLES column, so
-    // there is nothing to decode for them regardless of which computer they
-    // name.
-    final encryptedOnly = logbook.dives
-        .where(
-          (d) =>
-              (d.samplesBlob?.isNotEmpty ?? false) &&
-              !(d.rawDataBlob?.isNotEmpty ?? false),
-        )
-        .length;
-    if (encryptedOnly > 0) {
-      warnings.add(
-        ImportWarning(
-          severity: ImportWarningSeverity.info,
-          message:
-              '$encryptedOnly dive(s) store their profile in a MacDive format '
-              'Submersion cannot read. Export those from MacDive as XML '
-              '(File > Export > MacDive XML) to import their profiles.',
+          message: ffiAvailable
+              ? '$undecoded dive(s) had profile data Submersion could not '
+                    'decode. To import those profiles, export from MacDive '
+                    'as XML (File > Export > MacDive XML) and import that '
+                    'file instead.'
+              : '$undecoded dive(s) had dive computer data that could not be '
+                    'decoded on this platform. Their details were imported '
+                    'without depth profiles.',
           entityType: ImportEntityType.dives,
         ),
       );
@@ -309,6 +289,80 @@ class MacDiveDiveMapper {
 
   static bool _hasRawProfile(MacDiveRawDive d) =>
       d.rawDataBlob != null && d.rawDataBlob!.isNotEmpty;
+
+  static bool _hasSamples(MacDiveRawDive d) =>
+      d.samplesBlob != null && d.samplesBlob!.isNotEmpty;
+
+  /// Whether the dive stores a profile in either column, i.e. whether ending
+  /// up without one is worth telling the user about.
+  static bool _hasProfileBytes(MacDiveRawDive d) =>
+      _hasRawProfile(d) || _hasSamples(d);
+
+  /// Decodes [d]'s `ZSAMPLES` into profile samples on [map]. Returns false
+  /// when the column is absent or unreadable. An empty sample array is a
+  /// successful decode of a dive MacDive itself shows no profile for, so it
+  /// returns true and attaches nothing.
+  static bool _attachSamples(
+    MacDiveRawDive d,
+    Map<String, dynamic> map,
+    MacDiveUnitConverter converter,
+  ) {
+    if (!_hasSamples(d)) return false;
+    final samples = MacDiveSamplesDecoder.decode(d.samplesBlob!);
+    if (samples == null) return false;
+    if (samples.isEmpty) return true;
+
+    map['profile'] = [for (final s in samples) _samplePoint(s, converter)];
+    // As with the raw path, MacDive's scalar fields win where it has them.
+    final maxDepth = samples
+        .map((s) => s.depthMeters)
+        .reduce((a, b) => a > b ? a : b);
+    if (maxDepth > 0) map['maxDepth'] ??= maxDepth;
+    final temps = samples
+        .map((s) => s.temperatureCelsius)
+        .whereType<double>()
+        .toList();
+    if (temps.isNotEmpty) {
+      map['waterTemp'] ??= temps.reduce((a, b) => a < b ? a : b);
+    }
+    final last = samples.last.time;
+    if (last > Duration.zero) map['runtime'] ??= last;
+    return true;
+  }
+
+  /// One profile point in the shape `UddfEntityImporter` reads, matching the
+  /// keys `MacDiveXmlParser` emits for the same fields. Pressures come out of
+  /// the column in the diver's display unit, like the tank columns, so they
+  /// go through [converter]; depth and temperature are already SI. A zero
+  /// pressure, ppO2 or heart rate is MacDive's "no reading" and is left out
+  /// rather than charted as a real value.
+  static Map<String, dynamic> _samplePoint(
+    MacDiveSqliteSample s,
+    MacDiveUnitConverter converter,
+  ) {
+    final point = <String, dynamic>{
+      'timestamp': s.time.inSeconds,
+      'depth': s.depthMeters,
+    };
+    if (s.temperatureCelsius != null) {
+      point['temperature'] = s.temperatureCelsius;
+    }
+    final pressures = <Map<String, dynamic>>[
+      for (final (index, raw) in [s.pressure, s.pressure2].indexed)
+        if (raw != null && raw > 0)
+          {'pressure': converter.pressureToBar(raw), 'tankIndex': index},
+    ];
+    if (pressures.isNotEmpty) point['allTankPressures'] = pressures;
+    if (s.ppO2 != null && s.ppO2! > 0) point['ppO2'] = s.ppO2;
+    if (s.heartRate != null && s.heartRate! > 0) {
+      point['heartRate'] = s.heartRate;
+    }
+    if (s.ndtMinutes != null) point['ndl'] = s.ndtMinutes! * 60;
+    if (s.ttsMinutes != null) point['tts'] = s.ttsMinutes! * 60;
+    final stop = s.nextStopDepthMeters;
+    if (stop != null && stop > 0) point['ceiling'] = stop;
+    return point;
+  }
 
   /// Vendors whose `ZRAWDATA` is not yet in the layout libdivecomputer's
   /// parsers read, keyed by the descriptor vendor name.

--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -335,13 +335,15 @@ class MacDiveDiveMapper {
   /// the column in the diver's display unit, like the tank columns, so they
   /// go through [converter]; depth and temperature are already SI. A zero
   /// pressure, ppO2 or heart rate is MacDive's "no reading" and is left out
-  /// rather than charted as a real value.
+  /// rather than charted as a real value. Profile points carry whole seconds
+  /// app-wide, so a fractional sample time (none exist in the reference
+  /// library) lands on its nearest second rather than the one before it.
   static Map<String, dynamic> _samplePoint(
     MacDiveSqliteSample s,
     MacDiveUnitConverter converter,
   ) {
     final point = <String, dynamic>{
-      'timestamp': s.time.inSeconds,
+      'timestamp': (s.time.inMilliseconds / 1000).round(),
       'depth': s.depthMeters,
     };
     if (s.temperatureCelsius != null) {

--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -325,12 +325,21 @@ class MacDiveDiveMapper {
     if (temps.isNotEmpty) {
       map['waterTemp'] ??= temps.reduce((a, b) => a < b ? a : b);
     }
-    // The latest stamp rather than the last record: the decoder reports what
-    // MacDive stored, and one library is known to hold a backwards step.
+    // The latest stamp rather than the last record, rounded like the points
+    // are. Records stay in stored order: the one backwards step in the
+    // reference library is a second descent whose clock restarts after a
+    // surfacing, and sorting it would interleave the two segments into a
+    // zigzag where MacDive draws them one after the other.
     final end = samples.map((s) => s.time).reduce((a, b) => a > b ? a : b);
-    if (end > Duration.zero) map['runtime'] ??= end;
+    if (end > Duration.zero) {
+      map['runtime'] ??= Duration(seconds: _wholeSeconds(end));
+    }
     return true;
   }
+
+  /// Sample times to the nearest whole second, the resolution profile points
+  /// carry app-wide.
+  static int _wholeSeconds(Duration d) => (d.inMilliseconds / 1000).round();
 
   /// One profile point in the shape `UddfEntityImporter` reads, matching the
   /// keys `MacDiveXmlParser` emits for the same fields. Pressures come out of
@@ -345,7 +354,7 @@ class MacDiveDiveMapper {
     MacDiveUnitConverter converter,
   ) {
     final point = <String, dynamic>{
-      'timestamp': (s.time.inMilliseconds / 1000).round(),
+      'timestamp': _wholeSeconds(s.time),
       'depth': s.depthMeters,
     };
     if (s.temperatureCelsius != null) {

--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -126,7 +126,12 @@ class MacDiveDiveMapper {
     // Once the platform channel reports it is unavailable there is no point
     // retrying it for the remaining 500 dives.
     var ffiAvailable = true;
-    var undecoded = 0;
+    // Dives that end up without a profile, split by what the user can do
+    // about it: bytes that were read and rejected (the XML export can still
+    // rescue those) versus a raw download this platform could not attempt on
+    // a dive with nothing else to read.
+    var unreadable = 0;
+    var platformBlocked = 0;
 
     // The descriptor list is a static table inside libdivecomputer, identical
     // for every dive, so it is read once per import rather than once per dive.
@@ -176,27 +181,38 @@ class MacDiveDiveMapper {
       // Whatever kept the raw download from producing a profile, MacDive's
       // own copy of the samples is still there to read.
       if (!attached) attached = _attachSamples(d, map, converter);
-      if (!attached && _hasProfileBytes(d)) undecoded++;
+      if (!attached && _hasProfileBytes(d)) {
+        if (!ffiAvailable && _hasRawProfile(d) && !_hasSamples(d)) {
+          platformBlocked++;
+        } else {
+          unreadable++;
+        }
+      }
       diveMaps.add(map);
     }
 
-    // One aggregated warning, so a 500-dive import does not produce 500
-    // identical summary lines. Its wording depends on why: with no platform
-    // channel the raw downloads were never tried, whereas with one they were
-    // tried and rejected, and then MacDive's own samples could not be read
-    // either, which is the case the XML export can still rescue.
-    if (undecoded > 0) {
+    // Aggregated warnings, one per cause, so a 500-dive import does not
+    // produce 500 identical summary lines.
+    if (unreadable > 0) {
       warnings.add(
         ImportWarning(
           severity: ImportWarningSeverity.info,
-          message: ffiAvailable
-              ? '$undecoded dive(s) had profile data Submersion could not '
-                    'decode. To import those profiles, export from MacDive '
-                    'as XML (File > Export > MacDive XML) and import that '
-                    'file instead.'
-              : '$undecoded dive(s) had dive computer data that could not be '
-                    'decoded on this platform. Their details were imported '
-                    'without depth profiles.',
+          message:
+              '$unreadable dive(s) had profile data Submersion could not '
+              'decode. To import those profiles, export from MacDive as XML '
+              '(File > Export > MacDive XML) and import that file instead.',
+          entityType: ImportEntityType.dives,
+        ),
+      );
+    }
+    if (platformBlocked > 0) {
+      warnings.add(
+        ImportWarning(
+          severity: ImportWarningSeverity.info,
+          message:
+              '$platformBlocked dive(s) had dive computer data that could '
+              'not be decoded on this platform. Their details were imported '
+              'without depth profiles.',
           entityType: ImportEntityType.dives,
         ),
       );

--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -325,8 +325,10 @@ class MacDiveDiveMapper {
     if (temps.isNotEmpty) {
       map['waterTemp'] ??= temps.reduce((a, b) => a < b ? a : b);
     }
-    final last = samples.last.time;
-    if (last > Duration.zero) map['runtime'] ??= last;
+    // The latest stamp rather than the last record: the decoder reports what
+    // MacDive stored, and one library is known to hold a backwards step.
+    final end = samples.map((s) => s.time).reduce((a, b) => a > b ? a : b);
+    if (end > Duration.zero) map['runtime'] ??= end;
     return true;
   }
 

--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -313,24 +313,24 @@ class MacDiveDiveMapper {
     if (samples.isEmpty) return true;
 
     map['profile'] = [for (final s in samples) _samplePoint(s, converter)];
-    // As with the raw path, MacDive's scalar fields win where it has them.
-    final maxDepth = samples
-        .map((s) => s.depthMeters)
-        .reduce((a, b) => a > b ? a : b);
-    if (maxDepth > 0) map['maxDepth'] ??= maxDepth;
-    final temps = samples
-        .map((s) => s.temperatureCelsius)
-        .whereType<double>()
-        .toList();
-    if (temps.isNotEmpty) {
-      map['waterTemp'] ??= temps.reduce((a, b) => a < b ? a : b);
+
+    // Scalars in one pass. Records stay in stored order: the one backwards
+    // step in the reference library is a second descent whose clock restarts
+    // after a surfacing, and sorting it would interleave the two segments
+    // into a zigzag where MacDive draws them one after the other. So the
+    // runtime is the latest stamp rather than the last record's.
+    var maxDepth = 0.0;
+    double? minTemp;
+    var end = Duration.zero;
+    for (final s in samples) {
+      if (s.depthMeters > maxDepth) maxDepth = s.depthMeters;
+      final t = s.temperatureCelsius;
+      if (t != null && (minTemp == null || t < minTemp)) minTemp = t;
+      if (s.time > end) end = s.time;
     }
-    // The latest stamp rather than the last record, rounded like the points
-    // are. Records stay in stored order: the one backwards step in the
-    // reference library is a second descent whose clock restarts after a
-    // surfacing, and sorting it would interleave the two segments into a
-    // zigzag where MacDive draws them one after the other.
-    final end = samples.map((s) => s.time).reduce((a, b) => a > b ? a : b);
+    // As with the raw path, MacDive's scalar fields win where it has them.
+    if (maxDepth > 0) map['maxDepth'] ??= maxDepth;
+    if (minTemp != null) map['waterTemp'] ??= minTemp;
     if (end > Duration.zero) {
       map['runtime'] ??= Duration(seconds: _wholeSeconds(end));
     }

--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -16,6 +16,8 @@ import 'package:submersion/features/universal_import/data/services/macdive_sqlit
 import 'package:submersion/features/universal_import/data/services/macdive_unit_converter.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_unit_inference.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_value_mapper.dart';
+import 'package:submersion/features/universal_import/data/services/macdive_xml_models.dart'
+    show MacDiveUnitSystem;
 import 'package:submersion/features/universal_import/data/services/parsed_dive_profile_mapper.dart';
 import 'package:submersion/features/universal_import/data/services/raw_profile_sanity_check.dart';
 import 'package:submersion/features/universal_import/data/services/shearwater_raw_decompressor.dart';
@@ -38,6 +40,24 @@ typedef MacDiveDescriptorFetchFn =
 /// A transform applied to `ZRAWDATA` before libdivecomputer sees it, returning
 /// null when the bytes are not in the form this vendor's transform expects.
 typedef MacDiveRawPrePass = Uint8List? Function(Uint8List raw);
+
+/// What reading a dive's `ZSAMPLES` column produced.
+///
+/// The distinction the caller needs is between MacDive having no profile for
+/// a dive and MacDive having one this decoder could not read: only the second
+/// is worth telling the user about, and only when the dive has no other
+/// source left.
+enum _SamplesOutcome {
+  /// Profile points were decoded and attached.
+  attached,
+
+  /// The column is absent, or decoded cleanly to zero samples. Either way
+  /// MacDive itself draws no profile for this dive.
+  none,
+
+  /// The column holds bytes this decoder rejected.
+  unreadable,
+}
 
 /// Maps a [MacDiveRawLogbook] (raw SQLite rows read by [MacDiveDbReader])
 /// into a unified [ImportPayload] the rest of the import pipeline consumes
@@ -180,9 +200,21 @@ class MacDiveDiveMapper {
       }
       // Whatever kept the raw download from producing a profile, MacDive's
       // own copy of the samples is still there to read.
-      if (!attached) attached = _attachSamples(d, map, converter);
+      var samples = _SamplesOutcome.none;
+      if (!attached) {
+        samples = _attachSamples(d, map, converter);
+        attached = samples == _SamplesOutcome.attached;
+      }
       if (!attached && _hasProfileBytes(d)) {
-        if (!ffiAvailable && _hasRawProfile(d) && !_hasSamples(d)) {
+        if (samples == _SamplesOutcome.none && !_hasRawProfile(d)) {
+          // MacDive drew no profile for this dive and there was no other
+          // column to try. Nothing was lost, so there is nothing to report.
+        } else if (!ffiAvailable &&
+            _hasRawProfile(d) &&
+            samples == _SamplesOutcome.none) {
+          // The raw download was the only source that could have produced a
+          // profile, and this platform could not attempt it. An XML export
+          // would not help: MacDive has no samples of its own to export.
           platformBlocked++;
         } else {
           unreadable++;
@@ -314,19 +346,22 @@ class MacDiveDiveMapper {
   static bool _hasProfileBytes(MacDiveRawDive d) =>
       _hasRawProfile(d) || _hasSamples(d);
 
-  /// Decodes [d]'s `ZSAMPLES` into profile samples on [map]. Returns false
-  /// when the column is absent or unreadable. An empty sample array is a
-  /// successful decode of a dive MacDive itself shows no profile for, so it
-  /// returns true and attaches nothing.
-  static bool _attachSamples(
+  /// Decodes [d]'s `ZSAMPLES` into profile samples on [map].
+  ///
+  /// An empty sample array is a successful decode of a dive MacDive itself
+  /// shows no profile for, which is why it is [_SamplesOutcome.none] rather
+  /// than a failure - but it is not the same as having a profile, and the
+  /// caller has to know the difference for a dive whose raw download also
+  /// failed.
+  static _SamplesOutcome _attachSamples(
     MacDiveRawDive d,
     Map<String, dynamic> map,
     MacDiveUnitConverter converter,
   ) {
-    if (!_hasSamples(d)) return false;
+    if (!_hasSamples(d)) return _SamplesOutcome.none;
     final samples = MacDiveSamplesDecoder.decode(d.samplesBlob!);
-    if (samples == null) return false;
-    if (samples.isEmpty) return true;
+    if (samples == null) return _SamplesOutcome.unreadable;
+    if (samples.isEmpty) return _SamplesOutcome.none;
 
     map['profile'] = [for (final s in samples) _samplePoint(s, converter)];
 
@@ -350,7 +385,7 @@ class MacDiveDiveMapper {
     if (end > Duration.zero) {
       map['runtime'] ??= Duration(seconds: _wholeSeconds(end));
     }
-    return true;
+    return _SamplesOutcome.attached;
   }
 
   /// Sample times to the nearest whole second, the resolution profile points
@@ -360,7 +395,8 @@ class MacDiveDiveMapper {
   /// One profile point in the shape `UddfEntityImporter` reads, matching the
   /// keys `MacDiveXmlParser` emits for the same fields. Pressures come out of
   /// the column in the diver's display unit, like the tank columns, so they
-  /// go through [converter]; depth and temperature are already SI. A zero
+  /// go through [converter] and are dropped outright when it has no unit
+  /// system to convert from; depth and temperature are already SI. A zero
   /// pressure, ppO2 or heart rate is MacDive's "no reading" and is left out
   /// rather than charted as a real value. Profile points carry whole seconds
   /// app-wide, so a fractional sample time (none exist in the reference
@@ -376,10 +412,18 @@ class MacDiveDiveMapper {
     if (s.temperatureCelsius != null) {
       point['temperature'] = s.temperatureCelsius;
     }
+    // A pressure with no unit system to place it in is worse than no
+    // pressure: passing psi through as bar is #912 on a new column, and a
+    // charted number carries no hint that it might be wrong. MacDive's
+    // sample pressures are themselves a witness the inference reads
+    // ([MacDiveUnitInference]), so unknown here means a library whose only
+    // pressures sit past the end of that bounded scan.
+    final placeable = converter.units != MacDiveUnitSystem.unknown;
     final pressures = <Map<String, dynamic>>[
-      for (final (index, raw) in [s.pressure, s.pressure2].indexed)
-        if (raw != null && raw > 0)
-          {'pressure': converter.pressureToBar(raw), 'tankIndex': index},
+      if (placeable)
+        for (final (index, raw) in [s.pressure, s.pressure2].indexed)
+          if (raw != null && raw > 0)
+            {'pressure': converter.pressureToBar(raw), 'tankIndex': index},
     ];
     if (pressures.isNotEmpty) point['allTankPressures'] = pressures;
     if (s.ppO2 != null && s.ppO2! > 0) point['ppO2'] = s.ppO2;

--- a/lib/features/universal_import/data/services/macdive_samples_decoder.dart
+++ b/lib/features/universal_import/data/services/macdive_samples_decoder.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:submersion/features/universal_import/data/services/macdive_sqlite_sample.dart';
+import 'package:submersion/features/universal_import/data/services/raw_profile_sanity_check.dart';
 import 'package:submersion/features/universal_import/data/services/tea_block_cipher.dart';
 
 /// Decodes MacDive's `ZDIVE.ZSAMPLES` column, the profile MacDive itself
@@ -64,10 +65,10 @@ class MacDiveSamplesDecoder {
   /// corrupt or foreign column never turns into a plausible-looking profile.
   /// An empty list means MacDive stored a profile with no samples.
   ///
-  /// Time and depth must be finite for the blob to be accepted at all. An
-  /// optional field that is not finite is dropped from its sample instead:
-  /// that is a bad reading inside a profile MacDive still displays, not a
-  /// sign the blob is foreign.
+  /// Time and depth must be finite, and inside [_plausible]'s bounds, for the
+  /// blob to be accepted at all. An optional field that is not finite is
+  /// dropped from its sample instead: that is a bad reading inside a profile
+  /// MacDive still displays, not a sign the blob is foreign.
   static List<MacDiveSqliteSample>? decode(Uint8List blob) {
     if (blob.length < 4) return null;
     final version = ByteData.sublistView(blob).getUint32(0, Endian.little);
@@ -101,7 +102,7 @@ class MacDiveSamplesDecoder {
       final record = _RecordReader(plainData, offset, options);
       final time = record.float();
       final depth = record.float();
-      if (!time.isFinite || !depth.isFinite) return null;
+      if (!_plausible(time, depth)) return null;
       // The optional fields, in the order MacDive's encoder emits them,
       // straight from the disassembly. Each read advances only when its bit
       // is set.
@@ -148,7 +149,7 @@ class MacDiveSamplesDecoder {
       final record = _RecordReader(data, offset, 0);
       final time = record.float();
       final depth = record.float();
-      if (!time.isFinite || !depth.isFinite) return null;
+      if (!_plausible(time, depth)) return null;
       samples.add(
         MacDiveSqliteSample(
           time: _duration(time),
@@ -163,6 +164,35 @@ class MacDiveSamplesDecoder {
     return samples;
   }
 
+  /// Whether a record's time and depth are values MacDive could have drawn,
+  /// judged by the same bounds [RawProfileSanityCheck] applies to the raw
+  /// path so the two profile sources agree on what counts as nonsense.
+  ///
+  /// The structural checks above cannot stand alone. They pass any blob whose
+  /// version word is in range and whose record run divides by the stride the
+  /// options word implies, and a stride can be wrong while still dividing:
+  /// a future record layout stamped with a version this decoder claims, or an
+  /// options bit above [_optionMask] that a newer encoder emits a field for.
+  /// Fields read at the wrong offset are floats built from unrelated bytes,
+  /// so they land far outside these bounds rather than near them, which is
+  /// what lets a coarse gate reject them.
+  ///
+  /// The upper bound on time is load-bearing beyond plausibility: Dart's
+  /// [double.round] saturates at the int64 limit instead of throwing, so
+  /// without it [_duration] turns a huge finite time into a *negative*
+  /// Duration rather than failing.
+  static bool _plausible(double time, double depth) {
+    if (!time.isFinite || !depth.isFinite) return false;
+    if (time < 0 ||
+        time > RawProfileSanityCheck.maxPlausibleDuration.inSeconds) {
+      return false;
+    }
+    return depth >= RawProfileSanityCheck.minPlausibleDepthMeters &&
+        depth <= RawProfileSanityCheck.maxPlausibleDepthMeters;
+  }
+
+  /// Safe against overflow only because [_plausible] has already bounded
+  /// [seconds].
   static Duration _duration(double seconds) =>
       Duration(milliseconds: (seconds * 1000).round());
 

--- a/lib/features/universal_import/data/services/macdive_samples_decoder.dart
+++ b/lib/features/universal_import/data/services/macdive_samples_decoder.dart
@@ -23,7 +23,7 @@ import 'package:submersion/features/universal_import/data/services/tea_block_cip
 /// padding and, in the last four bytes of the buffer, the byte length of the
 /// record run. Every record starts with `time` and `depth` as 32-bit floats
 /// and then carries one 4-byte field per set options bit, in the fixed order
-/// [_fieldOrder] lists (which is not bit order).
+/// the reads in [_decodeV2] follow (which is not bit order).
 ///
 /// Version 1 predates the encryption: the same 4-byte version word, then
 /// unencrypted 24-byte records of time, depth, pressure, NDT, ppO2 and
@@ -40,8 +40,8 @@ class MacDiveSamplesDecoder {
   /// build blobs the same way MacDive's encoder does.
   static const cipher = TeaBlockCipher(0x86, 0x16, 0x80, 0x60);
 
-  /// Options bits. The optional fields are written in [_fieldOrder], not in
-  /// bit order, so the bit values matter only for presence.
+  /// Options bits. Presence is all they encode; the fields themselves are
+  /// laid out in the encoder's own order, not in bit order.
   static const int optionPressure = 1 << 0;
   static const int optionHeartRate = 1 << 1;
   static const int optionNdt = 1 << 2;
@@ -55,28 +55,6 @@ class MacDiveSamplesDecoder {
   /// tests bits 0 to 7 and nothing above.
   static const int _optionMask = 0xFF;
 
-  /// The order MacDive's encoder emits the optional fields, straight from
-  /// the disassembly: pressure, second pressure, heart rate, NDT, ppO2,
-  /// temperature, next stop depth, TTS.
-  static const List<int> _fieldOrder = [
-    optionPressure,
-    optionPressure2,
-    optionHeartRate,
-    optionNdt,
-    optionPpO2,
-    optionTemperature,
-    optionNextStopDepth,
-    optionTts,
-  ];
-
-  /// The fields MacDive stores as 32-bit integers; every other field is a
-  /// 32-bit float.
-  static const Set<int> _integerFields = {
-    optionHeartRate,
-    optionNdt,
-    optionTts,
-  };
-
   static const int _headerLength = 8;
   static const int _baseRecordLength = 8;
   static const int _fieldLength = 4;
@@ -85,6 +63,11 @@ class MacDiveSamplesDecoder {
   /// blob this decoder understands or fail its structural checks, so a
   /// corrupt or foreign column never turns into a plausible-looking profile.
   /// An empty list means MacDive stored a profile with no samples.
+  ///
+  /// Time and depth must be finite for the blob to be accepted at all. An
+  /// optional field that is not finite is dropped from its sample instead:
+  /// that is a bad reading inside a profile MacDive still displays, not a
+  /// sign the blob is foreign.
   static List<MacDiveSqliteSample>? decode(Uint8List blob) {
     if (blob.length < 4) return null;
     final version = ByteData.sublistView(blob).getUint32(0, Endian.little);
@@ -107,38 +90,38 @@ class MacDiveSamplesDecoder {
     final length = plainData.getUint32(plain.length - 4, Endian.little);
     if (length > plain.length - 4) return null;
 
-    var stride = _baseRecordLength;
-    for (final field in _fieldOrder) {
-      if ((options & field) != 0) stride += _fieldLength;
-    }
+    final stride = _baseRecordLength + _fieldLength * _bitCount(options);
     if (length % stride != 0) return null;
 
     final samples = <MacDiveSqliteSample>[];
     for (var offset = 0; offset < length; offset += stride) {
-      final reader = _RecordReader(plainData, offset);
-      final time = reader.float();
-      final depth = reader.float();
+      final record = _RecordReader(plainData, offset, options);
+      final time = record.float();
+      final depth = record.float();
       if (!time.isFinite || !depth.isFinite) return null;
-      // Optional fields, keyed by their option bit, read in emission order.
-      final values = <int, num>{
-        for (final field in _fieldOrder)
-          if ((options & field) != 0)
-            field: _integerFields.contains(field)
-                ? reader.int32()
-                : reader.float(),
-      };
+      // The optional fields, in the order MacDive's encoder emits them,
+      // straight from the disassembly. Each read advances only when its bit
+      // is set.
+      final pressure = record.optionalFloat(optionPressure);
+      final pressure2 = record.optionalFloat(optionPressure2);
+      final heartRate = record.optionalInt32(optionHeartRate);
+      final ndt = record.optionalInt32(optionNdt);
+      final ppO2 = record.optionalFloat(optionPpO2);
+      final temperature = record.optionalFloat(optionTemperature);
+      final nextStop = record.optionalFloat(optionNextStopDepth);
+      final tts = record.optionalInt32(optionTts);
       samples.add(
         MacDiveSqliteSample(
           time: _duration(time),
           depthMeters: depth,
-          pressure: values[optionPressure] as double?,
-          pressure2: values[optionPressure2] as double?,
-          heartRate: values[optionHeartRate] as int?,
-          ndtMinutes: values[optionNdt] as int?,
-          ppO2: values[optionPpO2] as double?,
-          temperatureCelsius: values[optionTemperature] as double?,
-          nextStopDepthMeters: values[optionNextStopDepth] as double?,
-          ttsMinutes: values[optionTts] as int?,
+          pressure: pressure,
+          pressure2: pressure2,
+          heartRate: heartRate,
+          ndtMinutes: ndt,
+          ppO2: ppO2,
+          temperatureCelsius: temperature,
+          nextStopDepthMeters: nextStop,
+          ttsMinutes: tts,
         ),
       );
     }
@@ -159,18 +142,18 @@ class MacDiveSamplesDecoder {
       offset + _v1RecordLength <= blob.length;
       offset += _v1RecordLength
     ) {
-      final reader = _RecordReader(data, offset);
-      final time = reader.float();
-      final depth = reader.float();
+      final record = _RecordReader(data, offset, 0);
+      final time = record.float();
+      final depth = record.float();
       if (!time.isFinite || !depth.isFinite) return null;
       samples.add(
         MacDiveSqliteSample(
           time: _duration(time),
           depthMeters: depth,
-          pressure: reader.float(),
-          ndtMinutes: reader.int32(),
-          ppO2: reader.float(),
-          temperatureCelsius: reader.float(),
+          pressure: record.finiteFloat(),
+          ndtMinutes: record.int32(),
+          ppO2: record.finiteFloat(),
+          temperatureCelsius: record.finiteFloat(),
         ),
       );
     }
@@ -179,13 +162,23 @@ class MacDiveSamplesDecoder {
 
   static Duration _duration(double seconds) =>
       Duration(milliseconds: (seconds * 1000).round());
+
+  /// Number of set bits in [v]; one 4-byte field per set option bit.
+  static int _bitCount(int v) {
+    var count = 0;
+    for (var rest = v; rest != 0; rest &= rest - 1) {
+      count++;
+    }
+    return count;
+  }
 }
 
 /// Sequential little-endian reads through one record.
 class _RecordReader {
-  _RecordReader(this._data, this._offset);
+  _RecordReader(this._data, this._offset, this._options);
 
   final ByteData _data;
+  final int _options;
   int _offset;
 
   double float() {
@@ -199,4 +192,17 @@ class _RecordReader {
     _offset += 4;
     return v;
   }
+
+  /// A float that is null when it is not a number MacDive could have shown.
+  double? finiteFloat() {
+    final v = float();
+    return v.isFinite ? v : null;
+  }
+
+  /// Reads a float only when [bit] is set in the record's options word.
+  double? optionalFloat(int bit) =>
+      (_options & bit) != 0 ? finiteFloat() : null;
+
+  /// Reads an int only when [bit] is set in the record's options word.
+  int? optionalInt32(int bit) => (_options & bit) != 0 ? int32() : null;
 }

--- a/lib/features/universal_import/data/services/macdive_samples_decoder.dart
+++ b/lib/features/universal_import/data/services/macdive_samples_decoder.dart
@@ -102,7 +102,7 @@ class MacDiveSamplesDecoder {
 
     var stride = _baseRecordLength;
     for (final field in _fieldOrder) {
-      if (options & field != 0) stride += _fieldLength;
+      if ((options & field) != 0) stride += _fieldLength;
     }
     if (length % stride != 0) return null;
 
@@ -121,7 +121,7 @@ class MacDiveSamplesDecoder {
       double? nextStop;
       int? tts;
       for (final field in _fieldOrder) {
-        if (options & field == 0) continue;
+        if ((options & field) == 0) continue;
         switch (field) {
           case optionPressure:
             pressure = reader.float();

--- a/lib/features/universal_import/data/services/macdive_samples_decoder.dart
+++ b/lib/features/universal_import/data/services/macdive_samples_decoder.dart
@@ -88,7 +88,10 @@ class MacDiveSamplesDecoder {
     final plain = cipher.decrypt(body);
     final plainData = ByteData.sublistView(plain);
     final length = plainData.getUint32(plain.length - 4, Endian.little);
-    if (length > plain.length - 4) return null;
+    // The encoder pads the record run to a block boundary and then appends
+    // the block that carries this word, so the run always ends before that
+    // last block starts.
+    if (length > plain.length - TeaBlockCipher.blockSize) return null;
 
     final stride = _baseRecordLength + _fieldLength * _bitCount(options);
     if (length % stride != 0) return null;

--- a/lib/features/universal_import/data/services/macdive_samples_decoder.dart
+++ b/lib/features/universal_import/data/services/macdive_samples_decoder.dart
@@ -1,0 +1,213 @@
+import 'dart:typed_data';
+
+import 'package:submersion/features/universal_import/data/services/macdive_sqlite_sample.dart';
+import 'package:submersion/features/universal_import/data/services/tea_block_cipher.dart';
+
+/// Decodes MacDive's `ZDIVE.ZSAMPLES` column, the profile MacDive itself
+/// draws for a dive.
+///
+/// The layout was recovered from MacDive 2.16.3's `MDSampleUtils` class
+/// (`sampleDataForArrayOfSamples:withOptions:` writes it,
+/// `sampleArrayFromDataV2:` reads it) and verified sample-for-sample against
+/// MacDive's own UDDF and XML exports of a 540-dive library; see
+/// `docs/import-formats/macdive-zsamples.md`.
+///
+/// ```text
+/// u32le version   1, or 2..4 (every blob seen in the wild says 4)
+/// u32le options   bitmask of the optional per-sample fields present
+/// bytes body      TEA-ECB ciphertext, a whole number of 8-byte blocks
+/// ```
+///
+/// The body decrypts under [cipher], whose key is a constant in the MacDive
+/// binary, to a run of fixed-width little-endian records followed by zero
+/// padding and, in
+/// the last four bytes of the buffer, the byte length of the record run.
+/// Every record starts with `time` and `depth` as 32-bit floats and then
+/// carries one 4-byte field per set options bit, in the fixed order
+/// [_fieldOrder] lists (which is not bit order).
+///
+/// Version 1 predates the encryption: the same 4-byte version word, then
+/// unencrypted 24-byte records of time, depth, pressure, NDT, ppO2 and
+/// temperature with no options word.
+///
+/// An earlier investigation concluded the column was AES under a per-dive
+/// key. It is not: the "per-dive markers" it saw were ECB blocks of a fixed
+/// key whose plaintext happened to repeat within a dive, and the CommonCrypto
+/// imports it found belong to the app's zip-archive password support.
+class MacDiveSamplesDecoder {
+  const MacDiveSamplesDecoder._();
+
+  /// TEA under the four key words MacDive compiles in. Public so tests can
+  /// build blobs the same way MacDive's encoder does.
+  static const cipher = TeaBlockCipher(0x86, 0x16, 0x80, 0x60);
+
+  /// Options bits. The optional fields are written in [_fieldOrder], not in
+  /// bit order, so the bit values matter only for presence.
+  static const int optionPressure = 1 << 0;
+  static const int optionHeartRate = 1 << 1;
+  static const int optionNdt = 1 << 2;
+  static const int optionPpO2 = 1 << 3;
+  static const int optionTemperature = 1 << 4;
+  static const int optionPressure2 = 1 << 5;
+  static const int optionNextStopDepth = 1 << 6;
+  static const int optionTts = 1 << 7;
+
+  /// Only the low byte of the options word selects fields; MacDive's decoder
+  /// tests bits 0 to 7 and nothing above.
+  static const int _optionMask = 0xFF;
+
+  /// The order MacDive's encoder emits the optional fields, straight from
+  /// the disassembly: pressure, second pressure, heart rate, NDT, ppO2,
+  /// temperature, next stop depth, TTS.
+  static const List<int> _fieldOrder = [
+    optionPressure,
+    optionPressure2,
+    optionHeartRate,
+    optionNdt,
+    optionPpO2,
+    optionTemperature,
+    optionNextStopDepth,
+    optionTts,
+  ];
+
+  static const int _headerLength = 8;
+  static const int _baseRecordLength = 8;
+  static const int _fieldLength = 4;
+
+  /// Decodes [blob]. Returns null when the bytes are not a MacDive sample
+  /// blob this decoder understands or fail its structural checks, so a
+  /// corrupt or foreign column never turns into a plausible-looking profile.
+  /// An empty list means MacDive stored a profile with no samples.
+  static List<MacDiveSqliteSample>? decode(Uint8List blob) {
+    if (blob.length < 4) return null;
+    final version = ByteData.sublistView(blob).getUint32(0, Endian.little);
+    if (version == 1) return _decodeV1(blob);
+    if (version < 2 || version > 4) return null;
+    return _decodeV2(blob);
+  }
+
+  static List<MacDiveSqliteSample>? _decodeV2(Uint8List blob) {
+    if (blob.length < _headerLength) return null;
+    final options =
+        ByteData.sublistView(blob).getUint32(4, Endian.little) & _optionMask;
+    final body = Uint8List.sublistView(blob, _headerLength);
+    if (body.isEmpty || body.length % TeaBlockCipher.blockSize != 0) {
+      return null;
+    }
+
+    final plain = cipher.decrypt(body);
+    final plainData = ByteData.sublistView(plain);
+    final length = plainData.getUint32(plain.length - 4, Endian.little);
+    if (length > plain.length - 4) return null;
+
+    var stride = _baseRecordLength;
+    for (final field in _fieldOrder) {
+      if (options & field != 0) stride += _fieldLength;
+    }
+    if (length % stride != 0) return null;
+
+    final samples = <MacDiveSqliteSample>[];
+    for (var offset = 0; offset < length; offset += stride) {
+      final reader = _RecordReader(plainData, offset);
+      final time = reader.float();
+      final depth = reader.float();
+      if (!time.isFinite || !depth.isFinite) return null;
+      double? pressure;
+      double? pressure2;
+      int? heartRate;
+      int? ndt;
+      double? ppO2;
+      double? temperature;
+      double? nextStop;
+      int? tts;
+      for (final field in _fieldOrder) {
+        if (options & field == 0) continue;
+        switch (field) {
+          case optionPressure:
+            pressure = reader.float();
+          case optionPressure2:
+            pressure2 = reader.float();
+          case optionHeartRate:
+            heartRate = reader.int32();
+          case optionNdt:
+            ndt = reader.int32();
+          case optionPpO2:
+            ppO2 = reader.float();
+          case optionTemperature:
+            temperature = reader.float();
+          case optionNextStopDepth:
+            nextStop = reader.float();
+          case optionTts:
+            tts = reader.int32();
+        }
+      }
+      samples.add(
+        MacDiveSqliteSample(
+          time: _duration(time),
+          depthMeters: depth,
+          pressure: pressure,
+          pressure2: pressure2,
+          heartRate: heartRate,
+          ndtMinutes: ndt,
+          ppO2: ppO2,
+          temperatureCelsius: temperature,
+          nextStopDepthMeters: nextStop,
+          ttsMinutes: tts,
+        ),
+      );
+    }
+    return samples;
+  }
+
+  static const int _v1HeaderLength = 4;
+  static const int _v1RecordLength = 24;
+
+  static List<MacDiveSqliteSample>? _decodeV1(Uint8List blob) {
+    final data = ByteData.sublistView(blob);
+    final samples = <MacDiveSqliteSample>[];
+    for (
+      var offset = _v1HeaderLength;
+      offset + _v1RecordLength <= blob.length;
+      offset += _v1RecordLength
+    ) {
+      final reader = _RecordReader(data, offset);
+      final time = reader.float();
+      final depth = reader.float();
+      if (!time.isFinite || !depth.isFinite) return null;
+      samples.add(
+        MacDiveSqliteSample(
+          time: _duration(time),
+          depthMeters: depth,
+          pressure: reader.float(),
+          ndtMinutes: reader.int32(),
+          ppO2: reader.float(),
+          temperatureCelsius: reader.float(),
+        ),
+      );
+    }
+    return samples;
+  }
+
+  static Duration _duration(double seconds) =>
+      Duration(milliseconds: (seconds * 1000).round());
+}
+
+/// Sequential little-endian reads through one record.
+class _RecordReader {
+  _RecordReader(this._data, this._offset);
+
+  final ByteData _data;
+  int _offset;
+
+  double float() {
+    final v = _data.getFloat32(_offset, Endian.little);
+    _offset += 4;
+    return v;
+  }
+
+  int int32() {
+    final v = _data.getInt32(_offset, Endian.little);
+    _offset += 4;
+    return v;
+  }
+}

--- a/lib/features/universal_import/data/services/macdive_samples_decoder.dart
+++ b/lib/features/universal_import/data/services/macdive_samples_decoder.dart
@@ -56,6 +56,21 @@ class MacDiveSamplesDecoder {
   /// tests bits 0 to 7 and nothing above.
   static const int _optionMask = 0xFF;
 
+  /// Ranges the integer fields must fall inside to be kept.
+  ///
+  /// Time and depth being plausible does not make the rest of a record so: a
+  /// stride wrong by one field shifts every later read, and an int32 built
+  /// from unrelated bytes is typically huge or negative. Unlike a bad time or
+  /// depth these do not condemn the blob, because the same thing happens for
+  /// an ordinary bad reading, but they must not reach the mapper - which
+  /// multiplies [MacDiveSqliteSample.ndtMinutes] and
+  /// [MacDiveSqliteSample.ttsMinutes] into seconds with no sign check of its
+  /// own. Zero stays a value here; "no reading" is the mapper's judgement to
+  /// make.
+  static const int _maxHeartRateBpm = 300;
+  static final int _maxFieldMinutes =
+      RawProfileSanityCheck.maxPlausibleDuration.inMinutes;
+
   static const int _headerLength = 8;
   static const int _baseRecordLength = 8;
   static const int _fieldLength = 4;
@@ -66,9 +81,10 @@ class MacDiveSamplesDecoder {
   /// An empty list means MacDive stored a profile with no samples.
   ///
   /// Time and depth must be finite, and inside [_plausible]'s bounds, for the
-  /// blob to be accepted at all. An optional field that is not finite is
-  /// dropped from its sample instead: that is a bad reading inside a profile
-  /// MacDive still displays, not a sign the blob is foreign.
+  /// blob to be accepted at all. An optional field that is not finite, or an
+  /// integer field outside the range its quantity can take, is dropped from
+  /// its sample instead: that is a bad reading inside a profile MacDive still
+  /// displays, not a sign the blob is foreign.
   static List<MacDiveSqliteSample>? decode(Uint8List blob) {
     if (blob.length < 4) return null;
     final version = ByteData.sublistView(blob).getUint32(0, Endian.little);
@@ -108,12 +124,12 @@ class MacDiveSamplesDecoder {
       // is set.
       final pressure = record.optionalFloat(optionPressure);
       final pressure2 = record.optionalFloat(optionPressure2);
-      final heartRate = record.optionalInt32(optionHeartRate);
-      final ndt = record.optionalInt32(optionNdt);
+      final heartRate = record.optionalInt32(optionHeartRate, _maxHeartRateBpm);
+      final ndt = record.optionalInt32(optionNdt, _maxFieldMinutes);
       final ppO2 = record.optionalFloat(optionPpO2);
       final temperature = record.optionalFloat(optionTemperature);
       final nextStop = record.optionalFloat(optionNextStopDepth);
-      final tts = record.optionalInt32(optionTts);
+      final tts = record.optionalInt32(optionTts, _maxFieldMinutes);
       samples.add(
         MacDiveSqliteSample(
           time: _duration(time),
@@ -155,7 +171,7 @@ class MacDiveSamplesDecoder {
           time: _duration(time),
           depthMeters: depth,
           pressure: record.finiteFloat(),
-          ndtMinutes: record.int32(),
+          ndtMinutes: record.boundedInt32(_maxFieldMinutes),
           ppO2: record.finiteFloat(),
           temperatureCelsius: record.finiteFloat(),
         ),
@@ -226,6 +242,13 @@ class _RecordReader {
     return v;
   }
 
+  /// An int that is null when it falls outside 0 to [max], the counterpart of
+  /// [finiteFloat] for the integer fields.
+  int? boundedInt32(int max) {
+    final v = int32();
+    return v >= 0 && v <= max ? v : null;
+  }
+
   /// A float that is null when it is not a number MacDive could have shown.
   double? finiteFloat() {
     final v = float();
@@ -236,6 +259,8 @@ class _RecordReader {
   double? optionalFloat(int bit) =>
       (_options & bit) != 0 ? finiteFloat() : null;
 
-  /// Reads an int only when [bit] is set in the record's options word.
-  int? optionalInt32(int bit) => (_options & bit) != 0 ? int32() : null;
+  /// Reads an int only when [bit] is set in the record's options word,
+  /// keeping it only when it falls inside 0 to [max].
+  int? optionalInt32(int bit, int max) =>
+      (_options & bit) != 0 ? boundedInt32(max) : null;
 }

--- a/lib/features/universal_import/data/services/macdive_samples_decoder.dart
+++ b/lib/features/universal_import/data/services/macdive_samples_decoder.dart
@@ -163,6 +163,9 @@ class MacDiveSamplesDecoder {
   static const int _v1RecordLength = 24;
 
   static List<MacDiveSqliteSample>? _decodeV1(Uint8List blob) {
+    // No length trailer in this version, so the only structural check is
+    // that the bytes divide into whole records.
+    if ((blob.length - _v1HeaderLength) % _v1RecordLength != 0) return null;
     final data = ByteData.sublistView(blob);
     final samples = <MacDiveSqliteSample>[];
     for (

--- a/lib/features/universal_import/data/services/macdive_samples_decoder.dart
+++ b/lib/features/universal_import/data/services/macdive_samples_decoder.dart
@@ -20,10 +20,9 @@ import 'package:submersion/features/universal_import/data/services/tea_block_cip
 ///
 /// The body decrypts under [cipher], whose key is a constant in the MacDive
 /// binary, to a run of fixed-width little-endian records followed by zero
-/// padding and, in
-/// the last four bytes of the buffer, the byte length of the record run.
-/// Every record starts with `time` and `depth` as 32-bit floats and then
-/// carries one 4-byte field per set options bit, in the fixed order
+/// padding and, in the last four bytes of the buffer, the byte length of the
+/// record run. Every record starts with `time` and `depth` as 32-bit floats
+/// and then carries one 4-byte field per set options bit, in the fixed order
 /// [_fieldOrder] lists (which is not bit order).
 ///
 /// Version 1 predates the encryption: the same 4-byte version word, then
@@ -70,6 +69,14 @@ class MacDiveSamplesDecoder {
     optionTts,
   ];
 
+  /// The fields MacDive stores as 32-bit integers; every other field is a
+  /// 32-bit float.
+  static const Set<int> _integerFields = {
+    optionHeartRate,
+    optionNdt,
+    optionTts,
+  };
+
   static const int _headerLength = 8;
   static const int _baseRecordLength = 8;
   static const int _fieldLength = 4;
@@ -112,47 +119,26 @@ class MacDiveSamplesDecoder {
       final time = reader.float();
       final depth = reader.float();
       if (!time.isFinite || !depth.isFinite) return null;
-      double? pressure;
-      double? pressure2;
-      int? heartRate;
-      int? ndt;
-      double? ppO2;
-      double? temperature;
-      double? nextStop;
-      int? tts;
-      for (final field in _fieldOrder) {
-        if ((options & field) == 0) continue;
-        switch (field) {
-          case optionPressure:
-            pressure = reader.float();
-          case optionPressure2:
-            pressure2 = reader.float();
-          case optionHeartRate:
-            heartRate = reader.int32();
-          case optionNdt:
-            ndt = reader.int32();
-          case optionPpO2:
-            ppO2 = reader.float();
-          case optionTemperature:
-            temperature = reader.float();
-          case optionNextStopDepth:
-            nextStop = reader.float();
-          case optionTts:
-            tts = reader.int32();
-        }
-      }
+      // Optional fields, keyed by their option bit, read in emission order.
+      final values = <int, num>{
+        for (final field in _fieldOrder)
+          if ((options & field) != 0)
+            field: _integerFields.contains(field)
+                ? reader.int32()
+                : reader.float(),
+      };
       samples.add(
         MacDiveSqliteSample(
           time: _duration(time),
           depthMeters: depth,
-          pressure: pressure,
-          pressure2: pressure2,
-          heartRate: heartRate,
-          ndtMinutes: ndt,
-          ppO2: ppO2,
-          temperatureCelsius: temperature,
-          nextStopDepthMeters: nextStop,
-          ttsMinutes: tts,
+          pressure: values[optionPressure] as double?,
+          pressure2: values[optionPressure2] as double?,
+          heartRate: values[optionHeartRate] as int?,
+          ndtMinutes: values[optionNdt] as int?,
+          ppO2: values[optionPpO2] as double?,
+          temperatureCelsius: values[optionTemperature] as double?,
+          nextStopDepthMeters: values[optionNextStopDepth] as double?,
+          ttsMinutes: values[optionTts] as int?,
         ),
       );
     }

--- a/lib/features/universal_import/data/services/macdive_sqlite_sample.dart
+++ b/lib/features/universal_import/data/services/macdive_sqlite_sample.dart
@@ -1,0 +1,53 @@
+/// One profile sample decoded from MacDive's `ZDIVE.ZSAMPLES` column.
+///
+/// Values are exactly as MacDive stored them. Depth and temperature are SI
+/// (metres, Celsius) like every other Core Data column of that kind, while
+/// the two tank pressures follow the diver's display unit at the time the
+/// dive was stored, the same convention as `ZTANKANDGAS.ZAIRSTART`. The
+/// caller converts those with `MacDiveUnitConverter`, which already knows the
+/// library's unit system; the decoder itself is unit-agnostic.
+///
+/// A null field means the dive's options word did not include that channel,
+/// not that the value was zero.
+class MacDiveSqliteSample {
+  const MacDiveSqliteSample({
+    required this.time,
+    required this.depthMeters,
+    this.pressure,
+    this.pressure2,
+    this.heartRate,
+    this.ndtMinutes,
+    this.ppO2,
+    this.temperatureCelsius,
+    this.nextStopDepthMeters,
+    this.ttsMinutes,
+  });
+
+  /// Elapsed time since the start of the dive.
+  final Duration time;
+
+  final double depthMeters;
+
+  /// Primary tank pressure in the diver's display unit (psi or bar).
+  final double? pressure;
+
+  /// Second transmitter's pressure, same unit as [pressure].
+  final double? pressure2;
+
+  final int? heartRate;
+
+  /// No-decompression time remaining, in minutes, as MacDive's own XML export
+  /// writes it.
+  final int? ndtMinutes;
+
+  /// Partial pressure of oxygen in bar.
+  final double? ppO2;
+
+  final double? temperatureCelsius;
+
+  /// Depth of the next required decompression stop; zero when there is none.
+  final double? nextStopDepthMeters;
+
+  /// Time to surface in minutes.
+  final int? ttsMinutes;
+}

--- a/lib/features/universal_import/data/services/macdive_unit_inference.dart
+++ b/lib/features/universal_import/data/services/macdive_unit_inference.dart
@@ -1,4 +1,5 @@
 import 'package:submersion/features/universal_import/data/services/macdive_raw_types.dart';
+import 'package:submersion/features/universal_import/data/services/macdive_samples_decoder.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_xml_models.dart'
     show MacDiveUnitSystem;
 
@@ -14,6 +15,12 @@ import 'package:submersion/features/universal_import/data/services/macdive_xml_m
 /// The magnitudes involved are far apart, so the data itself is a reliable
 /// witness. Working pressures are ~200-300 bar or ~2400-3500 psi - more than
 /// an order of magnitude apart, with nothing plausible in between.
+///
+/// The witnesses are tried cheapest first. The cylinder columns are already
+/// in memory; the sample pressures inside `ZSAMPLES` cost a decrypt per dive,
+/// so they are the last resort - reached only by a library that records no
+/// cylinders at all, which is exactly the library that used to have no
+/// witness whatsoever.
 class MacDiveUnitInference {
   const MacDiveUnitInference._();
 
@@ -23,6 +30,18 @@ class MacDiveUnitInference {
   /// Above this, a cylinder "size" can only be cubic feet: no single cylinder
   /// holds 40 litres of water.
   static const _tankSizeLitreCeiling = 40.0;
+
+  /// How many dives carrying a `ZSAMPLES` blob the last-resort scan will
+  /// decrypt before giving up.
+  ///
+  /// Decoding one costs a TEA pass over the dive's whole profile, and a
+  /// library that reaches this tier records no cylinders at all: if this many
+  /// of its dives carry no pressure reading, the next 500 almost certainly do
+  /// not either. The bound is what makes [MacDiveUnitSystem.unknown] still
+  /// reachable with sample pressures present further down the library, so
+  /// callers must keep treating unknown as "do not convert" rather than
+  /// assuming this tier saw everything.
+  static const sampleScanDiveLimit = 25;
 
   /// Resolves the display unit for [logbook], preferring MacDive's own
   /// declaration and falling back to inference from the data.
@@ -65,7 +84,46 @@ class MacDiveUnitInference {
           : MacDiveUnitSystem.metric;
     }
 
+    // Last resort: the pressures MacDive stored inside its own sample blobs.
+    // The same physical quantity as a cylinder fill, separated by the same
+    // ceiling, but it has to be decrypted, so it runs only once the free
+    // signals have come up empty.
+    final samplePressure = _maxSamplePressure(logbook);
+    if (samplePressure != null) {
+      return samplePressure > _pressureBarCeiling
+          ? MacDiveUnitSystem.imperial
+          : MacDiveUnitSystem.metric;
+    }
+
     // Nothing to go on. Passthrough is safer than a coin flip.
     return MacDiveUnitSystem.unknown;
+  }
+
+  /// The largest positive pressure in the first [sampleScanDiveLimit] dives
+  /// that carry a `ZSAMPLES` blob, or null when none of them holds one.
+  ///
+  /// Returns as soon as a reading can only be psi: no later reading can move
+  /// the answer, and stopping saves decrypting the rest of the library. A
+  /// blob the decoder rejects is skipped rather than ending the scan, since
+  /// one unreadable dive says nothing about the units of the others.
+  static double? _maxSamplePressure(MacDiveRawLogbook logbook) {
+    double? highest;
+    var scanned = 0;
+    for (final dive in logbook.dives) {
+      final blob = dive.samplesBlob;
+      if (blob == null || blob.isEmpty) continue;
+      if (scanned >= sampleScanDiveLimit) break;
+      scanned++;
+      final samples = MacDiveSamplesDecoder.decode(blob);
+      if (samples == null) continue;
+      for (final s in samples) {
+        for (final pressure in [s.pressure, s.pressure2]) {
+          if (pressure == null || pressure <= 0) continue;
+          if (highest == null || pressure > highest) highest = pressure;
+        }
+      }
+      if (highest != null && highest > _pressureBarCeiling) return highest;
+    }
+    return highest;
   }
 }

--- a/lib/features/universal_import/data/services/macdive_unit_inference.dart
+++ b/lib/features/universal_import/data/services/macdive_unit_inference.dart
@@ -103,9 +103,15 @@ class MacDiveUnitInference {
   /// that carry a `ZSAMPLES` blob, or null when none of them holds one.
   ///
   /// Returns as soon as a reading can only be psi: no later reading can move
-  /// the answer, and stopping saves decrypting the rest of the library. A
-  /// blob the decoder rejects is skipped rather than ending the scan, since
-  /// one unreadable dive says nothing about the units of the others.
+  /// the answer, and stopping saves decrypting the rest of the library.
+  ///
+  /// A blob the decoder rejects does not end the scan, since one unreadable
+  /// dive says nothing about the units of the others, but it does count
+  /// against [sampleScanDiveLimit]. The limit bounds decryption work, not
+  /// useful readings: any blob that gets past the cheap header checks is
+  /// rejected only after its body has been decrypted, so an unreadable dive
+  /// costs what a readable one costs. Counting only successful decodes would
+  /// leave a library of unreadable blobs with no bound at all.
   static double? _maxSamplePressure(MacDiveRawLogbook logbook) {
     double? highest;
     var scanned = 0;

--- a/lib/features/universal_import/data/services/raw_profile_sanity_check.dart
+++ b/lib/features/universal_import/data/services/raw_profile_sanity_check.dart
@@ -33,7 +33,7 @@ class RawProfileSanityCheck {
   /// Computers occasionally log a slightly negative depth at the surface from
   /// pressure-sensor drift. Anything past this is a sign bit read out of the
   /// wrong field.
-  static const _minPlausibleDepthMeters = -3.0;
+  static const minPlausibleDepthMeters = -3.0;
 
   /// How far the parsed values may diverge from what the source app recorded
   /// for the same dive before the parse is rejected.
@@ -79,7 +79,7 @@ class RawProfileSanityCheck {
       if (s.timeSeconds < 0 || s.timeSeconds < previousTime) return false;
       previousTime = s.timeSeconds;
       if (!s.depthMeters.isFinite) return false;
-      if (s.depthMeters < _minPlausibleDepthMeters) return false;
+      if (s.depthMeters < minPlausibleDepthMeters) return false;
       if (s.depthMeters > deepest) deepest = s.depthMeters;
     }
 

--- a/lib/features/universal_import/data/services/tea_block_cipher.dart
+++ b/lib/features/universal_import/data/services/tea_block_cipher.dart
@@ -1,0 +1,90 @@
+import 'dart:typed_data';
+
+/// The Tiny Encryption Algorithm (Wheeler and Needham, 1994): a 64-bit block
+/// cipher with a 128-bit key and 32 rounds of adds, shifts and XORs.
+///
+/// MacDive encrypts `ZDIVE.ZSAMPLES` with TEA in ECB mode under a key fixed
+/// in its application binary; see `MacDiveSamplesDecoder`. That is the only
+/// reason this class exists. TEA is decades past its cryptographic prime and
+/// nothing else in the app should reach for it, so it does exactly what that
+/// format needs: whole-buffer ECB in both directions, plus the single-block
+/// primitives for tests that want to build fixtures.
+///
+/// Words are little-endian on the wire, matching how MacDive reads the
+/// buffer as `uint32_t` pairs on Apple hardware.
+class TeaBlockCipher {
+  /// Takes the four 32-bit words `k[0]..k[3]` of the TEA key schedule.
+  const TeaBlockCipher(this.k0, this.k1, this.k2, this.k3);
+
+  final int k0;
+  final int k1;
+  final int k2;
+  final int k3;
+
+  /// Bytes per block.
+  static const int blockSize = 8;
+
+  /// The golden-ratio constant every TEA round adds to `sum`.
+  static const int _delta = 0x9E3779B9;
+  static const int _rounds = 32;
+  static const int _mask = 0xFFFFFFFF;
+
+  /// Decrypts [data] block by block. Returns a new buffer; [data] is left
+  /// untouched. Throws [ArgumentError] when the length is not a whole number
+  /// of blocks, since ECB has no padding of its own.
+  Uint8List decrypt(Uint8List data) => _apply(data, decryptBlock);
+
+  /// Encrypts [data] block by block. Same contract as [decrypt].
+  Uint8List encrypt(Uint8List data) => _apply(data, encryptBlock);
+
+  Uint8List _apply(Uint8List data, (int, int) Function(int, int) block) {
+    if (data.length % blockSize != 0) {
+      throw ArgumentError.value(
+        data.length,
+        'data',
+        'length must be a multiple of $blockSize bytes',
+      );
+    }
+    final out = Uint8List(data.length);
+    final src = ByteData.sublistView(data);
+    final dst = ByteData.sublistView(out);
+    for (var offset = 0; offset < data.length; offset += blockSize) {
+      final (v0, v1) = block(
+        src.getUint32(offset, Endian.little),
+        src.getUint32(offset + 4, Endian.little),
+      );
+      dst.setUint32(offset, v0, Endian.little);
+      dst.setUint32(offset + 4, v1, Endian.little);
+    }
+    return out;
+  }
+
+  /// Encrypts one block given as two 32-bit words.
+  (int, int) encryptBlock(int v0, int v1) {
+    var sum = 0;
+    for (var round = 0; round < _rounds; round++) {
+      sum = (sum + _delta) & _mask;
+      v0 = (v0 + _mix(v1, sum, k0, k1)) & _mask;
+      v1 = (v1 + _mix(v0, sum, k2, k3)) & _mask;
+    }
+    return (v0, v1);
+  }
+
+  /// Decrypts one block given as two 32-bit words.
+  (int, int) decryptBlock(int v0, int v1) {
+    var sum = (_delta * _rounds) & _mask;
+    for (var round = 0; round < _rounds; round++) {
+      v1 = (v1 - _mix(v0, sum, k2, k3)) & _mask;
+      v0 = (v0 - _mix(v1, sum, k0, k1)) & _mask;
+      sum = (sum - _delta) & _mask;
+    }
+    return (v0, v1);
+  }
+
+  /// The TEA round function: `((v << 4) + k0) ^ (v + sum) ^ ((v >> 5) + k1)`,
+  /// every term reduced to 32 bits.
+  static int _mix(int v, int sum, int k0, int k1) =>
+      ((((v << 4) & _mask) + k0) & _mask) ^
+      ((v + sum) & _mask) ^
+      (((v >> 5) + k1) & _mask);
+}

--- a/lib/features/universal_import/data/services/tea_block_cipher.dart
+++ b/lib/features/universal_import/data/services/tea_block_cipher.dart
@@ -13,8 +13,14 @@ import 'dart:typed_data';
 /// Words are little-endian on the wire, matching how MacDive reads the
 /// buffer as `uint32_t` pairs on Apple hardware.
 class TeaBlockCipher {
-  /// Takes the four 32-bit words `k[0]..k[3]` of the TEA key schedule.
-  const TeaBlockCipher(this.k0, this.k1, this.k2, this.k3);
+  /// Takes the four 32-bit words `k[0]..k[3]` of the TEA key schedule. Each
+  /// must already fit in 32 bits; the rounds reduce every sum modulo 2^32,
+  /// so an oversized word would be silently folded rather than rejected.
+  const TeaBlockCipher(this.k0, this.k1, this.k2, this.k3)
+    : assert(k0 >= 0 && k0 <= _mask, 'k0 must be a 32-bit word'),
+      assert(k1 >= 0 && k1 <= _mask, 'k1 must be a 32-bit word'),
+      assert(k2 >= 0 && k2 <= _mask, 'k2 must be a 32-bit word'),
+      assert(k3 >= 0 && k3 <= _mask, 'k3 must be a 32-bit word');
 
   final int k0;
   final int k1;

--- a/test/features/universal_import/data/parsers/macdive_sqlite_real_sample_test.dart
+++ b/test/features/universal_import/data/parsers/macdive_sqlite_real_sample_test.dart
@@ -10,6 +10,7 @@ import 'package:submersion/features/universal_import/data/models/import_enums.da
 import 'package:submersion/features/universal_import/data/models/import_warning.dart';
 import 'package:submersion/features/universal_import/data/parsers/macdive_sqlite_parser.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_db_reader.dart';
+import 'package:submersion/features/universal_import/data/services/macdive_samples_decoder.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_unit_inference.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_xml_models.dart'
     show MacDiveUnitSystem;
@@ -176,24 +177,70 @@ void main() {
         hasLength(267),
         reason: 'sample DB has 217 Teric + 50 Tern',
       );
-      // Every one of them has ZRAWDATA, which is why ZSAMPLES staying
-      // encrypted costs us nothing.
+      // Every one of them has ZRAWDATA as well as ZSAMPLES, so the raw path
+      // is tried first for all 267 and the samples only ever back it up.
       expect(
         shearwater.where((d) => d.rawDataBlob?.isNotEmpty ?? false),
         hasLength(267),
       );
+      expect(
+        shearwater.where((d) => d.samplesBlob?.isNotEmpty ?? false),
+        hasLength(267),
+      );
+    });
+
+    test('every ZSAMPLES blob in the library decodes', () async {
+      final logbook = await MacDiveDbReader.readAll(bytes);
+      final withSamples = logbook.dives
+          .where((d) => d.samplesBlob?.isNotEmpty ?? false)
+          .toList();
+      expect(withSamples, hasLength(350));
+
+      var nonEmpty = 0;
+      var nonMonotonic = 0;
+      for (final d in withSamples) {
+        final samples = MacDiveSamplesDecoder.decode(d.samplesBlob!);
+        expect(samples, isNotNull, reason: 'dive ${d.uuid} failed to decode');
+        if (samples!.isEmpty) continue;
+        nonEmpty++;
+        // The decoded series has to be the profile MacDive drew: its deepest
+        // point agrees with the stored max depth (the diver's own corrections
+        // account for the slack) and every depth is a real one.
+        final deepest = samples
+            .map((s) => s.depthMeters)
+            .reduce((a, b) => a > b ? a : b);
+        if (d.maxDepth != null) {
+          expect(
+            deepest,
+            closeTo(d.maxDepth!, 3.0),
+            reason: 'dive ${d.uuid} decoded deepest $deepest m',
+          );
+        }
+        expect(samples.every((s) => s.depthMeters >= 0), isTrue);
+        for (var i = 1; i < samples.length; i++) {
+          if (samples[i].time < samples[i - 1].time) {
+            nonMonotonic++;
+            break;
+          }
+        }
+      }
+      // Two dives store an empty sample array.
+      expect(nonEmpty, 348);
+      // One dive in the library really does run backwards for a sample; the
+      // decoder reports what MacDive stored rather than repairing it.
+      expect(nonMonotonic, lessThanOrEqualTo(1));
     });
 
     test('decoded profile samples carry timestamp and depth', () async {
       final payload = await const MacDiveSqliteParser().parse(bytes);
       final withProfiles = payload
           .entitiesOf(ImportEntityType.dives)
-          .where((d) => (d['profile'] as List?)?.isNotEmpty ?? false);
+          .where((d) => (d['profile'] as List?)?.isNotEmpty ?? false)
+          .toList();
 
-      // The parse channel is not registered in a unit-test host, so nothing
-      // decodes here; the byte-level guarantee is covered by the
-      // decompression test below.
-      if (withProfiles.isEmpty) return;
+      // The parse channel is not registered in a unit-test host, so every
+      // profile here came from ZSAMPLES: 350 blobs less the two empty ones.
+      expect(withProfiles, hasLength(348));
 
       final firstPoint =
           (withProfiles.first['profile'] as List).first as Map<String, dynamic>;
@@ -202,64 +249,41 @@ void main() {
       expect(firstPoint['timestamp'], 0);
     });
 
-    test('dives without raw data omit the profile key entirely', () async {
-      final payload = await const MacDiveSqliteParser().parse(bytes);
-      final nonShearwater = payload
-          .entitiesOf(ImportEntityType.dives)
-          .where(
-            (d) => !((d['diveComputerModel'] as String?) ?? '').startsWith(
-              'Shearwater',
-            ),
-          )
-          .toList();
-
-      expect(
-        nonShearwater,
-        isNotEmpty,
-        reason: 'sample DB has Oceanic and manual-entry dives',
-      );
-      for (final dive in nonShearwater) {
-        // Matches macdive_xml_parser: omit the key rather than emit an empty
-        // list, so downstream can tell "no samples" from "zero-length dive".
-        expect(dive.containsKey('profile'), isFalse);
-      }
-    });
-
     test(
-      'warning count bounded: <5% of Shearwater dives emit decode warnings',
+      'dives with no samples in either column omit the profile key',
       () async {
+        final logbook = await MacDiveDbReader.readAll(bytes);
+        final noBytes = logbook.dives
+            .where(
+              (d) =>
+                  !(d.samplesBlob?.isNotEmpty ?? false) &&
+                  !(d.rawDataBlob?.isNotEmpty ?? false),
+            )
+            .map((d) => d.uuid)
+            .toSet();
+        expect(noBytes, hasLength(190), reason: '540 dives, 350 with samples');
+
         final payload = await const MacDiveSqliteParser().parse(bytes);
-        final dives = payload.entitiesOf(ImportEntityType.dives);
-
-        final shearwaterDives = dives.where((d) {
-          final computer = (d['diveComputerModel'] as String?) ?? '';
-          return computer.startsWith('Shearwater');
-        }).toList();
-
-        // Filter warnings to decode-failure warnings only (not info messages
-        // about FFI unavailability, which is a single aggregate warning).
-        final decodeFailures = payload.warnings.where(
-          (w) =>
-              w.severity == ImportWarningSeverity.warning &&
-              w.message.contains('Profile decode failed'),
-        );
-
-        // When FFI is completely unavailable all Shearwater profiles are empty
-        // and the failure warnings dominate. Distinguish the "FFI broken"
-        // case (all dives failed) from a real regression (a handful failed).
-        if (decodeFailures.length >= shearwaterDives.length) {
-          // 100% failure = no plugin registered; not a regression, skip.
-          return;
+        for (final dive in payload.entitiesOf(ImportEntityType.dives)) {
+          if (!noBytes.contains(dive['sourceUuid'])) continue;
+          // Matches macdive_xml_parser: omit the key rather than emit an empty
+          // list, so downstream can tell "no samples" from "zero-length dive".
+          expect(dive.containsKey('profile'), isFalse);
         }
-
-        expect(
-          decodeFailures.length,
-          lessThan(shearwaterDives.length ~/ 20),
-          reason:
-              'decode-failure warnings should be well under 5% of the Shearwater dive set',
-        );
       },
     );
+
+    test('no dive is reported as undecodable', () async {
+      // With ZSAMPLES readable there is nothing left for the XML export to
+      // rescue, on any platform.
+      final payload = await const MacDiveSqliteParser().parse(bytes);
+      expect(
+        payload.warnings.where(
+          (w) => w.message.contains('decode') || w.message.contains('profile'),
+        ),
+        isEmpty,
+      );
+    });
 
     test('metadata records source and units', () async {
       final payload = await const MacDiveSqliteParser().parse(bytes);

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -882,6 +882,65 @@ void main() {
         expect(dive.containsKey('profile'), isFalse);
       });
 
+      test(
+        'without a channel, unreadable samples still get the XML hint',
+        () async {
+          // Two dives without a profile for two different reasons: one whose
+          // samples were read and rejected (the XML export can rescue it) and
+          // one whose only bytes are a raw download this platform cannot try.
+          // Lumping both under "this platform" would hide the remedy for the
+          // first, so each cause gets its own warning.
+          final logbook = _samplesLogbook(
+            computer: 'Shearwater Teric',
+            raw: _compressedFixture,
+            samples: Uint8List.fromList(List.filled(64, 0x42)),
+          );
+          final payload = await MacDiveDiveMapper.toPayload(
+            MacDiveRawLogbook(
+              dives: [
+                ...logbook.dives,
+                MacDiveRawDive(
+                  pk: 2,
+                  uuid: 'dive-2',
+                  computer: 'Shearwater Teric',
+                  rawDataBlob: _compressedFixture,
+                ),
+              ],
+              sitesByPk: const {},
+              buddiesByPk: const {},
+              tagsByPk: const {},
+              gearByPk: const {},
+              tanksByPk: const {},
+              gasesByPk: const {},
+              tankAndGases: const [],
+              crittersByPk: const {},
+              certifications: const [],
+              serviceRecords: const [],
+              events: const [],
+              diveToBuddyPks: const {},
+              diveToTagPks: const {},
+              diveToGearPks: const {},
+              diveToCritterPks: const {},
+              unitsPreference: 'Metric',
+            ),
+            fetchDescriptors: () async => throw MissingPluginException('none'),
+          );
+
+          expect(payload.warnings, hasLength(2));
+          final messages = payload.warnings.map((w) => w.message).toList();
+          expect(
+            messages.where((m) => m.startsWith('1 dive') && m.contains('XML')),
+            hasLength(1),
+          );
+          expect(
+            messages.where(
+              (m) => m.startsWith('1 dive') && m.contains('this platform'),
+            ),
+            hasLength(1),
+          );
+        },
+      );
+
       test('unreadable ZSAMPLES count toward the aggregated warning', () async {
         final payload = await MacDiveDiveMapper.toPayload(
           _samplesLogbook(

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -1040,6 +1040,31 @@ void main() {
         expect(last['temperature'], closeTo(24.0, 1e-6));
       });
 
+      test('heart rate and ceiling reach the profile point', () async {
+        // The Teric options word every other test here uses carries neither,
+        // so these two channels - the ones ZSAMPLES can supply that MacDive's
+        // own XML export cannot - had no test asserting they arrive.
+        final payload = await MacDiveDiveMapper.toPayload(
+          _samplesLogbook(
+            computer: 'Manual',
+            samples: _zsamplesPulseAndStop([
+              (0.0, 0.0, 70, 0.0),
+              (60.0, 30.0, 75, 3.0),
+            ]),
+          ),
+        );
+
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        final profile = dive['profile'] as List;
+        final descent = profile.last as Map<String, dynamic>;
+        expect(descent['heartRate'], 75);
+        expect(descent['ceiling'], closeTo(3.0, 1e-6));
+        // A zero next stop is MacDive's "no reading", not a stop at the
+        // surface, so it stays out the way a zero pressure does.
+        expect((profile.first as Map).containsKey('ceiling'), isFalse);
+        expect((profile.first as Map)['heartRate'], 70);
+      });
+
       test('unreadable ZSAMPLES count toward the aggregated warning', () async {
         final payload = await MacDiveDiveMapper.toPayload(
           _samplesLogbook(
@@ -1317,6 +1342,39 @@ Uint8List _zsamples(
     ..setUint32(0, 4, Endian.little)
     ..setUint32(4, options, Endian.little);
   blob.setRange(8, blob.length, cipher.encrypt(plain));
+  return blob;
+}
+
+/// A `ZSAMPLES` blob carrying only heart rate and next-stop depth, the two
+/// optional fields no other fixture here sets. Records are
+/// (time s, depth m, bpm, next stop m); in the encoder's emission order heart
+/// rate precedes next-stop depth, so the stride is 16.
+Uint8List _zsamplesPulseAndStop(List<(double, double, int, double)> records) {
+  const options =
+      MacDiveSamplesDecoder.optionHeartRate |
+      MacDiveSamplesDecoder.optionNextStopDepth;
+  const stride = 16;
+  final packed = Uint8List(records.length * stride);
+  final data = ByteData.sublistView(packed);
+  for (var i = 0; i < records.length; i++) {
+    final (time, depth, heartRate, nextStop) = records[i];
+    data
+      ..setFloat32(i * stride, time, Endian.little)
+      ..setFloat32(i * stride + 4, depth, Endian.little)
+      ..setInt32(i * stride + 8, heartRate, Endian.little)
+      ..setFloat32(i * stride + 12, nextStop, Endian.little);
+  }
+  final plain = Uint8List(((packed.length + 7) ~/ 8 + 1) * 8)
+    ..setRange(0, packed.length, packed);
+  ByteData.sublistView(
+    plain,
+  ).setUint32(plain.length - 4, packed.length, Endian.little);
+
+  final blob = Uint8List(8 + plain.length);
+  ByteData.sublistView(blob)
+    ..setUint32(0, 4, Endian.little)
+    ..setUint32(4, options, Endian.little);
+  blob.setRange(8, blob.length, MacDiveSamplesDecoder.cipher.encrypt(plain));
   return blob;
 }
 

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/universal_import/data/services/macdive_db_re
 import 'package:submersion/features/universal_import/data/services/macdive_dive_mapper.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_raw_types.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_samples_decoder.dart';
+import 'package:submersion/features/universal_import/data/services/macdive_unit_inference.dart';
 
 import '../../../../fixtures/macdive_sqlite/build_synthetic_db.dart';
 
@@ -941,6 +942,104 @@ void main() {
         },
       );
 
+      test('an empty sample array beside a failed raw parse warns', () async {
+        // MacDive drawing no profile is only the whole story when ZSAMPLES
+        // was the dive's only source. Here the raw download was there too and
+        // its parse was thrown out, so the dive lost a profile the XML export
+        // can still rescue - and reporting nothing would hide that.
+        final payload = await MacDiveDiveMapper.toPayload(
+          _samplesLogbook(
+            computer: 'Shearwater Teric',
+            raw: _compressedFixture,
+            samples: _zsamples(const []),
+          ),
+          fetchDescriptors: _fakeDescriptors,
+          parseRaw: (v, p, m, d) async => _parsedDive(
+            samples: [
+              pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+              pigeon.ProfileSample(timeSeconds: 600, depthMeters: 4000.0),
+            ],
+          ),
+        );
+
+        expect(payload.warnings, hasLength(1));
+        expect(payload.warnings.single.message, contains('1 dive'));
+        expect(payload.warnings.single.message, contains('XML'));
+      });
+
+      test(
+        'an empty sample array without a channel blames the platform',
+        () async {
+          // Same dive, but the raw bytes were never attempted. An XML export
+          // would not help: MacDive has no profile of its own to export.
+          final payload = await MacDiveDiveMapper.toPayload(
+            _samplesLogbook(
+              computer: 'Shearwater Teric',
+              raw: _compressedFixture,
+              samples: _zsamples(const []),
+            ),
+            fetchDescriptors: () async => throw MissingPluginException('none'),
+          );
+
+          expect(payload.warnings, hasLength(1));
+          expect(payload.warnings.single.message, contains('this platform'));
+        },
+      );
+
+      test(
+        'sample pressures set the unit for a cylinder-less library',
+        () async {
+          // No units row and no cylinder rows, so the sample pressures are the
+          // only witness there is. Charting 3000 psi as 3000 bar is #912.
+          final payload = await MacDiveDiveMapper.toPayload(
+            _samplesLogbook(
+              computer: 'Manual',
+              samples: _zsamples([(0.0, 0.0, 3000.0, 99, 0.21, 27.5, 0)]),
+              unitsPreference: null,
+            ),
+          );
+
+          expect(payload.metadata['units'], 'imperial');
+          final dive = payload.entitiesOf(ImportEntityType.dives).single;
+          final point =
+              (dive['profile'] as List).single as Map<String, dynamic>;
+          final pressure = (point['allTankPressures'] as List).single as Map;
+          expect(pressure['pressure'], closeTo(3000 * 0.0689476, 1e-3));
+        },
+      );
+
+      test('a pressure with no unit to place it in is dropped', () async {
+        // The inference scan is bounded, so a library whose only pressures
+        // sit past the limit still resolves to unknown. Passing those through
+        // would chart psi as bar; leaving them out costs a channel the dive
+        // did not have before ZSAMPLES were readable at all.
+        final blobs = [
+          for (var i = 0; i <= MacDiveUnitInference.sampleScanDiveLimit; i++)
+            _zsamples([
+              (
+                0.0,
+                3.0,
+                i < MacDiveUnitInference.sampleScanDiveLimit ? 0.0 : 3000.0,
+                99,
+                0.21,
+                24.0,
+                0,
+              ),
+            ]),
+        ];
+        final payload = await MacDiveDiveMapper.toPayload(
+          _samplesOnlyLogbook(blobs),
+        );
+
+        expect(payload.metadata['units'], 'unknown');
+        final dives = payload.entitiesOf(ImportEntityType.dives);
+        final last = (dives.last['profile'] as List).single as Map;
+        expect(last.containsKey('allTankPressures'), isFalse);
+        // Everything that does not depend on the unit still arrives.
+        expect(last['depth'], closeTo(3.0, 1e-6));
+        expect(last['temperature'], closeTo(24.0, 1e-6));
+      });
+
       test('unreadable ZSAMPLES count toward the aggregated warning', () async {
         final payload = await MacDiveDiveMapper.toPayload(
           _samplesLogbook(
@@ -1110,7 +1209,7 @@ MacDiveRawLogbook _samplesLogbook({
   required Uint8List samples,
   Uint8List? raw,
   double? maxDepth,
-  String unitsPreference = 'Metric',
+  String? unitsPreference = 'Metric',
 }) {
   return MacDiveRawLogbook(
     dives: [
@@ -1122,6 +1221,42 @@ MacDiveRawLogbook _samplesLogbook({
         samplesBlob: samples,
         rawDataBlob: raw,
       ),
+    ],
+    sitesByPk: const {},
+    buddiesByPk: const {},
+    tagsByPk: const {},
+    gearByPk: const {},
+    tanksByPk: const {},
+    gasesByPk: const {},
+    tankAndGases: const [],
+    crittersByPk: const {},
+    certifications: const [],
+    serviceRecords: const [],
+    events: const [],
+    diveToBuddyPks: const {},
+    diveToTagPks: const {},
+    diveToGearPks: const {},
+    diveToCritterPks: const {},
+    unitsPreference: unitsPreference,
+  );
+}
+
+/// A samples-only logbook of one dive per entry in [samples], with no
+/// cylinder rows, for exercising what the unit inference makes of the sample
+/// pressures themselves.
+MacDiveRawLogbook _samplesOnlyLogbook(
+  List<Uint8List> samples, {
+  String? unitsPreference,
+}) {
+  return MacDiveRawLogbook(
+    dives: [
+      for (final (index, blob) in samples.indexed)
+        MacDiveRawDive(
+          pk: index + 1,
+          uuid: 'dive-${index + 1}',
+          computer: 'Manual',
+          samplesBlob: blob,
+        ),
     ],
     sitesByPk: const {},
     buddiesByPk: const {},

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -747,6 +747,8 @@ void main() {
           (p) => (p as Map)['timestamp'],
         );
         expect(stamps, [0, 2, 8]);
+        // Runtime is rounded the same way, so it agrees with the last point.
+        expect(dive['runtime'], const Duration(seconds: 8));
       });
 
       test('zero readings are omitted rather than charted', () async {
@@ -797,6 +799,12 @@ void main() {
         );
         final dive = payload.entitiesOf(ImportEntityType.dives).single;
         expect(dive['runtime'], const Duration(seconds: 900));
+        // Stored order is kept: a restarted clock after a surfacing is a
+        // second descent, and sorting would interleave the two segments.
+        final stamps = (dive['profile'] as List).map(
+          (p) => (p as Map)['timestamp'],
+        );
+        expect(stamps, [0, 900, 600]);
       });
 
       test('a rejected raw parse falls back to ZSAMPLES silently', () async {

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -781,6 +781,24 @@ void main() {
         expect(dive['runtime'], const Duration(seconds: 900));
       });
 
+      test('runtime is the latest stamp, not the last record', () async {
+        // The reference library holds one dive whose samples step backwards
+        // once; the decoder passes that through, so the mapper must not
+        // trust record order for the dive's length.
+        final payload = await MacDiveDiveMapper.toPayload(
+          _samplesLogbook(
+            computer: 'Manual',
+            samples: _zsamples([
+              (0.0, 0.0, 200.0, 99, 0.21, 24.0, 0),
+              (900.0, 3.0, 120.0, 40, 0.27, 23.0, 0),
+              (600.0, 18.0, 150.0, 20, 0.6, 21.0, 0),
+            ]),
+          ),
+        );
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        expect(dive['runtime'], const Duration(seconds: 900));
+      });
+
       test('a rejected raw parse falls back to ZSAMPLES silently', () async {
         // Shearwater dives in the reference library have both columns. A raw
         // parse the sanity check throws out used to cost the dive its profile

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,6 +11,7 @@ import 'package:submersion/features/universal_import/data/models/import_warning.
 import 'package:submersion/features/universal_import/data/services/macdive_db_reader.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_dive_mapper.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_raw_types.dart';
+import 'package:submersion/features/universal_import/data/services/macdive_samples_decoder.dart';
 
 import '../../../../fixtures/macdive_sqlite/build_synthetic_db.dart';
 
@@ -685,43 +687,170 @@ void main() {
       );
     });
 
-    test(
-      'ZSAMPLES without ZRAWDATA warns about the unreadable format',
-      () async {
+    group('ZSAMPLES', () {
+      test('a dive with only ZSAMPLES gets its profile from them', () async {
+        // The 83 "(no computer)" dives of the reference library, and every
+        // dive from a computer MacDive did not download through
+        // libdivecomputer: no raw bytes, only MacDive's own samples.
         final payload = await MacDiveDiveMapper.toPayload(
-          MacDiveRawLogbook(
-            dives: [
-              MacDiveRawDive(
-                pk: 1,
-                uuid: 'dive-1',
-                computer: 'Oceanic Matrix Master',
-                samplesBlob: Uint8List.fromList(List.filled(64, 0x42)),
-              ),
+          _samplesLogbook(
+            computer: 'Oceanic Matrix Master',
+            samples: _zsamples([
+              (0.0, 0.0, 3000.0, 99, 0.21, 27.5, 0),
+              (10.0, 5.5, 2980.0, 60, 0.32, 26.0, 1),
+            ]),
+            unitsPreference: 'Imperial',
+          ),
+          fetchDescriptors: () async =>
+              fail('nothing to resolve without raw bytes'),
+        );
+
+        expect(payload.warnings, isEmpty);
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        final profile = dive['profile'] as List;
+        expect(profile, hasLength(2));
+        final point = profile[1] as Map<String, dynamic>;
+        expect(point['timestamp'], 10);
+        expect(point['depth'], closeTo(5.5, 1e-6));
+        expect(point['temperature'], closeTo(26.0, 1e-6));
+        // Sample pressures follow the display unit like the tank columns do:
+        // 2980 psi, not 2980 bar (#912 all over again otherwise).
+        final pressures = point['allTankPressures'] as List;
+        expect(pressures, hasLength(1));
+        expect(
+          (pressures.single as Map)['pressure'],
+          closeTo(2980 * 0.0689476, 1e-3),
+        );
+        expect((pressures.single as Map)['tankIndex'], 0);
+        expect(point['ppO2'], closeTo(0.32, 1e-6));
+        // Minutes in the column, seconds in the profile point, as the XML
+        // path already does for ndl.
+        expect(point['ndl'], 60 * 60);
+        expect(point['tts'], 60);
+        expect(point.containsKey('heartRate'), isFalse);
+        expect(point.containsKey('ceiling'), isFalse);
+      });
+
+      test('zero readings are omitted rather than charted', () async {
+        final payload = await MacDiveDiveMapper.toPayload(
+          _samplesLogbook(
+            computer: 'Manual',
+            samples: _zsamples([(0.0, 0.0, 0.0, 99, 0.0, 22.0, 0)]),
+          ),
+        );
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        final point = (dive['profile'] as List).single as Map<String, dynamic>;
+        expect(point.containsKey('allTankPressures'), isFalse);
+        expect(point.containsKey('ppO2'), isFalse);
+        expect(point['temperature'], 22.0);
+      });
+
+      test('samples fill scalar gaps but never override MacDive', () async {
+        final payload = await MacDiveDiveMapper.toPayload(
+          _samplesLogbook(
+            computer: 'Manual',
+            samples: _zsamples([
+              (0.0, 0.0, 200.0, 99, 0.21, 24.0, 0),
+              (600.0, 18.0, 150.0, 20, 0.6, 21.0, 0),
+              (900.0, 3.0, 120.0, 40, 0.27, 23.0, 0),
+            ]),
+            maxDepth: 18.4,
+          ),
+        );
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        expect(dive['maxDepth'], 18.4, reason: 'MacDive scalar wins');
+        expect(dive['waterTemp'], 21.0);
+        expect(dive['runtime'], const Duration(seconds: 900));
+      });
+
+      test('a rejected raw parse falls back to ZSAMPLES silently', () async {
+        // Shearwater dives in the reference library have both columns. A raw
+        // parse the sanity check throws out used to cost the dive its profile
+        // and earn a warning; now the samples cover it.
+        final payload = await MacDiveDiveMapper.toPayload(
+          _samplesLogbook(
+            computer: 'Shearwater Teric',
+            raw: _compressedFixture,
+            samples: _zsamples([
+              (0.0, 0.0, 200.0, 99, 0.21, 24.0, 0),
+              (60.0, 12.0, 190.0, 50, 0.46, 22.0, 0),
+            ]),
+          ),
+          fetchDescriptors: _fakeDescriptors,
+          parseRaw: (v, p, m, d) async => _parsedDive(
+            samples: [
+              pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+              pigeon.ProfileSample(timeSeconds: 600, depthMeters: 4000.0),
             ],
-            sitesByPk: const {},
-            buddiesByPk: const {},
-            tagsByPk: const {},
-            gearByPk: const {},
-            tanksByPk: const {},
-            gasesByPk: const {},
-            tankAndGases: const [],
-            crittersByPk: const {},
-            certifications: const [],
-            serviceRecords: const [],
-            events: const [],
-            diveToBuddyPks: const {},
-            diveToTagPks: const {},
-            diveToGearPks: const {},
-            diveToCritterPks: const {},
-            unitsPreference: 'Metric',
+          ),
+        );
+
+        expect(payload.warnings, isEmpty);
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        final profile = dive['profile'] as List;
+        expect(profile, hasLength(2));
+        expect((profile.last as Map)['depth'], closeTo(12.0, 1e-6));
+      });
+
+      test('a successful raw parse still takes precedence', () async {
+        final payload = await MacDiveDiveMapper.toPayload(
+          _samplesLogbook(
+            computer: 'Shearwater Teric',
+            raw: _compressedFixture,
+            samples: _zsamples([(0.0, 0.0, 200.0, 99, 0.21, 24.0, 0)]),
+          ),
+          fetchDescriptors: _fakeDescriptors,
+          parseRaw: (v, p, m, d) async => _parsedDive(
+            samples: [
+              pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+              pigeon.ProfileSample(timeSeconds: 30, depthMeters: 7.0),
+            ],
+          ),
+        );
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        expect(dive['profile'], hasLength(2));
+      });
+
+      test('without a platform channel ZSAMPLES still decode', () async {
+        final payload = await MacDiveDiveMapper.toPayload(
+          _samplesLogbook(
+            computer: 'Shearwater Teric',
+            raw: _compressedFixture,
+            samples: _zsamples([
+              (0.0, 0.0, 200.0, 99, 0.21, 24.0, 0),
+              (60.0, 12.0, 190.0, 50, 0.46, 22.0, 0),
+            ]),
+          ),
+          fetchDescriptors: () async => throw MissingPluginException('none'),
+        );
+        expect(payload.warnings, isEmpty);
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        expect(dive['profile'], hasLength(2));
+      });
+
+      test('an empty sample array is not a failure', () async {
+        // MacDive stores a header-only blob for a dive with no samples.
+        final payload = await MacDiveDiveMapper.toPayload(
+          _samplesLogbook(computer: 'Manual', samples: _zsamples(const [])),
+        );
+        expect(payload.warnings, isEmpty);
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        expect(dive.containsKey('profile'), isFalse);
+      });
+
+      test('unreadable ZSAMPLES count toward the aggregated warning', () async {
+        final payload = await MacDiveDiveMapper.toPayload(
+          _samplesLogbook(
+            computer: 'Oceanic Matrix Master',
+            samples: Uint8List.fromList(List.filled(64, 0x42)),
           ),
         );
 
         expect(payload.warnings, hasLength(1));
         expect(payload.warnings.single.message, contains('1 dive'));
-        expect(payload.warnings.single.message, contains('cannot read'));
-      },
-    );
+        expect(payload.warnings.single.message.toLowerCase(), contains('xml'));
+      });
+    });
 
     test('no warning when logbook has no ZRAWDATA', () async {
       const logbook = MacDiveRawLogbook(
@@ -869,6 +998,88 @@ MacDiveRawLogbook _suuntoRawDataLogbook({
     diveToCritterPks: const {},
     unitsPreference: 'Metric',
   );
+}
+
+/// One dive on [computer] carrying [samples] as its `ZSAMPLES` and,
+/// optionally, [raw] as its `ZRAWDATA`.
+MacDiveRawLogbook _samplesLogbook({
+  required String computer,
+  required Uint8List samples,
+  Uint8List? raw,
+  double? maxDepth,
+  String unitsPreference = 'Metric',
+}) {
+  return MacDiveRawLogbook(
+    dives: [
+      MacDiveRawDive(
+        pk: 1,
+        uuid: 'dive-1',
+        computer: computer,
+        maxDepth: maxDepth,
+        samplesBlob: samples,
+        rawDataBlob: raw,
+      ),
+    ],
+    sitesByPk: const {},
+    buddiesByPk: const {},
+    tagsByPk: const {},
+    gearByPk: const {},
+    tanksByPk: const {},
+    gasesByPk: const {},
+    tankAndGases: const [],
+    crittersByPk: const {},
+    certifications: const [],
+    serviceRecords: const [],
+    events: const [],
+    diveToBuddyPks: const {},
+    diveToTagPks: const {},
+    diveToGearPks: const {},
+    diveToCritterPks: const {},
+    unitsPreference: unitsPreference,
+  );
+}
+
+/// Encodes a `ZSAMPLES` blob the way MacDive does for a Shearwater Teric:
+/// version 4, options 0x9D (pressure, NDT, ppO2, temperature, TTS), records
+/// packed little-endian, padded to a TEA block, a trailing block carrying
+/// the byte length, and the whole body TEA-ECB encrypted under the app key.
+/// Each record is (time s, depth m, pressure, ndt min, ppO2, temp C, tts min).
+Uint8List _zsamples(
+  List<(double, double, double, int, double, double, int)> records,
+) {
+  const options =
+      MacDiveSamplesDecoder.optionPressure |
+      MacDiveSamplesDecoder.optionNdt |
+      MacDiveSamplesDecoder.optionPpO2 |
+      MacDiveSamplesDecoder.optionTemperature |
+      MacDiveSamplesDecoder.optionTts;
+  const stride = 28;
+  final packed = Uint8List(records.length * stride);
+  final data = ByteData.sublistView(packed);
+  for (var i = 0; i < records.length; i++) {
+    final (time, depth, pressure, ndt, ppO2, temp, tts) = records[i];
+    data
+      ..setFloat32(i * stride, time, Endian.little)
+      ..setFloat32(i * stride + 4, depth, Endian.little)
+      ..setFloat32(i * stride + 8, pressure, Endian.little)
+      ..setInt32(i * stride + 12, ndt, Endian.little)
+      ..setFloat32(i * stride + 16, ppO2, Endian.little)
+      ..setFloat32(i * stride + 20, temp, Endian.little)
+      ..setInt32(i * stride + 24, tts, Endian.little);
+  }
+  final blocks = (packed.length + 7) ~/ 8 + 1;
+  final plain = Uint8List(blocks * 8)..setRange(0, packed.length, packed);
+  ByteData.sublistView(
+    plain,
+  ).setUint32(plain.length - 4, packed.length, Endian.little);
+
+  const cipher = MacDiveSamplesDecoder.cipher;
+  final blob = Uint8List(8 + plain.length);
+  ByteData.sublistView(blob)
+    ..setUint32(0, 4, Endian.little)
+    ..setUint32(4, options, Endian.little);
+  blob.setRange(8, blob.length, cipher.encrypt(plain));
+  return blob;
 }
 
 /// Two dives carrying a real compressed blob plus one manual dive with none.

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -731,6 +731,24 @@ void main() {
         expect(point.containsKey('ceiling'), isFalse);
       });
 
+      test('fractional sample times round to the nearest second', () async {
+        final payload = await MacDiveDiveMapper.toPayload(
+          _samplesLogbook(
+            computer: 'Manual',
+            samples: _zsamples([
+              (0.0, 0.0, 200.0, 99, 0.21, 22.0, 0),
+              (2.4, 1.0, 200.0, 99, 0.21, 22.0, 0),
+              (7.6, 2.0, 200.0, 99, 0.21, 22.0, 0),
+            ]),
+          ),
+        );
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        final stamps = (dive['profile'] as List).map(
+          (p) => (p as Map)['timestamp'],
+        );
+        expect(stamps, [0, 2, 8]);
+      });
+
       test('zero readings are omitted rather than charted', () async {
         final payload = await MacDiveDiveMapper.toPayload(
           _samplesLogbook(

--- a/test/features/universal_import/data/services/macdive_samples_decoder_test.dart
+++ b/test/features/universal_import/data/services/macdive_samples_decoder_test.dart
@@ -185,6 +185,16 @@ void main() {
       expect(s.ttsMinutes, isNull);
     });
 
+    test('a slightly negative surface depth is kept', () {
+      // Pressure-sensor drift at the surface, the same allowance the raw
+      // path makes. The plausibility bounds must not cost a real sample.
+      final blob = _encode([
+        [0.0, -1.0],
+        [10.0, 5.0],
+      ], options: 0);
+      expect(MacDiveSamplesDecoder.decode(blob), hasLength(2));
+    });
+
     group('rejects', () {
       test('a blob too short to carry a version', () {
         expect(MacDiveSamplesDecoder.decode(Uint8List(3)), isNull);
@@ -261,6 +271,45 @@ void main() {
           [0.0, 0.0],
           [double.nan, 3.0],
         ], options: 0);
+        expect(MacDiveSamplesDecoder.decode(blob), isNull);
+      });
+
+      test('a time or depth outside anything a dive contains', () {
+        // The structural checks cannot catch a stride that is wrong in a way
+        // that still divides the run - a future record layout stamped with a
+        // version this decoder claims, or an options bit above the low byte
+        // that a newer encoder does emit a field for. Misaligned floats read
+        // as values no dive holds, and without a bound they reach the profile
+        // and seed the dive's max depth. The huge time is its own hazard:
+        // `double.round()` saturates at the int64 limit rather than throwing,
+        // so it would multiply out into a *negative* Duration.
+        for (final record in <List<double>>[
+          [0.0, 5000.0],
+          [0.0, -50.0],
+          [-5.0, 3.0],
+          [1e30, 3.0],
+        ]) {
+          final blob = _encode([
+            [0.0, 0.0],
+            record,
+          ], options: 0);
+          expect(
+            MacDiveSamplesDecoder.decode(blob),
+            isNull,
+            reason: 'record $record',
+          );
+        }
+      });
+
+      test('a version 1 record outside the plausible bounds', () {
+        // The unencrypted layout gets the same gate: whole records are its
+        // only structural guarantee, so a foreign blob whose length happens
+        // to divide by 24 has nothing else standing in its way.
+        final blob = Uint8List(4 + 24);
+        final data = ByteData.sublistView(blob);
+        data.setUint32(0, 1, Endian.little);
+        data.setFloat32(4, 0.0, Endian.little);
+        data.setFloat32(8, 5000.0, Endian.little);
         expect(MacDiveSamplesDecoder.decode(blob), isNull);
       });
 

--- a/test/features/universal_import/data/services/macdive_samples_decoder_test.dart
+++ b/test/features/universal_import/data/services/macdive_samples_decoder_test.dart
@@ -185,6 +185,40 @@ void main() {
       expect(s.ttsMinutes, isNull);
     });
 
+    test('an out-of-range integer field is dropped, not fatal', () {
+      // The same treatment a non-finite float gets. A record whose time and
+      // depth still look like a dive keeps its sample and loses the bad
+      // field, rather than costing the profile MacDive draws - but a negative
+      // NDT must not reach the mapper, which multiplies it into an `ndl` of
+      // seconds without a sign check of its own.
+      final blob = _encode([
+        [0.0, 0.0, 30],
+        [10.0, 5.5, -2000000000],
+        [20.0, 12.25, 999999],
+      ], options: MacDiveSamplesDecoder.optionNdt);
+      final samples = MacDiveSamplesDecoder.decode(blob)!;
+      expect(samples.map((s) => s.depthMeters), [0.0, 5.5, 12.25]);
+      expect(samples.map((s) => s.ndtMinutes), [30, null, null]);
+    });
+
+    test('an implausible heart rate is dropped', () {
+      final blob = _encode([
+        [0.0, 0.0, 70],
+        [10.0, 5.5, 40000],
+      ], options: MacDiveSamplesDecoder.optionHeartRate);
+      final samples = MacDiveSamplesDecoder.decode(blob)!;
+      expect(samples.map((s) => s.heartRate), [70, null]);
+    });
+
+    test('an out-of-range TTS is dropped', () {
+      final blob = _encode([
+        [0.0, 0.0, 5],
+        [10.0, 5.5, -1],
+      ], options: MacDiveSamplesDecoder.optionTts);
+      final samples = MacDiveSamplesDecoder.decode(blob)!;
+      expect(samples.map((s) => s.ttsMinutes), [5, null]);
+    });
+
     test('a slightly negative surface depth is kept', () {
       // Pressure-sensor drift at the surface, the same allowance the raw
       // path makes. The plausibility bounds must not cost a real sample.
@@ -325,17 +359,25 @@ void main() {
   });
 }
 
-/// Encodes float-only records the way MacDive's encoder does: pack each
-/// record's 32-bit floats back to back, pad to a block boundary, append a
-/// block whose last word is the byte length of the packed run, then TEA-ECB
-/// the lot under the app key. Every record must have the same width.
-Uint8List _encode(List<List<double>> records, {required int options}) {
+/// Encodes records the way MacDive's encoder does: pack each record's 32-bit
+/// fields back to back, pad to a block boundary, append a block whose last
+/// word is the byte length of the packed run, then TEA-ECB the lot under the
+/// app key. Every record must have the same width. A `double` is written as a
+/// float and an `int` as an int32, matching the field types the options bits
+/// select.
+Uint8List _encode(List<List<num>> records, {required int options}) {
   final width = records.isEmpty ? 0 : records.first.length * 4;
   final packed = Uint8List(records.length * width);
   final data = ByteData.sublistView(packed);
   for (var i = 0; i < records.length; i++) {
     for (var j = 0; j < records[i].length; j++) {
-      data.setFloat32(i * width + j * 4, records[i][j], Endian.little);
+      final value = records[i][j];
+      final offset = i * width + j * 4;
+      if (value is int) {
+        data.setInt32(offset, value, Endian.little);
+      } else {
+        data.setFloat32(offset, value.toDouble(), Endian.little);
+      }
     }
   }
   final blocks = (packed.length + 7) ~/ 8 + 1;

--- a/test/features/universal_import/data/services/macdive_samples_decoder_test.dart
+++ b/test/features/universal_import/data/services/macdive_samples_decoder_test.dart
@@ -206,6 +206,15 @@ void main() {
         final blob = _encode([(0.0, 0.0), (double.nan, 3.0)], options: 0);
         expect(MacDiveSamplesDecoder.decode(blob), isNull);
       });
+
+      test('a version 1 blob with a partial trailing record', () {
+        // Version 1 has no length trailer, so whole records are the only
+        // structural guarantee; a torn record must not decode as a prefix.
+        final blob = Uint8List(4 + 24 + 10);
+        ByteData.sublistView(blob).setUint32(0, 1, Endian.little);
+        expect(MacDiveSamplesDecoder.decode(blob), isNull);
+        expect(MacDiveSamplesDecoder.decode(blob.sublist(0, 28)), hasLength(1));
+      });
     });
   });
 }

--- a/test/features/universal_import/data/services/macdive_samples_decoder_test.dart
+++ b/test/features/universal_import/data/services/macdive_samples_decoder_test.dart
@@ -216,6 +216,33 @@ void main() {
         expect(MacDiveSamplesDecoder.decode(blob), isNull);
       });
 
+      test('a length word that reaches into the trailer block', () {
+        // One 12-byte temperature record needs three blocks from MacDive's
+        // encoder: the record, its padding, and the trailer block. Two blocks
+        // with a length of 12 would read the trailer's own first word as the
+        // temperature, so the run must end before the trailer block.
+        final plain = Uint8List(16);
+        ByteData.sublistView(plain)
+          ..setFloat32(0, 0.0, Endian.little)
+          ..setFloat32(4, 3.0, Endian.little)
+          ..setFloat32(8, 21.0, Endian.little)
+          ..setUint32(12, 12, Endian.little);
+        final blob = Uint8List(8 + plain.length);
+        ByteData.sublistView(blob)
+          ..setUint32(0, 4, Endian.little)
+          ..setUint32(
+            4,
+            MacDiveSamplesDecoder.optionTemperature,
+            Endian.little,
+          );
+        blob.setRange(
+          8,
+          blob.length,
+          MacDiveSamplesDecoder.cipher.encrypt(plain),
+        );
+        expect(MacDiveSamplesDecoder.decode(blob), isNull);
+      });
+
       test('a record run that is not a whole number of records', () {
         final blob = _encode([
           [0.0, 0.0],

--- a/test/features/universal_import/data/services/macdive_samples_decoder_test.dart
+++ b/test/features/universal_import/data/services/macdive_samples_decoder_test.dart
@@ -1,0 +1,236 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/universal_import/data/services/macdive_samples_decoder.dart';
+import 'package:submersion/features/universal_import/data/services/macdive_sqlite_sample.dart';
+
+/// Three samples encoded by a Python port of MacDive's own encoder, so these
+/// fixtures pin the byte layout independently of the Dart decoder. The
+/// Python encoder reproduced, byte for byte, ciphertext signatures observed
+/// in real `ZSAMPLES` blobs, and its decoder matched MacDive's UDDF export
+/// sample-for-sample across a 540-dive library.
+///
+/// Sample values, in record order: time, depth, then the optional fields.
+///
+/// | time | depth | air  | air2 | bpm | ndt | ppo2 | temp | nextStop | tts |
+/// |------|-------|------|------|-----|-----|------|------|----------|-----|
+/// | 0    | 0.0   | 3000 | 2900 | 70  | 99  | 0.21 | 27.5 | 0.0      | 0   |
+/// | 10   | 5.5   | 2980 | 2890 | 75  | 60  | 0.32 | 26.0 | 3.0      | 1   |
+/// | 20   | 12.25 | 2950 | 2880 | 80  | 30  | 0.47 | 24.5 | 6.0      | 2   |
+const _allFields = // options 0xFF
+    '04000000ff00000084b90aa09fbb1ecc2049c918d62c7ceba2affb6a442190266cb33c'
+    '2fe1add77784b90aa09fbb1ecc661a89ab790cd3e69cf4906ecb6bcd3e30b58f041717'
+    '4f2ebf550922123b3eaa8d9c9bc48edbbe43041b29d8446d86aa4ab20f9f62017bc2c7'
+    '8d881caabedea6ed8ebab32e035bcba920838ad92b9ec65c84e51200fcc0d2';
+
+/// Options 0x9D: pressure, NDT, ppO2, temperature and TTS. The layout of
+/// every Shearwater Teric dive in the reference library.
+const _tericFields =
+    '040000009d00000084b90aa09fbb1ecc707a303efd5ca4136cb33c2fe1add7778982a2'
+    '5a71ac47cc7712a88bff48c72d59c702e26818946bf577aa1d81920c4f041b29d8446d'
+    '86aa539dacfb348f9599ed8ebab32e035bcb1bf1a889d25515a01095ad38eec6379a';
+
+/// Options 0x10: temperature only.
+const _temperatureOnly =
+    '040000001000000084b90aa09fbb1ecc913727cb0760f109186d911e940f2f85041b29'
+    'd8446d86aafb82d2151205e2abfb9239925fb6da76';
+
+/// Options 0: bare time and depth.
+const _timeAndDepth =
+    '040000000000000084b90aa09fbb1ecc661a89ab790cd3e6041b29d8446d86aa242dfe'
+    'ce0112c369';
+
+/// Exactly what MacDive stores for a dive with an empty sample array: the
+/// header plus one block holding the zero length.
+const _empty = '040000000000000084b90aa09fbb1ecc';
+
+Uint8List _hex(String s) {
+  final out = Uint8List(s.length ~/ 2);
+  for (var i = 0; i < out.length; i++) {
+    out[i] = int.parse(s.substring(i * 2, i * 2 + 2), radix: 16);
+  }
+  return out;
+}
+
+void main() {
+  group('MacDiveSamplesDecoder', () {
+    test('decodes every optional field in encoder order', () {
+      final samples = MacDiveSamplesDecoder.decode(_hex(_allFields))!;
+      expect(samples, hasLength(3));
+
+      final MacDiveSqliteSample s = samples[1];
+      expect(s.time, const Duration(seconds: 10));
+      expect(s.depthMeters, closeTo(5.5, 1e-6));
+      expect(s.pressure, closeTo(2980.0, 1e-3));
+      expect(s.pressure2, closeTo(2890.0, 1e-3));
+      expect(s.heartRate, 75);
+      expect(s.ndtMinutes, 60);
+      expect(s.ppO2, closeTo(0.32, 1e-6));
+      expect(s.temperatureCelsius, closeTo(26.0, 1e-6));
+      expect(s.nextStopDepthMeters, closeTo(3.0, 1e-6));
+      expect(s.ttsMinutes, 1);
+
+      expect(samples[2].time, const Duration(seconds: 20));
+      expect(samples[2].depthMeters, closeTo(12.25, 1e-6));
+      expect(samples[2].ttsMinutes, 2);
+    });
+
+    test('the options word selects which fields each record carries', () {
+      final samples = MacDiveSamplesDecoder.decode(_hex(_tericFields))!;
+      expect(samples, hasLength(3));
+      final s = samples[2];
+      expect(s.depthMeters, closeTo(12.25, 1e-6));
+      expect(s.pressure, closeTo(2950.0, 1e-3));
+      expect(s.ndtMinutes, 30);
+      expect(s.ppO2, closeTo(0.47, 1e-6));
+      expect(s.temperatureCelsius, closeTo(24.5, 1e-6));
+      expect(s.ttsMinutes, 2);
+      // Absent from the options word, so absent from the record.
+      expect(s.pressure2, isNull);
+      expect(s.heartRate, isNull);
+      expect(s.nextStopDepthMeters, isNull);
+    });
+
+    test('a single optional field lands in the right slot', () {
+      final samples = MacDiveSamplesDecoder.decode(_hex(_temperatureOnly))!;
+      expect(samples.map((s) => s.temperatureCelsius), [27.5, 26.0, 24.5]);
+      expect(samples.map((s) => s.pressure), [null, null, null]);
+    });
+
+    test('no options means bare time and depth records', () {
+      final samples = MacDiveSamplesDecoder.decode(_hex(_timeAndDepth))!;
+      expect(samples.map((s) => s.time.inSeconds), [0, 10, 20]);
+      expect(samples.map((s) => s.depthMeters), [0.0, 5.5, 12.25]);
+    });
+
+    test('an empty sample array decodes to an empty list, not null', () {
+      expect(MacDiveSamplesDecoder.decode(_hex(_empty)), isEmpty);
+    });
+
+    test('fractional seconds survive the float', () {
+      final blob = _encode([(2.5, 1.0), (7.25, 2.0)], options: 0);
+      final samples = MacDiveSamplesDecoder.decode(blob)!;
+      expect(samples.map((s) => s.time.inMilliseconds), [2500, 7250]);
+    });
+
+    test('versions 2 and 3 share the version 4 layout', () {
+      for (final version in [2, 3]) {
+        final blob = _encode([(0.0, 0.0), (5.0, 3.0)], options: 0);
+        ByteData.sublistView(blob).setUint32(0, version, Endian.little);
+        final samples = MacDiveSamplesDecoder.decode(blob);
+        expect(samples, isNotNull, reason: 'version $version');
+        expect(samples!.last.depthMeters, 3.0);
+      }
+    });
+
+    test('bits above the low byte of the options word are ignored', () {
+      final blob = _encode([(0.0, 0.0), (5.0, 3.0)], options: 0);
+      ByteData.sublistView(blob).setUint32(4, 0x100, Endian.little);
+      expect(MacDiveSamplesDecoder.decode(blob), hasLength(2));
+    });
+
+    test('version 1 records are unencrypted 24-byte fixed layouts', () {
+      final blob = Uint8List(4 + 24 * 2);
+      final data = ByteData.sublistView(blob);
+      data.setUint32(0, 1, Endian.little);
+      var offset = 4;
+      for (final (time, depth, air, ndt, ppo2, temp) in [
+        (0.0, 0.0, 200.0, 99, 0.21, 22.0),
+        (30.0, 18.0, 190.0, 40, 0.59, 21.5),
+      ]) {
+        data.setFloat32(offset, time, Endian.little);
+        data.setFloat32(offset + 4, depth, Endian.little);
+        data.setFloat32(offset + 8, air, Endian.little);
+        data.setInt32(offset + 12, ndt, Endian.little);
+        data.setFloat32(offset + 16, ppo2, Endian.little);
+        data.setFloat32(offset + 20, temp, Endian.little);
+        offset += 24;
+      }
+
+      final samples = MacDiveSamplesDecoder.decode(blob)!;
+      expect(samples, hasLength(2));
+      final s = samples[1];
+      expect(s.time, const Duration(seconds: 30));
+      expect(s.depthMeters, 18.0);
+      expect(s.pressure, 190.0);
+      expect(s.ndtMinutes, 40);
+      expect(s.ppO2, closeTo(0.59, 1e-6));
+      expect(s.temperatureCelsius, 21.5);
+      expect(s.heartRate, isNull);
+      expect(s.ttsMinutes, isNull);
+    });
+
+    group('rejects', () {
+      test('a blob too short to carry a version', () {
+        expect(MacDiveSamplesDecoder.decode(Uint8List(3)), isNull);
+      });
+
+      test('an unknown version word', () {
+        // The mapper test's long-standing stand-in for "some bytes": 64
+        // bytes of 0x42 read as version 0x42424242.
+        final blob = Uint8List.fromList(List.filled(64, 0x42));
+        expect(MacDiveSamplesDecoder.decode(blob), isNull);
+        final zero = Uint8List(16);
+        expect(MacDiveSamplesDecoder.decode(zero), isNull);
+      });
+
+      test('a header with no body', () {
+        expect(MacDiveSamplesDecoder.decode(_hex('0400000000000000')), isNull);
+      });
+
+      test('a body that is not whole cipher blocks', () {
+        final blob = _hex(_timeAndDepth);
+        expect(MacDiveSamplesDecoder.decode(blob.sublist(0, 20)), isNull);
+      });
+
+      test('a length trailer that overruns the buffer', () {
+        // Corrupt the last cipher block: its plaintext becomes garbage whose
+        // length word is almost certainly larger than the buffer.
+        final blob = _hex(_timeAndDepth);
+        blob[blob.length - 1] ^= 0xFF;
+        expect(MacDiveSamplesDecoder.decode(blob), isNull);
+      });
+
+      test('a record run that is not a whole number of records', () {
+        final blob = _encode([(0.0, 0.0), (5.0, 3.0)], options: 0);
+        // Claim pressure is present: the stride becomes 12, which does not
+        // divide the 16-byte run.
+        ByteData.sublistView(
+          blob,
+        ).setUint32(4, MacDiveSamplesDecoder.optionPressure, Endian.little);
+        expect(MacDiveSamplesDecoder.decode(blob), isNull);
+      });
+
+      test('a non-finite time or depth', () {
+        final blob = _encode([(0.0, 0.0), (double.nan, 3.0)], options: 0);
+        expect(MacDiveSamplesDecoder.decode(blob), isNull);
+      });
+    });
+  });
+}
+
+/// Encodes bare (time, depth) records the way MacDive's encoder does: pack,
+/// pad to a block boundary, append a block whose last word is the byte length
+/// of the packed run, then TEA-ECB the lot under the app key.
+Uint8List _encode(List<(double, double)> records, {required int options}) {
+  final packed = Uint8List(records.length * 8);
+  final data = ByteData.sublistView(packed);
+  for (var i = 0; i < records.length; i++) {
+    data.setFloat32(i * 8, records[i].$1, Endian.little);
+    data.setFloat32(i * 8 + 4, records[i].$2, Endian.little);
+  }
+  final blocks = (packed.length + 7) ~/ 8 + 1;
+  final plain = Uint8List(blocks * 8)..setRange(0, packed.length, packed);
+  ByteData.sublistView(
+    plain,
+  ).setUint32(plain.length - 4, packed.length, Endian.little);
+
+  const cipher = MacDiveSamplesDecoder.cipher;
+  final blob = Uint8List(8 + plain.length);
+  ByteData.sublistView(blob)
+    ..setUint32(0, 4, Endian.little)
+    ..setUint32(4, options, Endian.little);
+  blob.setRange(8, blob.length, cipher.encrypt(plain));
+  return blob;
+}

--- a/test/features/universal_import/data/services/macdive_samples_decoder_test.dart
+++ b/test/features/universal_import/data/services/macdive_samples_decoder_test.dart
@@ -109,14 +109,20 @@ void main() {
     });
 
     test('fractional seconds survive the float', () {
-      final blob = _encode([(2.5, 1.0), (7.25, 2.0)], options: 0);
+      final blob = _encode([
+        [2.5, 1.0],
+        [7.25, 2.0],
+      ], options: 0);
       final samples = MacDiveSamplesDecoder.decode(blob)!;
       expect(samples.map((s) => s.time.inMilliseconds), [2500, 7250]);
     });
 
     test('versions 2 and 3 share the version 4 layout', () {
       for (final version in [2, 3]) {
-        final blob = _encode([(0.0, 0.0), (5.0, 3.0)], options: 0);
+        final blob = _encode([
+          [0.0, 0.0],
+          [5.0, 3.0],
+        ], options: 0);
         ByteData.sublistView(blob).setUint32(0, version, Endian.little);
         final samples = MacDiveSamplesDecoder.decode(blob);
         expect(samples, isNotNull, reason: 'version $version');
@@ -125,9 +131,25 @@ void main() {
     });
 
     test('bits above the low byte of the options word are ignored', () {
-      final blob = _encode([(0.0, 0.0), (5.0, 3.0)], options: 0);
+      final blob = _encode([
+        [0.0, 0.0],
+        [5.0, 3.0],
+      ], options: 0);
       ByteData.sublistView(blob).setUint32(4, 0x100, Endian.little);
       expect(MacDiveSamplesDecoder.decode(blob), hasLength(2));
+    });
+
+    test('a non-finite optional field is dropped, not fatal', () {
+      // A bad reading inside a profile MacDive still displays: keep the
+      // sample, lose the field.
+      final blob = _encode([
+        [0.0, 0.0, 27.5],
+        [10.0, 5.5, double.nan],
+        [20.0, 12.25, double.infinity],
+      ], options: MacDiveSamplesDecoder.optionTemperature);
+      final samples = MacDiveSamplesDecoder.decode(blob)!;
+      expect(samples.map((s) => s.depthMeters), [0.0, 5.5, 12.25]);
+      expect(samples.map((s) => s.temperatureCelsius), [27.5, null, null]);
     });
 
     test('version 1 records are unencrypted 24-byte fixed layouts', () {
@@ -137,7 +159,7 @@ void main() {
       var offset = 4;
       for (final (time, depth, air, ndt, ppo2, temp) in [
         (0.0, 0.0, 200.0, 99, 0.21, 22.0),
-        (30.0, 18.0, 190.0, 40, 0.59, 21.5),
+        (30.0, 18.0, double.nan, 40, 0.59, 21.5),
       ]) {
         data.setFloat32(offset, time, Endian.little);
         data.setFloat32(offset + 4, depth, Endian.little);
@@ -153,7 +175,9 @@ void main() {
       final s = samples[1];
       expect(s.time, const Duration(seconds: 30));
       expect(s.depthMeters, 18.0);
-      expect(s.pressure, 190.0);
+      // Non-finite optional values are dropped here too.
+      expect(s.pressure, isNull);
+      expect(samples[0].pressure, 200.0);
       expect(s.ndtMinutes, 40);
       expect(s.ppO2, closeTo(0.59, 1e-6));
       expect(s.temperatureCelsius, 21.5);
@@ -193,7 +217,10 @@ void main() {
       });
 
       test('a record run that is not a whole number of records', () {
-        final blob = _encode([(0.0, 0.0), (5.0, 3.0)], options: 0);
+        final blob = _encode([
+          [0.0, 0.0],
+          [5.0, 3.0],
+        ], options: 0);
         // Claim pressure is present: the stride becomes 12, which does not
         // divide the 16-byte run.
         ByteData.sublistView(
@@ -203,7 +230,10 @@ void main() {
       });
 
       test('a non-finite time or depth', () {
-        final blob = _encode([(0.0, 0.0), (double.nan, 3.0)], options: 0);
+        final blob = _encode([
+          [0.0, 0.0],
+          [double.nan, 3.0],
+        ], options: 0);
         expect(MacDiveSamplesDecoder.decode(blob), isNull);
       });
 
@@ -219,15 +249,18 @@ void main() {
   });
 }
 
-/// Encodes bare (time, depth) records the way MacDive's encoder does: pack,
-/// pad to a block boundary, append a block whose last word is the byte length
-/// of the packed run, then TEA-ECB the lot under the app key.
-Uint8List _encode(List<(double, double)> records, {required int options}) {
-  final packed = Uint8List(records.length * 8);
+/// Encodes float-only records the way MacDive's encoder does: pack each
+/// record's 32-bit floats back to back, pad to a block boundary, append a
+/// block whose last word is the byte length of the packed run, then TEA-ECB
+/// the lot under the app key. Every record must have the same width.
+Uint8List _encode(List<List<double>> records, {required int options}) {
+  final width = records.isEmpty ? 0 : records.first.length * 4;
+  final packed = Uint8List(records.length * width);
   final data = ByteData.sublistView(packed);
   for (var i = 0; i < records.length; i++) {
-    data.setFloat32(i * 8, records[i].$1, Endian.little);
-    data.setFloat32(i * 8 + 4, records[i].$2, Endian.little);
+    for (var j = 0; j < records[i].length; j++) {
+      data.setFloat32(i * width + j * 4, records[i][j], Endian.little);
+    }
   }
   final blocks = (packed.length + 7) ~/ 8 + 1;
   final plain = Uint8List(blocks * 8)..setRange(0, packed.length, packed);

--- a/test/features/universal_import/data/services/macdive_unit_inference_test.dart
+++ b/test/features/universal_import/data/services/macdive_unit_inference_test.dart
@@ -1,5 +1,8 @@
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_raw_types.dart';
+import 'package:submersion/features/universal_import/data/services/macdive_samples_decoder.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_unit_inference.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_xml_models.dart'
     show MacDiveUnitSystem;
@@ -8,9 +11,10 @@ MacDiveRawLogbook _logbook({
   String? unitsPreference,
   List<MacDiveRawTank> tanks = const [],
   List<MacDiveRawTankAndGas> tankAndGases = const [],
+  List<MacDiveRawDive> dives = const [],
 }) {
   return MacDiveRawLogbook(
-    dives: const [],
+    dives: dives,
     sitesByPk: const {},
     buddiesByPk: const {},
     tagsByPk: const {},
@@ -28,6 +32,39 @@ MacDiveRawLogbook _logbook({
     diveToCritterPks: const {},
     unitsPreference: unitsPreference,
   );
+}
+
+MacDiveRawDive _dive(Uint8List samples, {int pk = 1}) =>
+    MacDiveRawDive(pk: pk, uuid: 'dive-$pk', samplesBlob: samples);
+
+/// A `ZSAMPLES` blob whose only optional field is pressure, encoded the way
+/// MacDive does: records packed little-endian, padded to a TEA block, a
+/// trailing block holding the byte length of the run, and the whole body
+/// TEA-ECB encrypted under the app key. Local to this suite because the
+/// decoder and mapper suites pin different record shapes with their own
+/// encoders, and the point here is only that a pressure reaches the scan.
+Uint8List _pressureSamples(List<double> pressures) {
+  const stride = 12;
+  final packed = Uint8List(pressures.length * stride);
+  final data = ByteData.sublistView(packed);
+  for (var i = 0; i < pressures.length; i++) {
+    data
+      ..setFloat32(i * stride, i * 10.0, Endian.little)
+      ..setFloat32(i * stride + 4, 5.0, Endian.little)
+      ..setFloat32(i * stride + 8, pressures[i], Endian.little);
+  }
+  final plain = Uint8List(((packed.length + 7) ~/ 8 + 1) * 8)
+    ..setRange(0, packed.length, packed);
+  ByteData.sublistView(
+    plain,
+  ).setUint32(plain.length - 4, packed.length, Endian.little);
+
+  final blob = Uint8List(8 + plain.length);
+  ByteData.sublistView(blob)
+    ..setUint32(0, 4, Endian.little)
+    ..setUint32(4, MacDiveSamplesDecoder.optionPressure, Endian.little);
+  blob.setRange(8, blob.length, MacDiveSamplesDecoder.cipher.encrypt(plain));
+  return blob;
 }
 
 MacDiveRawTankAndGas _fill(double start, double end) => MacDiveRawTankAndGas(
@@ -137,6 +174,123 @@ void main() {
     test('stays unknown when nothing carries a signal', () {
       // Passthrough beats a coin flip.
       expect(MacDiveUnitInference.infer(_logbook()), MacDiveUnitSystem.unknown);
+    });
+
+    group('ZSAMPLES pressures', () {
+      test('answer for a library that records no cylinders', () {
+        // Before this witness existed such a library resolved to unknown, and
+        // every sample pressure was charted in whatever unit it was stored
+        // in: #912 again, on a column that only became readable with the
+        // ZSAMPLES decoder.
+        expect(
+          MacDiveUnitInference.infer(
+            _logbook(
+              dives: [
+                _dive(_pressureSamples([3000, 2400])),
+              ],
+            ),
+          ),
+          MacDiveUnitSystem.imperial,
+        );
+        expect(
+          MacDiveUnitInference.infer(
+            _logbook(
+              dives: [
+                _dive(_pressureSamples([232, 60])),
+              ],
+            ),
+          ),
+          MacDiveUnitSystem.metric,
+        );
+      });
+
+      test('rank below the cylinder columns, which cost nothing to read', () {
+        expect(
+          MacDiveUnitInference.infer(
+            _logbook(
+              tanks: const [
+                MacDiveRawTank(pk: 1, uuid: 't', workingPressure: 232),
+              ],
+              dives: [
+                _dive(_pressureSamples([3000])),
+              ],
+            ),
+          ),
+          MacDiveUnitSystem.metric,
+        );
+        expect(
+          MacDiveUnitInference.infer(
+            _logbook(
+              tanks: const [MacDiveRawTank(pk: 1, uuid: 't', size: 12)],
+              dives: [
+                _dive(_pressureSamples([3000])),
+              ],
+            ),
+          ),
+          MacDiveUnitSystem.metric,
+        );
+      });
+
+      test('of zero are "not set" here too', () {
+        expect(
+          MacDiveUnitInference.infer(
+            _logbook(
+              dives: [
+                _dive(_pressureSamples([0, 0])),
+              ],
+            ),
+          ),
+          MacDiveUnitSystem.unknown,
+        );
+      });
+
+      test('survive an unreadable blob earlier in the library', () {
+        expect(
+          MacDiveUnitInference.infer(
+            _logbook(
+              dives: [
+                _dive(Uint8List.fromList(List.filled(64, 0x42))),
+                _dive(_pressureSamples([3000]), pk: 2),
+              ],
+            ),
+          ),
+          MacDiveUnitSystem.imperial,
+        );
+      });
+
+      test('past the scan limit are not read', () {
+        // The documented cost of not decrypting a whole library to answer a
+        // question the cylinder columns normally answer for free. The mapper
+        // covers the gap by dropping sample pressures it cannot convert
+        // rather than charting them raw.
+        final dives = [
+          for (var i = 0; i <= MacDiveUnitInference.sampleScanDiveLimit; i++)
+            _dive(
+              _pressureSamples(
+                i < MacDiveUnitInference.sampleScanDiveLimit ? [0] : [3000],
+              ),
+              pk: i + 1,
+            ),
+        ];
+        expect(
+          MacDiveUnitInference.infer(_logbook(dives: dives)),
+          MacDiveUnitSystem.unknown,
+        );
+      });
+
+      test('stop the scan as soon as one can only be psi', () {
+        // A reading above the ceiling settles it; nothing later can change
+        // the answer, so the remaining blobs are never decrypted.
+        final dives = [
+          _dive(_pressureSamples([3000])),
+          for (var i = 1; i <= MacDiveUnitInference.sampleScanDiveLimit; i++)
+            _dive(_pressureSamples([0]), pk: i + 1),
+        ];
+        expect(
+          MacDiveUnitInference.infer(_logbook(dives: dives)),
+          MacDiveUnitSystem.imperial,
+        );
+      });
     });
   });
 }

--- a/test/features/universal_import/data/services/tea_block_cipher_test.dart
+++ b/test/features/universal_import/data/services/tea_block_cipher_test.dart
@@ -1,0 +1,77 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/universal_import/data/services/tea_block_cipher.dart';
+
+void main() {
+  group('TeaBlockCipher', () {
+    test('matches the published TEA known-answer vector', () {
+      // Wheeler and Needham's reference: an all-zero key on an all-zero
+      // block yields 41ea3a0a 94baa940.
+      const cipher = TeaBlockCipher(0, 0, 0, 0);
+      expect(cipher.encryptBlock(0, 0), (0x41EA3A0A, 0x94BAA940));
+      expect(cipher.decryptBlock(0x41EA3A0A, 0x94BAA940), (0, 0));
+    });
+
+    test('decryptBlock inverts encryptBlock under a non-trivial key', () {
+      // Computed with an independent Python implementation that was itself
+      // checked against real MacDive data, so this pins the key-word order.
+      const cipher = TeaBlockCipher(0x86, 0x16, 0x80, 0x60);
+      expect(cipher.encryptBlock(0x01234567, 0x89ABCDEF), (
+        0x4B3761A6,
+        0xCA4F7DA4,
+      ));
+      expect(cipher.decryptBlock(0x4B3761A6, 0xCA4F7DA4), (
+        0x01234567,
+        0x89ABCDEF,
+      ));
+    });
+
+    test('encrypt and decrypt walk a buffer block by block in ECB', () {
+      const cipher = TeaBlockCipher(1, 2, 3, 4);
+      final plain = Uint8List.fromList(List.generate(24, (i) => i * 9 & 0xFF));
+      final encrypted = cipher.encrypt(plain);
+      expect(encrypted, hasLength(24));
+      expect(encrypted, isNot(equals(plain)));
+      // ECB: identical plaintext blocks encrypt identically.
+      final repeated = Uint8List.fromList([
+        ...plain.sublist(0, 8),
+        ...plain.sublist(0, 8),
+      ]);
+      final twice = cipher.encrypt(repeated);
+      expect(twice.sublist(0, 8), twice.sublist(8, 16));
+      expect(cipher.decrypt(encrypted), plain);
+      // The input buffer is not modified in place.
+      expect(plain[3], 27);
+    });
+
+    test('a buffer that is not whole blocks is rejected', () {
+      const cipher = TeaBlockCipher(1, 2, 3, 4);
+      expect(() => cipher.decrypt(Uint8List(12)), throwsArgumentError);
+      expect(() => cipher.encrypt(Uint8List(1)), throwsArgumentError);
+      expect(cipher.decrypt(Uint8List(0)), isEmpty);
+    });
+
+    test(
+      'an all-zero block under the MacDive key is the surface signature',
+      () {
+        // The earlier investigation catalogued 84b90aa09fbb1ecc as a
+        // "body prefix" on 56% of dives without knowing why. It is the
+        // ciphertext of time 0.0 and depth 0.0, the first record of any dive
+        // that starts at the surface.
+        const cipher = TeaBlockCipher(0x86, 0x16, 0x80, 0x60);
+        expect(cipher.encrypt(Uint8List(8)), [
+          0x84,
+          0xB9,
+          0x0A,
+          0xA0,
+          0x9F,
+          0xBB,
+          0x1E,
+          0xCC,
+        ]);
+      },
+    );
+  });
+}

--- a/test/features/universal_import/data/services/tea_block_cipher_test.dart
+++ b/test/features/universal_import/data/services/tea_block_cipher_test.dart
@@ -46,6 +46,12 @@ void main() {
       expect(plain[3], 27);
     });
 
+    test('a key word outside 32 bits is rejected', () {
+      expect(() => TeaBlockCipher(1 << 32, 0, 0, 0), throwsAssertionError);
+      expect(() => TeaBlockCipher(0, 0, 0, -1), throwsAssertionError);
+      expect(const TeaBlockCipher(0xFFFFFFFF, 0, 0, 0).k0, 0xFFFFFFFF);
+    });
+
     test('a buffer that is not whole blocks is rejected', () {
       const cipher = TeaBlockCipher(1, 2, 3, 4);
       expect(() => cipher.decrypt(Uint8List(12)), throwsArgumentError);


### PR DESCRIPTION
## Summary

MacDive's `ZDIVE.ZSAMPLES` column holds the profile MacDive itself draws for a dive. The April investigation concluded it was AES under a per-dive key and left it unread, so every dive without a usable `ZRAWDATA` (83 of 350 in the reference library, plus every computer MacDive did not download through libdivecomputer) imported with no profile and a "format Submersion cannot read" warning.

It is not AES. Reading the codec out of MacDive 2.16.3's `MDSampleUtils` class shows it is classic TEA in ECB mode under a key compiled into the binary, over a simple fixed-width record layout selected by an options bitmask. The CommonCrypto imports the earlier spike keyed on belong to minizip's zip-password support. Every "per-dive marker" it catalogued was an ECB block of repeated plaintext.

This PR ports the decoder to Dart and uses it as the mapper's fallback behind the existing `ZRAWDATA` path. The raw download keeps precedence because libdivecomputer yields channels the samples never carry (per-cell ppO2, deco settings, events); the samples cover every dive without usable raw bytes, every rejected raw parse, and every platform without the native channel. The "cannot read" warning is gone; only a dive with unreadable bytes in both columns is reported.

Built on top of #1447, which rewrites the same section of the mapper, so this PR carries that PR's three commits until it merges; the diff shrinks to the ZSAMPLES change alone afterwards. Targeting main rather than the #1447 branch because the CI/CD workflow only runs for PRs into main.

## Changes

- `tea_block_cipher.dart`: TEA, 32 rounds, ECB over a buffer plus single-block primitives. Pinned to the published known-answer vector.
- `macdive_samples_decoder.dart` and `macdive_sqlite_sample.dart`: header (version, options), TEA body, length trailer, records in the encoder's field order. Versions 2 to 4 (encrypted) and version 1 (unencrypted 24-byte records). Fails closed on any structural check so a foreign blob never becomes a plausible profile.
- `MacDiveDiveMapper`: `_attachSamples` fallback; sample pressures go through the same display-unit conversion as the tank columns (psi in the reference library); NDT and TTS minutes become seconds; zero pressure, ppO2 and heart rate readings are omitted as "no reading"; samples fill max depth, water temperature and runtime gaps without overriding MacDive's scalars. One aggregated warning whose wording depends on whether the platform channel was available.
- `docs/import-formats/macdive-zsamples.md`: status corrected, full format specification and verification record appended; the earlier NO-GO sections retained unedited.
- Tests: cipher vectors, decoder fixtures generated by an independent Python encoder built from the disassembly (which reproduces real ciphertext byte for byte), mapper fallback and precedence cases, and real-data assertions that all 350 blobs decode and 348 profiles reach the payload.

## Verification against the 540-dive reference library

- All 350 `ZSAMPLES` blobs decode; two are empty sample arrays.
- Depth and time match MacDive's UDDF export sample for sample on all 348 non-empty dives. The export prepends a synthetic surface point when a dive starts submerged and appends one when it ends submerged, which accounts for exactly its 1 to 2 extra waypoints on 268 dives.
- Temperature matches the UDDF export on every dive carrying it; pressure matches the XML export's psi on all 257 dives with that field; NDT matches the XML minutes on all 268; ppO2 matches on all 340.

## Test Plan

- [x] `flutter test` passes on the touched suites (cipher, decoder, mapper, parser, db reader: 87 tests) and the pre-push affected set (93)
- [x] `flutter analyze` passes
- [x] Real-data suite against the 540-dive library with `MACDIVE_SQLITE_REAL_SAMPLE_PATH`: 28 tests
- [x] Manual testing on: macOS import of a MacDive library with non-Shearwater dives
