### PR TITLE
Read the segment count through AsyncValue.value (follow-up to #1508)

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -518,8 +518,17 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
               // it can be pulled back apart (issue #1504). Read separately
               // from the source count: the halves of a combined import
               // collapse to a single display source (#1451).
+              //
+              // Read through the built-in AsyncValue.value, which keeps the
+              // previous value while a provider reloads, for the reason
+              // spelled out in _buildProfileSection: the valueOrNull
+              // polyfill is `when(loading: () => null)`, so it answers null
+              // on a RELOAD that already has a value. This provider reloads
+              // behind every analysis-input tick and is invalidated outright
+              // after a separation, so the action would blink out of the
+              // section for a frame each time.
               final segmentCount =
-                  ref.watch(diveSegmentCountProvider(dive.id)).valueOrNull ?? 0;
+                  ref.watch(diveSegmentCountProvider(dive.id)).value ?? 0;
               return DataSourcesSection(
                 dataSources: dataSources,
                 diveCreatedAt: dive.dateTime,

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -519,14 +519,22 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
               // from the source count: the halves of a combined import
               // collapse to a single display source (#1451).
               //
-              // Read through the built-in AsyncValue.value, which keeps the
-              // previous value while a provider reloads, for the reason
-              // spelled out in _buildProfileSection: the valueOrNull
-              // polyfill is `when(loading: () => null)`, so it answers null
-              // on a RELOAD that already has a value. This provider reloads
-              // behind every analysis-input tick and is invalidated outright
-              // after a separation, so the action would blink out of the
-              // section for a frame each time.
+              // Read through the built-in AsyncValue.value, not the
+              // valueOrNull polyfill. The two agree on every rebuild this
+              // provider takes today: invalidateSelfWhen on the analysis tick
+              // and the outright invalidate after a separation are both
+              // self-invalidates, and the polyfill is `when`, which defaults
+              // skipLoadingOnRefresh: true, so a refresh keeps the previous
+              // count either way.
+              //
+              // They diverge on a RELOAD, the rebuild a changed dependency
+              // forces, where `when` takes its loading branch and valueOrNull
+              // answers null. Nothing reloads this provider yet: it watches
+              // only singletons that never rebuild. `.value` is what keeps the
+              // read correct if that changes, since `valueOrNull ?? 0` would
+              // read as "never combined" for a frame and blink the Separate
+              // action out of the section. _buildProfileSection reads the same
+              // way, and there the reload path is already live (#1468).
               final segmentCount =
                   ref.watch(diveSegmentCountProvider(dive.id)).value ?? 0;
               return DataSourcesSection(

--- a/test/core/providers/async_value_reload_test.dart
+++ b/test/core/providers/async_value_reload_test.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/async_value_extensions.dart';
+
+/// `valueOrNull` and the built-in `AsyncValue.value` are not interchangeable,
+/// and the difference is narrower than it looks.
+///
+/// The polyfill is `when(data:, error:, loading:)`, and `when` defaults to
+/// `skipLoadingOnRefresh: true` with `skipLoadingOnReload: false`. So an
+/// invalidate or refresh keeps the previous value through BOTH getters, while
+/// a reload driven by a dependency changing drops it through `valueOrNull`
+/// only. `value` keeps it in every case and never throws.
+///
+/// That asymmetry is why a `valueOrNull` read can look correct for a long
+/// time and then flicker once a provider gains a dependency that moves: the
+/// profile chart hit it (#1468), and the "Separate combined dives" action
+/// reads the same shape (#1504). Pinned so the two getters cannot be swapped
+/// on the assumption they agree.
+void main() {
+  late ProviderContainer container;
+  late Completer<int> next;
+
+  final trigger = NotifierProvider<_Trigger, int>(_Trigger.new);
+  final refreshed = FutureProvider<int>((ref) => next.future);
+  final derived = FutureProvider<int>((ref) {
+    ref.watch(trigger);
+    return next.future;
+  });
+
+  setUp(() {
+    next = Completer<int>();
+    container = ProviderContainer();
+  });
+
+  tearDown(() => container.dispose());
+
+  test('an invalidate keeps the previous value through both getters', () async {
+    container.listen(refreshed, (_, _) {});
+    next.complete(2);
+    expect(await container.read(refreshed.future), 2);
+
+    next = Completer<int>();
+    container.invalidate(refreshed);
+
+    final reloading = container.read(refreshed);
+    expect(reloading.isLoading, isTrue, reason: 'expected a refresh');
+    expect(reloading.value, 2);
+    // when() defaults skipLoadingOnRefresh: true, so the data branch runs.
+    expect(reloading.valueOrNull, 2);
+
+    next.complete(3);
+  });
+
+  test('a dependency-driven reload drops it through valueOrNull', () async {
+    container.listen(derived, (_, _) {});
+    next.complete(2);
+    expect(await container.read(derived.future), 2);
+
+    next = Completer<int>();
+    container.read(trigger.notifier).bump();
+
+    final reloading = container.read(derived);
+    expect(reloading.isLoading, isTrue, reason: 'expected a reload');
+    expect(reloading.value, 2);
+    // skipLoadingOnReload defaults to false, so the loading branch runs.
+    expect(reloading.valueOrNull, isNull);
+    // A caller's fallback turns that into a wrong answer: 0 segments reads
+    // as "this dive was never combined", so the action disappears.
+    expect(reloading.value ?? 0, 2);
+    expect(reloading.valueOrNull ?? 0, 0);
+
+    next.complete(3);
+  });
+
+  test('both are null on a first load, before any value exists', () {
+    container.listen(refreshed, (_, _) {});
+
+    final loading = container.read(refreshed);
+    expect(loading.isLoading, isTrue);
+    expect(loading.value, isNull);
+    expect(loading.valueOrNull, isNull);
+
+    next.complete(1);
+  });
+
+  test('value does not throw on an error state', () async {
+    container.listen(refreshed, (_, _) {});
+    next.completeError(StateError('boom'));
+    await expectLater(container.read(refreshed.future), throwsStateError);
+
+    final failed = container.read(refreshed);
+    expect(failed.hasError, isTrue);
+    expect(failed.value, isNull);
+    expect(failed.valueOrNull, isNull);
+  });
+}
+
+class _Trigger extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void bump() => state = state + 1;
+}

--- a/test/core/providers/async_value_reload_test.dart
+++ b/test/core/providers/async_value_reload_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/async_value_extensions.dart';
+import 'package:submersion/core/providers/ref_invalidate_on_change.dart';
 
 /// `valueOrNull` and the built-in `AsyncValue.value` are not interchangeable,
 /// and the difference is narrower than it looks.
@@ -70,6 +71,40 @@ void main() {
     // as "this dive was never combined", so the action disappears.
     expect(reloading.value ?? 0, 2);
     expect(reloading.valueOrNull ?? 0, 0);
+
+    next.complete(3);
+  });
+
+  // The tick that actually drives diveSegmentCountProvider: a repository
+  // change stream feeding invalidateSelfWhen, which calls invalidateSelf.
+  // That is a refresh rather than a reload, so both getters keep the previous
+  // count. Pinned because the opposite is the intuitive reading, and it is what
+  // made the dive-detail read look like a live flicker when it is not (#1504).
+  test('an invalidateSelfWhen tick refreshes, so both getters hold', () async {
+    final ticks = StreamController<void>.broadcast();
+    addTearDown(ticks.close);
+    final selfInvalidating = FutureProvider<int>((ref) {
+      ref.invalidateSelfWhen(ticks.stream);
+      return next.future;
+    });
+
+    container.listen(selfInvalidating, (_, _) {});
+    next.complete(2);
+    expect(await container.read(selfInvalidating.future), 2);
+
+    next = Completer<int>();
+    ticks.add(null);
+    await Future<void>.delayed(Duration.zero);
+
+    final rebuilding = container.read(selfInvalidating);
+    expect(rebuilding.isLoading, isTrue);
+    expect(
+      rebuilding.isReloading,
+      isFalse,
+      reason: 'invalidateSelf is a refresh, not a dependency-driven reload',
+    );
+    expect(rebuilding.value, 2);
+    expect(rebuilding.valueOrNull, 2);
 
     next.complete(3);
   });


### PR DESCRIPTION
Follow-up to #1508, which is merged. This is the one commit from that branch
that missed the merge: it was pushed 42 minutes after #1508 landed, so it never
had a PR to travel on, and the change is still absent from `main`.

## What it fixes

`dive_detail_page.dart` reads the segment count that decides whether to offer
"Separate combined dives" (#1504). On `main` today that read is:

```dart
ref.watch(diveSegmentCountProvider(dive.id)).valueOrNull ?? 0
```

`_buildProfileSection` in the same file already documents why the async reads
around it use the built-in `AsyncValue.value` rather than the repo's
`valueOrNull` polyfill; this read did not follow that.

## The mechanism is narrower than "valueOrNull nulls during reloads"

Worth stating precisely, because the imprecise version is what lets the trap
survive a reading. The polyfill is `when(...)`, and `when` defaults to
`skipLoadingOnRefresh: true` with `skipLoadingOnReload: false`:

| transition | `valueOrNull` | `value` |
| --- | --- | --- |
| invalidate / refresh | keeps previous | keeps previous |
| dependency-driven reload | **null** | keeps previous |
| first load | null | null |
| error | null | null, does not throw |

`diveSegmentCountProvider` is invalidated by `invalidateSelfWhen` and again by
a separation, and both of those are *refreshes*. So on the ticks that fire
today `valueOrNull` was in fact retaining the count, and the action was not
blinking.

The exposure is the reload path: the provider watches `diveRepositoryProvider`
and `diveUncombineServiceProvider`, so a rebuild of either drops the count, the
`?? 0` reads as "this dive was never combined", and the action disappears from
the Data Sources section. That is the same shape as #1468, where the profile
chart lost its overlays and estimated pressures for a frame.

`value` is correct under every transition rather than only the ones that happen
to fire now, and it is what this file already says to use.

## Tests

`test/core/providers/async_value_reload_test.dart` pins all four rows of that
table, so the two getters cannot be swapped again on the assumption they agree.

Driven through a real `ProviderContainer` rather than a hand-built
`AsyncValue`: the reload state this is about is one only Riverpod produces.
`copyWithPrevious` would have been the shortcut and it is `@internal`, so the
container route is also the one that will not rot.
