### PR TITLE
Fix the Service Due equipment filter reading the retired legacy clock

### DIFF
--- a/lib/features/equipment/data/repositories/equipment_repository_impl.dart
+++ b/lib/features/equipment/data/repositories/equipment_repository_impl.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/equipment/data/repositories/service_schedule
 import 'package:submersion/features/equipment/domain/entities/equipment_attribute.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
+import 'package:submersion/features/equipment/domain/entities/service_schedule.dart';
 
 class EquipmentRepository {
   AppDatabase get _db => DatabaseService.instance.database;
@@ -248,6 +249,7 @@ class EquipmentRepository {
           type: equipment.type,
           diverId: equipment.diverId,
         );
+        await _attachLegacyIntervalClock(id, equipment);
       } catch (e, stackTrace) {
         _log.error(
           'Auto-attach of default service clocks failed for equipment $id; '
@@ -271,6 +273,39 @@ class EquipmentRepository {
       );
       rethrow;
     }
+  }
+
+  /// Mirror a legacy single-clock interval onto the service ledger.
+  ///
+  /// The ledger is the only source the due-service surfaces read, and the
+  /// legacy `serviceIntervalDays` column has no editor left in the app -- but
+  /// UDDF import still carries one, so an imported item would otherwise land
+  /// with an interval nothing evaluates. The deterministic
+  /// `legacy-svc-<equipment id>` id and General service kind match the v122
+  /// and v131 migrations, so an item that arrives by import and the same item
+  /// that arrives by migration or sync converge on one clock, not two.
+  Future<void> _attachLegacyIntervalClock(
+    String id,
+    EquipmentItem equipment,
+  ) async {
+    final intervalDays = equipment.serviceIntervalDays;
+    if (intervalDays == null) return;
+    final scheduleId = 'legacy-svc-$id';
+    final repository = ServiceScheduleRepository();
+    final existing = await repository.getSchedulesForEquipment(id);
+    if (existing.any((s) => s.id == scheduleId)) return;
+    final now = DateTime.now();
+    await repository.createSchedule(
+      ServiceSchedule(
+        id: scheduleId,
+        equipmentId: id,
+        serviceKindId: 'general-service',
+        intervalDays: intervalDays,
+        anchorDate: equipment.lastServiceDate,
+        createdAt: now,
+        updatedAt: now,
+      ),
+    );
   }
 
   /// Update equipment
@@ -458,14 +493,6 @@ class EquipmentRepository {
       );
       rethrow;
     }
-  }
-
-  /// Get equipment with service due
-  Future<List<EquipmentItem>> getEquipmentWithServiceDue({
-    String? diverId,
-  }) async {
-    final allEquipment = await getActiveEquipment(diverId: diverId);
-    return allEquipment.where((g) => g.isServiceDue).toList();
   }
 
   /// Get all active equipment with service due dates for notification scheduling

--- a/lib/features/equipment/data/repositories/equipment_repository_impl.dart
+++ b/lib/features/equipment/data/repositories/equipment_repository_impl.dart
@@ -243,17 +243,28 @@ class EquipmentRepository {
       // must not rethrow and make the caller treat the whole create as failed
       // (which could prompt a retry and duplicate the item). The clocks can be
       // added manually later; log and continue.
+      // Each step is caught on its own so one failing does not skip the
+      // other, and so the log names the step that actually failed.
       try {
         await ServiceScheduleRepository().autoAttachForEquipment(
           equipmentId: id,
           type: equipment.type,
           diverId: equipment.diverId,
         );
-        await _attachLegacyIntervalClock(id, equipment);
       } catch (e, stackTrace) {
         _log.error(
           'Auto-attach of default service clocks failed for equipment $id; '
           'the equipment was still created',
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
+      try {
+        await _attachLegacyIntervalClock(id, equipment);
+      } catch (e, stackTrace) {
+        _log.error(
+          'Mirroring the legacy service interval onto the ledger failed for '
+          'equipment $id; the equipment was still created',
           error: e,
           stackTrace: stackTrace,
         );

--- a/lib/features/equipment/presentation/providers/equipment_providers.dart
+++ b/lib/features/equipment/presentation/providers/equipment_providers.dart
@@ -237,16 +237,25 @@ final equipmentTripIdsProvider = FutureProvider.family<List<String>, String>((
   return repository.getTripIdsForEquipment(equipmentId);
 });
 
-/// Equipment with service due provider
+/// Active gear with at least one service clock due soon or overdue, worst
+/// first.
+///
+/// Reads the service ledger (schedules + records + usage, via
+/// [dueClocksProvider]), the same source as the row badges and the dashboard
+/// card. It must not go back to the legacy `EquipmentItem.isServiceDue`
+/// getter: that reads `serviceIntervalDays`, a column the v122/v131
+/// migrations copied into the ledger and no in-app editor writes any more, so
+/// the Service Due filter always came back empty while the badges said
+/// overdue.
 final serviceDueEquipmentProvider = FutureProvider<List<EquipmentItem>>((
   ref,
 ) async {
-  final repository = ref.watch(equipmentRepositoryProvider);
-  final validatedDiverId = await ref.watch(
-    validatedCurrentDiverIdProvider.future,
-  );
-  ref.invalidateSelfWhen(repository.watchEquipmentChanges());
-  return repository.getEquipmentWithServiceDue(diverId: validatedDiverId);
+  final due = await ref.watch(dueClocksProvider.future);
+  final items = <String, EquipmentItem>{};
+  for (final clock in due) {
+    items.putIfAbsent(clock.item.id, () => clock.item);
+  }
+  return items.values.toList();
 });
 
 /// Equipment search provider
@@ -320,7 +329,9 @@ class EquipmentListNotifier
     _ref.invalidate(activeEquipmentProvider);
     _ref.invalidate(retiredEquipmentProvider);
     _ref.invalidate(allEquipmentProvider);
-    _ref.invalidate(serviceDueEquipmentProvider);
+    // The service-due list derives from the clock evaluation, which caches per
+    // item; invalidating the leaf alone would replay the cached verdicts.
+    _ref.invalidate(activeEquipmentClocksProvider);
     // Invalidate all status filters
     for (final status in EquipmentStatus.values) {
       _ref.invalidate(equipmentByStatusProvider(status));
@@ -456,7 +467,9 @@ class ServiceRecordNotifier
     _ref.invalidate(equipmentItemProvider(equipmentId));
     // A new record of kind X resets clock X: re-evaluate clocks and lists.
     _ref.invalidate(serviceClockStatusesProvider(equipmentId));
-    _ref.invalidate(dueClocksProvider);
+    // The base evaluation, not the derived lists: dueClocksProvider and the
+    // service-due list would otherwise rebuild off its cached verdicts.
+    _ref.invalidate(activeEquipmentClocksProvider);
   }
 
   Future<ServiceRecord> addRecord(ServiceRecord record) async {

--- a/lib/features/equipment/presentation/widgets/equipment_list_content.dart
+++ b/lib/features/equipment/presentation/widgets/equipment_list_content.dart
@@ -127,7 +127,9 @@ class _EquipmentListContentState extends ConsumerState<EquipmentListContent> {
   void _invalidateCurrentProvider(WidgetRef ref) {
     final filter = ref.read(equipmentFilterProvider);
     if (filter.serviceDueOnly) {
-      ref.invalidate(serviceDueEquipmentProvider);
+      // The service-due list derives from the clock evaluation, so refresh
+      // that base rather than the leaf, which would replay cached verdicts.
+      ref.invalidate(activeEquipmentClocksProvider);
     } else if (filter.status == null) {
       ref.invalidate(activeEquipmentProvider);
     } else {

--- a/lib/features/import_wizard/data/services/import_provider_invalidator.dart
+++ b/lib/features/import_wizard/data/services/import_provider_invalidator.dart
@@ -65,7 +65,8 @@ void invalidateImportRelatedProviders(
         invalidate(allEquipmentProvider);
         invalidate(activeEquipmentProvider);
         invalidate(retiredEquipmentProvider);
-        invalidate(serviceDueEquipmentProvider);
+        // Base clock evaluation: the service-due list derives from it.
+        invalidate(activeEquipmentClocksProvider);
         invalidate(equipmentListNotifierProvider);
 
       case ImportEntityType.equipmentSets:

--- a/test/features/equipment/data/repositories/equipment_repository_test.dart
+++ b/test/features/equipment/data/repositories/equipment_repository_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/data/repositories/service_schedule_repository.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_attribute.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 
@@ -569,36 +570,46 @@ void main() {
       });
     });
 
-    group('getEquipmentWithServiceDue', () {
-      test('should return equipment with service overdue', () async {
-        // Equipment with service overdue
-        await repository.createEquipment(
-          createTestEquipment(
-            name: 'Overdue Reg',
-            lastServiceDate: DateTime.now().subtract(const Duration(days: 400)),
-            serviceIntervalDays: 365,
-          ),
-        );
+    group('legacy service interval', () {
+      test(
+        'createEquipment mirrors a legacy interval onto the service ledger',
+        () async {
+          final created = await repository.createEquipment(
+            createTestEquipment(
+              name: 'Imported Reg',
+              lastServiceDate: DateTime(2020, 6, 1),
+              serviceIntervalDays: 365,
+            ),
+          );
 
-        // Equipment not due
-        await repository.createEquipment(
-          createTestEquipment(
-            name: 'Fresh Reg',
-            lastServiceDate: DateTime.now().subtract(const Duration(days: 30)),
-            serviceIntervalDays: 365,
-          ),
-        );
+          final schedules = await ServiceScheduleRepository()
+              .getSchedulesForEquipment(created.id);
+          final legacy = schedules.firstWhere(
+            (s) => s.id == 'legacy-svc-${created.id}',
+          );
 
-        // Equipment with no service date
-        await repository.createEquipment(
-          createTestEquipment(name: 'No Service Date'),
-        );
+          expect(legacy.serviceKindId, equals('general-service'));
+          expect(legacy.intervalDays, equals(365));
+          expect(legacy.anchorDate, equals(DateTime(2020, 6, 1)));
+        },
+      );
 
-        final results = await repository.getEquipmentWithServiceDue();
+      test(
+        'createEquipment adds no legacy clock without an interval',
+        () async {
+          final created = await repository.createEquipment(
+            createTestEquipment(name: 'Plain Reg'),
+          );
 
-        expect(results.length, equals(1));
-        expect(results[0].name, equals('Overdue Reg'));
-      });
+          final schedules = await ServiceScheduleRepository()
+              .getSchedulesForEquipment(created.id);
+
+          expect(
+            schedules.where((s) => s.id == 'legacy-svc-${created.id}'),
+            isEmpty,
+          );
+        },
+      );
     });
   });
 }

--- a/test/features/equipment/presentation/providers/equipment_providers_test.dart
+++ b/test/features/equipment/presentation/providers/equipment_providers_test.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/equipment/domain/entities/service_record.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
@@ -20,6 +21,7 @@ EquipmentItem _makeEquipment({
   String? diverId,
   DateTime? lastServiceDate,
   int? serviceIntervalDays,
+  DateTime? purchaseDate,
 }) {
   return EquipmentItem(
     id: id,
@@ -28,6 +30,7 @@ EquipmentItem _makeEquipment({
     diverId: diverId,
     lastServiceDate: lastServiceDate,
     serviceIntervalDays: serviceIntervalDays,
+    purchaseDate: purchaseDate,
   );
 }
 
@@ -199,5 +202,96 @@ void main() {
         );
       },
     );
+
+    test('includes gear whose service-ledger clock is overdue, with no legacy '
+        'interval column set', () async {
+      final diver = await seedCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      // A regulator bought years ago and never serviced. createEquipment
+      // auto-attaches the built-in 365-day regulator-service clock, which
+      // anchors on the purchase date, so the clock is long overdue. The
+      // legacy serviceIntervalDays column is null -- no in-app surface has
+      // written it since the service ledger landed (DB v122/v131).
+      await equipmentRepo.createEquipment(
+        _makeEquipment(
+          name: 'Neglected Reg',
+          diverId: diver.id,
+          purchaseDate: DateTime(2020),
+        ),
+      );
+
+      final names = (await container.read(
+        serviceDueEquipmentProvider.future,
+      )).map((e) => e.name).toList();
+
+      expect(
+        names,
+        contains('Neglected Reg'),
+        reason:
+            'The Service Due filter must read the service ledger; the '
+            'legacy single-clock columns are no longer written',
+      );
+    });
+
+    test('drops an item once its overdue clock is serviced', () async {
+      final diver = await seedCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      final reg = await equipmentRepo.createEquipment(
+        _makeEquipment(
+          name: 'Serviced Reg',
+          diverId: diver.id,
+          purchaseDate: DateTime(2020),
+        ),
+      );
+
+      expect(
+        (await container.read(
+          serviceDueEquipmentProvider.future,
+        )).map((e) => e.name),
+        contains('Serviced Reg'),
+      );
+
+      // Logging the service resets that clock's anchor, so the item must
+      // leave the list the notifier's refresh feeds.
+      final now = DateTime.now();
+      await container
+          .read(serviceRecordNotifierProvider(reg.id).notifier)
+          .addRecord(
+            ServiceRecord(
+              id: '',
+              equipmentId: reg.id,
+              serviceCategory: ServiceCategory.annual,
+              serviceKindId: 'regulator-service',
+              serviceDate: now,
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+
+      expect(await container.read(serviceDueEquipmentProvider.future), isEmpty);
+    });
+
+    test('excludes gear whose ledger clocks are all still ok', () async {
+      final diver = await seedCurrentDiver();
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      await equipmentRepo.createEquipment(
+        _makeEquipment(
+          name: 'Fresh Reg',
+          diverId: diver.id,
+          purchaseDate: DateTime.now(),
+        ),
+      );
+
+      expect(await container.read(serviceDueEquipmentProvider.future), isEmpty);
+    });
   });
 }

--- a/test/features/import_wizard/data/services/import_provider_invalidator_test.dart
+++ b/test/features/import_wizard/data/services/import_provider_invalidator_test.dart
@@ -80,7 +80,9 @@ void main() {
       expect(recorded, contains(allEquipmentProvider));
       expect(recorded, contains(activeEquipmentProvider));
       expect(recorded, contains(retiredEquipmentProvider));
-      expect(recorded, contains(serviceDueEquipmentProvider));
+      // The service-due list derives from this base evaluation; invalidating
+      // the leaf would replay cached clock verdicts.
+      expect(recorded, contains(activeEquipmentClocksProvider));
       expect(recorded, contains(equipmentListNotifierProvider));
     });
 


### PR DESCRIPTION
## Problem

The **Service Due** choice in the equipment filter panel returns nothing, even for gear the same list badges as OVERDUE.

## Root cause

Service tracking moved to the service ledger (`service_schedules` + `service_records` + `ServiceDueEngine`) in DB v122, and v131 reconciled the items whose legacy interval was set after that. The row badges, the dashboard card, the Service Due sort and the Next Service Due table column all read the ledger.

The filter did not. `serviceDueEquipmentProvider` called `getEquipmentWithServiceDue()`, which filtered on the legacy `EquipmentItem.isServiceDue` getter. That getter needs `equipment.service_interval_days`, a column the migrations copied into the ledger and that no in-app editor has written since the legacy field was removed. So the predicate was false for every item and the list fell through to its "everything is up to date" empty state.

## Changes

- `serviceDueEquipmentProvider` derives from `dueClocksProvider`, one entry per item, worst clock first.
- Drop the unused `getEquipmentWithServiceDue()` repository method so there is one due-service source, not two.
- `createEquipment` mirrors a legacy `serviceIntervalDays` onto the ledger as the deterministic `legacy-svc-<id>` General service clock, matching the v122/v131 migrations. UDDF import is the last live writer of that column, so without this an imported item would carry an interval nothing evaluates.
- Invalidate `activeEquipmentClocksProvider` rather than a derived leaf from pull-to-refresh, the equipment list notifier, the service record notifier and the import invalidator. Invalidating a leaf re-runs its body against the cached upstream, so a freshly logged service left the item sitting in the list.

## Tests

Five new tests:

- ledger-overdue gear appears in the filter with no legacy column set (fails before the fix)
- an item drops out once its clock is serviced (fails if the invalidation target is reverted)
- gear whose clocks are all ok stays out
- `createEquipment` writes the legacy clock when an interval is present, and does not when it is absent

`flutter analyze` clean, full suite green (23549 passed, 21 skipped).