### PR TITLE
ci: assert generated l10n matches the ARB files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,6 +235,35 @@ jobs:
       - name: Check formatting
         run: dart format --set-exit-if-changed .
 
+      # lib/l10n/arb/app_localizations*.dart is produced by `flutter gen-l10n`
+      # and is CHECKED IN, unlike the build_runner outputs (*.g.dart /
+      # *.freezed.dart / *.mocks.dart), which are gitignored and rebuilt by the
+      # codegen job above. Nothing else in the pipeline regenerates it, and
+      # `flutter test` does not either despite `generate: true` in pubspec.yaml,
+      # so what is committed is exactly what ships. Without this assertion an
+      # ARB edit that skipped `flutter gen-l10n`, or a generated file that was
+      # hand-edited or hand-resolved during a merge (these conflict often, since
+      # every locale changes together), merges fully green and the app serves
+      # the stale string. Only the handful of keys some test asserts by value
+      # would catch it today, out of ~9800.
+      #
+      # Runs LAST so the analyze and format verdicts above are reported against
+      # the tree as committed, not against a freshly regenerated copy.
+      - name: Verify generated localizations match the ARB files
+        run: |
+          flutter gen-l10n
+          # --porcelain rather than `git diff --exit-code` so a brand-new locale
+          # whose generated file was never added shows up as untracked drift too.
+          drift="$(git status --porcelain -- 'lib/l10n/arb/app_localizations*.dart')"
+          if [ -n "$drift" ]; then
+            echo "Generated localizations do not match the ARB files:"
+            printf '%s\n' "$drift"
+            git --no-pager diff -- 'lib/l10n/arb/app_localizations*.dart'
+            echo "::error::lib/l10n/arb/app_localizations*.dart is out of date. Run 'flutter gen-l10n' and commit the result."
+            exit 1
+          fi
+          echo "Generated localizations are up to date."
+
   test:
     name: Test (shard ${{ matrix.shard }})
     needs: codegen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,9 @@ else in one, run:
 
 ## Git Hooks
 
-Pre-push hooks live in the `hooks/` directory and run format, analyze, and test
-checks. They are not active until you point git at them.
+Pre-push hooks live in the `hooks/` directory and run format, analyze,
+generated-l10n staleness, and test checks. They are not active until you point
+git at them.
 
 **Setup:** Run `git config core.hooksPath hooks` (or use `./scripts/setup.sh`)
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -175,7 +175,8 @@ fi
 # exactly what ships. An ARB edit that skipped gen-l10n, or a generated file
 # hand-resolved during a merge (they conflict often, since every locale changes
 # together), otherwise reaches main with the stale string intact. CI asserts the
-# same thing in Analyze & Format; here it is a second cheaper.
+# same thing in Analyze & Format; this hook is the cheaper second check that
+# catches it before the push rather than after.
 #
 # Only runs when the push touches lib/l10n/. gen-l10n rewrites all 12 files
 # unconditionally, even when the bytes are identical, and app_localizations.dart
@@ -183,7 +184,7 @@ fi
 # on every push would bump those mtimes and force a pointless recompile.
 #
 # The verdict is HEAD-relative, like CI's, because HEAD is what gets pushed.
-# Regenerate, then read `git status` for the three states that tells apart:
+# Regenerate, then read `git status`, which tells these three states apart:
 #
 #   generated dirty, ARBs clean -> HEAD's committed ARBs do not produce HEAD's
 #     committed output. Definitively stale: block. Covers both "forgot to run

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Pre-push hook for Submersion
-# Runs dart format check, flutter analyze, and a SCOPED test run before pushing.
+# Runs dart format check, flutter analyze, a generated-l10n staleness check, and
+# a SCOPED test run before pushing.
 #
 # Why scoped tests: the full suite is ~1900 test files. Measured on the full
 # suite, 79% of local test wall-clock is `loading <file>` (isolate spawn +
@@ -164,6 +165,80 @@ else
     range_resolved=0
 fi
 
+# --- Generated-l10n staleness ----------------------------------------------
+#
+# lib/l10n/arb/app_localizations*.dart is produced by `flutter gen-l10n` and is
+# CHECKED IN. It is the only generated output in the repo that can go stale:
+# *.g.dart, *.freezed.dart and *.mocks.dart are gitignored and rebuilt per tree.
+# Nothing regenerates the l10n on the way to a build either -- `flutter test`
+# does not, despite `generate: true` in pubspec.yaml -- so what is committed is
+# exactly what ships. An ARB edit that skipped gen-l10n, or a generated file
+# hand-resolved during a merge (they conflict often, since every locale changes
+# together), otherwise reaches main with the stale string intact. CI asserts the
+# same thing in Analyze & Format; here it is a second cheaper.
+#
+# Only runs when the push touches lib/l10n/. gen-l10n rewrites all 12 files
+# unconditionally, even when the bytes are identical, and app_localizations.dart
+# is imported by 378 test files -- the biggest hub in the repo -- so doing this
+# on every push would bump those mtimes and force a pointless recompile.
+#
+# Compares against the WORKING TREE, not HEAD: an ARB edit and its regenerated
+# output that are both still uncommitted pass, while a stale pair fails whether
+# or not it has been committed. Runs BEFORE the parallel stage rather than
+# inside it, because rewriting these files underneath a concurrent
+# `flutter analyze` would let it read a half-written source.
+l10n_touched=0
+if [ "$range_resolved" = "0" ]; then
+    # Push range unknown: check rather than guess. It costs about 3s.
+    l10n_touched=1
+else
+    while IFS= read -r f; do
+        case "$f" in
+            lib/l10n/*) l10n_touched=1; break ;;
+        esac
+    done <<< "$changed_files"
+fi
+
+l10n_failed=0
+if [ "$l10n_touched" = "1" ]; then
+    echo "🌍 Verifying generated localizations match the ARB files..."
+    l10n_before=$(mktemp -d)
+    l10n_after=$(mktemp -d)
+    l10n_log=$(mktemp)
+    set +e
+    cp lib/l10n/arb/app_localizations*.dart "$l10n_before/" 2>/dev/null
+    flutter gen-l10n > "$l10n_log" 2>&1
+    l10n_status=$?
+    set -e
+    if [ "$l10n_status" -ne 0 ]; then
+        echo "❌ flutter gen-l10n failed!"
+        cat "$l10n_log"
+        l10n_failed=1
+    else
+        cp lib/l10n/arb/app_localizations*.dart "$l10n_after/" 2>/dev/null || true
+        stale=""
+        for f in "$l10n_after"/*.dart; do
+            [ -e "$f" ] || continue
+            base=$(basename "$f")
+            if [ ! -f "$l10n_before/$base" ] || ! cmp -s "$f" "$l10n_before/$base"; then
+                stale="${stale}   lib/l10n/arb/${base}"$'\n'
+            fi
+        done
+        if [ -n "$stale" ]; then
+            echo "❌ Generated localizations were stale! These did not match their ARBs:"
+            printf '%s' "$stale"
+            echo "   They have been REGENERATED IN PLACE. Review and commit them,"
+            echo "   then push again."
+            l10n_failed=1
+        else
+            echo "✅ Generated localizations are up to date"
+        fi
+    fi
+    rm -rf "$l10n_before" "$l10n_after"
+    rm -f "$l10n_log"
+    echo ""
+fi
+
 # --- Static checks ----------------------------------------------------------
 #
 # Format and analyze are independent, so run them concurrently and report both
@@ -243,6 +318,12 @@ fi
 
 rm -f "$fmt_log" "$ana_log"
 echo ""
+
+# Reported above, before the parallel stage; gated here so format, analyze and
+# l10n all get a verdict on one run rather than stopping at the first failure.
+if [ "$l10n_failed" -ne 0 ]; then
+    checks_failed=1
+fi
 
 if [ "$checks_failed" -ne 0 ]; then
     echo "Fix the issues above before pushing."

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -182,11 +182,21 @@ fi
 # is imported by 378 test files -- the biggest hub in the repo -- so doing this
 # on every push would bump those mtimes and force a pointless recompile.
 #
-# Compares against the WORKING TREE, not HEAD: an ARB edit and its regenerated
-# output that are both still uncommitted pass, while a stale pair fails whether
-# or not it has been committed. Runs BEFORE the parallel stage rather than
-# inside it, because rewriting these files underneath a concurrent
-# `flutter analyze` would let it read a half-written source.
+# The verdict is HEAD-relative, like CI's, because HEAD is what gets pushed.
+# Regenerate, then read `git status` for the three states that tells apart:
+#
+#   generated dirty, ARBs clean -> HEAD's committed ARBs do not produce HEAD's
+#     committed output. Definitively stale: block. Covers both "forgot to run
+#     gen-l10n" and "ran it but committed only the ARB".
+#   generated dirty, ARBs dirty -> the output was regenerated from sources HEAD
+#     does not have, so it says nothing about the commits being pushed. Warn and
+#     let it through rather than block a developer mid-ARB-edit from pushing
+#     unrelated commits; CI still checks the pushed tree.
+#   nothing dirty -> HEAD is self-consistent.
+#
+# Runs BEFORE the parallel stage rather than inside it, because rewriting these
+# files underneath a concurrent `flutter analyze` would let it read a
+# half-written source.
 l10n_touched=0
 if [ "$range_resolved" = "0" ]; then
     # Push range unknown: check rather than guess. It costs about 3s.
@@ -202,11 +212,14 @@ fi
 l10n_failed=0
 if [ "$l10n_touched" = "1" ]; then
     echo "🌍 Verifying generated localizations match the ARB files..."
+    # Snapshot with -p so the mtimes can be put back when nothing drifted:
+    # gen-l10n rewrites all 12 files regardless, and letting that bump the
+    # mtime of the repo's biggest import hub would throw away an already-warm
+    # compile before this hook's own test stage runs.
     l10n_before=$(mktemp -d)
-    l10n_after=$(mktemp -d)
     l10n_log=$(mktemp)
     set +e
-    cp lib/l10n/arb/app_localizations*.dart "$l10n_before/" 2>/dev/null
+    cp -p lib/l10n/arb/app_localizations*.dart "$l10n_before/" 2>/dev/null
     flutter gen-l10n > "$l10n_log" 2>&1
     l10n_status=$?
     set -e
@@ -215,26 +228,29 @@ if [ "$l10n_touched" = "1" ]; then
         cat "$l10n_log"
         l10n_failed=1
     else
-        cp lib/l10n/arb/app_localizations*.dart "$l10n_after/" 2>/dev/null || true
-        stale=""
-        for f in "$l10n_after"/*.dart; do
-            [ -e "$f" ] || continue
-            base=$(basename "$f")
-            if [ ! -f "$l10n_before/$base" ] || ! cmp -s "$f" "$l10n_before/$base"; then
-                stale="${stale}   lib/l10n/arb/${base}"$'\n'
-            fi
-        done
-        if [ -n "$stale" ]; then
-            echo "❌ Generated localizations were stale! These did not match their ARBs:"
-            printf '%s' "$stale"
-            echo "   They have been REGENERATED IN PLACE. Review and commit them,"
-            echo "   then push again."
-            l10n_failed=1
-        else
+        # --porcelain, not `git diff`: a brand-new locale whose generated file
+        # was never added is untracked, which a diff cannot see at all.
+        stale=$(git status --porcelain -- 'lib/l10n/arb/app_localizations*.dart')
+        arbs_dirty=$(git status --porcelain -- 'lib/l10n/arb/*.arb')
+        if [ -z "$stale" ]; then
+            # Byte-identical to HEAD, so this only restores the mtimes.
+            cp -p "$l10n_before"/*.dart lib/l10n/arb/ 2>/dev/null || true
             echo "✅ Generated localizations are up to date"
+        elif [ -n "$arbs_dirty" ]; then
+            echo "⚠️  Uncommitted ARB edits, so the pushed commits cannot be"
+            echo "   verified here. Regenerating from the working tree changed:"
+            printf '%s\n' "$stale" | sed 's/^/   /'
+            echo "   Commit these alongside the ARBs. CI checks the pushed tree."
+        else
+            echo "❌ Generated localizations are stale!"
+            printf '%s\n' "$stale" | sed 's/^/   /'
+            echo "   The ARBs are committed, but the committed generated output"
+            echo "   is not what they produce. gen-l10n has REGENERATED these in"
+            echo "   place: review and commit them, then push again."
+            l10n_failed=1
         fi
     fi
-    rm -rf "$l10n_before" "$l10n_after"
+    rm -rf "$l10n_before"
     rm -f "$l10n_log"
     echo ""
 fi


### PR DESCRIPTION
Closes #1489.

`lib/l10n/arb/app_localizations*.dart` is produced by `flutter gen-l10n` and is
**checked in**. It is the only generated output in the repo that can go stale:
`*.g.dart`, `*.freezed.dart` and `*.mocks.dart` are gitignored and rebuilt per
tree by the `codegen` job. Nothing regenerated or compared the l10n, and
`flutter test` does not regenerate it either despite `generate: true` in
`pubspec.yaml`, so the committed Dart is exactly what ships.

That left two mistakes able to merge fully green:

- an ARB edit that skipped `flutter gen-l10n`, leaving the generated Dart behind
- a generated file hand-edited, or hand-resolved during a merge (they conflict
  often, since every locale changes together)

Only the handful of the ~9800 keys that some test asserts by value would have
caught it, and almost nothing asserts the ten non-English locales.

Current `main` is clean; `flutter gen-l10n` produces a zero diff today. This is
a missing gate, not an active bug.

## The gate

**CI**, as the last step of `Analyze & Format`:

```yaml
flutter gen-l10n
drift="$(git status --porcelain -- 'lib/l10n/arb/app_localizations*.dart')"
```

Two deliberate choices there:

- **Last in the job**, so the `flutter analyze` and `dart format` verdicts above
  it are still reported against the tree as committed, not against a freshly
  regenerated copy. It also means a drift failure does not starve the PR of the
  rest of its feedback, which putting it in `codegen` (the producer everything
  `needs:`) would have done.
- **`git status --porcelain` rather than the `git diff --exit-code` the issue
  suggested.** Adding a new locale ARB leaves its `app_localizations_xx.dart`
  **untracked**, which `git diff` cannot see at all; only the hub file's change
  shows up in the diff. The porcelain `??` line is what names the missing file.

**`hooks/pre-push`**, gated on the push touching `lib/l10n/`:

- The gating is load-bearing. `gen-l10n` rewrites all 12 files unconditionally,
  bumping mtimes even when the bytes are identical (verified), and
  `app_localizations.dart` is imported by 378 test files, the biggest hub in the
  repo. Running it on every push would force a pointless recompile of exactly
  that hub before the hook's own test stage.
- It compares against the **working tree**, not HEAD, so an ARB edit and its
  regenerated output that are both still uncommitted pass together, while a
  stale pair fails whether or not it has been committed.
- It runs **before** the parallel format/analyze stage, not inside it, because
  rewriting these sources underneath a concurrent `flutter analyze` would let it
  read a half-written file. Its verdict is folded into the same combined
  failure gate, so all three checks still report on one run.
- On failure the files have already been regenerated in place, so the fix is
  `git add lib/l10n/arb && git push` rather than looking up which command
  regenerates this.

## Verification

The CI command was exercised locally against four states, and the hook against
three:

| state | expected | result |
| --- | --- | --- |
| clean tree | pass | exit 0 |
| ARB edited, generated stale | fail | exit 1, names both changed files |
| generated file hand-edited and committed | fail | exit 1 |
| new locale ARB, generated file untracked | fail | exit 1, `??` names the file |
| hook: push does not touch `lib/l10n/` | check skipped | skipped |
| hook: `lib/l10n/` touched, correctly regenerated | pass | up to date |
| hook: ARB edited without regenerating | fail | exit 1, files regenerated in place |

`flutter gen-l10n` measures at 2.7s, negligible against the rest of either
pipeline.

## Note on `[full-ci]`

This PR changes only `.github/`, `hooks/` and `CLAUDE.md`, every one of which
the `changes` job classifies as inert. Without an override the whole pipeline
would skip and the new step would never run on the PR that adds it, so the
commit message carries `[full-ci]`.
