### PR TITLE
ci(linux): drop the build container and keep the runner's glibc floor

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -711,13 +711,23 @@ jobs:
           set -euo pipefail
           UBUNTU_TAG="ubuntu:$(. /etc/os-release && echo "$VERSION_ID")"
           echo "runner is $UBUNTU_TAG"
+          # Every image runs even when an earlier one fails, so one run says
+          # whether the .deb, the .rpm, or both are broken. Testing the exit
+          # status with `if !` keeps the failure from tripping `set -e`.
+          failed=()
           for image in "$UBUNTU_TAG" fedora:latest; do
             echo "=== $image ==="
-            docker run --rm \
+            if ! docker run --rm \
               -v "$PWD/packages:/p" \
               -v "$PWD/scripts/release/verify_linux_package.sh:/verify.sh:ro" \
-              "$image" bash /verify.sh
+              "$image" bash /verify.sh; then
+              failed+=("$image")
+            fi
           done
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo "::error::package verification failed on: ${failed[*]}"
+            exit 1
+          fi
 
   # ============================================================================
   # Android Build

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -558,7 +558,16 @@ jobs:
 
     steps:
       # Before checkout: a bare image has no git, so actions/checkout cannot
-      # fetch submodules, and no curl/unzip for subosito/flutter-action.
+      # fetch submodules, and none of the tools the Flutter setup assumes.
+      #
+      # The last two lines are things the GitHub-hosted image preinstalls and
+      # a bare container does not, so nothing outside this job needs them:
+      #   jq                        subosito/flutter-action parses its release
+      #                             manifest with it and exits 1 without it
+      #   zip, xz-utils, libglu1-mesa  Flutter's own documented Linux
+      #                             prerequisites
+      #   binutils                  readelf, for scripts/linux_package_deps.py
+      #   file                      used by fpm to classify packaged files
       - name: Install Linux dependencies
         run: |
           apt-get update -y
@@ -567,7 +576,8 @@ jobs:
             libgtk-3-dev liblzma-dev libstdc++-12-dev \
             libsqlite3-dev libsecret-1-dev libwebkit2gtk-4.1-dev \
             libssl-dev \
-            curl git unzip xz-utils ca-certificates file binutils
+            curl git unzip xz-utils zip ca-certificates \
+            jq file binutils libglu1-mesa
 
       # actions/checkout inside a container trips git's dubious-ownership
       # check, which makes every later git command fail.

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -549,41 +549,9 @@ jobs:
   build-linux:
     name: Build Linux
     runs-on: ubuntu-latest
-    # The glibc floor is pinned by the container image, not the runner label:
-    # GitHub retires runner images on its own schedule, and a label-pinned
-    # floor would rise silently the day 22.04 is removed. glibc 2.35 covers
-    # Ubuntu 22.04+, Debian 12+, and every current Fedora and openSUSE.
-    container: ubuntu:22.04
-    timeout-minutes: 40
+    timeout-minutes: 30
 
     steps:
-      # Before checkout: a bare image has no git, so actions/checkout cannot
-      # fetch submodules, and none of the tools the Flutter setup assumes.
-      #
-      # The last two lines are things the GitHub-hosted image preinstalls and
-      # a bare container does not, so nothing outside this job needs them:
-      #   jq                        subosito/flutter-action parses its release
-      #                             manifest with it and exits 1 without it
-      #   zip, xz-utils, libglu1-mesa  Flutter's own documented Linux
-      #                             prerequisites
-      #   binutils                  readelf, for scripts/linux_package_deps.py
-      #   file                      used by fpm to classify packaged files
-      - name: Install Linux dependencies
-        run: |
-          apt-get update -y
-          DEBIAN_FRONTEND=noninteractive apt-get install -y \
-            clang cmake ninja-build pkg-config \
-            libgtk-3-dev liblzma-dev libstdc++-12-dev \
-            libsqlite3-dev libsecret-1-dev libwebkit2gtk-4.1-dev \
-            libssl-dev \
-            curl git unzip xz-utils zip ca-certificates \
-            jq file binutils libglu1-mesa
-
-      # actions/checkout inside a container trips git's dubious-ownership
-      # check, which makes every later git command fail.
-      - name: Trust the workspace
-        run: git config --global --add safe.directory '*'
-
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
@@ -593,6 +561,26 @@ jobs:
       - name: Read Flutter version
         id: flutter-ver
         run: echo "version=$(cat ${{ env.FLUTTER_VERSION_FILE }})" >> "$GITHUB_OUTPUT"
+
+      # The runner image sets the glibc floor of everything shipped here.
+      # Deliberately left as ubuntu-latest: the released tarball has always
+      # required GLIBC_2.38, pinned by libsqlcipher.so and the two plugin
+      # libraries rather than by the app, so building on an older host would
+      # buy reach the project has never claimed at the cost of a container
+      # and its toolchain. See docs/guide/installation.md for the distro
+      # requirement this implies.
+      #
+      # binutils supplies readelf for scripts/linux_package_deps.py; the
+      # hosted image already has it, and it is named here so a future image
+      # change cannot remove it silently.
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            clang cmake ninja-build pkg-config \
+            libgtk-3-dev liblzma-dev libstdc++-12-dev \
+            libsqlite3-dev libsecret-1-dev libwebkit2gtk-4.1-dev \
+            libssl-dev binutils
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -640,9 +628,8 @@ jobs:
 
       - name: Install packaging tools
         run: |
-          DEBIAN_FRONTEND=noninteractive apt-get install -y \
-            ruby ruby-dev build-essential rpm python3-pil
-          gem install --no-document fpm
+          sudo apt-get install -y ruby ruby-dev build-essential rpm python3-pil
+          sudo gem install --no-document fpm
 
       # Staged before the tarball step, so the installer scripts the tarball
       # carries never leak into the package trees.
@@ -696,15 +683,6 @@ jobs:
     needs: build-linux
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - image: debian:12
-            format: deb
-          - image: fedora:latest
-            format: rpm
-
     steps:
       # Checkout first: actions/checkout cleans the workspace by default, so
       # downloading the artifact before it would delete the download.
@@ -723,13 +701,23 @@ jobs:
       # Installing through the real package manager is the point: it proves
       # every declared dependency is resolvable on a stock system, which is
       # exactly what the tar.gz could never demonstrate.
-      - name: Install and run in a clean ${{ matrix.image }}
+      # The .deb is verified against the runner's own Ubuntu release, not an
+      # older distro: build-linux runs on ubuntu-latest, so its binaries
+      # require that runner's glibc and cannot run anywhere older. The tag is
+      # derived rather than pinned so it keeps matching when GitHub moves
+      # ubuntu-latest. Mirrors the same step in ci.yaml.
+      - name: Install and run in clean containers
         run: |
           set -euo pipefail
-          docker run --rm \
-            -v "$PWD/packages:/p" \
-            -v "$PWD/scripts/release/verify_linux_package.sh:/verify.sh:ro" \
-            ${{ matrix.image }} bash /verify.sh
+          UBUNTU_TAG="ubuntu:$(. /etc/os-release && echo "$VERSION_ID")"
+          echo "runner is $UBUNTU_TAG"
+          for image in "$UBUNTU_TAG" fedora:latest; do
+            echo "=== $image ==="
+            docker run --rm \
+              -v "$PWD/packages:/p" \
+              -v "$PWD/scripts/release/verify_linux_package.sh:/verify.sh:ro" \
+              "$image" bash /verify.sh
+          done
 
   # ============================================================================
   # Android Build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1132,8 +1132,8 @@ jobs:
       # than an older distro. This job builds on ubuntu-latest, so its binary
       # requires that runner's glibc, and installing it on debian:12
       # (glibc 2.36) fails with "GLIBC_2.38 not found" no matter how correct
-      # the packaging is. build-all.yml builds inside an ubuntu:22.04
-      # container and is where installation on older distros is proven.
+      # the packaging is. build-all.yml builds on ubuntu-latest too, so no
+      # job proves installation on older distros: none is supported.
       #
       # The tag is derived from the runner rather than pinned, so this keeps
       # matching when GitHub moves ubuntu-latest to the next release.
@@ -1142,13 +1142,23 @@ jobs:
           set -euo pipefail
           UBUNTU_TAG="ubuntu:$(. /etc/os-release && echo "$VERSION_ID")"
           echo "runner is $UBUNTU_TAG"
+          # Every image runs even when an earlier one fails, so one run says
+          # whether the .deb, the .rpm, or both are broken. Testing the exit
+          # status with `if !` keeps the failure from tripping `set -e`.
+          failed=()
           for image in "$UBUNTU_TAG" fedora:latest; do
             echo "=== $image ==="
-            docker run --rm \
+            if ! docker run --rm \
               -v "$PWD/packages:/p" \
               -v "$PWD/scripts/release/verify_linux_package.sh:/verify.sh:ro" \
-              "$image" bash /verify.sh
+              "$image" bash /verify.sh; then
+              failed+=("$image")
+            fi
           done
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo "::error::package verification failed on: ${failed[*]}"
+            exit 1
+          fi
 
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -334,11 +334,12 @@ The built app will be at `build\windows\x64\runner\Release\`.
 <details>
 <summary><b>Linux: installing</b></summary>
 
-> **Distro requirement:** the packages need glibc 2.38 or newer, which means
+> **Distro requirement:** Submersion needs glibc 2.38 or newer, which means
 > Ubuntu 24.04+, Debian 13+, Fedora 39+, Linux Mint 22+, Arch, or openSUSE
-> Tumbleweed. On Debian 12, Ubuntu 22.04, or RHEL 9 the packages will install
-> but the app will not start; use the tarball below instead, which works on
-> those systems today.
+> Tumbleweed. Debian 12, Ubuntu 22.04, and RHEL 9 cannot run any current
+> Submersion build. The packages install but the app will not start, and the
+> tarball fails the same way, because three bundled libraries require
+> GLIBC_2.38. Upgrading the distribution is the only path.
 
 **Debian, Ubuntu, Mint, and derivatives**
 

--- a/README.md
+++ b/README.md
@@ -334,6 +334,12 @@ The built app will be at `build\windows\x64\runner\Release\`.
 <details>
 <summary><b>Linux: installing</b></summary>
 
+> **Distro requirement:** the packages need glibc 2.38 or newer, which means
+> Ubuntu 24.04+, Debian 13+, Fedora 39+, Linux Mint 22+, Arch, or openSUSE
+> Tumbleweed. On Debian 12, Ubuntu 22.04, or RHEL 9 the packages will install
+> but the app will not start; use the tarball below instead, which works on
+> those systems today.
+
 **Debian, Ubuntu, Mint, and derivatives**
 
 Download `Submersion-<version>-Linux-amd64.deb` from

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -29,6 +29,12 @@ resolve their own dependencies, register a desktop entry and icon, and install
 udev rules so dive computers connected by USB are reachable without any group
 membership or `usermod` step.
 
+> **Distro requirement:** the packages need glibc 2.38 or newer, which means
+> Ubuntu 24.04+, Debian 13+, Fedora 39+, Linux Mint 22+, Arch, or openSUSE
+> Tumbleweed. On Debian 12, Ubuntu 22.04, or RHEL 9 the packages will install
+> but the app will not start; use the tarball below instead, which works on
+> those systems today.
+
 <!-- tabs:start -->
 
 #### **Debian / Ubuntu / Mint**

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -29,11 +29,12 @@ resolve their own dependencies, register a desktop entry and icon, and install
 udev rules so dive computers connected by USB are reachable without any group
 membership or `usermod` step.
 
-> **Distro requirement:** the packages need glibc 2.38 or newer, which means
+> **Distro requirement:** Submersion needs glibc 2.38 or newer, which means
 > Ubuntu 24.04+, Debian 13+, Fedora 39+, Linux Mint 22+, Arch, or openSUSE
-> Tumbleweed. On Debian 12, Ubuntu 22.04, or RHEL 9 the packages will install
-> but the app will not start; use the tarball below instead, which works on
-> those systems today.
+> Tumbleweed. Debian 12, Ubuntu 22.04, and RHEL 9 cannot run any current
+> Submersion build. The packages install but the app will not start, and the
+> tarball fails the same way, because three bundled libraries require
+> GLIBC_2.38. Upgrading the distribution is the only path.
 
 <!-- tabs:start -->
 

--- a/docs/superpowers/specs/2026-09-03-linux-packaging-design.md
+++ b/docs/superpowers/specs/2026-09-03-linux-packaging-design.md
@@ -24,7 +24,7 @@ get:
 | Any dependency declaration | GTK3, `libwebkit2gtk-4.1`, `libsoup-3.0`, `libsecret-1`, `liblzma`, `libstdc++` must already be present. Absent any of them, the loader emits a soname error, not a message. |
 | `.desktop` file and icons | No menu entry, no dock icon, no `StartupWMClass` binding. Launch is `./submersion` from a terminal. |
 | Device permissions | The Linux dive computer path opens `/dev/hidraw*` (`packages/libdivecomputer_plugin/linux/usbhid_enumerator.c`), `/dev/ttyUSB*` and `/dev/ttyACM*` (`serial_scanner.c`), and BlueZ over D-Bus (`ble_scanner.c`). `hidraw` is root-only by default, so USB dive computers simply never appear. |
-| A glibc floor anyone chose | Built on `ubuntu-latest`, so the binary refuses to start on anything older than whatever image GitHub happens to be shipping. |
+| A stated distro requirement | Built on `ubuntu-latest`, and the shipped libraries require GLIBC_2.38, so the binary refuses to start on Debian 12 or Ubuntu 22.04. Nothing said so anywhere, which is the part this design fixes; the floor itself is kept (see Section 3). |
 | A working updater | `lib/features/auto_update/presentation/providers/update_providers.dart:43` points Linux at the `Linux.tar.gz` asset, and `update_banner.dart:49` opens it in a browser. There is no install step to hand it to. |
 
 This was a deliberate deferral, not an oversight:
@@ -36,7 +36,7 @@ formats (Snap, Flatpak, AppImage) -- tar.gz only for now."
 | Decision | Choice |
 | --- | --- |
 | Formats | `.deb` and `.rpm` as the primary path, plus an upgraded tarball for everything else. No Flatpak, AppImage, or Snap. |
-| Compatibility floor | glibc 2.35 (Ubuntu 22.04), covering Ubuntu 22.04/24.04/26.04, Debian 12 and 13, Mint 21/22, and every current Fedora and openSUSE. |
+| Compatibility floor | glibc 2.38, the floor the released tarball has always had. Covers Ubuntu 24.04+, Debian 13+, Fedora 39+, Mint 22, Arch and Tumbleweed. Excludes Debian 12, Ubuntu 22.04, and RHEL 9, which keep the tarball as today. |
 | Updates | Self-hosted APT and DNF repositories, so `apt upgrade` and `dnf upgrade` carry Submersion along with everything else. |
 | Repo hosting | A new `submersion-app/linux-packages` repo published to GitHub Pages, rebuilt statelessly on each release. |
 | Channels | `stable` and `beta` suites from day one. |
@@ -164,17 +164,44 @@ Both `Recommends`, never `Requires`:
 
 ## Section 3: Build and CI wiring
 
-### The glibc floor is pinned by a container, not a runner label
+### The glibc floor is the runner's, and is left alone
 
-`runs-on: ubuntu-22.04` is the obvious move and the wrong one: GitHub retires
-runner images on its own schedule, and when 22.04 goes the floor would rise
-silently on some future Tuesday with no commit to blame.
+An earlier revision of this design built inside an `ubuntu:22.04` container to
+pin a glibc 2.35 floor. That was reverted, for two reasons.
+
+The first is that it reversed a decision without saying so. The floor question
+was asked and answered as "build on the ubuntu-22.04 runner"; the container
+arrived later in the design, argued as a fresh recommendation rather than as a
+change, on the premise that a retired runner label would raise the floor
+silently. Retired labels fail loudly, so the premise was wrong.
+
+The second is that the reach was never real to begin with. Measured against
+the shipped v1.7.6.7161 tarball, the released binaries already require
+GLIBC_2.38:
+
+| File | Requires |
+| --- | --- |
+| `libflutter_secure_storage_linux_plugin.so` | GLIBC_2.38 |
+| `liblibdivecomputer_plugin_plugin.so` | GLIBC_2.38 |
+| `libsqlcipher.so` | GLIBC_2.38 |
+| `submersion` | GLIBC_2.34 |
+
+The floor is set by three libraries, not by the app. Lowering it would have
+extended Submersion to distros it has never supported, at the cost of a
+container, a toolchain install on every run, and a class of missing-tool
+failures that no pull request can catch, since `build-all.yml` is
+`workflow_call`-only. Debian 12 and Ubuntu 22.04 users keep the tarball, which
+works for them today and continues to.
 
 ```yaml
 build-linux:
-  runs-on: ubuntu-latest
-  container: ubuntu:22.04     # glibc 2.35 floor, explicit and durable
+  runs-on: ubuntu-latest      # glibc floor follows the runner image
 ```
+
+The consequence to accept: when GitHub moves `ubuntu-latest` to the next
+release, the floor rises with it and nothing announces that. The distro
+requirement in the install docs is therefore a statement about the current
+build environment rather than a guarantee.
 
 The existing `apt-get install` step (`build-all.yml:565`) moves inside the
 container and gains `curl git unzip xz-utils ca-certificates`, which a bare
@@ -366,8 +393,9 @@ Listed so they are deliberate rather than forgotten:
 
 | Risk | Mitigation |
 | --- | --- |
-| ~~`libwebkit2gtk-4.1` may be unavailable on Ubuntu 22.04~~ | Resolved 2026-09-03. The Ubuntu archive publishes `libwebkit2gtk-4.1-dev` 2.50.4-0ubuntu0.22.04.1 and `libsoup-3.0-dev` 3.0.5-1 for jammy, so the chosen floor gets webkit 4.1 paired with libsoup 3.0 and no CMake fallback occurs. The webkit build sits in the updates pocket, which the stock `ubuntu:22.04` image already has in its sources. Residual risk is covered by construction: a fallback would put `libwebkit2gtk-4.0.so.37` in the derived dependency list, and an unmapped soname fails the build. |
+| ~~`libwebkit2gtk-4.1` may be unavailable on Ubuntu 22.04~~ | Moot as of 2026-09-04: the 22.04 build environment was reverted, so the build uses the runner's own webkit 4.1. The fallback remains impossible to ship unnoticed either way, since it would put `libwebkit2gtk-4.0.so.37` in the derived dependency list and an unmapped soname fails the build. |
 | A libdivecomputer submodule bump changes the descriptor table's shape and the udev generator emits nothing. | Fixture test on the generator's output. |
 | A plugin update introduces a new shared-library dependency. | `linux_package_deps.py` fails the build on any unmapped soname. |
 | Pages bandwidth or size limits are reached as the Linux audience grows. | Two-versions-per-suite retention, an 800 MB pre-deploy guard, and a documented migration path to a package registry if the limits bind. |
 | The repository publish dispatch is dropped and users stop seeing updates. | Daily reconcile job republishes when the site and the latest releases disagree. |
+| The glibc floor rises silently when GitHub moves `ubuntu-latest` to a newer release, invalidating the distro requirement in the install docs. | Accepted deliberately in exchange for build simplicity. The requirement is documented as a statement about the current build environment, not a guarantee. A CI guard asserting the maximum required GLIBC symbol version would make the drift visible; not implemented. |

--- a/docs/superpowers/specs/2026-09-03-linux-packaging-design.md
+++ b/docs/superpowers/specs/2026-09-03-linux-packaging-design.md
@@ -190,8 +190,9 @@ The floor is set by three libraries, not by the app. Lowering it would have
 extended Submersion to distros it has never supported, at the cost of a
 container, a toolchain install on every run, and a class of missing-tool
 failures that no pull request can catch, since `build-all.yml` is
-`workflow_call`-only. Debian 12 and Ubuntu 22.04 users keep the tarball, which
-works for them today and continues to.
+`workflow_call`-only. Debian 12 and Ubuntu 22.04 have never been able to run a
+release and gain no fallback here: the tarball bundles the same three libraries
+and fails on those distros for the same reason.
 
 ```yaml
 build-linux:


### PR DESCRIPTION
## What changed and why

This started as a one-line fix for `jq` missing in the `ubuntu:22.04` build container. It ends by removing the container, which makes that fix unnecessary.

**The container reversed a decision without saying so.** When the compatibility floor was decided, the option chosen was "build on the ubuntu-22.04 runner". The container appeared later in the design document, argued as a fresh recommendation rather than as a change, on the premise that a retired runner label would raise the floor silently. Retired labels fail loudly, so the premise was wrong.

**The reach it bought was never real.** Measured against the shipped v1.7.6.7161 tarball:

| File | Requires |
| --- | --- |
| `libflutter_secure_storage_linux_plugin.so` | GLIBC_2.38 |
| `liblibdivecomputer_plugin_plugin.so` | GLIBC_2.38 |
| `libsqlcipher.so` | GLIBC_2.38 |
| `submersion` | GLIBC_2.34 |

The floor is set by three libraries, not by the app. Debian 12 and Ubuntu 22.04 have therefore never been able to run a Submersion release. Lowering it would have extended support to distros the project has never claimed, in exchange for a container, a toolchain install on every run, and a class of missing-tool failures that no pull request can catch, since `build-all.yml` is `workflow_call`-only.

## Changes

- `build-linux` returns to plain `ubuntu-latest`: no container, no `safe.directory` workaround, no root, timeout back to 30 minutes, `sudo` restored. `binutils` is now named explicitly since `scripts/linux_package_deps.py` needs `readelf` and an image change should not remove it silently.
- The verify job installs into the runner's own Ubuntu rather than `debian:12`, which would fail on glibc for exactly the reason `ci.yaml`'s did yesterday. The tag is derived from `/etc/os-release` so it keeps matching when GitHub moves `ubuntu-latest`.
- Section 3 of the design is rewritten to record the reversal, the measurement, and the drift risk now accepted.
- README and the installation guide state the requirement where users meet it: glibc 2.38 or newer, and Debian 12, Ubuntu 22.04, and RHEL 9 cannot run any current build. An earlier revision of this branch offered the tarball as a fallback on those distros; that was wrong, since the tarball carries the same three GLIBC_2.38 libraries and fails there identically. Corrected in 9b37661dc58, which also drops the matching claim from section 3 of the design.

## Accepted tradeoff

When GitHub moves `ubuntu-latest` to a newer release, the floor rises with it and nothing announces that. The documented requirement is a statement about the current build environment, not a guarantee. A CI guard asserting the maximum required GLIBC symbol version would make that drift visible; it is recorded in the design's risk table as not implemented.

## Verification

`build-all.yml` parses; all four script suites pass; no em-dashes. The real proof is the next beta build reaching `Build .deb and .rpm` and then `Verify Linux Packages`, which has never run.
