### PR TITLE
ci: gate Script Tests behind CI Success and retry the pip install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1319,6 +1319,18 @@ jobs:
       - submodule-pointer
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+
+      - name: Check CI aggregation gate
+        # Deliberately duplicated from script-tests, which runs the same guard
+        # for a faster signal. This copy is the enforcing one: a guard that
+        # runs only inside a gated job cannot report its own de-gating, since
+        # dropping that job from `needs` below would make its failure advisory
+        # too. Running it here, in the one job branch protection requires,
+        # closes that loop. Ordered before the results check so a de-gated
+        # pipeline reports the cause rather than a downstream symptom.
+        run: python3 scripts/check_ci_success_gate.py
+
       - name: Verify all required jobs succeeded
         run: |
           results="${{ join(needs.*.result, ' ') }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -472,7 +472,32 @@ jobs:
           python-version: '3.x'
 
       - name: Install coverage.py
-        run: python3 -m pip install coverage
+        # Retried: a single unreachable-index blip used to fail the whole job.
+        # pip reports that as `(from versions: none)` -- an empty candidate
+        # list, not a version conflict -- after silently exhausting its own
+        # retries, e.g. run 33789978791.
+        run: |
+          for attempt in 1 2 3; do
+            if python3 -m pip install coverage; then
+              exit 0
+            fi
+            echo "::warning::pip install coverage failed (attempt $attempt/3)"
+            # An `[ ... ] && sleep` one-liner would abort the step with no
+            # message here: the step shell is `bash -e`, and on the last
+            # attempt the false test makes the loop body's final command
+            # return 1. See scripts/pre_push_hook_test.sh for the same bug.
+            if [ "$attempt" -lt 3 ]; then
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "::error::pip install coverage failed after 3 attempts"
+          exit 1
+
+      - name: Check CI aggregation gate
+        # Fails if a job is missing from ci-success.needs. Such a job shows red
+        # on the PR while the required check stays green, which is how
+        # script-tests itself went ungated from 2026-06-24 to 2026-09-03.
+        run: python3 scripts/check_ci_success_gate.py
 
       - name: Check JNI local-reference hygiene (source)
         # Source-level guard: no build artifact needed (unlike the APK/mapping
@@ -489,7 +514,7 @@ jobs:
       - name: Run Python guard tests with coverage
         run: |
           mkdir -p coverage
-          guards='scripts/check_proguard_serial_keep.py,scripts/check_native_libs_present.py,scripts/check_bundled_native_assets.py,scripts/check_jni_local_refs.py,scripts/check_dc_process_isolation.py,scripts/fix_macho_symbol_order.py,scripts/release/sanitize_apple_store_notes.py'
+          guards='scripts/check_proguard_serial_keep.py,scripts/check_native_libs_present.py,scripts/check_bundled_native_assets.py,scripts/check_jni_local_refs.py,scripts/check_dc_process_isolation.py,scripts/check_ci_success_gate.py,scripts/fix_macho_symbol_order.py,scripts/release/sanitize_apple_store_notes.py'
           python3 -m coverage run --include="$guards" \
             scripts/check_proguard_serial_keep_test.py
           python3 -m coverage run --append --include="$guards" \
@@ -500,6 +525,8 @@ jobs:
             scripts/check_jni_local_refs_test.py
           python3 -m coverage run --append --include="$guards" \
             scripts/check_dc_process_isolation_test.py
+          python3 -m coverage run --append --include="$guards" \
+            scripts/check_ci_success_gate_test.py
           python3 -m coverage run --append --include="$guards" \
             scripts/fix_macho_symbol_order_test.py
           python3 -m coverage run --append --include="$guards" \
@@ -1270,6 +1297,9 @@ jobs:
           echo "::error::libdivecomputer pointer would revert the commits listed above. Rebase the submodule branch onto the current submersion-patches tip and update the pointer."
           exit 1
 
+  # Adding a job below WITHOUT adding it here makes it advisory: red on the PR,
+  # ignored by the merge box. scripts/check_ci_success_gate.py fails the build
+  # if that happens; exempt a genuinely non-gating job there, not by omission.
   ci-success:
     name: CI Success
     if: always()
@@ -1279,6 +1309,7 @@ jobs:
       - analyze
       - test
       - timezone-tests
+      - script-tests
       - integration-test
       - build-ios
       - build-macos

--- a/scripts/check_ci_success_gate.py
+++ b/scripts/check_ci_success_gate.py
@@ -36,11 +36,18 @@ GATE_JOB = "ci-success"
 #              costs a coverage annotation, not correctness.
 EXEMPT_JOBS = frozenset({"pr-number"})
 
-_JOBS_KEY = re.compile(r"^jobs:\s*$")
-_JOB_ID = re.compile(r"^  ([A-Za-z0-9_-]+):\s*(?:#.*)?$")
-_NEEDS_BLOCK = re.compile(r"^    needs:\s*$")
-_NEEDS_INLINE = re.compile(r"^    needs:\s*\[(.*)\]\s*$")
-_NEEDS_ITEM = re.compile(r"^      - ([A-Za-z0-9_-]+)\s*(?:#.*)?$")
+# Every pattern tolerates a trailing `# comment`: comments are valid YAML and
+# carry no meaning, so a parser that stopped recognising an annotated key would
+# turn a comment edit into a CI failure.
+_COMMENT = r"\s*(?:#.*)?$"
+
+_JOBS_KEY = re.compile(r"^jobs:" + _COMMENT)
+_JOB_ID = re.compile(r"^  ([A-Za-z0-9_-]+):" + _COMMENT)
+_NEEDS_BLOCK = re.compile(r"^    needs:" + _COMMENT)
+# `[^]]*` rather than `.*` so a trailing comment cannot be swallowed into the
+# captured list by greedy matching.
+_NEEDS_INLINE = re.compile(r"^    needs:\s*\[([^\]]*)\]" + _COMMENT)
+_NEEDS_ITEM = re.compile(r"^      - ([A-Za-z0-9_-]+)" + _COMMENT)
 
 
 def _job_lines(text):

--- a/scripts/check_ci_success_gate.py
+++ b/scripts/check_ci_success_gate.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Verify every CI job reaches the `ci-success` aggregation gate.
+
+`CI Success` is the only check marked required in branch protection, and it
+decides pass/fail by looping over `join(needs.*.result)`. That expression can
+only ever see jobs named in its `needs:` list, so a job left out of that list
+is advisory: it shows red on the pull request while the merge box stays green.
+
+This is not hypothetical. `script-tests` was added in bc40ab67c40 (2026-06-24)
+without being added to the gate, so for over two months the JNI local-reference
+guard (#318), the dive-download process isolation check, the pre-push hook test
+and the release-notes tests could all fail without blocking a merge.
+
+GitHub Actions offers no wildcard for "every job in this workflow", so the list
+has to be maintained by hand. This guard is what makes that maintenance
+enforced rather than remembered. Pure stdlib: the CI job that runs it has no
+YAML parser installed, and the small subset of YAML that job declarations use
+is parsed directly here.
+
+Usage: check_ci_success_gate.py [workflow.yaml ...]
+"""
+
+import re
+import sys
+
+DEFAULT_WORKFLOW = ".github/workflows/ci.yaml"
+
+# The job that aggregates the others; the one to mark required in protection.
+GATE_JOB = "ci-success"
+
+# Jobs deliberately outside the gate. Keep this as short as possible: every
+# entry is a job whose failure cannot block a merge.
+#
+#   pr-number  Writes the PR number to an artifact for the coverage upload to
+#              pick up. It builds nothing and verifies nothing, so its failure
+#              costs a coverage annotation, not correctness.
+EXEMPT_JOBS = frozenset({"pr-number"})
+
+_JOBS_KEY = re.compile(r"^jobs:\s*$")
+_JOB_ID = re.compile(r"^  ([A-Za-z0-9_-]+):\s*(?:#.*)?$")
+_NEEDS_BLOCK = re.compile(r"^    needs:\s*$")
+_NEEDS_INLINE = re.compile(r"^    needs:\s*\[(.*)\]\s*$")
+_NEEDS_ITEM = re.compile(r"^      - ([A-Za-z0-9_-]+)\s*(?:#.*)?$")
+
+
+def _job_lines(text):
+    """Yield (job_id, [lines]) for each top-level job, in file order.
+
+    Only lines after the `jobs:` key are considered. Top-level workflow keys
+    such as `on:` nest their own two-space children (`push:`, `branches:`),
+    which are indistinguishable from job ids by indentation alone.
+    """
+    lines = text.splitlines()
+    try:
+        start = next(i for i, ln in enumerate(lines) if _JOBS_KEY.match(ln)) + 1
+    except StopIteration:
+        return
+    current, body = None, []
+    for line in lines[start:]:
+        match = _JOB_ID.match(line)
+        if match:
+            if current is not None:
+                yield current, body
+            current, body = match.group(1), []
+        elif current is not None:
+            body.append(line)
+    if current is not None:
+        yield current, body
+
+
+def job_ids(text):
+    """Return every top-level job id declared in the workflow, in file order."""
+    return [job_id for job_id, _ in _job_lines(text)]
+
+
+def gate_needs(text):
+    """Return the gate job's `needs` entries, or None if it declares none.
+
+    Handles both the block sequence and the inline flow sequence spellings.
+    """
+    for job_id, body in _job_lines(text):
+        if job_id != GATE_JOB:
+            continue
+        for index, line in enumerate(body):
+            inline = _NEEDS_INLINE.match(line)
+            if inline:
+                return [n.strip() for n in inline.group(1).split(",") if n.strip()]
+            if _NEEDS_BLOCK.match(line):
+                needs = []
+                for item in body[index + 1:]:
+                    entry = _NEEDS_ITEM.match(item)
+                    if not entry:
+                        break
+                    needs.append(entry.group(1))
+                return needs
+        return None
+    return None
+
+
+def find_violations(text):
+    """Return a list of violation strings; empty == every job is gated."""
+    jobs = job_ids(text)
+    if GATE_JOB not in jobs:
+        return [f"no {GATE_JOB} job found -- nothing aggregates the pipeline"]
+
+    needs = gate_needs(text)
+    if needs is None:
+        return [
+            f"{GATE_JOB} declares no needs -- it can never observe another "
+            "job's result, so it reports green unconditionally"
+        ]
+
+    violations = []
+    for job_id in jobs:
+        if job_id == GATE_JOB or job_id in EXEMPT_JOBS or job_id in needs:
+            continue
+        violations.append(
+            f"job '{job_id}' is not in {GATE_JOB}.needs -- it can fail while "
+            "the required check stays green (add it, or exempt it in "
+            "EXEMPT_JOBS with a reason)"
+        )
+    for need in needs:
+        if need not in jobs:
+            violations.append(
+                f"{GATE_JOB}.needs lists '{need}', which is not a job in this "
+                "workflow -- Actions rejects the workflow as invalid"
+            )
+    return violations
+
+
+def check_file(path):
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        violations = find_violations(fh.read())
+    lines = [f"  FAIL  {v}" for v in violations]
+    if not violations:
+        lines.append(f"  ok    every job reaches the {GATE_JOB} gate")
+    return not violations, lines
+
+
+def main(argv):
+    paths = argv[1:] or [DEFAULT_WORKFLOW]
+    all_ok = True
+    for path in paths:
+        print(f"Checking CI aggregation gate: {path}")
+        try:
+            ok, lines = check_file(path)
+        except OSError as exc:
+            print(f"  ERROR reading {path}: {exc}")
+            all_ok = False
+            continue
+        for line in lines:
+            print(line)
+        print("  -> PASS" if ok else "  -> FAIL: a job can fail without blocking a merge")
+        all_ok = all_ok and ok
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main(sys.argv))

--- a/scripts/check_ci_success_gate.py
+++ b/scripts/check_ci_success_gate.py
@@ -28,6 +28,12 @@ DEFAULT_WORKFLOW = ".github/workflows/ci.yaml"
 # The job that aggregates the others; the one to mark required in protection.
 GATE_JOB = "ci-success"
 
+# This script. The gate job must run it, not merely some gated job: a guard
+# that runs only inside a job listed in `needs` cannot report its own
+# de-gating, because removing that job from `needs` also makes the guard's
+# failure advisory. Running it in the gate closes that loop.
+GUARD_SCRIPT = "check_ci_success_gate.py"
+
 # Jobs deliberately outside the gate. Keep this as short as possible: every
 # entry is a job whose failure cannot block a merge.
 #
@@ -104,6 +110,19 @@ def gate_needs(text):
     return None
 
 
+def gate_runs_guard(text):
+    """Return True if the gate job itself invokes this guard.
+
+    Scoped to the gate job's own body on purpose: finding the script anywhere
+    in the file would be satisfied by running it in a merely gated job, which
+    is the arrangement this check exists to reject.
+    """
+    for job_id, body in _job_lines(text):
+        if job_id == GATE_JOB:
+            return any(GUARD_SCRIPT in line for line in body)
+    return False
+
+
 def find_violations(text):
     """Return a list of violation strings; empty == every job is gated."""
     jobs = job_ids(text)
@@ -118,6 +137,12 @@ def find_violations(text):
         ]
 
     violations = []
+    if not gate_runs_guard(text):
+        violations.append(
+            f"{GATE_JOB} does not run {GUARD_SCRIPT} -- running it only in a "
+            "gated job means removing that job from needs would silence this "
+            "guard along with it"
+        )
     for job_id in jobs:
         if job_id == GATE_JOB or job_id in EXEMPT_JOBS or job_id in needs:
             continue

--- a/scripts/check_ci_success_gate.py
+++ b/scripts/check_ci_success_gate.py
@@ -54,6 +54,9 @@ _NEEDS_BLOCK = re.compile(r"^    needs:" + _COMMENT)
 # captured list by greedy matching.
 _NEEDS_INLINE = re.compile(r"^    needs:\s*\[([^\]]*)\]" + _COMMENT)
 _NEEDS_ITEM = re.compile(r"^      - ([A-Za-z0-9_-]+)" + _COMMENT)
+# Captures the text before `run:` so its width gives the key's indent, which
+# is what delimits a block scalar's content from the next sibling key.
+_RUN_KEY = re.compile(r"^(\s*(?:-\s+)?)run:\s*(.*)$")
 
 
 def _job_lines(text):
@@ -110,16 +113,55 @@ def gate_needs(text):
     return None
 
 
-def gate_runs_guard(text):
-    """Return True if the gate job itself invokes this guard.
+def _strip_comment(value):
+    """Drop a trailing comment. ` #` starts one; a bare `#` inside a word does not."""
+    cut = value.find(" #")
+    return value if cut < 0 else value[:cut]
 
-    Scoped to the gate job's own body on purpose: finding the script anywhere
-    in the file would be satisfied by running it in a merely gated job, which
-    is the arrangement this check exists to reject.
+
+def _run_commands(body):
+    """Yield the shell text of every `run:` step in a job body.
+
+    Only text that actually executes: YAML comments never appear, and neither
+    do shell comment lines inside a `run: |` block. Both spellings are
+    covered, the inline `run: cmd` and the block scalar.
+    """
+    lines = list(body)
+    index = 0
+    while index < len(lines):
+        match = _RUN_KEY.match(lines[index])
+        index += 1
+        if not match:
+            continue
+        prefix, rest = match.group(1), match.group(2)
+        if not rest.startswith(("|", ">")):
+            yield _strip_comment(rest)
+            continue
+        # Block scalar: everything indented deeper than the `run` key itself.
+        key_indent = len(prefix)
+        while index < len(lines):
+            line = lines[index]
+            if line.strip() and len(line) - len(line.lstrip()) <= key_indent:
+                break
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                yield _strip_comment(stripped)
+            index += 1
+
+
+def gate_runs_guard(text):
+    """Return True if the gate job itself executes this guard.
+
+    Two scopes matter, and both are deliberate. The gate job's own body,
+    because finding the script anywhere in the file would be satisfied by
+    running it in a merely gated job, which is the arrangement this check
+    exists to reject. And `run:` text only, because a comment naming the
+    script is not an invocation: accepting one would let someone delete the
+    step, leave the documentation, and still be told the gate runs it.
     """
     for job_id, body in _job_lines(text):
         if job_id == GATE_JOB:
-            return any(GUARD_SCRIPT in line for line in body)
+            return any(GUARD_SCRIPT in cmd for cmd in _run_commands(body))
     return False
 
 
@@ -165,7 +207,13 @@ def check_file(path):
         violations = find_violations(fh.read())
     lines = [f"  FAIL  {v}" for v in violations]
     if not violations:
-        lines.append(f"  ok    every job reaches the {GATE_JOB} gate")
+        # "non-exempt" matters: EXEMPT_JOBS are allowed to stay outside the
+        # gate, so an unqualified "every job" would overstate the check.
+        exempt = ", ".join(sorted(EXEMPT_JOBS)) or "none"
+        lines.append(
+            f"  ok    every non-exempt job reaches the {GATE_JOB} gate "
+            f"(exempt: {exempt})"
+        )
     return not violations, lines
 
 

--- a/scripts/check_ci_success_gate_test.py
+++ b/scripts/check_ci_success_gate_test.py
@@ -65,6 +65,20 @@ GREEN_INLINE_NEEDS = GREEN.replace(
 
 RED_NO_GATE_JOB = GREEN.replace("  ci-success:\n", "  something-else:\n")
 
+# Trailing comments are valid YAML and carry no meaning. A parser that stops
+# recognising a key because someone annotated it turns a comment edit into a
+# CI failure, so every key this guard matches has to tolerate them.
+GREEN_COMMENTED_KEYS = (
+    GREEN.replace("jobs:\n", "jobs:  # the pipeline\n")
+    .replace("    needs:\n", "    needs:  # every job below\n")
+    .replace("      - analyze\n", "      - analyze  # lint and format\n")
+)
+
+GREEN_COMMENTED_INLINE_NEEDS = GREEN_INLINE_NEEDS.replace(
+    "    needs: [changes, analyze, script-tests]\n",
+    "    needs: [changes, analyze, script-tests]  # every job below\n",
+)
+
 RED_GATE_WITHOUT_NEEDS = """\
 jobs:
   analyze:
@@ -98,6 +112,24 @@ class ParserTests(unittest.TestCase):
     def test_needs_is_none_when_gate_has_no_needs(self):
         self.assertIsNone(guard.gate_needs(RED_GATE_WITHOUT_NEEDS))
 
+    def test_trailing_comments_do_not_hide_jobs_key(self):
+        self.assertEqual(
+            guard.job_ids(GREEN_COMMENTED_KEYS),
+            ["changes", "analyze", "script-tests", "pr-number", "ci-success"],
+        )
+
+    def test_trailing_comments_do_not_hide_block_needs(self):
+        self.assertEqual(
+            guard.gate_needs(GREEN_COMMENTED_KEYS),
+            ["changes", "analyze", "script-tests"],
+        )
+
+    def test_trailing_comments_do_not_hide_inline_needs(self):
+        self.assertEqual(
+            guard.gate_needs(GREEN_COMMENTED_INLINE_NEEDS),
+            ["changes", "analyze", "script-tests"],
+        )
+
 
 class GuardTests(unittest.TestCase):
     def test_green_has_no_violations(self):
@@ -105,6 +137,11 @@ class GuardTests(unittest.TestCase):
 
     def test_inline_needs_green_has_no_violations(self):
         self.assertEqual(guard.find_violations(GREEN_INLINE_NEEDS), [])
+
+    def test_commented_keys_have_no_violations(self):
+        # Annotating a key must not be reported as "the gate has no needs".
+        self.assertEqual(guard.find_violations(GREEN_COMMENTED_KEYS), [])
+        self.assertEqual(guard.find_violations(GREEN_COMMENTED_INLINE_NEEDS), [])
 
     def test_ungated_job_is_flagged(self):
         violations = guard.find_violations(RED_UNGATED_JOB)

--- a/scripts/check_ci_success_gate_test.py
+++ b/scripts/check_ci_success_gate_test.py
@@ -101,6 +101,37 @@ RED_GATE_DOES_NOT_RUN_GUARD = GREEN.replace(
     "      - run: python3 scripts/check_ci_success_gate.py\n", ""
 )
 
+# Deleting the step but leaving documentation behind must not read as running
+# it. A guard that accepts a mention of its own filename as proof of execution
+# is the false green it exists to prevent.
+RED_GATE_ONLY_MENTIONS_GUARD_IN_COMMENT = GREEN.replace(
+    "      - run: python3 scripts/check_ci_success_gate.py\n",
+    "      # we used to run scripts/check_ci_success_gate.py here\n",
+)
+
+# A shell comment inside a run block is equally non-executing.
+RED_GATE_MENTIONS_GUARD_IN_SHELL_COMMENT = GREEN.replace(
+    "      - run: python3 scripts/check_ci_success_gate.py\n",
+    """      - run: |
+          # scripts/check_ci_success_gate.py used to run here
+          echo done
+""",
+)
+
+# The inline spelling with a trailing YAML comment still genuinely runs it.
+GREEN_RUN_WITH_TRAILING_COMMENT = GREEN.replace(
+    "      - run: python3 scripts/check_ci_success_gate.py\n",
+    "      - run: python3 scripts/check_ci_success_gate.py  # self-hosting\n",
+)
+
+# So does the block-scalar spelling.
+GREEN_RUN_AS_BLOCK_SCALAR = GREEN.replace(
+    "      - run: python3 scripts/check_ci_success_gate.py\n",
+    """      - run: |
+          python3 scripts/check_ci_success_gate.py
+""",
+)
+
 
 class ParserTests(unittest.TestCase):
     def test_job_ids_skip_non_job_top_level_keys(self):
@@ -161,6 +192,24 @@ class GuardTests(unittest.TestCase):
     def test_gate_runs_guard_detects_the_step(self):
         self.assertTrue(guard.gate_runs_guard(GREEN))
         self.assertFalse(guard.gate_runs_guard(RED_GATE_DOES_NOT_RUN_GUARD))
+
+    def test_yaml_comment_mentioning_the_guard_does_not_count(self):
+        self.assertFalse(
+            guard.gate_runs_guard(RED_GATE_ONLY_MENTIONS_GUARD_IN_COMMENT)
+        )
+        violations = guard.find_violations(RED_GATE_ONLY_MENTIONS_GUARD_IN_COMMENT)
+        self.assertTrue(any(guard.GUARD_SCRIPT in v for v in violations))
+
+    def test_shell_comment_mentioning_the_guard_does_not_count(self):
+        self.assertFalse(
+            guard.gate_runs_guard(RED_GATE_MENTIONS_GUARD_IN_SHELL_COMMENT)
+        )
+
+    def test_inline_run_with_trailing_comment_counts(self):
+        self.assertTrue(guard.gate_runs_guard(GREEN_RUN_WITH_TRAILING_COMMENT))
+
+    def test_block_scalar_run_counts(self):
+        self.assertTrue(guard.gate_runs_guard(GREEN_RUN_AS_BLOCK_SCALAR))
 
     def test_guard_step_in_another_job_does_not_satisfy_the_gate(self):
         # Running it only in a gated job is the arrangement that cannot survive
@@ -228,6 +277,14 @@ class FileTests(unittest.TestCase):
     def test_check_file_ok(self):
         ok, _ = guard.check_file(self._write(GREEN))
         self.assertTrue(ok)
+
+    def test_pass_message_acknowledges_exemptions(self):
+        # EXEMPT_JOBS are allowed outside the gate, so a bare "every job
+        # reaches the gate" would overstate what was verified.
+        _, lines = guard.check_file(self._write(GREEN))
+        self.assertTrue(
+            any("non-exempt" in line for line in lines), lines
+        )
 
     def test_check_file_red(self):
         ok, _ = guard.check_file(self._write(RED_UNGATED_JOB))

--- a/scripts/check_ci_success_gate_test.py
+++ b/scripts/check_ci_success_gate_test.py
@@ -46,6 +46,9 @@ jobs:
       - analyze
       - script-tests
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: python3 scripts/check_ci_success_gate.py
 """
 
 # script-tests exists but never reaches the gate: it can fail while the required
@@ -86,7 +89,17 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
+    steps:
+      - run: python3 scripts/check_ci_success_gate.py
 """
+
+# The guard runs only in a gated job, never in the gate itself. Dropping that
+# job from `needs` would then make the guard advisory, so it could no longer
+# report its own de-gating: exactly the self-concealing failure it exists to
+# prevent. The gate has to run it too.
+RED_GATE_DOES_NOT_RUN_GUARD = GREEN.replace(
+    "      - run: python3 scripts/check_ci_success_gate.py\n", ""
+)
 
 
 class ParserTests(unittest.TestCase):
@@ -137,6 +150,35 @@ class GuardTests(unittest.TestCase):
 
     def test_inline_needs_green_has_no_violations(self):
         self.assertEqual(guard.find_violations(GREEN_INLINE_NEEDS), [])
+
+    def test_gate_that_does_not_run_the_guard_is_flagged(self):
+        violations = guard.find_violations(RED_GATE_DOES_NOT_RUN_GUARD)
+        self.assertTrue(
+            any(guard.GUARD_SCRIPT in v for v in violations),
+            f"expected a violation naming {guard.GUARD_SCRIPT}: {violations}",
+        )
+
+    def test_gate_runs_guard_detects_the_step(self):
+        self.assertTrue(guard.gate_runs_guard(GREEN))
+        self.assertFalse(guard.gate_runs_guard(RED_GATE_DOES_NOT_RUN_GUARD))
+
+    def test_guard_step_in_another_job_does_not_satisfy_the_gate(self):
+        # Running it only in a gated job is the arrangement that cannot survive
+        # a needs-list edit, so it must not count as the gate running it.
+        text = RED_GATE_DOES_NOT_RUN_GUARD.replace(
+            """  script-tests:
+    name: Script Tests
+    runs-on: ubuntu-latest
+""",
+            """  script-tests:
+    name: Script Tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: python3 scripts/check_ci_success_gate.py
+""",
+        )
+        self.assertIn("check_ci_success_gate.py", text)
+        self.assertFalse(guard.gate_runs_guard(text))
 
     def test_commented_keys_have_no_violations(self):
         # Annotating a key must not be reported as "the gate has no needs".

--- a/scripts/check_ci_success_gate_test.py
+++ b/scripts/check_ci_success_gate_test.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Unit tests for check_ci_success_gate.py."""
+
+import contextlib
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "check_ci_success_gate",
+    os.path.join(_HERE, "check_ci_success_gate.py"),
+)
+guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(guard)
+
+# Every job reaches the gate, so a failure anywhere turns the required check red.
+GREEN = """\
+name: CI/CD
+on:
+  push:
+    branches: [main]
+concurrency:
+  group: ${{ github.workflow }}
+jobs:
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+  analyze:
+    name: Analyze & Format
+    runs-on: ubuntu-latest
+  script-tests:
+    name: Script Tests
+    runs-on: ubuntu-latest
+  pr-number:
+    name: Record PR number
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+  ci-success:
+    name: CI Success
+    if: always()
+    needs:
+      - changes
+      - analyze
+      - script-tests
+    runs-on: ubuntu-latest
+"""
+
+# script-tests exists but never reaches the gate: it can fail while the required
+# check stays green. This is the defect the guard exists to catch.
+RED_UNGATED_JOB = GREEN.replace("      - script-tests\n", "")
+
+# The inline flow-sequence spelling of needs must be understood too, otherwise
+# rewriting the list in that style would silently disable the guard.
+GREEN_INLINE_NEEDS = GREEN.replace(
+    """    needs:
+      - changes
+      - analyze
+      - script-tests
+""",
+    "    needs: [changes, analyze, script-tests]\n",
+)
+
+RED_NO_GATE_JOB = GREEN.replace("  ci-success:\n", "  something-else:\n")
+
+RED_GATE_WITHOUT_NEEDS = """\
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+"""
+
+
+class ParserTests(unittest.TestCase):
+    def test_job_ids_skip_non_job_top_level_keys(self):
+        # `push` and `group` sit at the same indent as job ids but precede
+        # `jobs:`, so keying off indentation alone would wrongly collect them.
+        self.assertEqual(
+            guard.job_ids(GREEN),
+            ["changes", "analyze", "script-tests", "pr-number", "ci-success"],
+        )
+
+    def test_needs_parses_block_sequence(self):
+        self.assertEqual(
+            guard.gate_needs(GREEN), ["changes", "analyze", "script-tests"]
+        )
+
+    def test_needs_parses_inline_sequence(self):
+        self.assertEqual(
+            guard.gate_needs(GREEN_INLINE_NEEDS),
+            ["changes", "analyze", "script-tests"],
+        )
+
+    def test_needs_is_none_when_gate_has_no_needs(self):
+        self.assertIsNone(guard.gate_needs(RED_GATE_WITHOUT_NEEDS))
+
+
+class GuardTests(unittest.TestCase):
+    def test_green_has_no_violations(self):
+        self.assertEqual(guard.find_violations(GREEN), [])
+
+    def test_inline_needs_green_has_no_violations(self):
+        self.assertEqual(guard.find_violations(GREEN_INLINE_NEEDS), [])
+
+    def test_ungated_job_is_flagged(self):
+        violations = guard.find_violations(RED_UNGATED_JOB)
+        self.assertTrue(any("script-tests" in v for v in violations))
+
+    def test_exempt_job_is_not_required_to_be_gated(self):
+        # pr-number only uploads the PR number for the coverage upload; it is
+        # deliberately outside the gate and must not be reported.
+        self.assertEqual(
+            [v for v in guard.find_violations(GREEN) if "pr-number" in v], []
+        )
+
+    def test_gate_never_requires_itself(self):
+        self.assertEqual(
+            [v for v in guard.find_violations(GREEN) if "ci-success" in v], []
+        )
+
+    def test_missing_gate_job_is_flagged(self):
+        violations = guard.find_violations(RED_NO_GATE_JOB)
+        self.assertTrue(any(guard.GATE_JOB in v for v in violations))
+
+    def test_gate_without_needs_is_flagged(self):
+        violations = guard.find_violations(RED_GATE_WITHOUT_NEEDS)
+        self.assertTrue(any("needs" in v for v in violations))
+
+    def test_needs_entry_for_unknown_job_is_flagged(self):
+        # A renamed or deleted job left behind in `needs` makes the whole
+        # workflow invalid, so catch it here rather than at run time.
+        text = GREEN.replace("      - analyze\n", "      - analyse\n")
+        violations = guard.find_violations(text)
+        self.assertTrue(any("analyse" in v for v in violations))
+
+
+class FileTests(unittest.TestCase):
+    def _write(self, text):
+        fd, path = tempfile.mkstemp(suffix=".yaml")
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_check_file_ok(self):
+        ok, _ = guard.check_file(self._write(GREEN))
+        self.assertTrue(ok)
+
+    def test_check_file_red(self):
+        ok, _ = guard.check_file(self._write(RED_UNGATED_JOB))
+        self.assertFalse(ok)
+
+    def test_main_passes_on_green(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = guard.main(["check", self._write(GREEN)])
+        self.assertEqual(rc, 0)
+
+    def test_main_fails_on_red(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = guard.main(["check", self._write(RED_UNGATED_JOB)])
+        self.assertEqual(rc, 1)
+        self.assertIn("script-tests", buf.getvalue())
+
+    def test_main_reports_unreadable_file(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = guard.main(["check", os.path.join(_HERE, "no-such-file.yaml")])
+        self.assertEqual(rc, 1)
+        self.assertIn("ERROR", buf.getvalue())
+
+    def test_repository_workflow_is_gated(self):
+        # The real thing: guards against this file drifting out of date.
+        path = os.path.join(
+            os.path.dirname(_HERE), ".github", "workflows", "ci.yaml"
+        )
+        ok, lines = guard.check_file(path)
+        self.assertTrue(ok, "\n".join(lines))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`Script Tests` has never been able to block a merge.

`CI Success` is the only check marked required in branch protection, and it decides pass/fail by looping over `join(needs.*.result, ' ')`. That expression can only observe jobs named in its `needs:` list. `script-tests` was added in bc40ab67c40 (2026-06-24) without being added to that list, so from then until now it has been advisory: red on the pull request, ignored by the merge box.

Observed on [run 33789978791](https://github.com/submersion-app/submersion/actions/runs/33789978791), where `Script Tests` failed and `CI Success` still reported success.

What was ungated: the JNI local-reference guard (#318), the dive-download process isolation check, the pre-push hook test, and the appcast, release-notes, changelog, contributors, App Review notes and fastlane guards.

## Changes

**1. Add `script-tests` to `ci-success.needs`.** These failures now block a merge.

**2. Add `scripts/check_ci_success_gate.py`.** Actions has no wildcard for "every job in this workflow", so the `needs` list is maintained by hand. This guard fails the build if any job is missing from it, making that maintenance enforced rather than remembered. Pure stdlib, because the job that runs it has no YAML parser installed. `pr-number` is the single documented exemption, since it writes an artifact and verifies nothing.

Its parser is cross-checked against PyYAML: both agree the workflow declares 14 jobs with 12 in `needs` and none ungated.

**3. Retry the `coverage.py` install.** That same run died on a single unreachable-index blip, which pip reports as `(from versions: none)`, an empty candidate list rather than a version conflict, after silently exhausting its own retries. This matters more now that the job gates merges: previously a pip blip was cosmetic, and after change 1 it would block.

The retry uses an `if` block rather than `[ ... ] && sleep`. Under the step's `bash -e` shell the one-liner's false test on the last attempt would become the loop's exit status and abort the step with no message, which is the same defect `scripts/pre_push_hook_test.sh` already guards against in `hooks/pre-push`.

## Verification

- 18 new unit tests. Before the fix, `test_repository_workflow_is_gated` failed against the real `ci.yaml`, naming `script-tests` exactly; after, all pass.
- The entire Script Tests job run locally: all 8 Python guard suites, both source guards, all 7 shell suites, both Ruby suites. All pass.
- The retry block exercised under `bash -e` with a stubbed pip: recovers from 1 or 2 failures (exit 0), and after 3 prints its diagnostic and exits 1, confirming no silent `set -e` abort.

Note that this PR makes `CI Success` strictly harder to turn green, so it is worth confirming the new gate behaves as expected on this PR's own run before merging.