### PR TITLE
fix(sync): stop the temp-file sweep deleting another process's in-flight base export

### DIFF
--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -2932,20 +2932,48 @@ class SyncService {
     _log.info('Local sync state repaired');
   }
 
+  /// How recently a sync temp file must have been touched to be spared as
+  /// "probably still being written" rather than swept as a leftover. Mirrors
+  /// `ResumableBasePublishStore._orphanGrace`, for the same reason.
+  static const Duration _tempFileGrace = Duration(minutes: 5);
+
   /// Best-effort sweep of leftover streaming-base temp files (base export
   /// base export `ssv1_base_*.json` and assembled `ssv1_*.base` / `ssv1_adopt_*`
   /// parts) from the app temp dir. Every sync temp file is prefixed `ssv1_`, so
   /// the sweep matches ONLY that prefix -- never an unrelated app temp file
   /// (the dir is a shared, general-purpose temp location). Failure is logged
   /// and ignored; a stale temp file is harmless.
-  Future<void> deleteLeftoverBaseTempFiles() async {
+  ///
+  /// Skips anything touched within [_tempFileGrace]. The prefix keeps the
+  /// sweep off files this app did not write, but NOT off files another
+  /// instance of it is writing right now: under `flutter test`
+  /// [resolveSyncTempDir] falls back to the machine-wide
+  /// `Directory.systemTemp`, so every concurrent test process shares one
+  /// directory and a base export in flight in one of them sits next to this
+  /// sweep running in another. Deleting it fails that publish, which surfaces
+  /// as a sync returning non-success in a test file that touched no sync code
+  /// at all. The uuid in each name prevents collisions but cannot help here,
+  /// because the sweep matches on prefix rather than on a name it chose. A
+  /// leftover worth reaping is by definition from a run that already ended, so
+  /// it is old; a true orphan younger than the grace is simply reclaimed by
+  /// the next sweep.
+  ///
+  /// [tempDir] is injectable so tests can sweep a private directory instead of
+  /// the shared one -- otherwise this test would be the very hazard it covers.
+  Future<void> deleteLeftoverBaseTempFiles({
+    @visibleForTesting Future<Directory> Function()? tempDir,
+  }) async {
     try {
-      final dir = await resolveSyncTempDir();
+      final dir = await (tempDir?.call() ?? resolveSyncTempDir());
+      final cutoff = DateTime.now().subtract(_tempFileGrace);
       await for (final entity in dir.list(followLinks: false)) {
         if (entity is! File) continue;
         final name = entity.uri.pathSegments.last;
         if (name.startsWith('ssv1_')) {
           try {
+            // Inside the try: the file can vanish between the listing and the
+            // stat, which is exactly what a concurrent sweep looks like.
+            if ((await entity.lastModified()).isAfter(cutoff)) continue;
             await entity.delete();
           } catch (_) {
             // best effort

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -2937,9 +2937,9 @@ class SyncService {
   /// `ResumableBasePublishStore._orphanGrace`, for the same reason.
   static const Duration _tempFileGrace = Duration(minutes: 5);
 
-  /// Best-effort sweep of leftover streaming-base temp files (base export
-  /// base export `ssv1_base_*.json` and assembled `ssv1_*.base` / `ssv1_adopt_*`
-  /// parts) from the app temp dir. Every sync temp file is prefixed `ssv1_`, so
+  /// Best-effort sweep of leftover streaming-base temp files (base exports
+  /// `ssv1_base_*.json` and assembled `ssv1_*.base` / `ssv1_adopt_*` parts)
+  /// from the app temp dir. Every sync temp file is prefixed `ssv1_`, so
   /// the sweep matches ONLY that prefix -- never an unrelated app temp file
   /// (the dir is a shared, general-purpose temp location). Failure is logged
   /// and ignored; a stale temp file is harmless.

--- a/test/core/services/sync/base_temp_file_sweep_test.dart
+++ b/test/core/services/sync/base_temp_file_sweep_test.dart
@@ -1,0 +1,103 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// [SyncService.deleteLeftoverBaseTempFiles] reaps `ssv1_` temp files from the
+/// sync temp directory.
+///
+/// Under `flutter test` that directory is `Directory.systemTemp` -- machine
+/// wide -- because `getTemporaryDirectory()` throws `MissingPluginException`
+/// with no plugin host. Every concurrent test process therefore shares it, and
+/// a base export in flight in one process sits right next to the sweep running
+/// in another. The `ssv1_` prefix keeps the sweep off UNRELATED files, but the
+/// files it is most likely to hit are another run's, which is why the age
+/// guard, not the prefix, is what makes this safe.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    tempDir = await Directory.systemTemp.createTemp('base_temp_sweep_');
+  });
+
+  tearDown(() async {
+    DatabaseService.instance.resetForTesting();
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  SyncService buildService() => SyncService(
+    syncRepository: SyncRepository(),
+    serializer: SyncDataSerializer(),
+  );
+
+  File write(String name, {Duration? age}) {
+    final file = File('${tempDir.path}/$name')..writeAsStringSync('x');
+    if (age != null) {
+      file.setLastModifiedSync(DateTime.now().subtract(age));
+    }
+    return file;
+  }
+
+  test('spares a base export that is still being written', () async {
+    // The regression: a sibling test process publishing a base has its
+    // ssv1_base_*.json open in this same directory. Sweeping it kills that
+    // publish, the sync returns non-success, and every assertion downstream
+    // of "a successful sync" fails in a file that touched no sync code.
+    final live = write('ssv1_base_device-a_1.abc123.json');
+
+    await buildService().deleteLeftoverBaseTempFiles(
+      tempDir: () async => tempDir,
+    );
+
+    expect(
+      live.existsSync(),
+      isTrue,
+      reason: 'a file written seconds ago is in flight, not a leftover',
+    );
+  });
+
+  test('deletes a leftover from an earlier run', () async {
+    // The case the sweep exists for: a crash left an export behind. It is old
+    // by definition, since a live one is being written right now.
+    final stale = write(
+      'ssv1_base_device-a_1.def456.json',
+      age: const Duration(hours: 2),
+    );
+
+    await buildService().deleteLeftoverBaseTempFiles(
+      tempDir: () async => tempDir,
+    );
+
+    expect(stale.existsSync(), isFalse);
+  });
+
+  test('never touches a file without the ssv1_ prefix, at any age', () async {
+    final unrelated = write('someone_elses.json', age: const Duration(days: 3));
+
+    await buildService().deleteLeftoverBaseTempFiles(
+      tempDir: () async => tempDir,
+    );
+
+    expect(unrelated.existsSync(), isTrue);
+  });
+
+  test('sweeps the stale ones and spares the live ones in one pass', () async {
+    final live = write('ssv1_adopt_live.base');
+    final stale = write('ssv1_adopt_old.base', age: const Duration(days: 1));
+
+    await buildService().deleteLeftoverBaseTempFiles(
+      tempDir: () async => tempDir,
+    );
+
+    expect(live.existsSync(), isTrue);
+    expect(stale.existsSync(), isFalse);
+  });
+}

--- a/test/core/services/sync/sync_service_repair_test.dart
+++ b/test/core/services/sync/sync_service_repair_test.dart
@@ -68,8 +68,18 @@ void main() {
       );
       await epochStore.setLastAccepted(marker);
       await epochStore.setPendingReplace(marker);
+      // Aged, because a LEFTOVER is by definition from a run that already
+      // ended. The sweep spares recent files: the temp dir is shared, so a
+      // young ssv1_ file is far more likely to be a base export another
+      // process is writing right now than an orphan (see
+      // deleteLeftoverBaseTempFiles).
       final leftover = File('${fakeAppTemp.path}/ssv1_base_dev_0.abc.json');
       await leftover.writeAsString('stale');
+      leftover.setLastModifiedSync(
+        DateTime.now().subtract(const Duration(hours: 2)),
+      );
+      final inFlight = File('${fakeAppTemp.path}/ssv1_base_dev_9.xyz.json');
+      await inFlight.writeAsString('being written');
       // An unrelated temp file (the dir is shared) must be left untouched.
       final unrelated = File('${fakeAppTemp.path}/user_photo.jpg');
       await unrelated.writeAsString('keep');
@@ -79,6 +89,11 @@ void main() {
       expect(epochStore.lastAcceptedMarker, isNull);
       expect(epochStore.pendingReplace, isNull);
       expect(leftover.existsSync(), isFalse);
+      expect(
+        inFlight.existsSync(),
+        isTrue,
+        reason: 'a repair must not delete a base export still being written',
+      );
       expect(unrelated.existsSync(), isTrue);
     },
   );


### PR DESCRIPTION
## Summary

This is the root cause of the long-standing `sync_providers_*` full-suite flake
family — the one whose standing advice has been "rerun the file alone, it passes
14/14". It does pass alone. Here is why it does not pass in the full suite.

`SyncService.deleteLeftoverBaseTempFiles()` listed `resolveSyncTempDir()` and
deleted **every** file whose name starts with `ssv1_`. Under `flutter test`,
`getTemporaryDirectory()` throws `MissingPluginException`, so that resolves to
the machine-wide `Directory.systemTemp` (`$TMPDIR`), which is where base exports
are written as `ssv1_base_<deviceId>_<seq>.<uuid>.json`.

The uuid makes each *name* unique, which is exactly why this looked safe. But
the sweep does not match on a name it chose — it matches on a **prefix**, so
uniqueness buys nothing. Any concurrently running test process (another file in
the same run, or a sibling session's suite) has its own in-flight `ssv1_` export
sitting in that same directory. The sweep deletes it, that publish fails, its
sync returns non-success, and every assertion downstream of "a successful sync"
fails — in a test file whose diff touched no sync code at all.

Only `repairLocalSyncState` / Reset Sync State calls the sweep, which is why the
victim was random and the failure rare: it needs one process resetting while
another publishes.

## Changes

- **Skip anything modified within a 5-minute grace.** This mirrors
  `ResumableBasePublishStore._orphanGrace`, whose doc comment already spells out
  the identical reasoning for the sibling `sync_base_publish/` directory — that
  guard existed, this one did not. A leftover worth reaping is from a run that
  already ended, so it is old; a live export is seconds old.
- **The temp directory is now injectable.** A test of this behaviour against the
  real shared directory would *be* the hazard it covers, so
  `test/core/services/sync/base_temp_file_sweep_test.dart` sweeps a private one.
- **`sync_service_repair_test` asserted the sweep deletes a just-created file.**
  That expectation changed deliberately: a file being written *right now* was
  never a leftover, it only looked like one to a prefix match. The test now ages
  the stale file, and additionally pins that an in-flight export **survives** a
  repair — a stronger guarantee, and correct in production too, since a Reset
  Sync State that deletes an upload in progress was always wrong.

## Test Plan

- [x] `flutter test` passes (23,549 passed, 21 skipped)
- [x] `flutter analyze lib/ test/` passes, no infos
- [x] **Reproduced deterministically before the fix**: running
      `while :; do rm -f "$TMPDIR"ssv1_*; sleep 0.01; done` alongside
      `sync_backend_switch_test.dart` yields the exact observed failure —
      same test, same line 287, same `Expected: 's3' Actual: <null>`.
- [x] **Reproduced naturally**: `flutter test test/core/services/sync/
      test/features/settings/presentation/providers/` in a loop failed on
      iteration 3 before the fix; 6/6 clean iterations after.
- [x] 4 new tests covering spare-the-live, delete-the-stale, never-touch-a
      -non-`ssv1_`-file, and both in one pass.

## Notes

Three plausible causes were ruled out by experiment before this one, which is
worth recording so nobody re-treads them: the documented
`$TMPDIR/sync_base_publish` collision (deleting that directory during the test
does not reproduce it — different directory, different failure signature),
SharedPreferences cache contamination (`setMockInitialValues` sets
`_completer = null`, so `getInstance()` is always fresh), and auto-dispose or
auto-sync timing (`syncStateProvider` is not auto-dispose, and `autoSyncEnabled`
defaults to false under empty prefs).

Not fixed here, same class, worth a follow-up:
`ResumableBasePublishStore.clearForProvider` still deletes records by
`providerId` across processes, so two concurrent runs using the same provider id
can still discard each other's records. That is the separate, already-documented
`PathNotFoundException` flake rather than this assertion-shaped one.
