### PR TITLE
fix(dive-detail): show the site suggestion only above the header card

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -854,6 +854,14 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            // The site suggestion sits above the header card, never inside
+            // it. Embedded mode has its own copy under the toolbar (which
+            // stays put while the body scrolls), so only the standalone page
+            // renders one here; otherwise the banner would appear twice.
+            // Collapses to nothing when there is no suggestion, so no
+            // spacing of its own is needed.
+            if (!widget.embedded)
+              SiteSuggestionCard(diveId: dive.id, currentSite: dive.site),
             // Fixed: Header
             Consumer(
               builder: (context, ref, _) {
@@ -1417,7 +1425,6 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
               );
             },
           ),
-          SiteSuggestionCard(diveId: dive.id, currentSite: dive.site),
           const SizedBox(height: 16),
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceAround,

--- a/test/features/dive_log/presentation/pages/dive_detail_site_suggestion_placement_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_site_suggestion_placement_test.dart
@@ -40,15 +40,6 @@ void main() {
       tester.view.resetDevicePixelRatio();
     });
 
-    // The header card lays a map under a gradient; overflow warnings in the
-    // constrained test viewport say nothing about banner placement.
-    final originalOnError = FlutterError.onError;
-    FlutterError.onError = (details) {
-      if (details.toString().contains('overflowed')) return;
-      originalOnError?.call(details);
-    };
-    addTearDown(() => FlutterError.onError = originalOnError);
-
     final overrides = await getBaseOverrides();
     await tester.pumpWidget(
       ProviderScope(
@@ -93,7 +84,6 @@ void main() {
           ),
           findsNothing,
         );
-        tester.takeException();
       },
     );
   }

--- a/test/features/dive_log/presentation/pages/dive_detail_site_suggestion_placement_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_site_suggestion_placement_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_locations_map.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/site_suggestion_banner.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/dive_sites/presentation/providers/site_suggestion_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../support/fake_matching_service.dart';
+
+/// The site suggestion banner belongs above the header card, never inside it.
+/// Embedded mode renders its own copy under the toolbar, so a copy in the
+/// header card showed the same banner twice on the master-detail layout.
+void main() {
+  // Entry coordinates make the header render as the map card, which is the
+  // container the banner must stay out of.
+  final dive = Dive(
+    id: 'dive-1',
+    diveNumber: 44,
+    dateTime: DateTime(2026, 1, 1),
+    entryLocation: const GeoPoint(35.819674, 14.451480),
+  );
+
+  Future<void> pumpDetail(WidgetTester tester, {required bool embedded}) async {
+    tester.view.devicePixelRatio = 1.0;
+    // Embedded is the master-detail pane; standalone stays under the
+    // master-detail breakpoint, where a root-level detail page would
+    // otherwise redirect itself into the split view.
+    tester.view.physicalSize = embedded
+        ? const Size(1400, 2400)
+        : const Size(900, 2400);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    // The header card lays a map under a gradient; overflow warnings in the
+    // constrained test viewport say nothing about banner placement.
+    final originalOnError = FlutterError.onError;
+    FlutterError.onError = (details) {
+      if (details.toString().contains('overflowed')) return;
+      originalOnError?.call(details);
+    };
+    addTearDown(() => FlutterError.onError = originalOnError);
+
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          diveProvider(dive.id).overrideWith((ref) async => dive),
+          diveDataSourcesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <DiveDataSource>[]),
+          siteSuggestionForDiveProvider(
+            dive.id,
+          ).overrideWith((ref) async => suggestionFor(FakeMatchingService())),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DiveDetailPage(diveId: dive.id, embedded: embedded),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+  }
+
+  /// The header card: the Card wrapping the location map.
+  Finder headerCard() => find.ancestor(
+    of: find.byType(DiveLocationsMap),
+    matching: find.byType(Card),
+  );
+
+  for (final embedded in [true, false]) {
+    testWidgets(
+      'shows the suggestion once, outside the header card (embedded: $embedded)',
+      (tester) async {
+        await pumpDetail(tester, embedded: embedded);
+
+        expect(find.byType(SiteSuggestionBanner), findsOneWidget);
+        expect(
+          find.descendant(
+            of: headerCard(),
+            matching: find.byType(SiteSuggestionBanner),
+          ),
+          findsNothing,
+        );
+        tester.takeException();
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Problem

On the master-detail layout the "Location from dive computer" suggestion appeared twice: once under the detail toolbar and again inside the dive header card, overlaying the map.

`DiveDetailPage` renders `SiteSuggestionCard` in two places:

- `_buildEmbeddedHeader`, below the toolbar (embedded mode only)
- `_buildHeaderSection`, inside the header Card

In embedded mode both are live, hence the duplicate. In standalone mode only the in-card copy exists, so it could not simply be deleted.

## Change

- Removed the `SiteSuggestionCard` from inside the header card.
- Added one at the top of the scroll body, rendered only when not embedded, so the standalone page keeps its banner and embedded mode keeps the toolbar copy.

Each layout now shows exactly one banner, always above the header card. The card collapses to `SizedBox.shrink()` with no suggestion and the banner carries its own vertical margin, so no extra spacing is introduced.

## Tests

New `dive_detail_site_suggestion_placement_test.dart` pumps the detail page in both modes with a suggestion present and asserts exactly one `SiteSuggestionBanner`, none of it descending from the header card. Standalone pumps under the master-detail breakpoint so the page does not redirect itself into the split view.

`flutter test test/features/dive_log/presentation` passes (1870 tests), `flutter analyze lib test` clean.