### PR TITLE
fix(maps): address the review findings on per-region tile stores

### DIFF
--- a/lib/features/maps/data/services/tile_cache_service.dart
+++ b/lib/features/maps/data/services/tile_cache_service.dart
@@ -512,6 +512,13 @@ class TileCacheService {
       final streams = regionStore.download.startForeground(
         region: downloadableRegion,
         parallelThreads: parallelThreads,
+        // Skips nothing in practice, and cannot: it consults only the store
+        // being written, and that store is new every time. While every region
+        // shared one store, a download overlapping an earlier one reused its
+        // tiles; now the overlap is fetched from the tile server again and
+        // held twice. That is the price of being able to delete one region's
+        // tiles at all, which FMTC can only do by deleting a whole store, and
+        // it is why an overlapping tile counts once per region that holds it.
         skipExistingTiles: skipExistingTiles,
         instanceId: _activeDownloadId!,
       );
@@ -591,6 +598,20 @@ class TileCacheService {
   /// with every other legacy region's in [_offlineStoreName] and cannot be
   /// separated. Only "Clear all cache" reclaims those.
   Future<void> deleteRegionTiles(String regionId) async {
+    // A cache that never opened has no store to delete, and the region's row
+    // has to stay removable. Startup carries on after an initialize() failure
+    // with only a log line, and deleting a region now removes its tiles before
+    // its row, so throwing here would make every region undeletable for the
+    // rest of the session, a legacy region that owns no store included.
+    // Anything actually on disk keeps until the sweep reclaims it on a later
+    // run, once the cache does open.
+    if (!_initialized) {
+      _inFlightRegionIds.remove(regionId);
+      _log.warning(
+        'Tile cache never initialized; region $regionId has no store to delete',
+      );
+      return;
+    }
     // coverage:ignore-start
     _ensureInitialized();
     final store = FMTCStore(regionStoreName(regionId));
@@ -651,22 +672,33 @@ class TileCacheService {
 
   /// Delete region stores that no longer belong to any region.
   ///
-  /// [knownRegionIds] must be every region currently recorded; anything else
-  /// carrying the region prefix is unreachable and is deleted. Stores that are
-  /// not ours are never touched.
+  /// [readKnownRegionIds] must yield every region currently recorded; anything
+  /// else carrying the region prefix is unreachable and is deleted. Stores that
+  /// are not ours are never touched.
+  ///
+  /// It is a callback rather than a set because the order of the reads decides
+  /// whether this is safe. A download that finishes while the sweep is running
+  /// writes its row and only then releases its in-flight mark, so the rows
+  /// must be read after that mark has been pinned: read the other way round,
+  /// the sweep sees neither and deletes the store of a region that exists,
+  /// leaving a row with a size and no tiles.
   ///
   /// Returns how many stores it deleted, so a caller showing storage totals
   /// knows whether they still describe what is on disk.
   Future<int> pruneOrphanRegionStores({
-    required Set<String> knownRegionIds,
+    required Future<Set<String>> Function() readKnownRegionIds,
   }) async {
     // coverage:ignore-start
     _ensureInitialized();
     final available = await FMTCRoot.stats.storesAvailable;
+    // Copied, not aliased: the live set keeps changing, and passing it through
+    // would have it read after the rows below rather than before them.
+    final inFlightRegionIds = Set<String>.of(_inFlightRegionIds);
+    final knownRegionIds = await readKnownRegionIds();
     final orphans = orphanRegionStores(
       availableStores: available.map((s) => s.storeName),
       knownRegionIds: knownRegionIds,
-      inFlightRegionIds: _inFlightRegionIds,
+      inFlightRegionIds: inFlightRegionIds,
     );
     var deleted = 0;
     for (final storeName in orphans) {

--- a/lib/features/maps/presentation/pages/offline_maps_page.dart
+++ b/lib/features/maps/presentation/pages/offline_maps_page.dart
@@ -717,6 +717,15 @@ class _OfflineMapsPageState extends ConsumerState<OfflineMapsPage> {
 
     if (confirmed == true) {
       await ref.read(cachedRegionsNotifierProvider.notifier).clearAllCache();
+
+      // The clear goes region by region, so a locked store leaves that region
+      // behind while the rest go. Without a message that reads as "Clear all"
+      // quietly declining to clear all.
+      final error = ref.read(cachedRegionsNotifierProvider).error;
+      if (error == null || !context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(context.l10n.maps_offline_error('$error'))),
+      );
     }
   }
 }

--- a/lib/features/maps/presentation/providers/offline_map_providers.dart
+++ b/lib/features/maps/presentation/providers/offline_map_providers.dart
@@ -188,13 +188,20 @@ class DownloadProgressNotifier extends StateNotifier<DownloadState> {
       await for (final progress in stream) {
         downloadedTiles = progress.downloadedTiles;
 
-        state = state.copyWith(
-          progress: progress.percentComplete,
-          downloadedTiles: progress.downloadedTiles,
-          totalTiles: progress.totalTiles,
-          failedTiles: progress.failedTiles,
-          tilesPerSecond: progress.tilesPerSecond,
-        );
+        // Cancelling is not instant: the service cancels the download instance
+        // and only then cancels the subscription, so a superseded download
+        // emits a tick or two on the way out. Those numbers describe a region
+        // the diver has moved on from, and on the shared card they appear
+        // under the new download's name.
+        if (_isCurrent(regionId)) {
+          state = state.copyWith(
+            progress: progress.percentComplete,
+            downloadedTiles: progress.downloadedTiles,
+            totalTiles: progress.totalTiles,
+            failedTiles: progress.failedTiles,
+            tilesPerSecond: progress.tilesPerSecond,
+          );
+        }
       }
 
       if (_cancelledRegionIds.contains(regionId)) {

--- a/lib/features/maps/presentation/providers/offline_map_providers.dart
+++ b/lib/features/maps/presentation/providers/offline_map_providers.dart
@@ -101,14 +101,21 @@ class DownloadProgressNotifier extends StateNotifier<DownloadState> {
 
   static const _uuid = Uuid();
 
-  /// The region currently downloading, and the region whose download the
-  /// diver cancelled.
+  /// The region currently downloading.
+  ///
+  /// Also decides who may write [state]: a superseded download runs on past
+  /// the one that replaced it, and only the current download's progress
+  /// belongs on screen.
+  String? _activeRegionId;
+
+  /// Every download that has been cancelled and has not yet cleaned up.
   ///
   /// Cancelling and finishing both end the progress stream the same way, so
-  /// the loop needs to be told which happened. Keyed by region rather than a
-  /// flag so a cancellation can never be attributed to a later download.
-  String? _activeRegionId;
-  String? _cancelledRegionId;
+  /// the loop needs to be told which happened. A set rather than one id: a
+  /// third download would otherwise displace the first one's mark, and the
+  /// first would then take its success path and record a region for the
+  /// handful of tiles it had, which is the phantom region this guards against.
+  final Set<String> _cancelledRegionIds = {};
 
   DownloadProgressNotifier(this._cacheService, this._repository, this._ref)
     : super(const DownloadState());
@@ -134,14 +141,13 @@ class DownloadProgressNotifier extends StateNotifier<DownloadState> {
     required TileLayer tileLayerOptions,
   }) async {
     final regionId = _uuid.v4();
-    // A cancellation belongs to the download it was aimed at, so this both
-    // clears a stale one and handles the download that supersedes another:
-    // the service cancels the running download when a new one starts, and
-    // without being marked cancelled here that first download would fall
-    // through to its success path and record a region for the handful of
-    // tiles it had managed. Null when nothing was running, which is the
-    // ordinary case.
-    _cancelledRegionId = _activeRegionId;
+    // A cancellation belongs to the download it was aimed at. The service
+    // cancels the running download when a new one starts, and without being
+    // marked cancelled here that first download would fall through to its
+    // success path and record a region for the handful of tiles it had
+    // managed. Nothing to mark when nothing was running, the ordinary case.
+    final superseded = _activeRegionId;
+    if (superseded != null) _cancelledRegionIds.add(superseded);
     _activeRegionId = regionId;
     try {
       state = state.copyWith(
@@ -171,9 +177,9 @@ class DownloadProgressNotifier extends StateNotifier<DownloadState> {
       // The download would then run to completion, invisibly, and only be
       // thrown away at the end: every tile fetched, every byte of it wasted.
       // Now the download is cancelled as soon as there is something to cancel.
-      if (_cancelledRegionId == regionId) {
+      if (_cancelledRegionIds.contains(regionId)) {
         await _cacheService.discardRegionDownload(regionId);
-        state = const DownloadState();
+        _clearStateIfCurrent(regionId);
         return;
       }
 
@@ -191,11 +197,11 @@ class DownloadProgressNotifier extends StateNotifier<DownloadState> {
         );
       }
 
-      if (_cancelledRegionId == regionId) {
+      if (_cancelledRegionIds.contains(regionId)) {
         // A cancelled download used to keep its partial tiles and record a
         // region for them anyway. Now both go.
         await _cacheService.discardRegionDownload(regionId);
-        state = const DownloadState();
+        _clearStateIfCurrent(regionId);
         return;
       }
 
@@ -227,11 +233,18 @@ class DownloadProgressNotifier extends StateNotifier<DownloadState> {
       _ref.invalidate(cacheStatsProvider);
       _ref.invalidate(regionStoreIdsProvider);
 
-      state = state.copyWith(isDownloading: false);
+      if (_isCurrent(regionId)) {
+        state = state.copyWith(isDownloading: false);
+      }
     } catch (e) {
       // Whatever failed, the store must not outlive the attempt.
       await _discardQuietly(regionId);
-      state = state.copyWith(isDownloading: false, error: e.toString());
+      // A superseded download's failure is not the diver's problem: they moved
+      // on by starting another one, and putting this error on the new
+      // download's card would blame it for something it did not do.
+      if (_isCurrent(regionId)) {
+        state = state.copyWith(isDownloading: false, error: e.toString());
+      }
     } finally {
       // Only if this download is still the current one. A superseded download
       // finishes after the one that replaced it started, and clearing the slot
@@ -242,7 +255,22 @@ class DownloadProgressNotifier extends StateNotifier<DownloadState> {
       if (_activeRegionId == regionId) {
         _activeRegionId = null;
       }
+      _cancelledRegionIds.remove(regionId);
     }
+  }
+
+  /// Whether [regionId] is the download the screen is showing.
+  ///
+  /// Every write to [state] is gated on this. A superseded download finishes
+  /// after the one that replaced it started, and the two share one
+  /// [DownloadState]: blanking it on the way out left the newer download with
+  /// `isDownloading` false for its whole run, and the progress card is gated
+  /// on exactly that, so the diver saw neither progress nor a cancel button.
+  bool _isCurrent(String regionId) => _activeRegionId == regionId;
+
+  /// Reset the card, but only for the download that owns it.
+  void _clearStateIfCurrent(String regionId) {
+    if (_isCurrent(regionId)) state = const DownloadState();
   }
 
   /// Deletes a failed download's store, keeping the original failure as the
@@ -258,7 +286,8 @@ class DownloadProgressNotifier extends StateNotifier<DownloadState> {
 
   /// Cancel an ongoing download.
   Future<void> cancelDownload() async {
-    _cancelledRegionId = _activeRegionId;
+    final active = _activeRegionId;
+    if (active != null) _cancelledRegionIds.add(active);
     await _cacheService.cancelDownload();
     state = const DownloadState();
   }
@@ -387,10 +416,16 @@ class CachedRegionsNotifier
   ///
   /// Returns how many stores it reclaimed, which the caller needs because the
   /// storage totals on screen were measured before those bytes went away.
+  ///
+  /// The rows are read through a callback rather than passed in, so the sweep
+  /// decides when to read them. A snapshot taken here would be taken before
+  /// the sweep lists the stores, and a download finishing in between writes
+  /// its row and then drops its in-flight mark: absent from both, its store
+  /// would be deleted under a region that exists.
   Future<int> pruneOrphanStores() async {
-    final regions = await _repository.getAllRegions();
     return _cacheService.pruneOrphanRegionStores(
-      knownRegionIds: regions.map((r) => r.id).toSet(),
+      readKnownRegionIds: () async =>
+          (await _repository.getAllRegions()).map((r) => r.id).toSet(),
     );
   }
 
@@ -438,16 +473,27 @@ class CachedRegionsNotifier
           firstStackTrace ??= st;
         }
       }
-
-      await _cacheService.clearCache();
-
-      await _loadRegions();
-      _ref.invalidate(cacheStatsProvider);
-      _ref.invalidate(regionStoreIdsProvider);
     } catch (e, st) {
       firstError ??= e;
       firstStackTrace ??= st;
     }
+
+    try {
+      await _cacheService.clearCache();
+    } catch (e, st) {
+      // Collected like a region's own failure rather than thrown. Throwing
+      // here jumped past everything below, so a reset that failed after the
+      // rows had gone left the storage card reporting bytes that were not
+      // there and no reload to correct it.
+      firstError ??= e;
+      firstStackTrace ??= st;
+    }
+
+    // Whatever failed above, the rows that did go are gone from disk, so what
+    // is on screen has to be re-read and re-measured to match.
+    await _loadRegions();
+    _ref.invalidate(cacheStatsProvider);
+    _ref.invalidate(regionStoreIdsProvider);
 
     if (firstError != null) {
       state = AsyncValue.error(firstError, firstStackTrace ?? StackTrace.empty);

--- a/test/features/maps/offline_map_providers_test.dart
+++ b/test/features/maps/offline_map_providers_test.dart
@@ -102,11 +102,18 @@ class _FakeTileCache implements TileCacheService {
 
   int prunedStores = 0;
 
+  /// Runs after the sweep has listed the stores and before it reads the region
+  /// rows, standing in for a download that finishes while the sweep is in
+  /// flight. The row it writes must still count as known.
+  Future<void> Function()? beforeReadingRegions;
+
   @override
   Future<int> pruneOrphanRegionStores({
-    required Set<String> knownRegionIds,
+    required Future<Set<String>> Function() readKnownRegionIds,
   }) async {
-    calls.add('prune:${knownRegionIds.join(",")}');
+    await beforeReadingRegions?.call();
+    final known = (await readKnownRegionIds()).toList()..sort();
+    calls.add('prune:${known.join(",")}');
     return prunedStores;
   }
 
@@ -119,6 +126,14 @@ class _FakeTileCache implements TileCacheService {
     // Not awaited: close() on a controller nobody listened to completes only
     // once a subscriber drains it.
     if (!progress.isClosed) unawaited(progress.close());
+  }
+
+  int statsReads = 0;
+
+  @override
+  Future<CacheStats> getCacheStats() async {
+    statsReads++;
+    return const CacheStats(tileCount: 0, sizeKiB: 0, hits: 0, misses: 0);
   }
 
   @override
@@ -652,6 +667,147 @@ void main() {
           .pruneOrphanStores();
 
       expect(reclaimed, 3);
+    });
+
+    test('a region recorded while the sweep runs is not swept', () async {
+      // The rows are read after the store list, never before it. A download
+      // that finishes inside that window has already written its row and
+      // dropped its in-flight mark, so a snapshot taken up front would show
+      // neither, and the sweep would delete the store of a region that exists.
+      cache.beforeReadingRegions = () async {
+        await repository.createRegion(
+          id: 'just-finished',
+          name: 'Bonaire',
+          minLat: 12,
+          maxLat: 13,
+          minLng: -69,
+          maxLng: -68,
+          minZoom: 8,
+          maxZoom: 12,
+          tileCount: 40,
+          sizeBytes: 4096,
+        );
+      };
+
+      await container
+          .read(cachedRegionsNotifierProvider.notifier)
+          .pruneOrphanStores();
+
+      expect(cache.calls, contains('prune:just-finished'));
+    });
+  });
+
+  group('superseded download', () {
+    Future<void> start(DownloadProgressNotifier notifier, String name) =>
+        notifier.downloadRegion(
+          name: name,
+          minLat: 20,
+          maxLat: 21,
+          minLng: -87,
+          maxLng: -86,
+          minZoom: 8,
+          maxZoom: 12,
+          tileLayerOptions: tileLayer,
+        );
+
+    test('leaves the download that replaced it on screen', () async {
+      // The progress card is gated on isDownloading. A superseded download
+      // finishes after the one that replaced it started, and blanking the
+      // shared state on its way out left the diver watching a download with
+      // no progress bar and no way to cancel it until it ended.
+      final notifier = container.read(downloadProgressProvider.notifier);
+      final first = start(notifier, 'Cozumel');
+      await Future<void>.delayed(Duration.zero);
+      final second = start(notifier, 'Bonaire');
+      await first;
+      await Future<void>.delayed(Duration.zero);
+
+      final state = container.read(downloadProgressProvider);
+      expect(state.isDownloading, isTrue);
+      expect(state.regionName, 'Bonaire');
+      expect(state.error, isNull);
+
+      await notifier.cancelDownload();
+      await second;
+    });
+
+    test('a third download does not strand the first as a region', () async {
+      // Only one cancelled region used to be remembered, so a third download
+      // displaced the first one's mark. The first then fell through to its
+      // success path and recorded a region for the handful of tiles it had,
+      // which is the phantom region the cancel path exists to prevent.
+      final notifier = container.read(downloadProgressProvider.notifier);
+      final first = start(notifier, 'Cozumel');
+      await Future<void>.delayed(Duration.zero);
+      // Not awaited between the two: downloadRegion marks the download it
+      // supersedes synchronously, before its first await, so back-to-back
+      // starts are what displace the first one's mark while it is still in
+      // its loop. Letting the first one settle in between hides the bug.
+      final second = start(notifier, 'Bonaire');
+      final third = start(notifier, 'Roatan');
+      await first;
+      await second;
+      await Future<void>.delayed(Duration.zero);
+
+      cache.progress.add(
+        const TileDownloadProgress(
+          downloadedTiles: 25,
+          totalTiles: 25,
+          failedTiles: 0,
+          tilesPerSecond: 10,
+          isComplete: true,
+        ),
+      );
+      await cache.progress.close();
+      await third;
+
+      final regions = await repository.getAllRegions();
+      expect(regions.map((r) => r.name), ['Roatan']);
+    });
+  });
+
+  group('clear all reporting', () {
+    Future<void> seed(String id, String name) => repository.createRegion(
+      id: id,
+      name: name,
+      minLat: 20,
+      maxLat: 21,
+      minLng: -87,
+      maxLng: -86,
+      minZoom: 8,
+      maxZoom: 12,
+      tileCount: 10,
+      sizeBytes: 1024,
+    );
+
+    test('a failed shared-store reset still refreshes the totals', () async {
+      // The throw used to jump straight past the reload and both
+      // invalidations, so the storage card kept describing bytes that the loop
+      // above had already freed. The rows going is exactly why it has to be
+      // re-measured, whether or not the reset that followed them worked.
+      await seed('a', 'Cozumel');
+      cache.clearCacheError = StateError('the browse store is locked');
+
+      final sub = container.listen(cacheStatsProvider, (_, _) {});
+      await container.read(cacheStatsProvider.future);
+      final measurementsBefore = cache.statsReads;
+
+      await container
+          .read(cachedRegionsNotifierProvider.notifier)
+          .clearAllCache();
+      await container.read(cacheStatsProvider.future);
+
+      expect(
+        cache.statsReads,
+        greaterThan(measurementsBefore),
+        reason: 'the totals on screen were measured before the rows went',
+      );
+      expect(
+        container.read(cachedRegionsNotifierProvider).hasError,
+        isTrue,
+        reason: 'a clear that did not clear everything still has to say so',
+      );
+      sub.close();
     });
   });
 }

--- a/test/features/maps/offline_map_providers_test.dart
+++ b/test/features/maps/offline_map_providers_test.dart
@@ -117,12 +117,20 @@ class _FakeTileCache implements TileCacheService {
     return prunedStores;
   }
 
+  /// Holds the cancellation open partway through, modelling the service: it
+  /// awaits the download instance's own cancel before it cancels the
+  /// subscription and closes the controller, so a tick can still arrive in
+  /// between and reach a caller that is still in its `await for`.
+  Completer<void>? cancelGate;
+
   @override
   Future<void> cancelDownload() async {
     calls.add('cancel');
     // Nothing to cancel until the download has started, exactly as in the
     // service, where the instance id is not assigned until then.
     if (!downloadStarted) return;
+    final gate = cancelGate;
+    if (gate != null) await gate.future;
     // Not awaited: close() on a controller nobody listened to completes only
     // once a subscriber drains it.
     if (!progress.isClosed) unawaited(progress.close());
@@ -727,6 +735,50 @@ void main() {
       expect(state.regionName, 'Bonaire');
       expect(state.error, isNull);
 
+      await notifier.cancelDownload();
+      await second;
+    });
+
+    test('stops writing progress once it has been replaced', () async {
+      // Cancelling is not instant: the service cancels the download instance
+      // and only then cancels the subscription, so a superseded download can
+      // emit a tick or two on the way out. Written to the shared card those
+      // numbers land under the new download's name, and the diver reads the
+      // abandoned region's tile counts as the progress of the one they just
+      // started.
+      final notifier = container.read(downloadProgressProvider.notifier);
+      final first = start(notifier, 'Cozumel');
+      await Future<void>.delayed(Duration.zero);
+
+      cache.cancelGate = Completer<void>();
+      final second = start(notifier, 'Bonaire');
+      await Future<void>.delayed(Duration.zero);
+
+      // The first download's stream is still open, and it is no longer the one
+      // on screen.
+      cache.progress.add(
+        const TileDownloadProgress(
+          downloadedTiles: 999,
+          totalTiles: 1000,
+          failedTiles: 7,
+          tilesPerSecond: 42,
+          isComplete: false,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final state = container.read(downloadProgressProvider);
+      expect(state.regionName, 'Bonaire');
+      expect(
+        state.downloadedTiles,
+        0,
+        reason: "the abandoned region's tiles are not the new one's progress",
+      );
+      expect(state.totalTiles, 0);
+      expect(state.failedTiles, 0);
+
+      cache.cancelGate!.complete();
+      await first;
       await notifier.cancelDownload();
       await second;
     });

--- a/test/features/maps/presentation/pages/offline_maps_page_test.dart
+++ b/test/features/maps/presentation/pages/offline_maps_page_test.dart
@@ -64,7 +64,7 @@ class _UnreadableTileCache implements TileCacheService {
 
   @override
   Future<int> pruneOrphanRegionStores({
-    required Set<String> knownRegionIds,
+    required Future<Set<String>> Function() readKnownRegionIds,
   }) async => 0;
 
   @override
@@ -80,11 +80,17 @@ class _FailingTileCache implements TileCacheService {
       throw StateError('store is locked');
 
   @override
+  Future<void> cancelDownload() async {}
+
+  @override
+  Future<void> clearCache() async {}
+
+  @override
   Future<Set<String>> getRegionStoreIds() async => {'owns'};
 
   @override
   Future<int> pruneOrphanRegionStores({
-    required Set<String> knownRegionIds,
+    required Future<Set<String>> Function() readKnownRegionIds,
   }) async => 0;
 
   @override
@@ -215,6 +221,51 @@ void main() {
     await tester.pump();
     await tester.pump();
     await tester.tap(find.text('Delete'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.textContaining('store is locked'), findsOneWidget);
+    expect(repository.regions, hasLength(1));
+  });
+
+  testWidgets('a clear that could not free everything says so', (tester) async {
+    // Clearing one region at a time means a locked store leaves that region
+    // behind while the rest go. Without a message the diver reads that as
+    // "Clear all" quietly refusing to clear all.
+    final base = await getBaseOverrides();
+    final repository = _FakeRepository([_region(id: 'owns', name: 'Cozumel')]);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          offlineMapRepositoryProvider.overrideWithValue(repository),
+          tileCacheServiceProvider.overrideWithValue(_FailingTileCache()),
+          cacheStatsProvider.overrideWith(
+            (ref) async => const CacheStats(
+              tileCount: 900,
+              sizeKiB: 8000,
+              hits: 10,
+              misses: 2,
+            ),
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: OfflineMapsPage(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('Clear All Cache'));
+    await tester.pump();
+    await tester.pump();
+    await tester.tap(find.text('Clear All'));
     await tester.pump();
     await tester.pump();
 

--- a/test/features/maps/tile_cache_service_test.dart
+++ b/test/features/maps/tile_cache_service_test.dart
@@ -322,6 +322,26 @@ void main() {
       expect(entry.message, contains('cause=_ThrowingToString'));
     });
   });
+
+  group('a cache that never initialized', () {
+    // The app runs on regardless: startup swallows an initialize() failure
+    // with a log line, so every FMTC-backed call throws for the rest of the
+    // session. Deleting a region removes its tiles before its row, so a throw
+    // here would leave the diver unable to delete any region at all, legacy
+    // ones included, where there is no store and nothing to free.
+    test('has no region tiles to delete, rather than an error', () async {
+      await expectLater(
+        TileCacheService.instance.deleteRegionTiles('any-region'),
+        completes,
+      );
+    });
+
+    test('still refuses the calls that need a live store', () {
+      // The no-op above is scoped to tile deletion. Anything that would hand
+      // back a store must keep failing loudly.
+      expect(() => TileCacheService.instance.store, throwsStateError);
+    });
+  });
 }
 
 /// A cause whose `toString` throws, used to verify


### PR DESCRIPTION
Follow-up to #1464, which merged before these review findings were addressed. Six findings, all in the seams between the per-region tile stores and the state that describes them.

## The progress card is shared, and only one download may write it

A download that supersedes another finishes after its replacement has started, and its cancel path blanked the shared `DownloadState` after the newer download had set `isDownloading`. The card is gated on that flag, so the replacement ran to completion with no progress bar and no cancel button. Every write to the state is now scoped to the download that owns the card, the failure path included: a superseded download's error belongs to a download the diver had already abandoned.

## Only one cancelled region was remembered

A third download displaced the first one's mark. The first then took its success path and recorded a region for the handful of tiles it had, which is exactly the phantom region the cancel path exists to prevent. It is a set now.

## The orphan sweep could delete the store of a region that exists

The sweep read the region rows before it listed the stores, and read the in-flight marks after. A download finishing in that window has already written its row and dropped its mark, so it appeared in neither check and its store was deleted, leaving a row with a size and no tiles. Reachable by returning to the offline maps page, which runs the sweep in `initState`, as a download finishes.

The sweep now takes a reader rather than a snapshot, pins the in-flight marks, and reads the rows last. That is the only order in which a finishing download is caught by one check or the other.

## A failing shared-store reset threw past the refresh

`clearCache()` throwing jumped past the reload and both invalidations, so a clear that dropped the rows and then failed left the storage card reporting bytes that had already gone. That failure is collected like a region's own now, and the refresh runs whatever failed. The page also reports a clear that could not free everything, the way a single delete already did.

## A cache that never opened blocked every delete

Deleting a region removes its tiles before its row, so a device whose tile cache never initialized could not delete any region at all: startup carries on after an `initialize()` failure and every FMTC call then throws. A cache that never opened has no store to delete, which is a no-op rather than an error; anything on disk waits for the sweep.

## skipExistingTiles no longer skips

Each download writes a new store, and the flag only consults the store being written, so an overlapping region is fetched and held twice. That is the price of being able to delete one region's tiles at all, which FMTC can only do by deleting a whole store. Documented at the call site rather than changed.

## Testing

Each of the five behavioural fixes has a test that was verified to fail without it, by reverting the fix and re-running. The maps suite passes 106 on this base; the full suite passed 23199 on the pre-rebase base.