### PR TITLE
fix(nav): keep the More overflow sheet clear of the status bar

### DIFF
--- a/integration_test/screenshots_test.dart
+++ b/integration_test/screenshots_test.dart
@@ -668,9 +668,6 @@ Future<void> _enableProfileToggles(WidgetTester tester) async {
   }
 }
 
-/// Taps a bottom navigation item by its icon.
-/// Uses position filtering to ensure we tap the icon in the bottom navigation
-/// area, not icons with the same IconData elsewhere (e.g., app bar menus).
 /// Scrolls the open "More" overflow sheet until [target] is on screen.
 ///
 /// The sheet is capped at a fraction of the screen height (issue #1480), so
@@ -690,6 +687,9 @@ Future<void> _scrollMoreSheetTo(WidgetTester tester, Finder target) async {
   await _settle(tester);
 }
 
+/// Taps a bottom navigation item by its icon.
+/// Uses position filtering to ensure we tap the icon in the bottom navigation
+/// area, not icons with the same IconData elsewhere (e.g., app bar menus).
 Future<void> _tapBottomNavItem(WidgetTester tester, IconData icon) async {
   // Get the screen height to identify bottom navigation area
   final screenSize = tester.view.physicalSize / tester.view.devicePixelRatio;

--- a/integration_test/screenshots_test.dart
+++ b/integration_test/screenshots_test.dart
@@ -464,6 +464,7 @@ void main() {
         await _tapBottomNavItem(tester, Icons.more_horiz_outlined);
         await _settle(tester);
         final equipmentText = find.text('Equipment');
+        await _scrollMoreSheetTo(tester, equipmentText);
         if (equipmentText.evaluate().isNotEmpty) {
           await tester.tap(equipmentText.first);
           await _settle(tester);
@@ -485,6 +486,7 @@ void main() {
         await _tapBottomNavItem(tester, Icons.more_horiz_outlined);
         await _settle(tester);
         final statisticsText = find.text('Statistics');
+        await _scrollMoreSheetTo(tester, statisticsText);
         if (statisticsText.evaluate().isNotEmpty) {
           await tester.tap(statisticsText.first);
           await _settle(tester);
@@ -508,6 +510,7 @@ void main() {
         await _tapBottomNavItem(tester, Icons.more_horiz_outlined);
         await _settle(tester);
         final recordsInMore = find.text('Records');
+        await _scrollMoreSheetTo(tester, recordsInMore);
         if (recordsInMore.evaluate().isNotEmpty) {
           await tester.tap(recordsInMore.first);
           await _settle(tester);
@@ -539,7 +542,9 @@ void main() {
     Future<void> openNavCustomization(WidgetTester tester) async {
       await tester.tap(find.widgetWithText(NavigationDestination, 'More'));
       await _settle(tester);
-      await tester.tap(find.widgetWithText(ListTile, 'Settings').first);
+      final settingsTile = find.widgetWithText(ListTile, 'Settings');
+      await _scrollMoreSheetTo(tester, settingsTile);
+      await tester.tap(settingsTile.first);
       await _settle(tester);
       await tester.tap(find.widgetWithText(ListTile, 'Appearance').first);
       await _settle(tester);
@@ -666,6 +671,25 @@ Future<void> _enableProfileToggles(WidgetTester tester) async {
 /// Taps a bottom navigation item by its icon.
 /// Uses position filtering to ensure we tap the icon in the bottom navigation
 /// area, not icons with the same IconData elsewhere (e.g., app bar menus).
+/// Scrolls the open "More" overflow sheet until [target] is on screen.
+///
+/// The sheet is capped at a fraction of the screen height (issue #1480), so
+/// destinations past the fold are not built until the list scrolls. Gives up
+/// quietly: every caller already guards on whether the target turned up.
+Future<void> _scrollMoreSheetTo(WidgetTester tester, Finder target) async {
+  final sheetList = find.descendant(
+    of: find.byType(BottomSheet),
+    matching: find.byType(Scrollable),
+  );
+  if (sheetList.evaluate().isEmpty) return;
+  try {
+    await tester.scrollUntilVisible(target, 120, scrollable: sheetList.first);
+  } on StateError {
+    // Not in this sheet at all; the caller's isNotEmpty check handles it.
+  }
+  await _settle(tester);
+}
+
 Future<void> _tapBottomNavItem(WidgetTester tester, IconData icon) async {
   // Get the screen height to identify bottom navigation area
   final screenSize = tester.view.physicalSize / tester.view.devicePixelRatio;

--- a/lib/shared/widgets/main_scaffold.dart
+++ b/lib/shared/widgets/main_scaffold.dart
@@ -14,6 +14,11 @@ import 'package:submersion/shared/widgets/global_drop_target.dart';
 import 'package:submersion/shared/widgets/nav/nav_destinations.dart';
 import 'package:submersion/shared/widgets/nav/nav_primary_provider.dart';
 
+/// Fraction of the screen height the phone overflow ("More") sheet may fill.
+///
+/// The remainder is scrim the user can tap to dismiss the sheet.
+const double _moreSheetMaxHeight = 0.85;
+
 class MainScaffold extends ConsumerStatefulWidget {
   final Widget child;
 
@@ -110,8 +115,25 @@ class _MainScaffoldState extends ConsumerState<MainScaffold> {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
+      // Scroll-controlled means the sheet has no height ceiling, and a dozen
+      // overflow destinations are taller than a phone screen. Left alone the
+      // sheet grew to y=0, putting its title and close button under the
+      // Android status bar (issue #1480). The safe area keeps it clear of the
+      // status bar and cutouts; the height cap leaves a strip of scrim above
+      // it so tapping outside stays an obvious way out.
+      useSafeArea: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * _moreSheetMaxHeight,
+      ),
+      // Not redundant with useSafeArea: that inserts SafeArea(bottom: false),
+      // so the sheet deliberately runs to the bottom edge of the screen. This
+      // one supplies the bottom inset the outer one skips, keeping the last
+      // tile clear of the home indicator. Nothing is applied twice -- a
+      // SafeArea strips the padding it consumes out of the MediaQuery, so the
+      // horizontal insets are already zero by the time this one reads them.
       builder: (sheetContext) => SafeArea(
         child: Column(
+          key: const ValueKey('navOverflowSheetBody'),
           mainAxisSize: MainAxisSize.min,
           children: [
             Padding(

--- a/test/shared/widgets/main_scaffold_test.dart
+++ b/test/shared/widgets/main_scaffold_test.dart
@@ -280,6 +280,7 @@ void main() {
   group('MainScaffold mobile nav customization', () {
     Future<({Widget app, GoRouter router})> buildHarnessWithRouter({
       required AppSettingsRepository repo,
+      EdgeInsets systemPadding = EdgeInsets.zero,
     }) async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
@@ -367,14 +368,26 @@ void main() {
           locale: const Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
+          // MaterialApp.builder wraps the Navigator, so padding stated here
+          // is what the modal route's own SafeArea sees.
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(padding: systemPadding),
+            child: child!,
+          ),
         ),
       );
 
       return (app: app, router: router);
     }
 
-    Future<Widget> buildHarness({required AppSettingsRepository repo}) async {
-      final result = await buildHarnessWithRouter(repo: repo);
+    Future<Widget> buildHarness({
+      required AppSettingsRepository repo,
+      EdgeInsets systemPadding = EdgeInsets.zero,
+    }) async {
+      final result = await buildHarnessWithRouter(
+        repo: repo,
+        systemPadding: systemPadding,
+      );
       return result.app;
     }
 
@@ -536,21 +549,112 @@ void main() {
       await tester.tap(find.widgetWithText(NavigationDestination, 'More'));
       await tester.pumpAndSettle();
 
-      // The overflow sheet should contain the items NOT in primary.
-      expect(find.widgetWithText(ListTile, 'Dives'), findsOneWidget);
-      expect(find.widgetWithText(ListTile, 'Sites'), findsOneWidget);
-      expect(find.widgetWithText(ListTile, 'Trips'), findsOneWidget);
-      expect(find.widgetWithText(ListTile, 'Dive Centers'), findsOneWidget);
-      expect(find.widgetWithText(ListTile, 'Certifications'), findsOneWidget);
-      expect(find.widgetWithText(ListTile, 'Courses'), findsOneWidget);
-      expect(find.widgetWithText(ListTile, 'Planning'), findsOneWidget);
-      expect(find.widgetWithText(ListTile, 'Transfer'), findsOneWidget);
-      expect(find.widgetWithText(ListTile, 'Settings'), findsOneWidget);
+      // The overflow sheet should contain the items NOT in primary. The sheet
+      // is height-capped, so the tiles past the fold have to be scrolled to;
+      // reaching them all is itself the guard that none is stranded.
+      final sheetList = find.descendant(
+        of: find.byType(BottomSheet),
+        matching: find.byType(Scrollable),
+      );
+      for (final label in const [
+        'Dives',
+        'Sites',
+        'Trips',
+        'Dive Centers',
+        'Certifications',
+        'Courses',
+        'Planning',
+        'Transfer',
+        'Settings',
+      ]) {
+        final tile = find.widgetWithText(ListTile, label);
+        await tester.scrollUntilVisible(tile, 100, scrollable: sheetList);
+        expect(tile, findsOneWidget);
+      }
 
       // Items now in primary should NOT appear in the overflow sheet.
       expect(find.widgetWithText(ListTile, 'Equipment'), findsNothing);
       expect(find.widgetWithText(ListTile, 'Buddies'), findsNothing);
       expect(find.widgetWithText(ListTile, 'Statistics'), findsNothing);
+    });
+
+    // Issue #1480: the overflow sheet is scroll-controlled, and a dozen
+    // destinations are taller than a phone screen, so the sheet grew until it
+    // touched y=0 and its header sat under the Android status bar.
+    testWidgets('overflow sheet stops short of the top edge on a phone', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(360, 560);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(await buildHarness(repo: _FakeRepo()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(NavigationDestination, 'More'));
+      await tester.pumpAndSettle();
+
+      expect(tester.getRect(find.byType(BottomSheet)).top, greaterThan(0));
+    });
+
+    // `useSafeArea: true` inserts `SafeArea(bottom: false)`, so it covers top,
+    // left and right and deliberately lets the sheet run to the bottom edge.
+    // The SafeArea in the builder supplies the bottom inset the outer one
+    // skips; it is not a double application, because a SafeArea strips the
+    // padding it consumes out of the MediaQuery it hands down.
+    testWidgets('overflow sheet applies every system inset exactly once', (
+      tester,
+    ) async {
+      const insets = EdgeInsets.only(top: 44, left: 30, right: 30, bottom: 34);
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        await buildHarness(repo: _FakeRepo(), systemPadding: insets),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(NavigationDestination, 'More'));
+      await tester.pumpAndSettle();
+
+      final screen = tester.getRect(find.byType(MaterialApp));
+      final sheet = tester.getRect(find.byType(BottomSheet));
+      final body = tester.getRect(
+        find.byKey(const ValueKey('navOverflowSheetBody')),
+      );
+
+      expect(sheet.left, insets.left);
+      expect(sheet.right, screen.right - insets.right);
+      expect(sheet.top, greaterThanOrEqualTo(insets.top));
+      expect(sheet.bottom, screen.bottom);
+      expect(body.bottom, screen.bottom - insets.bottom);
+      expect(body.left, sheet.left);
+      expect(body.right, sheet.right);
+    });
+
+    testWidgets('overflow sheet close action survives scrolling the list', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(360, 560);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(await buildHarness(repo: _FakeRepo()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(NavigationDestination, 'More'));
+      await tester.pumpAndSettle();
+
+      final closeButton = find.widgetWithIcon(IconButton, Icons.close);
+      final before = tester.getRect(closeButton);
+      await tester.drag(find.byType(ListView), const Offset(0, -200));
+      await tester.pumpAndSettle();
+      expect(tester.getRect(closeButton), before);
+
+      await tester.tap(closeButton);
+      await tester.pumpAndSettle();
+      expect(find.byType(BottomSheet), findsNothing);
     });
   });
 


### PR DESCRIPTION
Fixes #1480.

## The problem

The phone "More" overflow sheet opened with `isScrollControlled: true` and nothing else. That flag removes the sheet's height ceiling rather than making it scroll, and a dozen overflow destinations are taller than a phone screen, so the sheet expanded all the way to `y = 0`. Its title row and close button then sat under the Android status bar.

## The fix

The same three-part shape used for the terrain appearance sheet in #1188:

- `useSafeArea: true` on the route. The `SafeArea` already inside the builder cannot help at the top: without this flag, `ModalBottomSheetRoute` wraps the page in `MediaQuery.removePadding(removeTop: true)`, so that inner `SafeArea` reads a top inset of zero.
- `constraints: BoxConstraints(maxHeight: height * 0.85)`, so a strip of scrim is always left above the sheet to tap. `useSafeArea` alone is not enough, and in widget tests it contributes nothing (padding is zero there), so the cap is what a `sheet.top > 0` assertion actually proves.
- The pinned header with its Close action, which this sheet already had.

## Knock-on changes

Capping the height shrinks the list viewport, so tiles past the fold are no longer built up front. Two callers were relying on that:

- `overflow sheet reflects current customization` was passing only because the uncapped sheet was tall enough for the `ListView` to build all twelve tiles at once (viewport plus the 250px `cacheExtent`). It now scrolls to each label in turn, which is a stronger guard: it proves every overflow destination stays reachable.
- `integration_test/screenshots_test.dart` taps Equipment, Statistics, Records and Settings inside the sheet. A `_scrollMoreSheetTo` helper brings them into view first, and gives up quietly so the existing `isNotEmpty` guards still decide.

## Tests

New guard tests on the overflow sheet:

- it stops short of the top edge at `Size(360, 560)`;
- every system inset is applied exactly once (horizontal from the route's `SafeArea`, bottom from the builder's, nothing doubled);
- the close action holds its position while the list scrolls, and still dismisses the sheet.

Full suite green locally: 23418 passed, 21 skipped, 0 failures. `flutter analyze` clean across the project.