### PR TITLE
fix(import): stop double-converting MacDive O2/He gas percentages

### DIFF
--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -830,9 +830,13 @@ class MacDiveDiveMapper {
           entry['runtime'] = Duration(seconds: t.duration!.round());
         }
         if (t.supplyType != null) entry['supplyType'] = t.supplyType;
+        // MacDive's ZGAS.ZOXYGEN/ZHELIUM store whole percent (32.0 for
+        // EAN32), not a 0-1 fraction - confirmed against a real MacDive
+        // database, where every gas row (including "Trimix 21/35" at
+        // ZOXYGEN=21.0/ZHELIUM=35.0) matches its percent-based name exactly.
         entry['gasMix'] = GasMix(
-          o2: (gas?.oxygen ?? 0.21) * 100.0,
-          he: (gas?.helium ?? 0.0) * 100.0,
+          o2: gas?.oxygen ?? 21.0,
+          he: gas?.helium ?? 0.0,
         );
         tanks.add(entry);
       }

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -300,7 +300,7 @@ void main() {
       expect(tank.containsKey('workingPressureBar'), isFalse);
       // gasMix must be a `GasMix` object, not a Map — UddfEntityImporter does
       // `t['gasMix'] as GasMix?` and a Map cast would throw at runtime.
-      // MacDive stores oxygen as a fraction (0.32); GasMix.o2 is a percent.
+      // MacDive stores oxygen as a whole percent (32.0), matching GasMix.o2.
       expect(tank['gasMix'], isA<GasMix>());
       final gasMix = tank['gasMix'] as GasMix;
       expect(gasMix.o2, closeTo(32.0, 0.01));

--- a/test/fixtures/macdive_sqlite/build_synthetic_db.dart
+++ b/test/fixtures/macdive_sqlite/build_synthetic_db.dart
@@ -230,8 +230,8 @@ void _insertFixtureRows(Database db) {
   // ---- gas mixes ----
   db.execute('''
     INSERT INTO ZGAS (Z_PK, ZNAME, ZOXYGEN, ZHELIUM, ZUUID) VALUES
-      (1, 'EAN32', 0.32, 0, 'gas-uuid-1'),
-      (2, 'EAN80', 0.80, 0, 'gas-uuid-2')
+      (1, 'EAN32', 32.0, 0, 'gas-uuid-1'),
+      (2, 'EAN80', 80.0, 0, 'gas-uuid-2')
   ''');
 
   // ---- tanks ----


### PR DESCRIPTION
## Summary

Tanks imported from a MacDive SQLite database show gas mixes inflated by 100x for any non-air fill - e.g. an EAN32 tank imports as 3200% O2 and -3100% N2, which corrupts OTU/CNS calculations for the dive.

`ZGAS.ZOXYGEN`/`ZGAS.ZHELIUM` were assumed to be 0-1 fractions (0.32 for EAN32) and scaled by `*100` to reach `GasMix`'s percent scale. That assumption, introduced in ea4349a7 (April 2026) alongside the SQLite gas-mix cast fix, was never checked against a real gas table - only against a synthetic test fixture that encoded the same unverified assumption.

A real MacDive database's `ZGAS` table shows every row already stores whole percent: 21.0 for air, 32.0 for EAN32, and 21.0/35.0 for a gas literally named "Trimix 21/35" - which only makes sense read as percent, not as a 0-1 fraction.

Found while manually validating #1399 / #1400 (the Suunto `ZRAWDATA` profile-decoding fix) against a real MacDive database: once Suunto dive profiles started decoding, their OTU calculations exposed this separate, pre-existing bug. It is unrelated to the Suunto fix itself and affects any MacDive import with a non-air gas, Suunto or otherwise.

Fixes #1493

## Changes

- `_buildDiveMap`'s tank mapping now passes `gas.oxygen`/`gas.helium` straight through to `GasMix` instead of multiplying by 100.
- Default fallback (used when a tank has no linked gas) changes from `0.21` to `21.0` to stay a valid percent.
- Updated the synthetic test fixture (`test/fixtures/macdive_sqlite/build_synthetic_db.dart`) to store `ZOXYGEN` as whole percent (32.0), matching real MacDive data, and corrected the stale test comment.

## Test Plan

- [x] `flutter test` passes
- [x] `flutter analyze` passes
- [x] Manual testing on: macOS - reproduced the bug against a real MacDive database (EAN32 tank showing 3200% O2), applied the fix, and confirmed the same tank now imports as 32% O2