### PR TITLE
feat(dive computer): report the Cressi Leonardo deco obligation (relands #342)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1194,6 +1194,82 @@ jobs:
   # `changes` is likewise listed: on a docs/CI-only change it reports code=false
   # and the whole pipeline SKIPS (an accepted green), but if the detector itself
   # FAILS we must not silently skip-then-green, so its failure must reach here.
+  # A submodule pointer is a single sha with no file diff, so a pull request
+  # that moves libdivecomputer backwards reverts every fork commit in between
+  # while showing a reviewer nothing at all to look at. PR #342 sat with a
+  # pointer that would have silently undone two shipped driver fixes. Nothing
+  # else in the pipeline can catch this: the app still builds, and the reverted
+  # commits are drivers no CI job exercises.
+  #
+  # The invariant is one-directional on purpose. The pointer may run AHEAD of
+  # the fork's submersion-patches tip (a patch is pushed to the fork before the
+  # app pull request that adopts it merges), and it may stand still. It may
+  # never contain less than the base branch already contains.
+  submodule-pointer:
+    name: libdivecomputer pointer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: The libdivecomputer pointer must not go backwards
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          sub=packages/libdivecomputer_plugin/third_party/libdivecomputer
+          if [ "$EVENT" = "pull_request" ]; then
+            base="$PR_BASE"; head="$PR_HEAD"
+          else
+            base="$PUSH_BEFORE"; head="$PUSH_AFTER"
+          fi
+          if [ -z "$base" ] || ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
+            echo "Base commit unavailable ('$base'); nothing to compare against."
+            exit 0
+          fi
+
+          base_link="$(git rev-parse --verify --quiet "${base}:${sub}" || true)"
+          head_link="$(git rev-parse --verify "${head}:${sub}")"
+          if [ -z "$base_link" ]; then
+            echo "The submodule is new on this branch; nothing to compare against."
+            exit 0
+          fi
+          if [ "$base_link" = "$head_link" ]; then
+            echo "Pointer unchanged at $head_link."
+            exit 0
+          fi
+
+          # The base pointer may be unreachable from the shallow submodule
+          # clone, and either end may live on a branch this checkout never
+          # fetched, so take the whole fork before deciding.
+          git -C "$sub" fetch --quiet --tags origin '+refs/heads/*:refs/remotes/origin/*'
+
+          for sha in "$base_link" "$head_link"; do
+            if ! git -C "$sub" cat-file -e "${sha}^{commit}" 2>/dev/null; then
+              echo "::error::libdivecomputer commit $sha is not reachable in $(git config -f .gitmodules submodule.${sub}.url). Push the branch it lives on before merging."
+              exit 1
+            fi
+          done
+
+          if git -C "$sub" merge-base --is-ancestor "$base_link" "$head_link"; then
+            echo "Pointer moves forward: $base_link -> $head_link"
+            exit 0
+          fi
+
+          echo "The libdivecomputer pointer moves to a commit that does not contain the base branch's."
+          echo "Base: $base_link"
+          echo "Head: $head_link"
+          echo "These commits are on the base pointer and would be reverted:"
+          git -C "$sub" log --oneline "${head_link}..${base_link}"
+          echo "::error::libdivecomputer pointer would revert the commits listed above. Rebase the submodule branch onto the current submersion-patches tip and update the pointer."
+          exit 1
+
   ci-success:
     name: CI Success
     if: always()
@@ -1209,6 +1285,7 @@ jobs:
       - build-android
       - build-linux
       - build-windows
+      - submodule-pointer
     runs-on: ubuntu-latest
     steps:
       - name: Verify all required jobs succeeded

--- a/lib/features/dive_computer/data/services/dive_import_service.dart
+++ b/lib/features/dive_computer/data/services/dive_import_service.dart
@@ -595,6 +595,11 @@ class DiveImportService {
       entryLongitude: dive.entryLongitude,
       exitLatitude: dive.exitLatitude,
       exitLongitude: dive.exitLongitude,
+      // Already resolved by parsed_dive_mapper: the dive header's minimum
+      // where the computer reports one, else the coldest sample. Computers
+      // that log temperature only in the header (the Cressi Leonardo) have no
+      // other route into the dive record.
+      minTemperature: dive.minTemperature,
     );
 
     return diveId;
@@ -682,6 +687,11 @@ class DiveImportService {
       entryLongitude: dive.entryLongitude,
       exitLatitude: dive.exitLatitude,
       exitLongitude: dive.exitLongitude,
+      // Already resolved by parsed_dive_mapper: the dive header's minimum
+      // where the computer reports one, else the coldest sample. Computers
+      // that log temperature only in the header (the Cressi Leonardo) have no
+      // other route into the dive record.
+      minTemperature: dive.minTemperature,
     );
   }
 

--- a/lib/features/dive_computer/data/services/libdc_sample_units.dart
+++ b/lib/features/dive_computer/data/services/libdc_sample_units.dart
@@ -1,10 +1,17 @@
-/// Unit conversions at the libdivecomputer boundary.
+/// Units and constants at the libdivecomputer boundary.
 ///
 /// The plugin hands Pigeon samples through with libdc's own units. Most of
 /// them already match what the app stores; this file holds the ones that do
 /// not, so every path from a libdc sample into the app (download, raw-log
 /// import, reparse) converts in exactly one place.
 library;
+
+/// libdc's `SAMPLE_FLAGS_END`: an event carrying it closes the state the
+/// matching `SAMPLE_FLAGS_BEGIN` (1) opened, rather than being a second
+/// occurrence of it. Both ends of a decompression stop arrive as the same
+/// `SAMPLE_EVENT_DECOSTOP`, so this flag is the only thing that separates
+/// them.
+const int kLibdcSampleFlagsEnd = 2;
 
 /// libdc's `DC_SAMPLE_RBT` (remaining bottom time, or gas time remaining on
 /// an air-integrated Shearwater) is reported in minutes. Profile points store

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -608,7 +608,10 @@ class ReparseService {
 
     await db.batch((batch) {
       for (final e in parsed.events) {
-        final eventType = _mapEventTypeString(e.type);
+        final eventType = _mapEventTypeString(
+          e.type,
+          flags: int.tryParse(e.data?['flags'] ?? ''),
+        );
         if (eventType == null) continue;
 
         batch.insert(
@@ -888,7 +891,7 @@ class ReparseService {
   }
 
   /// Map libdivecomputer event type strings to ProfileEventType enum names.
-  static String? _mapEventTypeString(String type) {
+  static String? _mapEventTypeString(String type, {int? flags}) {
     switch (type) {
       case 'safetystop':
       case 'safetystop_voluntary':
@@ -896,7 +899,11 @@ class ReparseService {
         return 'safetyStopStart';
       case 'deco':
       case 'deepstop':
-        return 'decoStopStart';
+        // libdivecomputer reports the two ends of a stop as one event type
+        // with SAMPLE_FLAGS_BEGIN (1) or SAMPLE_FLAGS_END (2); an event with
+        // neither is a bare marker and reads as the start. Mirrors the
+        // download path in dive_computer_repository_impl.dart.
+        return flags == kLibdcSampleFlagsEnd ? 'decoStopEnd' : 'decoStopStart';
       case 'violation':
         return 'decoViolation';
       case 'gaschange':

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -19,6 +19,7 @@ import 'package:submersion/core/database/imported_computer_identity.dart';
 import 'package:submersion/core/matching/match_scorer.dart';
 import 'package:submersion/core/utils/deco_dive_detector.dart';
 import 'package:submersion/core/utils/stream_debounce.dart';
+import 'package:submersion/features/dive_computer/data/services/libdc_sample_units.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/repositories/profile_series_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/safety_findings_repository.dart';
@@ -1113,6 +1114,11 @@ class DiveComputerRepository {
     double? entryLongitude,
     double? exitLatitude,
     double? exitLongitude,
+    // Minimum water temperature the computer reported for the dive as a
+    // whole. Some computers (the Cressi Leonardo among them) log it only in
+    // the dive header and never as a sample, so it cannot be recovered from
+    // the profile points.
+    double? minTemperature,
   }) async {
     try {
       _log.info('Importing profile from computer $computerId');
@@ -1177,7 +1183,7 @@ class DiveComputerRepository {
         // the persisted profile events and their icons are unchanged.
         final decoEventMaps = events
             ?.where((e) => !_nonDecoEventTypes.contains(e.type))
-            .map((e) => _mapEventTypeString(e.type))
+            .map((e) => _mapEventTypeString(e.type, flags: e.flags))
             .whereType<String>()
             .map((type) => {'eventType': type})
             .toList();
@@ -1296,16 +1302,20 @@ class DiveComputerRepository {
         );
 
         // Create a data source record for provenance tracking.
-        // Derive water temp from profile samples when not provided as a
+        // Derive water temp from profile samples when the computer reported no
         // top-level value (e.g. Shearwater); maxCns is derived at the top of
-        // this branch.
+        // this branch. The header value wins where there is one, and a missing
+        // header value never blanks a temperature the samples do carry, which
+        // is the same order re-parse applies (ReparseService._minWaterTemp).
         final sampleTemps = points
             .map((p) => p.temperature)
             .whereType<double>()
             .toList();
-        final minWaterTemp = sampleTemps.isNotEmpty
-            ? sampleTemps.reduce((a, b) => a < b ? a : b)
-            : null;
+        final minWaterTemp =
+            minTemperature ??
+            (sampleTemps.isNotEmpty
+                ? sampleTemps.reduce((a, b) => a < b ? a : b)
+                : null);
 
         final nowDt = DateTime.fromMillisecondsSinceEpoch(now);
         await _db
@@ -1568,7 +1578,10 @@ class DiveComputerRepository {
       if (events != null && events.isNotEmpty) {
         await _db.batch((batch) {
           for (final event in events) {
-            final eventType = _mapEventTypeString(event.type);
+            final eventType = _mapEventTypeString(
+              event.type,
+              flags: event.flags,
+            );
             if (eventType == null) continue;
 
             // Find depth at event time from profile points
@@ -2042,7 +2055,7 @@ class DiveComputerRepository {
   ///
   /// Only maps to values that exist in [ProfileEventType]. Returns null for
   /// unknown event types that should be skipped.
-  String? _mapEventTypeString(String type) {
+  String? _mapEventTypeString(String type, {int? flags}) {
     switch (type) {
       case 'safetystop':
       case 'safetystop_voluntary':
@@ -2050,7 +2063,10 @@ class DiveComputerRepository {
         return 'safetyStopStart';
       case 'deco':
       case 'deepstop':
-        return 'decoStopStart';
+        // libdivecomputer reports the two ends of a stop as one event type
+        // with SAMPLE_FLAGS_BEGIN (1) or SAMPLE_FLAGS_END (2); an event with
+        // neither is a bare marker and reads as the start.
+        return flags == kLibdcSampleFlagsEnd ? 'decoStopEnd' : 'decoStopStart';
       case 'violation':
         return 'decoViolation';
       case 'gaschange':

--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -431,10 +431,17 @@ ProfileAnalysisService _resolveAnalysisService(
   MetricDataSource gtrSource = MetricDataSource.calculated,
   RebreatherPpO2? rebreatherPpO2,
 }) {
-  final hasComputerNdl = profile.any((p) => p.ndl != null);
-  final hasComputerCeiling = profile.any((p) => p.ceiling != null);
-  // TTS=0 is a sentinel from dive computers that don't track TTS;
-  // treat it as unavailable so we fall back to calculated values.
+  // A zero is not a reading. Computers that do not measure one of these
+  // still leave a zero in every sample, so a series that is zero from end to
+  // end counts as unreported and the calculated curve stands. TTS has always
+  // been read that way; the Cressi Leonardo forces the same rule on the other
+  // two, because it logs its deco obligation as a single bit and no numbers,
+  // leaving a stop depth of zero through a stop and a no-stop time of zero
+  // for the rest of the dive.
+  final hasComputerNdl = profile.any((p) => p.ndl != null && p.ndl! > 0);
+  final hasComputerCeiling = profile.any(
+    (p) => p.ceiling != null && p.ceiling! > 0,
+  );
   final hasComputerTts = profile.any((p) => p.tts != null && p.tts! > 0);
   final hasComputerCns = profile.any((p) => p.cns != null);
   // Air-integrated computers log their own GTR (libdc RBT, stored in

--- a/packages/libdivecomputer_plugin/patches/0008-cressi-leonardo-deco-and-ascent-fix.patch
+++ b/packages/libdivecomputer_plugin/patches/0008-cressi-leonardo-deco-and-ascent-fix.patch
@@ -1,0 +1,73 @@
+diff --git a/src/cressi_leonardo_parser.c b/src/cressi_leonardo_parser.c
+index df382c5..6866c8a 100644
+--- a/src/cressi_leonardo_parser.c
++++ b/src/cressi_leonardo_parser.c
+@@ -30,6 +30,7 @@
+ 
+ #define SZ_HEADER 82
+ 
++#define LEONARDO 1
+ #define DRAKE 6
+ 
+ typedef struct cressi_leonardo_parser_t cressi_leonardo_parser_t;
+@@ -177,6 +178,14 @@ cressi_leonardo_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callbac
+ 		gasmix = gasmix_previous;
+ 	}
+ 
++	// The Leonardo reports a decompression obligation in bit 11 of the sample
++	// word, and grades its ascent rate on four levels of which only the
++	// highest sounds the alarm. The other models in this family share the
++	// record layout, but neither has been confirmed on them, so they keep the
++	// original behaviour.
++	unsigned int is_leonardo = (parser->model == LEONARDO);
++	unsigned int deco_previous = 0;
++
+ 	unsigned int offset = SZ_HEADER;
+ 	while (offset + 2 <= size) {
+ 		dc_sample_value_t sample = {0};
+@@ -199,6 +208,7 @@ cressi_leonardo_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callbac
+ 		} else {
+ 			unsigned int value = array_uint16_le (data + offset);
+ 			unsigned int depth = value & 0x07FF;
++			unsigned int deco = is_leonardo ? (value & 0x0800) >> 11 : 0;
+ 			unsigned int ascent = (value & 0xC000) >> 14;
+ 
+ 			// Time (seconds).
+@@ -217,8 +227,35 @@ cressi_leonardo_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callbac
+ 				gasmix_previous = gasmix;
+ 			}
+ 
+-			// Ascent rate
+-			if (ascent) {
++			// Deco obligation, reported only when it changes: it is state
++			// the computer holds rather than a reading it retakes, and the
++			// first report is therefore always the start of a stop. Nothing
++			// at all is reported for a dive that never incurs one, which
++			// leaves the obligation unknown rather than asserting there is
++			// none. The stop depth, the stop time and the remaining no-stop
++			// time are all absent from the 16 bits this computer logs, so
++			// they stay zero: DC_DECO_NDL here means the obligation has
++			// cleared, not that zero minutes of no-stop time remain.
++			if (deco != deco_previous) {
++				sample.deco.type = deco ? DC_DECO_DECOSTOP : DC_DECO_NDL;
++				sample.deco.time = 0;
++				sample.deco.depth = 0.0;
++				sample.deco.tts = 0;
++				if (callback) callback (DC_SAMPLE_DECO, &sample, userdata);
++
++				sample.event.type = SAMPLE_EVENT_DECOSTOP;
++				sample.event.time = 0;
++				sample.event.flags = deco ? SAMPLE_FLAGS_BEGIN : SAMPLE_FLAGS_END;
++				sample.event.value = 0;
++				if (callback) callback (DC_SAMPLE_EVENT, &sample, userdata);
++
++				deco_previous = deco;
++			}
++
++			// Ascent rate. Levels 1 and 2 move the rate indicator on the
++			// Leonardo's display without sounding its alarm, so raising an
++			// event for them marked most of an ordinary ascent as a warning.
++			if (is_leonardo ? ascent == 3 : ascent != 0) {
+ 				sample.event.type = SAMPLE_EVENT_ASCENT;
+ 				sample.event.time = 0;
+ 				sample.event.flags = 0;

--- a/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
@@ -298,6 +298,28 @@ if(WIN32)
     target_link_libraries(test_ratio_ix3m2_record_type PRIVATE SetupAPI.lib ws2_32.lib)
 endif()
 
+# PR #342: the Cressi Leonardo logs a deco obligation in bit 11 of each sample
+# word and grades its ascent rate 0-3, of which only level 3 sounds the alarm.
+# Goes through the wrapper, because what the parser may leave unreported
+# depends on the wrapper carrying deco state forward across samples.
+add_executable(test_cressi_leonardo_deco
+    test_cressi_leonardo_deco.c
+    ${WRAPPER_DIR}/libdc_wrapper.c
+    ${WRAPPER_DIR}/libdc_download.c
+    ${LIBDC_ALL_SOURCES}
+)
+target_include_directories(test_cressi_leonardo_deco PRIVATE
+    ${WRAPPER_DIR}
+    ${LIBDC_DIR}/include
+    ${LIBDC_DIR}/src
+    ${PLATFORM_CONFIG_DIR}
+)
+target_compile_definitions(test_cressi_leonardo_deco PRIVATE HAVE_CONFIG_H)
+if(WIN32)
+    target_compile_definitions(test_cressi_leonardo_deco PRIVATE _CRT_SECURE_NO_WARNINGS)
+    target_link_libraries(test_cressi_leonardo_deco PRIVATE SetupAPI.lib ws2_32.lib)
+endif()
+
 enable_testing()
 add_test(NAME test_dive_converter COMMAND test_dive_converter)
 add_test(NAME test_serial_callbacks COMMAND test_serial_callbacks)
@@ -319,3 +341,4 @@ add_test(NAME test_shearwater_o2_millivolt COMMAND test_shearwater_o2_millivolt
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 add_test(NAME test_ratio_ix3m2_record_type COMMAND test_ratio_ix3m2_record_type)
+add_test(NAME test_cressi_leonardo_deco COMMAND test_cressi_leonardo_deco)

--- a/packages/libdivecomputer_plugin/test/native/test_cressi_leonardo_deco.c
+++ b/packages/libdivecomputer_plugin/test/native/test_cressi_leonardo_deco.c
@@ -1,0 +1,260 @@
+/* PR #342: the Cressi Leonardo logged a decompression obligation that never
+   reached the app, and marked most of an ordinary ascent as a warning.
+
+   Each in-water sample is a single 16-bit word: depth in bits 0-10, a deco
+   obligation flag in bit 11, and an ascent rate graded 0-3 in bits 14-15.
+   Only level 3 sounds the computer's alarm; the lower levels move the rate
+   indicator on its display. The parser used to ignore bit 11 entirely and to
+   raise SAMPLE_EVENT_ASCENT for every non-zero level.
+
+   The reporting rule under test matters as much as the bits. libdc_download.c
+   carries deco state forward across samples and seeds it with "never
+   reported", so the parser reports the obligation only when it changes, and a
+   dive that never incurs one is left unknown rather than being told there is
+   none. The Leonardo logs no stop depth, no stop time and no remaining
+   no-stop time, so those stay zero and must not be read as measurements.
+
+   Bit 11 and the ascent grading are confirmed on the Leonardo only. The
+   Giotto, Newton and Drake share this parser and keep the original
+   behaviour, which the last test pins.
+
+   The fixtures are synthesised from the record layout the parser documents,
+   which keeps the bits under test visible rather than buried in a blob. */
+
+#include <assert.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <libdivecomputer/parser.h>
+
+#include "libdc_wrapper.h"
+
+#define CRESSI_VENDOR   "Cressi"
+#define LEONARDO_PRODUCT "Leonardo"
+#define LEONARDO_MODEL  1
+#define GIOTTO_PRODUCT  "Giotto"
+#define GIOTTO_MODEL    4
+
+#define SZ_HEADER 82
+#define INTERVAL  20 /* seconds per sample, fixed on every model but the Drake */
+
+/* One in-water sample as the computer packs it. */
+typedef struct {
+    unsigned int depth_dm; /* 1/10 m, bits 0-10 */
+    unsigned int deco;     /* bit 11 */
+    unsigned int ascent;   /* 0-3, bits 14-15 */
+} leonardo_sample_t;
+
+static void put_u16(unsigned char *p, unsigned int value) {
+    p[0] = (unsigned char)(value & 0xFF);
+    p[1] = (unsigned char)((value >> 8) & 0xFF);
+}
+
+/* Build a raw Leonardo dive: an 82-byte header followed by 2-byte samples. */
+static unsigned char *build_dive(const leonardo_sample_t *samples,
+                                 unsigned int count,
+                                 unsigned int *size_out) {
+    unsigned int size = SZ_HEADER + count * 2;
+    unsigned char *data = (unsigned char *)calloc(1, size);
+    assert(data != NULL);
+
+    put_u16(data + 0x06, count); /* sample count, also the dive time */
+    data[0x08] = 24;             /* 2024 */
+    data[0x09] = 6;
+    data[0x0A] = 15;
+    data[0x0B] = 10;
+    data[0x0C] = 30;
+    data[0x19] = 21;             /* O2 % */
+    data[0x22] = 18;             /* minimum water temperature, degrees C */
+
+    unsigned int max_depth_dm = 0;
+    for (unsigned int i = 0; i < count; i++) {
+        const leonardo_sample_t *s = &samples[i];
+        unsigned int word = (s->depth_dm & 0x07FF) |
+                            (s->deco ? 0x0800 : 0) |
+                            ((s->ascent & 0x03) << 14);
+        put_u16(data + SZ_HEADER + i * 2, word);
+        if (s->depth_dm > max_depth_dm) max_depth_dm = s->depth_dm;
+    }
+    put_u16(data + 0x20, max_depth_dm);
+
+    *size_out = size;
+    return data;
+}
+
+/* libdc_parse_raw_dive fills a caller-owned struct, so its two heap members
+   are released individually; libdc_parsed_dive_free() would also free the
+   struct itself, which is undefined for a stack dive. */
+static void release(libdc_parsed_dive_t *dive) {
+    free(dive->samples);
+    free(dive->events);
+    dive->samples = NULL;
+    dive->events = NULL;
+}
+
+static void parse(const char *product, unsigned int model,
+                  const leonardo_sample_t *samples, unsigned int count,
+                  libdc_parsed_dive_t *dive) {
+    unsigned int size = 0;
+    unsigned char *data = build_dive(samples, count, &size);
+
+    char err[256] = {0};
+    int rc = libdc_parse_raw_dive(CRESSI_VENDOR, product, model,
+                                  data, size, dive, err, sizeof(err));
+    if (rc != 0) {
+        printf("FAIL: libdc_parse_raw_dive returned %d (%s)\n", rc, err);
+    }
+    assert(rc == 0);
+    free(data);
+}
+
+/* A ten-sample dive: down to 18 m and back, no deco, no ascent alarm. */
+static void fill_recreational(leonardo_sample_t *samples) {
+    static const unsigned int depths[10] = {50,  110, 160, 180, 180,
+                                            170, 120, 80,  40,  10};
+    for (unsigned int i = 0; i < 10; i++) {
+        samples[i].depth_dm = depths[i];
+        samples[i].deco = 0;
+        samples[i].ascent = 0;
+    }
+}
+
+/* A dive with no obligation must leave the obligation unknown. Reporting
+   DC_DECO_NDL with a zero time on every sample instead would tell the app the
+   computer measured zero minutes of no-stop time for the whole dive, which it
+   then draws in place of its own calculated curve. */
+static void test_no_deco_dive_leaves_obligation_unknown(void) {
+    leonardo_sample_t samples[10];
+    fill_recreational(samples);
+
+    libdc_parsed_dive_t dive;
+    parse(LEONARDO_PRODUCT, LEONARDO_MODEL, samples, 10, &dive);
+
+    printf("  recreational: %u samples, %u events, deco_type[0]=%u\n",
+           dive.sample_count, dive.event_count, dive.samples[0].deco_type);
+    assert(dive.sample_count == 10);
+    assert(dive.event_count == 0);
+    for (unsigned int i = 0; i < dive.sample_count; i++) {
+        assert(dive.samples[i].deco_type == UINT32_MAX);
+    }
+
+    release(&dive);
+    printf("PASS: test_no_deco_dive_leaves_obligation_unknown\n");
+}
+
+/* The obligation is reported on each transition and carried in between, and
+   the stop depth stays absent because the computer never logs one. */
+static void test_deco_run_reports_begin_and_end(void) {
+    leonardo_sample_t samples[10];
+    fill_recreational(samples);
+    for (unsigned int i = 3; i <= 6; i++) samples[i].deco = 1;
+
+    libdc_parsed_dive_t dive;
+    parse(LEONARDO_PRODUCT, LEONARDO_MODEL, samples, 10, &dive);
+
+    assert(dive.sample_count == 10);
+    printf("  deco run: %u events\n", dive.event_count);
+    assert(dive.event_count == 2);
+
+    assert(dive.events[0].type == SAMPLE_EVENT_DECOSTOP);
+    assert(dive.events[0].flags == SAMPLE_FLAGS_BEGIN);
+    assert(dive.events[0].time_ms == 4 * INTERVAL * 1000);
+    assert(dive.events[1].type == SAMPLE_EVENT_DECOSTOP);
+    assert(dive.events[1].flags == SAMPLE_FLAGS_END);
+    assert(dive.events[1].time_ms == 8 * INTERVAL * 1000);
+
+    /* Unknown before the obligation, a stop while it stands, cleared after. */
+    for (unsigned int i = 0; i < 3; i++) {
+        assert(dive.samples[i].deco_type == UINT32_MAX);
+    }
+    for (unsigned int i = 3; i <= 6; i++) {
+        assert(dive.samples[i].deco_type == DC_DECO_DECOSTOP);
+        assert(dive.samples[i].deco_time == 0);
+        assert(dive.samples[i].deco_depth == 0.0);
+    }
+    for (unsigned int i = 7; i < 10; i++) {
+        assert(dive.samples[i].deco_type == DC_DECO_NDL);
+    }
+
+    release(&dive);
+    printf("PASS: test_deco_run_reports_begin_and_end\n");
+}
+
+/* Only the level that sounds the alarm is an event. */
+static void test_ascent_event_only_at_the_alarm_level(void) {
+    leonardo_sample_t samples[10];
+    fill_recreational(samples);
+    samples[6].ascent = 1;
+    samples[7].ascent = 2;
+    samples[8].ascent = 3;
+
+    libdc_parsed_dive_t dive;
+    parse(LEONARDO_PRODUCT, LEONARDO_MODEL, samples, 10, &dive);
+
+    printf("  ascent levels 1/2/3: %u events\n", dive.event_count);
+    assert(dive.event_count == 1);
+    assert(dive.events[0].type == SAMPLE_EVENT_ASCENT);
+    assert(dive.events[0].value == 3);
+    assert(dive.events[0].time_ms == 9 * INTERVAL * 1000);
+
+    release(&dive);
+    printf("PASS: test_ascent_event_only_at_the_alarm_level\n");
+}
+
+/* Bit 11 and the ascent grading are confirmed on the Leonardo only, so the
+   other models in this family must be untouched: every ascent level is still
+   an event, and bit 11 is still ignored. */
+static void test_other_models_keep_original_behaviour(void) {
+    leonardo_sample_t samples[10];
+    fill_recreational(samples);
+    samples[4].deco = 1;
+    samples[6].ascent = 1;
+
+    libdc_parsed_dive_t dive;
+    parse(GIOTTO_PRODUCT, GIOTTO_MODEL, samples, 10, &dive);
+
+    printf("  Giotto: %u events\n", dive.event_count);
+    assert(dive.event_count == 1);
+    assert(dive.events[0].type == SAMPLE_EVENT_ASCENT);
+    assert(dive.events[0].value == 1);
+    for (unsigned int i = 0; i < dive.sample_count; i++) {
+        assert(dive.samples[i].deco_type == UINT32_MAX);
+    }
+
+    release(&dive);
+    printf("PASS: test_other_models_keep_original_behaviour\n");
+}
+
+/* The Leonardo reports its water temperature in the header and never as a
+   sample, so the dive-level minimum is the only place it exists. */
+static void test_header_supplies_the_water_temperature(void) {
+    leonardo_sample_t samples[10];
+    fill_recreational(samples);
+
+    libdc_parsed_dive_t dive;
+    parse(LEONARDO_PRODUCT, LEONARDO_MODEL, samples, 10, &dive);
+
+    printf("  min_temp: %.1f C\n", dive.min_temp);
+    assert(!isnan(dive.min_temp));
+    assert(fabs(dive.min_temp - 18.0) < 0.001);
+    for (unsigned int i = 0; i < dive.sample_count; i++) {
+        assert(isnan(dive.samples[i].temperature));
+    }
+
+    release(&dive);
+    printf("PASS: test_header_supplies_the_water_temperature\n");
+}
+
+int main(void) {
+    printf("Running Cressi Leonardo deco and ascent tests (PR #342)...\n");
+    test_no_deco_dive_leaves_obligation_unknown();
+    test_deco_run_reports_begin_and_end();
+    test_ascent_event_only_at_the_alarm_level();
+    test_other_models_keep_original_behaviour();
+    test_header_supplies_the_water_temperature();
+    printf("All Cressi Leonardo deco and ascent tests passed\n");
+    return 0;
+}

--- a/test/features/dive_computer/data/services/dive_import_service_test.dart
+++ b/test/features/dive_computer/data/services/dive_import_service_test.dart
@@ -1049,4 +1049,66 @@ void main() {
       expect(loads, 1);
     });
   });
+  group('water temperature (PR #342)', () {
+    setUp(() {
+      when(
+        mockDiveRepo.getDiveNumberForDate(any, diverId: anyNamed('diverId')),
+      ).thenAnswer((_) async => 1);
+    });
+
+    test(
+      'forwards the dive minimum so header-only computers keep it',
+      () async {
+        // The Cressi Leonardo reports its water temperature in the dive header
+        // and never in the sample stream, so a value the repository cannot
+        // derive from the profile has to be handed to it.
+        await service.importDives(
+          dives: [
+            DownloadedDive(
+              fingerprint: 'fp-leonardo',
+              startTime: DateTime(2026, 3, 3, 9, 0),
+              durationSeconds: 2400,
+              maxDepth: 18.0,
+              minTemperature: 18.0,
+              profile: const [],
+              tanks: const [],
+              events: const [],
+            ),
+          ],
+          computer: computer,
+        );
+
+        final captured = verify(
+          mockComputerRepo.importProfile(
+            computerId: anyNamed('computerId'),
+            profileStartTime: anyNamed('profileStartTime'),
+            points: anyNamed('points'),
+            durationSeconds: anyNamed('durationSeconds'),
+            maxDepth: anyNamed('maxDepth'),
+            avgDepth: anyNamed('avgDepth'),
+            isPrimary: anyNamed('isPrimary'),
+            diverId: anyNamed('diverId'),
+            tanks: anyNamed('tanks'),
+            decoAlgorithm: anyNamed('decoAlgorithm'),
+            gfLow: anyNamed('gfLow'),
+            gfHigh: anyNamed('gfHigh'),
+            decoConservatism: anyNamed('decoConservatism'),
+            events: anyNamed('events'),
+            gasSwitches: anyNamed('gasSwitches'),
+            diveNumber: anyNamed('diveNumber'),
+            forceNew: anyNamed('forceNew'),
+            rawData: anyNamed('rawData'),
+            rawFingerprint: anyNamed('rawFingerprint'),
+            descriptorVendor: anyNamed('descriptorVendor'),
+            descriptorProduct: anyNamed('descriptorProduct'),
+            descriptorModel: anyNamed('descriptorModel'),
+            libdivecomputerVersion: anyNamed('libdivecomputerVersion'),
+            minTemperature: captureAnyNamed('minTemperature'),
+          ),
+        ).captured;
+
+        expect(captured.single, 18.0);
+      },
+    );
+  });
 }

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -2249,6 +2249,62 @@ void main() {
       expect(events[6].severity, 'alert');
     });
 
+    test(
+      'a deco event carrying the END flag re-parses as decoStopEnd',
+      () async {
+        // libdivecomputer reports both ends of a stop as SAMPLE_EVENT_DECOSTOP
+        // and separates them with SAMPLE_FLAGS_BEGIN (1) / SAMPLE_FLAGS_END (2),
+        // which the platform bindings pass through in the event data map. The
+        // Cressi Leonardo is the first computer whose parser reports the pair
+        // (PR #342); without the flag both ends persisted as a stop starting.
+        await insertDive('dive-1');
+        await insertComputer('comp-1');
+        await insertSource(
+          id: 'src-1',
+          diveId: 'dive-1',
+          computerId: 'comp-1',
+          isPrimary: true,
+        );
+
+        final parsed = makeParsedDive(
+          events: [
+            pigeon.DiveEvent(
+              timeSeconds: 200,
+              type: 'deco',
+              data: {'flags': '1', 'value': '0'},
+            ),
+            pigeon.DiveEvent(
+              timeSeconds: 400,
+              type: 'deco',
+              data: {'flags': '2', 'value': '0'},
+            ),
+            pigeon.DiveEvent(timeSeconds: 600, type: 'deco'),
+          ],
+        );
+
+        await service.applyParsedUpdate(
+          diveId: 'dive-1',
+          sourceRowId: 'src-1',
+          parsed: parsed,
+          descriptorVendor: null,
+          descriptorProduct: null,
+          descriptorModel: null,
+          libdivecomputerVersion: null,
+        );
+
+        final events =
+            await (db.select(db.diveProfileEvents)
+                  ..where((t) => t.diveId.equals('dive-1'))
+                  ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+                .get();
+        expect(events.map((e) => e.eventType).toList(), [
+          'decoStopStart',
+          'decoStopEnd',
+          'decoStopStart',
+        ]);
+      },
+    );
+
     test('rbt and airtime events re-parse as lowGas warnings', () async {
       // Before the event-code table was corrected, libdivecomputer's RBT code
       // arrived as 'ascent' and its AIRTIME code as 'PO2', so neither name

--- a/test/features/dive_log/data/repositories/dive_computer_repository_leonardo_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_repository_leonardo_test.dart
@@ -1,0 +1,193 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// PR #342, the Cressi Leonardo.
+///
+/// Two gaps in the download path that computer shows up: a deco stop's end
+/// arrives as the same libdivecomputer event as its start, distinguished only
+/// by a flag, and a computer that reports its water temperature in the dive
+/// header rather than in the sample stream never had that value carried into
+/// the dive record.
+void main() {
+  late DiveComputerRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveComputerRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<String> insertComputer() async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion.insert(
+            id: 'cressi-leonardo',
+            name: 'Cressi Leonardo',
+            manufacturer: const Value('Cressi'),
+            model: const Value('Leonardo'),
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+    return 'cressi-leonardo';
+  }
+
+  Future<List<String>> eventTypesFor(String diveId) async {
+    final rows =
+        await (db.select(db.diveProfileEvents)
+              ..where((t) => t.diveId.equals(diveId))
+              ..orderBy([(t) => OrderingTerm(expression: t.timestamp)]))
+            .get();
+    return rows.map((r) => r.eventType).toList();
+  }
+
+  Future<double?> waterTempFor(String diveId) async {
+    final row = await (db.select(
+      db.diveDataSources,
+    )..where((t) => t.diveId.equals(diveId))).getSingle();
+    return row.waterTemp;
+  }
+
+  const points = [
+    ProfilePointData(timestamp: 0, depth: 1.0),
+    ProfilePointData(timestamp: 600, depth: 18.0),
+    ProfilePointData(timestamp: 1200, depth: 6.0),
+  ];
+
+  group('deco stop events', () {
+    test(
+      'the END flag persists the end of the stop, not another start',
+      () async {
+        final computerId = await insertComputer();
+
+        final diveId = await repository.importProfile(
+          computerId: computerId,
+          profileStartTime: DateTime(2026, 5, 1, 9, 0),
+          points: points,
+          durationSeconds: 1800,
+          maxDepth: 18.0,
+          events: const [
+            EventData(timestamp: 600, type: 'deco', flags: 1),
+            EventData(timestamp: 900, type: 'deco', flags: 2),
+          ],
+          forceNew: true,
+        );
+
+        expect(await eventTypesFor(diveId), ['decoStopStart', 'decoStopEnd']);
+      },
+    );
+
+    test('an unflagged deco event is still the start of a stop', () async {
+      final computerId = await insertComputer();
+
+      final diveId = await repository.importProfile(
+        computerId: computerId,
+        profileStartTime: DateTime(2026, 5, 1, 10, 0),
+        points: points,
+        durationSeconds: 1800,
+        maxDepth: 18.0,
+        events: const [EventData(timestamp: 600, type: 'deco')],
+        forceNew: true,
+      );
+
+      expect(await eventTypesFor(diveId), ['decoStopStart']);
+    });
+
+    test(
+      'a start and end pair still defaults the dive type to technical',
+      () async {
+        final computerId = await insertComputer();
+
+        final diveId = await repository.importProfile(
+          computerId: computerId,
+          profileStartTime: DateTime(2026, 5, 1, 11, 0),
+          points: points,
+          durationSeconds: 1800,
+          maxDepth: 18.0,
+          events: const [
+            EventData(timestamp: 600, type: 'deco', flags: 1),
+            EventData(timestamp: 900, type: 'deco', flags: 2),
+          ],
+          forceNew: true,
+        );
+
+        final dive = await (db.select(
+          db.dives,
+        )..where((t) => t.id.equals(diveId))).getSingle();
+        expect(dive.diveType, 'technical');
+      },
+    );
+  });
+
+  group('water temperature', () {
+    test(
+      'the dive header value is stored when no sample carries one',
+      () async {
+        final computerId = await insertComputer();
+
+        final diveId = await repository.importProfile(
+          computerId: computerId,
+          profileStartTime: DateTime(2026, 5, 1, 12, 0),
+          points: points,
+          durationSeconds: 1800,
+          maxDepth: 18.0,
+          minTemperature: 18.0,
+          forceNew: true,
+        );
+
+        expect(await waterTempFor(diveId), 18.0);
+      },
+    );
+
+    test(
+      'the sample-derived minimum stands when the header carries none',
+      () async {
+        final computerId = await insertComputer();
+
+        final diveId = await repository.importProfile(
+          computerId: computerId,
+          profileStartTime: DateTime(2026, 5, 1, 13, 0),
+          points: const [
+            ProfilePointData(timestamp: 0, depth: 1.0, temperature: 24.0),
+            ProfilePointData(timestamp: 600, depth: 18.0, temperature: 14.5),
+            ProfilePointData(timestamp: 1200, depth: 6.0, temperature: 19.0),
+          ],
+          durationSeconds: 1800,
+          maxDepth: 18.0,
+          forceNew: true,
+        );
+
+        expect(await waterTempFor(diveId), 14.5);
+      },
+    );
+
+    test('a null header value never blanks a sample-derived minimum', () async {
+      final computerId = await insertComputer();
+
+      final diveId = await repository.importProfile(
+        computerId: computerId,
+        profileStartTime: DateTime(2026, 5, 1, 14, 0),
+        points: const [
+          ProfilePointData(timestamp: 0, depth: 1.0, temperature: 24.0),
+          ProfilePointData(timestamp: 600, depth: 18.0, temperature: 14.5),
+        ],
+        durationSeconds: 1800,
+        maxDepth: 18.0,
+        minTemperature: null,
+        forceNew: true,
+      );
+
+      expect(await waterTempFor(diveId), 14.5);
+    });
+  });
+}

--- a/test/features/dive_log/presentation/providers/profile_analysis_zero_sentinel_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_analysis_zero_sentinel_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/profile_metrics.dart';
+import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+
+/// A computer that never measures a metric can still leave a zero in every
+/// sample, and a zero is not a reading. TTS has been treated that way for a
+/// while; NDL and the ceiling need the same rule.
+///
+/// The Cressi Leonardo is the case that forces it (PR #342): it logs a deco
+/// obligation as a single bit and no numbers at all, so its stop depth is zero
+/// throughout a deco stop and its no-stop time is zero for the rest of the
+/// dive. Read literally that says "the ceiling is at the surface" and "you
+/// have no no-stop time left", drawn over the app's own calculated curves.
+void main() {
+  late ProfileAnalysisService service;
+  late List<DiveProfilePoint> profile;
+  late ProfileAnalysis base;
+
+  setUp(() {
+    service = ProfileAnalysisService(gfLow: 0.30, gfHigh: 0.70);
+    profile = List.generate(
+      361,
+      (i) => DiveProfilePoint(timestamp: i * 10, depth: 20.0),
+    );
+    base = service.analyze(
+      diveId: 'zero-sentinel',
+      depths: profile.map((p) => p.depth).toList(),
+      timestamps: profile.map((p) => p.timestamp).toList(),
+    );
+  });
+
+  group('overlayComputerDecoData NDL', () {
+    test('treats an all-zero NDL series as unreported', () {
+      final zeroed = [for (final p in profile) p.copyWith(ndl: 0)];
+
+      final (result, info) = overlayComputerDecoData(
+        base,
+        zeroed,
+        ndlSource: MetricDataSource.computer,
+      );
+
+      expect(result.ndlCurve, same(base.ndlCurve));
+      expect(info.ndlActual, MetricDataSource.calculated);
+    });
+
+    test('uses the computer NDL when any sample reports one', () {
+      final reported = [
+        for (var i = 0; i < profile.length; i++)
+          if (i < 100)
+            profile[i].copyWith(ndl: 12)
+          else
+            profile[i].copyWith(ndl: 0),
+      ];
+
+      final (result, info) = overlayComputerDecoData(
+        base,
+        reported,
+        ndlSource: MetricDataSource.computer,
+      );
+
+      expect(info.ndlActual, MetricDataSource.computer);
+      expect(result.ndlCurve[50], 12);
+      expect(result.ndlCurve[200], 0);
+    });
+  });
+
+  group('overlayComputerDecoData ceiling', () {
+    test('treats an all-zero ceiling series as unreported', () {
+      final zeroed = [for (final p in profile) p.copyWith(ceiling: 0.0)];
+
+      final (result, info) = overlayComputerDecoData(
+        base,
+        zeroed,
+        ceilingSource: MetricDataSource.computer,
+      );
+
+      expect(result.ceilingCurve, same(base.ceilingCurve));
+      expect(info.ceilingActual, MetricDataSource.calculated);
+    });
+
+    test('uses the computer ceiling when any sample reports one', () {
+      final reported = [
+        for (var i = 0; i < profile.length; i++)
+          if (i >= 100 && i < 300)
+            profile[i].copyWith(ceiling: 6.0)
+          else
+            profile[i].copyWith(ceiling: 0.0),
+      ];
+
+      final (result, info) = overlayComputerDecoData(
+        base,
+        reported,
+        ceilingSource: MetricDataSource.computer,
+      );
+
+      expect(info.ceilingActual, MetricDataSource.computer);
+      expect(result.ceilingCurve[200], 6.0);
+      expect(result.ceilingCurve[50], 0.0);
+    });
+  });
+}


### PR DESCRIPTION
Relands the substance of #342 by @essengee, which has been open since June and
is now 900+ commits behind main. Closes #342.

## What #342 found, and what is left of it

Two real discoveries about the original Cressi Leonardo, both still valid:

- it logs a **decompression obligation in bit 11** of each 16-bit sample word,
  which nothing ever read, so neither the obligation nor its start and end
  reached the app;
- it grades its **ascent rate on four levels** and only level 3 sounds the
  alarm, so raising `SAMPLE_EVENT_ASCENT` for every non-zero level marked most
  of an ordinary ascent as a warning.

#342 also fixed the off-by-one in the platform event-code tables. Main fixed
that independently on 2 September with one shared `libdc_event_type_name()`
table, so those four binding files are **not touched here**; merging #342's
version would have reverted the consolidation.

## The parser change

Reports the obligation **on each transition** rather than on every sample,
which is what the wrapper's deco carry-forward in `libdc_download.c` expects.
A dive that never incurs an obligation reports nothing at all and stays
*unknown*, rather than asserting `DC_DECO_NDL` with a zero time on every
sample.

That distinction is the reason this is not just #342's patch rebased. The
Leonardo measures no numbers to go with the obligation: no stop depth, no stop
time, no remaining no-stop time. Reporting `NDL = 0` for a whole recreational
dive would be read literally by `parsed_dive_mapper` (`ndl: s.decoType == 0 ?
s.decoTime : null`) and offered to the profile as the computer's own NDL
series.

So the profile overlay gets the rule it already applies to TTS: a series that
is zero from end to end counts as unreported, and the app's calculated curve
stands rather than being overdrawn with zeroes. NDL and ceiling now match TTS.

Bit 11 and the ascent grading are **confirmed on the Leonardo only**. The
Giotto, Newton and Drake share this parser and keep their previous behaviour,
pinned by a test.

## Deco stop start and end

Both ends of a stop arrive as the same `SAMPLE_EVENT_DECOSTOP`, separated only
by `SAMPLE_FLAGS_BEGIN` (1) and `SAMPLE_FLAGS_END` (2). Without reading the
flag the end of a stop persisted as another stop starting. Download and
re-parse now both read it, through one shared constant in
`libdc_sample_units.dart` rather than a copy each.

## Water temperature

The Leonardo reports it in the dive header and never as a sample. The download
path only ever derived it from samples, so it was lost, while re-parse already
preferred the header value. Download now matches re-parse, and a missing
header value still cannot blank a temperature the samples do carry.

## CI: the submodule pointer gate

A submodule pointer is a single sha with no file diff, so a pull request that
moves libdivecomputer backwards reverts every fork commit in between while
showing a reviewer nothing at all to look at. #342 sat with a pointer that
would have silently undone the Seac Tablet BLE name filter (#1419) and the
Ratio iX3M 2 APOS5 record-type fix (#1481). Nothing else in the pipeline could
catch it: the app still builds, and the reverted commits are drivers no CI job
exercises.

The new `submodule-pointer` job asserts the pointer never contains less than
the base branch already contains. It may run ahead of the fork's
`submersion-patches` tip (a patch is pushed to the fork before the app PR that
adopts it merges) or stand still; it may not go backwards. Run against #342 as
it stands, it fails and names the six commits that would be lost.

## libdivecomputer

`submersion-patches` fast-forwarded `ac84a2d..5955815`, so the patch line stays
linear and no branch diverges. The pointer here moves forward to `5955815`, and
the change is mirrored in `patches/0008-cressi-leonardo-deco-and-ascent-fix.patch`.

## Testing

- `packages/libdivecomputer_plugin/test/native/test_cressi_leonardo_deco.c`:
  five cases through `libdc_parse_raw_dive`, the same entry point downloads and
  re-parses use, so the parser change and the wrapper's carry-forward are
  covered together. Verified to fail against the unpatched parser.
- Dart: deco start/end mapping on both the download and re-parse paths, the
  header/sample water-temperature order including the no-clobber case, the
  zero-series rule for NDL and ceiling, and that a start/end pair still
  defaults the dive to technical.
- `flutter analyze --fatal-infos` clean, `dart format` clean, full suite green.

## Note for existing users

Already-downloaded Leonardo dives keep their stored events and samples. The
dive computer detail page's "Re-parse all dives" rebuilds them from the stored
raw data.
