### PR TITLE
fix(libdc): correct the off-by-one event-code table behind false deco violations

### DIFF
--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -911,6 +911,11 @@ class ReparseService {
         return 'decoViolation';
       case 'PO2':
         return 'ppO2High';
+      case 'rbt':
+      case 'airtime':
+        // Remaining bottom time (Uwatec) and air time (Suunto) alarms both
+        // mean the gas supply is running short at the current rate.
+        return 'lowGas';
       default:
         return null;
     }
@@ -923,6 +928,7 @@ class ReparseService {
       case 'ppO2High':
         return 'alert';
       case 'ascentRateWarning':
+      case 'lowGas':
         return 'warning';
       default:
         return 'info';

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -2066,6 +2066,11 @@ class DiveComputerRepository {
         return 'decoViolation';
       case 'PO2':
         return 'ppO2High';
+      case 'rbt':
+      case 'airtime':
+        // Remaining bottom time (Uwatec) and air time (Suunto) alarms both
+        // mean the gas supply is running short at the current rate.
+        return 'lowGas';
       default:
         return null;
     }
@@ -2080,6 +2085,7 @@ class DiveComputerRepository {
       case 'ppO2High':
         return 'alert';
       case 'ascentRateWarning':
+      case 'lowGas':
         return 'warning';
       case 'safetyStopStart':
       case 'decoStopStart':

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -712,7 +712,7 @@ class DiveComputerHostApiImpl(
             if (e[1] == 0L) return@mapNotNull null  // skip EVENT_NONE
             DiveEvent(
                 timeSeconds = e[0] / 1000,
-                type = mapEventType(e[1].toInt()),
+                type = libdcEventTypeName(e[1].toInt()),
                 data = mapOf("flags" to e[2].toString(), "value" to e[3].toString())
             )
         }
@@ -868,34 +868,5 @@ class DiveComputerHostApiImpl(
                 "latest version."
         )
         return false
-    }
-
-    private fun mapEventType(type: Int): String = when (type) {
-        0 -> "none"
-        1 -> "deco"
-        2 -> "ascent"
-        3 -> "ceiling"
-        4 -> "workload"
-        5 -> "transmitter"
-        6 -> "violation"
-        7 -> "bookmark"
-        8 -> "surface"
-        9 -> "safetystop"
-        10 -> "gaschange"
-        11 -> "safetystop_voluntary"
-        12 -> "safetystop_mandatory"
-        13 -> "deepstop"
-        14 -> "ceiling_safetystop"
-        15 -> "floor"
-        16 -> "divetime"
-        17 -> "maxdepth"
-        18 -> "OLF"
-        19 -> "PO2"
-        20 -> "airtime"
-        21 -> "rgbm"
-        22 -> "heading"
-        23 -> "tissuelevel"
-        24 -> "gaschange2"
-        else -> "unknown_$type"
     }
 }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/LibdcEventTypeNames.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/LibdcEventTypeNames.kt
@@ -1,0 +1,47 @@
+package com.submersion.libdivecomputer
+
+/**
+ * Name of a libdivecomputer sample event type (`parser_sample_event_t`), in
+ * the spelling the Dart layer switches on ("ascent", "ceiling", ...).
+ *
+ * This is the JVM twin of `libdc_event_type_name` in the C wrapper
+ * (`macos/Classes/libdc_download.c`), which every other platform calls
+ * directly. The JNI layer hands events to Kotlin as positional arrays, and a
+ * JVM unit test cannot load the native library, so the table is kept here in
+ * Kotlin and pinned to the enum order in
+ * `third_party/libdivecomputer/include/libdivecomputer/parser.h` by
+ * [LibdcEventTypeNamesTest].
+ *
+ * The per-file copies this replaced had all skipped `SAMPLE_EVENT_RBT` (2),
+ * which shifted every later code by one: ascent-rate alarms were reported as
+ * "ceiling" and displayed as deco violations on no-deco dives.
+ */
+internal fun libdcEventTypeName(type: Int): String = when (type) {
+    0 -> "none"
+    1 -> "deco"
+    2 -> "rbt"
+    3 -> "ascent"
+    4 -> "ceiling"
+    5 -> "workload"
+    6 -> "transmitter"
+    7 -> "violation"
+    8 -> "bookmark"
+    9 -> "surface"
+    10 -> "safetystop"
+    11 -> "gaschange"
+    12 -> "safetystop_voluntary"
+    13 -> "safetystop_mandatory"
+    14 -> "deepstop"
+    15 -> "ceiling_safetystop"
+    16 -> "floor"
+    17 -> "divetime"
+    18 -> "maxdepth"
+    19 -> "OLF"
+    20 -> "PO2"
+    21 -> "airtime"
+    22 -> "rgbm"
+    23 -> "heading"
+    24 -> "tissuelevel"
+    25 -> "gaschange2"
+    else -> "unknown"
+}

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/SerialDownloadRunner.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/SerialDownloadRunner.kt
@@ -13,11 +13,12 @@ private const val RUNNER_LIBDC_STATUS_CANCELLED = -10
  * (see SerialDownloadClient). Adapted from DiveComputerHostApiImpl's in-process
  * serial download; emits results through the AIDL callback instead of Pigeon.
  *
- * NOTE: convertParsedDive / mapEventType below are duplicated verbatim from
- * DiveComputerHostApiImpl (they read the native dive pointer, which is valid in
+ * NOTE: convertParsedDive below is duplicated verbatim from
+ * DiveComputerHostApiImpl (it reads the native dive pointer, which is valid in
  * whichever process owns it). FOLLOW-UP: once this branch builds in CI, extract
- * them into a shared `DiveConverter` object used by both the BLE (in-process)
- * and serial (:dc) paths, to remove the duplication.
+ * it into a shared `DiveConverter` object used by both the BLE (in-process)
+ * and serial (:dc) paths, to remove the duplication. The event-name table has
+ * already been extracted (see libdcEventTypeName).
  */
 class SerialDownloadRunner(private val context: Context) {
 
@@ -217,7 +218,7 @@ class SerialDownloadRunner(private val context: Context) {
             if (e[1] == 0L) return@mapNotNull null  // skip EVENT_NONE
             DiveEvent(
                 timeSeconds = e[0] / 1000,
-                type = mapEventType(e[1].toInt()),
+                type = libdcEventTypeName(e[1].toInt()),
                 data = mapOf("flags" to e[2].toString(), "value" to e[3].toString())
             )
         }
@@ -271,34 +272,5 @@ class SerialDownloadRunner(private val context: Context) {
             rawData = rawData,
             rawFingerprint = rawFingerprint
         )
-    }
-
-    private fun mapEventType(type: Int): String = when (type) {
-        0 -> "none"
-        1 -> "deco"
-        2 -> "ascent"
-        3 -> "ceiling"
-        4 -> "workload"
-        5 -> "transmitter"
-        6 -> "violation"
-        7 -> "bookmark"
-        8 -> "surface"
-        9 -> "safetystop"
-        10 -> "gaschange"
-        11 -> "safetystop_voluntary"
-        12 -> "safetystop_mandatory"
-        13 -> "deepstop"
-        14 -> "ceiling_safetystop"
-        15 -> "floor"
-        16 -> "divetime"
-        17 -> "maxdepth"
-        18 -> "OLF"
-        19 -> "PO2"
-        20 -> "airtime"
-        21 -> "rgbm"
-        22 -> "heading"
-        23 -> "tissuelevel"
-        24 -> "gaschange2"
-        else -> "unknown_$type"
     }
 }

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/LibdcEventTypeNamesTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/LibdcEventTypeNamesTest.kt
@@ -1,0 +1,67 @@
+package com.submersion.libdivecomputer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Pins [libdcEventTypeName] to the order of `parser_sample_event_t` in
+ * `third_party/libdivecomputer/include/libdivecomputer/parser.h`. The C
+ * wrapper's copy of this table is checked against the enum symbols themselves
+ * by `test/native/test_event_type_names.c`; this JVM copy cannot see the
+ * header, so the enum order is spelled out here and must be kept in step.
+ */
+class LibdcEventTypeNamesTest {
+    // parser_sample_event_t, in declaration order.
+    private val enumOrder = listOf(
+        "none",                 // SAMPLE_EVENT_NONE
+        "deco",                 // SAMPLE_EVENT_DECOSTOP
+        "rbt",                  // SAMPLE_EVENT_RBT
+        "ascent",               // SAMPLE_EVENT_ASCENT
+        "ceiling",              // SAMPLE_EVENT_CEILING
+        "workload",             // SAMPLE_EVENT_WORKLOAD
+        "transmitter",          // SAMPLE_EVENT_TRANSMITTER
+        "violation",            // SAMPLE_EVENT_VIOLATION
+        "bookmark",             // SAMPLE_EVENT_BOOKMARK
+        "surface",              // SAMPLE_EVENT_SURFACE
+        "safetystop",           // SAMPLE_EVENT_SAFETYSTOP
+        "gaschange",            // SAMPLE_EVENT_GASCHANGE
+        "safetystop_voluntary", // SAMPLE_EVENT_SAFETYSTOP_VOLUNTARY
+        "safetystop_mandatory", // SAMPLE_EVENT_SAFETYSTOP_MANDATORY
+        "deepstop",             // SAMPLE_EVENT_DEEPSTOP
+        "ceiling_safetystop",   // SAMPLE_EVENT_CEILING_SAFETYSTOP
+        "floor",                // SAMPLE_EVENT_FLOOR
+        "divetime",             // SAMPLE_EVENT_DIVETIME
+        "maxdepth",             // SAMPLE_EVENT_MAXDEPTH
+        "OLF",                  // SAMPLE_EVENT_OLF
+        "PO2",                  // SAMPLE_EVENT_PO2
+        "airtime",              // SAMPLE_EVENT_AIRTIME
+        "rgbm",                 // SAMPLE_EVENT_RGBM
+        "heading",              // SAMPLE_EVENT_HEADING
+        "tissuelevel",          // SAMPLE_EVENT_TISSUELEVEL
+        "gaschange2",           // SAMPLE_EVENT_GASCHANGE2
+    )
+
+    @Test
+    fun `every enum member maps to its name in declaration order`() {
+        enumOrder.forEachIndexed { code, name ->
+            assertEquals("code $code", name, libdcEventTypeName(code))
+        }
+    }
+
+    @Test
+    fun `an ascent-rate alarm is never reported as a ceiling`() {
+        // The Mares Icon HD family raises SAMPLE_EVENT_ASCENT (3) for its
+        // fast-ascent alarms, several times on an ordinary recreational dive.
+        assertEquals("ascent", libdcEventTypeName(3))
+        assertNotEquals("ceiling", libdcEventTypeName(3))
+        assertEquals("ceiling", libdcEventTypeName(4))
+    }
+
+    @Test
+    fun `codes outside the enum are unknown`() {
+        assertEquals("unknown", libdcEventTypeName(enumOrder.size))
+        assertEquals("unknown", libdcEventTypeName(-1))
+        assertEquals("unknown", libdcEventTypeName(Int.MAX_VALUE))
+    }
+}

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
@@ -886,7 +886,9 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
             for i in 0..<Int(dive.event_count) {
                 let e = eventsPtr[i]
                 guard e.type != 0 else { continue }  // skip SAMPLE_EVENT_NONE
-                let typeName = Self.mapEventType(e.type)
+                // One shared table for every platform; see
+                // libdc_event_type_name in libdc_wrapper.h.
+                let typeName = String(cString: libdc_event_type_name(e.type))
                 let data: [String: String] = [
                     "flags": String(e.flags),
                     "value": String(e.value),
@@ -958,37 +960,6 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
             exitLatitude: dive.exit_latitude.isNaN ? nil : dive.exit_latitude,
             exitLongitude: dive.exit_longitude.isNaN ? nil : dive.exit_longitude
         )
-    }
-
-    private static func mapEventType(_ type: UInt32) -> String {
-        switch type {
-        case 0: return "none"
-        case 1: return "deco"
-        case 2: return "ascent"
-        case 3: return "ceiling"
-        case 4: return "workload"
-        case 5: return "transmitter"
-        case 6: return "violation"
-        case 7: return "bookmark"
-        case 8: return "surface"
-        case 9: return "safetystop"
-        case 10: return "gaschange"
-        case 11: return "safetystop_voluntary"
-        case 12: return "safetystop_mandatory"
-        case 13: return "deepstop"
-        case 14: return "ceiling_safetystop"
-        case 15: return "floor"
-        case 16: return "divetime"
-        case 17: return "maxdepth"
-        case 18: return "OLF"
-        case 19: return "PO2"
-        case 20: return "airtime"
-        case 21: return "rgbm"
-        case 22: return "heading"
-        case 23: return "tissuelevel"
-        case 24: return "gaschange2"
-        default: return "unknown_\(type)"
-        }
     }
 
     // MARK: - Parse Raw Dive Data

--- a/packages/libdivecomputer_plugin/linux/dive_converter.c
+++ b/packages/libdivecomputer_plugin/linux/dive_converter.c
@@ -7,34 +7,9 @@
 #include <string.h>
 
 const char* map_event_type(unsigned int type) {
-    switch (type) {
-        case 0: return "none";
-        case 1: return "deco";
-        case 2: return "ascent";
-        case 3: return "ceiling";
-        case 4: return "workload";
-        case 5: return "transmitter";
-        case 6: return "violation";
-        case 7: return "bookmark";
-        case 8: return "surface";
-        case 9: return "safetystop";
-        case 10: return "gaschange";
-        case 11: return "safetystop_voluntary";
-        case 12: return "safetystop_mandatory";
-        case 13: return "deepstop";
-        case 14: return "ceiling_safetystop";
-        case 15: return "floor";
-        case 16: return "divetime";
-        case 17: return "maxdepth";
-        case 18: return "OLF";
-        case 19: return "PO2";
-        case 20: return "airtime";
-        case 21: return "rgbm";
-        case 22: return "heading";
-        case 23: return "tissuelevel";
-        case 24: return "gaschange2";
-        default: return "unknown";
-    }
+    // One shared table for every platform; see libdc_event_type_name in
+    // libdc_wrapper.h for why this is no longer a local switch.
+    return libdc_event_type_name(type);
 }
 
 LibdivecomputerPluginParsedDive* convert_parsed_dive(

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
@@ -149,6 +149,41 @@ static int is_usable_location(double latitude, double longitude) {
            longitude >= -180.0 && longitude <= 180.0;
 }
 
+const char *libdc_event_type_name(unsigned int type) {
+    // Switch on the enum symbols, never on literal codes: each symbol's value
+    // is owned by libdivecomputer's parser.h, and the native test
+    // (test_event_type_names.c) walks the whole enum against this table.
+    switch (type) {
+    case SAMPLE_EVENT_NONE: return "none";
+    case SAMPLE_EVENT_DECOSTOP: return "deco";
+    case SAMPLE_EVENT_RBT: return "rbt";
+    case SAMPLE_EVENT_ASCENT: return "ascent";
+    case SAMPLE_EVENT_CEILING: return "ceiling";
+    case SAMPLE_EVENT_WORKLOAD: return "workload";
+    case SAMPLE_EVENT_TRANSMITTER: return "transmitter";
+    case SAMPLE_EVENT_VIOLATION: return "violation";
+    case SAMPLE_EVENT_BOOKMARK: return "bookmark";
+    case SAMPLE_EVENT_SURFACE: return "surface";
+    case SAMPLE_EVENT_SAFETYSTOP: return "safetystop";
+    case SAMPLE_EVENT_GASCHANGE: return "gaschange";
+    case SAMPLE_EVENT_SAFETYSTOP_VOLUNTARY: return "safetystop_voluntary";
+    case SAMPLE_EVENT_SAFETYSTOP_MANDATORY: return "safetystop_mandatory";
+    case SAMPLE_EVENT_DEEPSTOP: return "deepstop";
+    case SAMPLE_EVENT_CEILING_SAFETYSTOP: return "ceiling_safetystop";
+    case SAMPLE_EVENT_FLOOR: return "floor";
+    case SAMPLE_EVENT_DIVETIME: return "divetime";
+    case SAMPLE_EVENT_MAXDEPTH: return "maxdepth";
+    case SAMPLE_EVENT_OLF: return "OLF";
+    case SAMPLE_EVENT_PO2: return "PO2";
+    case SAMPLE_EVENT_AIRTIME: return "airtime";
+    case SAMPLE_EVENT_RGBM: return "rgbm";
+    case SAMPLE_EVENT_HEADING: return "heading";
+    case SAMPLE_EVENT_TISSUELEVEL: return "tissuelevel";
+    case SAMPLE_EVENT_GASCHANGE2: return "gaschange2";
+    default: return "unknown";
+    }
+}
+
 static void push_event(libdc_parsed_dive_t *dive,
                         unsigned int time_ms,
                         unsigned int type,

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
@@ -226,6 +226,14 @@ typedef struct {
     unsigned int usage;        // dc_usage_t (0=none, 1=oxygen, 2=diluent, 3=sidemount)
 } libdc_tank_t;
 
+// Name of a libdivecomputer sample event type (parser_sample_event_t), in
+// the spelling the Dart layer switches on ("ascent", "ceiling", ...). This is
+// the single table every platform binding must use: the per-platform copies
+// it replaced had all skipped SAMPLE_EVENT_RBT, shifting every later code by
+// one so ascent-rate alarms were reported as ceiling breaches. Returns
+// "unknown" for codes outside the enum. Statically allocated (do not free).
+const char *libdc_event_type_name(unsigned int type);
+
 #define LIBDC_MAX_EVENTS 256
 
 typedef struct {

--- a/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
@@ -216,6 +216,26 @@ if(WIN32)
     target_link_libraries(test_parse_raw_dive PRIVATE SetupAPI.lib ws2_32.lib)
 endif()
 
+# The event-name table is shared by every platform binding, so it is tested
+# against the libdivecomputer enum symbols here rather than per platform.
+add_executable(test_event_type_names
+    test_event_type_names.c
+    ${WRAPPER_DIR}/libdc_wrapper.c
+    ${WRAPPER_DIR}/libdc_download.c
+    ${LIBDC_ALL_SOURCES}
+)
+target_include_directories(test_event_type_names PRIVATE
+    ${WRAPPER_DIR}
+    ${LIBDC_DIR}/include
+    ${LIBDC_DIR}/src
+    ${PLATFORM_CONFIG_DIR}
+)
+target_compile_definitions(test_event_type_names PRIVATE HAVE_CONFIG_H)
+if(WIN32)
+    target_compile_definitions(test_event_type_names PRIVATE _CRT_SECURE_NO_WARNINGS)
+    target_link_libraries(test_event_type_names PRIVATE SetupAPI.lib ws2_32.lib)
+endif()
+
 # Regression test for issue #810: the Shearwater parser must report the raw O2
 # cell output even when the logged calibration value cannot be trusted. Exercises
 # the parser through the public API only, so it needs the full library but not
@@ -266,6 +286,7 @@ add_test(NAME test_hw_ostc3_read COMMAND test_hw_ostc3_read)
 add_test(NAME test_shearwater_petrel_foreach COMMAND test_shearwater_petrel_foreach)
 add_test(NAME test_shearwater_common_download COMMAND test_shearwater_common_download)
 add_test(NAME test_uwatec_smart_ble_download COMMAND test_uwatec_smart_ble_download)
+add_test(NAME test_event_type_names COMMAND test_event_type_names)
 add_test(NAME test_parse_raw_dive COMMAND test_parse_raw_dive
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )

--- a/packages/libdivecomputer_plugin/test/native/test_event_type_names.c
+++ b/packages/libdivecomputer_plugin/test/native/test_event_type_names.c
@@ -1,0 +1,91 @@
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <libdivecomputer/parser.h>
+#include "libdc_wrapper.h"
+
+/* Every platform binding used to carry its own copy of the event-name table,
+   and every copy skipped SAMPLE_EVENT_RBT, so each code from 2 upward was
+   off by one: an ascent-rate alarm (SAMPLE_EVENT_ASCENT) came through as
+   "ceiling" and was displayed as a deco violation on no-deco dives (Mares
+   Sirius report on ScubaBoard, 2026-08-30). The table now lives in the C
+   wrapper, and this test pins each name to the enum SYMBOL rather than a
+   magic number, so an upstream enum change fails here instead of in a
+   diver's profile. */
+static const struct {
+    parser_sample_event_t type;
+    const char *name;
+} expected[] = {
+    { SAMPLE_EVENT_NONE, "none" },
+    { SAMPLE_EVENT_DECOSTOP, "deco" },
+    { SAMPLE_EVENT_RBT, "rbt" },
+    { SAMPLE_EVENT_ASCENT, "ascent" },
+    { SAMPLE_EVENT_CEILING, "ceiling" },
+    { SAMPLE_EVENT_WORKLOAD, "workload" },
+    { SAMPLE_EVENT_TRANSMITTER, "transmitter" },
+    { SAMPLE_EVENT_VIOLATION, "violation" },
+    { SAMPLE_EVENT_BOOKMARK, "bookmark" },
+    { SAMPLE_EVENT_SURFACE, "surface" },
+    { SAMPLE_EVENT_SAFETYSTOP, "safetystop" },
+    { SAMPLE_EVENT_GASCHANGE, "gaschange" },
+    { SAMPLE_EVENT_SAFETYSTOP_VOLUNTARY, "safetystop_voluntary" },
+    { SAMPLE_EVENT_SAFETYSTOP_MANDATORY, "safetystop_mandatory" },
+    { SAMPLE_EVENT_DEEPSTOP, "deepstop" },
+    { SAMPLE_EVENT_CEILING_SAFETYSTOP, "ceiling_safetystop" },
+    { SAMPLE_EVENT_FLOOR, "floor" },
+    { SAMPLE_EVENT_DIVETIME, "divetime" },
+    { SAMPLE_EVENT_MAXDEPTH, "maxdepth" },
+    { SAMPLE_EVENT_OLF, "OLF" },
+    { SAMPLE_EVENT_PO2, "PO2" },
+    { SAMPLE_EVENT_AIRTIME, "airtime" },
+    { SAMPLE_EVENT_RGBM, "rgbm" },
+    { SAMPLE_EVENT_HEADING, "heading" },
+    { SAMPLE_EVENT_TISSUELEVEL, "tissuelevel" },
+    { SAMPLE_EVENT_GASCHANGE2, "gaschange2" },
+};
+
+static void test_every_enum_member_has_its_name(void) {
+    size_t count = sizeof(expected) / sizeof(expected[0]);
+    for (size_t i = 0; i < count; i++) {
+        const char *actual = libdc_event_type_name(expected[i].type);
+        assert(actual != NULL);
+        if (strcmp(actual, expected[i].name) != 0) {
+            printf("FAIL: code %u expected \"%s\" got \"%s\"\n",
+                   (unsigned int)expected[i].type, expected[i].name, actual);
+            assert(0);
+        }
+    }
+    /* The table above must cover the whole enum, in order. */
+    assert(count == (size_t)SAMPLE_EVENT_GASCHANGE2 + 1);
+    for (size_t i = 0; i < count; i++) {
+        assert((size_t)expected[i].type == i);
+    }
+    printf("PASS: test_every_enum_member_has_its_name (%zu names)\n", count);
+}
+
+/* The Mares Icon HD family raises SAMPLE_EVENT_ASCENT for its fast-ascent
+   and slow-down alarms, several times on an ordinary recreational dive.
+   Those must never surface as a ceiling breach. */
+static void test_ascent_alarm_is_not_a_ceiling(void) {
+    const char *name = libdc_event_type_name(SAMPLE_EVENT_ASCENT);
+    assert(strcmp(name, "ascent") == 0);
+    assert(strcmp(name, "ceiling") != 0);
+    assert(strcmp(libdc_event_type_name(SAMPLE_EVENT_CEILING), "ceiling") == 0);
+    printf("PASS: test_ascent_alarm_is_not_a_ceiling\n");
+}
+
+static void test_codes_outside_the_enum_are_unknown(void) {
+    assert(strcmp(libdc_event_type_name(SAMPLE_EVENT_GASCHANGE2 + 1),
+                  "unknown") == 0);
+    assert(strcmp(libdc_event_type_name(UINT_MAX), "unknown") == 0);
+    printf("PASS: test_codes_outside_the_enum_are_unknown\n");
+}
+
+int main(void) {
+    test_every_enum_member_has_its_name();
+    test_ascent_alarm_is_not_a_ceiling();
+    test_codes_outside_the_enum_are_unknown();
+    printf("All event type name tests passed.\n");
+    return 0;
+}

--- a/packages/libdivecomputer_plugin/windows/dive_converter.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_converter.cc
@@ -12,34 +12,9 @@
 namespace libdivecomputer_plugin {
 
 std::string MapEventType(unsigned int type) {
-    switch (type) {
-        case 0: return "none";
-        case 1: return "deco";
-        case 2: return "ascent";
-        case 3: return "ceiling";
-        case 4: return "workload";
-        case 5: return "transmitter";
-        case 6: return "violation";
-        case 7: return "bookmark";
-        case 8: return "surface";
-        case 9: return "safetystop";
-        case 10: return "gaschange";
-        case 11: return "safetystop_voluntary";
-        case 12: return "safetystop_mandatory";
-        case 13: return "deepstop";
-        case 14: return "ceiling_safetystop";
-        case 15: return "floor";
-        case 16: return "divetime";
-        case 17: return "maxdepth";
-        case 18: return "OLF";
-        case 19: return "PO2";
-        case 20: return "airtime";
-        case 21: return "rgbm";
-        case 22: return "heading";
-        case 23: return "tissuelevel";
-        case 24: return "gaschange2";
-        default: return "unknown_" + std::to_string(type);
-    }
+    // One shared table for every platform; see libdc_event_type_name in
+    // libdc_wrapper.h for why this is no longer a local switch.
+    return libdc_event_type_name(type);
 }
 
 ParsedDive ConvertParsedDive(const libdc_parsed_dive_t& dive) {

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -2249,6 +2249,45 @@ void main() {
       expect(events[6].severity, 'alert');
     });
 
+    test('rbt and airtime events re-parse as lowGas warnings', () async {
+      // Before the event-code table was corrected, libdivecomputer's RBT code
+      // arrived as 'ascent' and its AIRTIME code as 'PO2', so neither name
+      // ever reached this mapping. Both mean the gas supply is running short.
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      final parsed = makeParsedDive(
+        events: [
+          pigeon.DiveEvent(timeSeconds: 60, type: 'rbt'),
+          pigeon.DiveEvent(timeSeconds: 120, type: 'airtime'),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final events =
+          await (db.select(db.diveProfileEvents)
+                ..where((t) => t.diveId.equals('dive-1'))
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+      expect(events.map((e) => e.eventType), ['lowGas', 'lowGas']);
+      expect(events.map((e) => e.severity), ['warning', 'warning']);
+    });
+
     test('unknown event types are not inserted', () async {
       await insertDive('dive-1');
       await insertComputer('comp-1');

--- a/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
@@ -902,6 +902,44 @@ void main() {
       expect(await diveTypeIdsFor(diveId), ['technical']);
     });
 
+    test('rbt and airtime events are stored as lowGas warnings and do not '
+        'make the dive technical', () async {
+      // Before the event-code table was corrected, libdivecomputer's RBT code
+      // arrived as 'ascent' and its AIRTIME code as 'PO2', so neither name
+      // ever reached this mapping. Both mean the gas supply is running short.
+      final computerId = await insertComputer();
+      final entryTime = DateTime(2026, 4, 1, 11, 55);
+
+      final diveId = await repository.importProfile(
+        computerId: computerId,
+        profileStartTime: entryTime,
+        points: const [
+          ProfilePointData(timestamp: 0, depth: 1.0, ndl: 3600),
+          ProfilePointData(timestamp: 600, depth: 18.0, ndl: 1200),
+        ],
+        durationSeconds: 1800,
+        maxDepth: 18.0,
+        events: const [
+          EventData(timestamp: 600, type: 'rbt'),
+          EventData(timestamp: 900, type: 'airtime'),
+        ],
+        forceNew: true,
+      );
+
+      final events =
+          await (db.select(db.diveProfileEvents)
+                ..where((t) => t.diveId.equals(diveId))
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+      expect(events.map((e) => e.eventType), ['lowGas', 'lowGas']);
+      expect(events.map((e) => e.severity), ['warning', 'warning']);
+
+      final dive = await (db.select(
+        db.dives,
+      )..where((t) => t.id.equals(diveId))).getSingle();
+      expect(dive.diveType, 'recreational');
+    });
+
     test('a no-deco profile defaults the dive type to recreational', () async {
       final computerId = await insertComputer();
       final entryTime = DateTime(2026, 4, 1, 12, 0);


### PR DESCRIPTION
## Summary

A Mares Sirius owner on ScubaBoard reported "Deco Violation" markers all over a 16 m no-deco dive after a BLE download ([post](https://scubaboard.com/community/threads/submersion-free-open-source-dive-log-app-all-platforms-looking-for-dive-computer-testers.667061/post-10819457)).

**Root cause.** libdivecomputer's `parser_sample_event_t` is `NONE, DECOSTOP, RBT, ASCENT, CEILING, ...`. Every per-platform event-name table in the plugin (Linux, Windows, darwin, and both Android download paths) omitted `RBT`, so each code from 2 upward was off by one:

| libdc code | libdc meaning | plugin reported | app stored as |
| --- | --- | --- | --- |
| 3 | ASCENT (ascent-rate alarm) | `ceiling` | Deco Violation |
| 4 | CEILING | `workload` | dropped |
| 14 | DEEPSTOP | `ceiling_safetystop` | Deco Violation (until #1439's follow-up filtered it) |
| 20 | PO2 | `airtime` | dropped |

Mares Icon HD computers raise the ascent alarm several times on an ordinary dive, which is why a Sirius owner saw it first. The earlier follow-up to #1439 reasoned "enum 14 is ceiling_safetystop, confirmed identical in the bindings"; the bindings agreed with each other but not with the header.

## Changes

- One `libdc_event_type_name()` in the shared C wrapper (`libdc_download.c`, already compiled on every platform and symlinked into ios/), switching on the enum symbols rather than literal codes. Linux, Windows, and macOS/iOS call it and their local tables are deleted.
- Kotlin keeps a single twin, `LibdcEventTypeNames.kt`, used by both Android download paths, because a JVM unit test cannot load the native library. `LibdcEventTypeNamesTest` pins it to the enum order.
- New native test `test/native/test_event_type_names.c` walks the whole enum against the C table (ctest picks it up in the existing CI job).
- Dart maps the newly reachable `rbt` and `airtime` alarms to `lowGas` (warning) in both the download and re-parse paths, with tests in each.

## User-facing note

Dives already downloaded keep their persisted events. The dive computer page's "Re-parse all dives" action rebuilds them from stored raw data, so affected users should run that once after updating.

## Verification

- Native ctest suite 12/12 (asserts confirmed present in the binary)
- `reparse_service_test` and `dive_computer_repository_impl_test`: 133/133
- Plugin Kotlin unit suite green; new test proven to run via a bogus-filter control
- `flutter build macos --debug` and `flutter build apk --debug` both build
- `flutter analyze` on changed files clean; whole-project `dart format` reports no changes
