### PR TITLE
feat(safety): lead the emergency card with the diver's own insurer (#1522)

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -52,6 +52,13 @@ class Divers extends Table {
   TextColumn get insuranceProvider => text().nullable()();
   TextColumn get insurancePolicyNumber => text().nullable()();
   IntColumn get insuranceExpiryDate => integer().nullable()(); // Unix timestamp
+
+  /// The insurer's 24-hour dive emergency assistance line, and its general or
+  /// office line (issue #1522). Without these the emergency card can only lead
+  /// with the regional diver hotline, which is the wrong first call for a
+  /// diver insured by anyone else.
+  TextColumn get insuranceEmergencyPhone => text().nullable()();
+  TextColumn get insurancePhone => text().nullable()();
   // General
   TextColumn get notes => text().withDefault(const Constant(''))();
   BoolColumn get isDefault => boolean().withDefault(const Constant(false))();
@@ -3374,7 +3381,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 187;
+  static const int currentSchemaVersion = 188;
 
   /// The oldest schema whose reader can apply this build's sync payloads
   /// without loss or misinterpretation (the compatibility floor).
@@ -3834,6 +3841,12 @@ class AppDatabase extends _$AppDatabase {
     // already treats as "nothing known" for a resolved legacy row.
     // Renumbered from 182 for the same reason as 186 above.
     187,
+    // v188: divers.insurance_emergency_phone and divers.insurance_phone, the
+    // insurer's 24h assistance line and office line (issue #1522). Column-only
+    // rung, no backfill: nothing in an existing database can tell us an
+    // insurer's hotline, so every pre-existing row correctly reads back as
+    // "not recorded" and the card keeps leading with the regional hotline.
+    188,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -6046,6 +6059,25 @@ class AppDatabase extends _$AppDatabase {
     await customStatement(
       'ALTER TABLE pre_dive_session_items ADD COLUMN overdue_services TEXT',
     );
+  }
+
+  /// v188: the two insurer phone numbers the emergency card leads with.
+  /// Column-only and independently guarded, so an interrupted upgrade that
+  /// added one of the two still gets the other.
+  Future<void> _assertInsurancePhoneColumns() async {
+    final cols = await customSelect("PRAGMA table_info('divers')").get();
+    if (cols.isEmpty) return;
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    if (!names.contains('insurance_emergency_phone')) {
+      await customStatement(
+        'ALTER TABLE divers ADD COLUMN insurance_emergency_phone TEXT',
+      );
+    }
+    if (!names.contains('insurance_phone')) {
+      await customStatement(
+        'ALTER TABLE divers ADD COLUMN insurance_phone TEXT',
+      );
+    }
   }
 
   Future<void> _assertBuddyFavoriteColumn() async {
@@ -10027,6 +10059,12 @@ class AppDatabase extends _$AppDatabase {
           await _assertSessionItemOverdueServicesColumn();
         }
         if (from < 187) await reportProgress();
+        // v188: divers.insurance_emergency_phone + divers.insurance_phone
+        // (issue #1522). Column-only rung, no backfill.
+        if (from < 188) {
+          await _assertInsurancePhoneColumns();
+        }
+        if (from < 188) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -10388,6 +10426,12 @@ class AppDatabase extends _$AppDatabase {
         // on every open: the helper is column-only with no backfill, so it
         // cannot resurrect or overwrite diver data.
         await _assertSessionItemOverdueServicesColumn();
+
+        // v188 backstop: re-assert the divers insurance phone columns. Every
+        // diver read selects the whole row, so a database that arrives by
+        // restore or sync-adopt without the rung would throw on the first read
+        // rather than merely lack the numbers.
+        await _assertInsurancePhoneColumns();
 
         // v145 backstop: re-assert the gps_tracks provenance and trim columns.
         await _assertGpsTrackColumns();

--- a/lib/core/services/export/uddf/uddf_export_builders.dart
+++ b/lib/core/services/export/uddf/uddf_export_builders.dart
@@ -1509,6 +1509,15 @@ class UddfExportBuilders {
                             nest: owner.insurance.expiryDate!.toIso8601String(),
                           );
                         }
+                        if (owner.insurance.emergencyPhone != null) {
+                          builder.element(
+                            'emergencyphone',
+                            nest: owner.insurance.emergencyPhone,
+                          );
+                        }
+                        if (owner.insurance.phone != null) {
+                          builder.element('phone', nest: owner.insurance.phone);
+                        }
                       },
                     );
                   }

--- a/lib/core/services/export/uddf/uddf_export_builders.dart
+++ b/lib/core/services/export/uddf/uddf_export_builders.dart
@@ -1489,14 +1489,19 @@ class UddfExportBuilders {
                       },
                     );
                   }
-                  if (owner.insurance.provider != null) {
+                  // Gated on any detail, not on the provider name: a policy
+                  // number or an assistance line saved without naming the
+                  // insurer would otherwise never reach the file.
+                  if (owner.insurance.hasAnyDetail) {
                     builder.element(
                       'insurance',
                       nest: () {
-                        builder.element(
-                          'provider',
-                          nest: owner.insurance.provider,
-                        );
+                        if (owner.insurance.provider != null) {
+                          builder.element(
+                            'provider',
+                            nest: owner.insurance.provider,
+                          );
+                        }
                         if (owner.insurance.policyNumber != null) {
                           builder.element(
                             'policynumber',

--- a/lib/core/services/export/uddf/uddf_export_builders.dart
+++ b/lib/core/services/export/uddf/uddf_export_builders.dart
@@ -1496,16 +1496,16 @@ class UddfExportBuilders {
                     builder.element(
                       'insurance',
                       nest: () {
-                        if (owner.insurance.provider != null) {
+                        if (owner.insurance.providerLabel != null) {
                           builder.element(
                             'provider',
-                            nest: owner.insurance.provider,
+                            nest: owner.insurance.providerLabel,
                           );
                         }
-                        if (owner.insurance.policyNumber != null) {
+                        if (owner.insurance.policyLabel != null) {
                           builder.element(
                             'policynumber',
-                            nest: owner.insurance.policyNumber,
+                            nest: owner.insurance.policyLabel,
                           );
                         }
                         if (owner.insurance.expiryDate != null) {
@@ -1514,14 +1514,17 @@ class UddfExportBuilders {
                             nest: owner.insurance.expiryDate!.toIso8601String(),
                           );
                         }
-                        if (owner.insurance.emergencyPhone != null) {
+                        if (owner.insurance.assistanceLine != null) {
                           builder.element(
                             'emergencyphone',
-                            nest: owner.insurance.emergencyPhone,
+                            nest: owner.insurance.assistanceLine,
                           );
                         }
-                        if (owner.insurance.phone != null) {
-                          builder.element('phone', nest: owner.insurance.phone);
+                        if (owner.insurance.officeLine != null) {
+                          builder.element(
+                            'phone',
+                            nest: owner.insurance.officeLine,
+                          );
                         }
                       },
                     );

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -448,6 +448,11 @@ class UddfImportParsers {
       if (expiryDate != null) {
         owner['insuranceExpiryDate'] = DateTime.tryParse(expiryDate);
       }
+      owner['insuranceEmergencyPhone'] = getElementText(
+        insuranceElement,
+        'emergencyphone',
+      );
+      owner['insurancePhone'] = getElementText(insuranceElement, 'phone');
     }
   }
 

--- a/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -151,7 +151,7 @@ bool _hasSafetyAlert(DashboardGauges g) {
   // it must not force the strip open either.
   final expiredPolicy =
       insurance != null &&
-      !(insurance.provider?.isEmpty ?? true) &&
+      insurance.providerLabel != null &&
       insurance.isExpired;
   // Overflow counts as overdue gear in its own right. With the shipped caps
   // it can only be positive alongside a shown overdue gauge, so this clause

--- a/lib/features/dashboard/presentation/widgets/gauge_strip.dart
+++ b/lib/features/dashboard/presentation/widgets/gauge_strip.dart
@@ -140,7 +140,7 @@ class GaugeStrip extends ConsumerWidget {
     //
     // Narrowed to a nullable local rather than a bool so the branches below
     // get null promotion on the policy itself.
-    final policy = insurance != null && !(insurance.provider?.isEmpty ?? true)
+    final policy = insurance != null && insurance.providerLabel != null
         ? insurance
         : null;
     if (policy != null && policy.isExpired) {

--- a/lib/features/divers/data/repositories/diver_repository.dart
+++ b/lib/features/divers/data/repositories/diver_repository.dart
@@ -165,6 +165,8 @@ class DiverRepository {
               insuranceExpiryDate: Value(
                 diver.insurance.expiryDate?.millisecondsSinceEpoch,
               ),
+              insuranceEmergencyPhone: Value(diver.insurance.emergencyPhone),
+              insurancePhone: Value(diver.insurance.phone),
               notes: Value(diver.notes),
               isDefault: Value(diver.isDefault),
               createdAt: Value(now.millisecondsSinceEpoch),
@@ -228,6 +230,8 @@ class DiverRepository {
           insuranceExpiryDate: Value(
             diver.insurance.expiryDate?.millisecondsSinceEpoch,
           ),
+          insuranceEmergencyPhone: Value(diver.insurance.emergencyPhone),
+          insurancePhone: Value(diver.insurance.phone),
           notes: Value(diver.notes),
           isDefault: Value(diver.isDefault),
           updatedAt: Value(now),
@@ -785,6 +789,8 @@ class DiverRepository {
         expiryDate: row.insuranceExpiryDate != null
             ? DateTime.fromMillisecondsSinceEpoch(row.insuranceExpiryDate!)
             : null,
+        emergencyPhone: row.insuranceEmergencyPhone,
+        phone: row.insurancePhone,
       ),
       notes: row.notes,
       isDefault: row.isDefault,

--- a/lib/features/divers/domain/entities/diver.dart
+++ b/lib/features/divers/domain/entities/diver.dart
@@ -76,6 +76,20 @@ class DiverInsurance extends Equatable {
   /// Whether the diver recorded any insurer number at all.
   bool get hasCallNumber => callNumber != null;
 
+  /// Whether the diver recorded anything at all under insurance.
+  ///
+  /// Persistence and export must key off this rather than [provider]: a policy
+  /// number or an assistance line can be saved without ever naming the
+  /// insurer, and gating on the name alone silently drops the rest.
+  bool get hasAnyDetail {
+    final name = provider?.trim();
+    if (name != null && name.isNotEmpty) return true;
+    final policy = policyNumber?.trim();
+    if (policy != null && policy.isNotEmpty) return true;
+    if (expiryDate != null) return true;
+    return hasCallNumber;
+  }
+
   bool get isExpired {
     if (expiryDate == null) return false;
     return DateTime.now().isAfter(expiryDate!);

--- a/lib/features/divers/domain/entities/diver.dart
+++ b/lib/features/divers/domain/entities/diver.dart
@@ -52,20 +52,30 @@ class DiverInsurance extends Equatable {
     this.phone,
   });
 
-  /// Trims a stored number and reports a blank one as absent. An emptied text
-  /// field round-trips through the database as `''` on some paths, and
-  /// dialling that would fail silently at the very worst moment.
-  static String? _dialable(String? value) {
+  /// Trims a stored value and reports a blank one as absent. An emptied text
+  /// field round-trips through the database as `''` on some paths: a blank
+  /// number would fail to dial silently at the very worst moment, and a blank
+  /// policy number would print an empty "Policy" line on the emergency card.
+  ///
+  /// Every getter below goes through this, so "is it there?" gets one answer
+  /// across the card, the export, and the persistence gates.
+  static String? _presentOrNull(String? value) {
     final trimmed = value?.trim();
     return (trimmed == null || trimmed.isEmpty) ? null : trimmed;
   }
 
   /// The 24-hour assistance line, ready to dial, or null if not recorded.
   /// This is the only insurer number the emergency card will lead with.
-  String? get assistanceLine => _dialable(emergencyPhone);
+  String? get assistanceLine => _presentOrNull(emergencyPhone);
 
   /// The office line, ready to dial, or null if not recorded.
-  String? get officeLine => _dialable(phone);
+  String? get officeLine => _presentOrNull(phone);
+
+  /// The insurer's name, ready to display, or null if not recorded.
+  String? get providerLabel => _presentOrNull(provider);
+
+  /// The policy number, ready to display, or null if not recorded.
+  String? get policyLabel => _presentOrNull(policyNumber);
 
   /// An insurer number to dial at all, preferring the assistance line. Used to
   /// decide whether the insurance block has anything to show; deciding what
@@ -81,14 +91,11 @@ class DiverInsurance extends Equatable {
   /// Persistence and export must key off this rather than [provider]: a policy
   /// number or an assistance line can be saved without ever naming the
   /// insurer, and gating on the name alone silently drops the rest.
-  bool get hasAnyDetail {
-    final name = provider?.trim();
-    if (name != null && name.isNotEmpty) return true;
-    final policy = policyNumber?.trim();
-    if (policy != null && policy.isNotEmpty) return true;
-    if (expiryDate != null) return true;
-    return hasCallNumber;
-  }
+  bool get hasAnyDetail =>
+      providerLabel != null ||
+      policyLabel != null ||
+      expiryDate != null ||
+      hasCallNumber;
 
   bool get isExpired {
     if (expiryDate == null) return false;

--- a/lib/features/divers/domain/entities/diver.dart
+++ b/lib/features/divers/domain/entities/diver.dart
@@ -31,7 +31,40 @@ class DiverInsurance extends Equatable {
   final String? policyNumber;
   final DateTime? expiryDate;
 
-  const DiverInsurance({this.provider, this.policyNumber, this.expiryDate});
+  /// The insurer's 24-hour dive emergency assistance line. This is the number
+  /// an insured diver is meant to call first: their own assistance provider
+  /// authorises the evacuation and coordinates the chamber referral, which is
+  /// the role the emergency card otherwise attributes to the regional diver
+  /// hotline. Preferred by [callNumber].
+  final String? emergencyPhone;
+
+  /// The insurer's general or office line. Answers during business hours only
+  /// for most providers, so it is a fallback for [callNumber], never the
+  /// number a card leads with when [emergencyPhone] is known.
+  final String? phone;
+
+  const DiverInsurance({
+    this.provider,
+    this.policyNumber,
+    this.expiryDate,
+    this.emergencyPhone,
+    this.phone,
+  });
+
+  /// The insurer number to dial, or null when the diver recorded neither.
+  /// Blank strings are treated as absent: an emptied text field round-trips
+  /// through the database as `''` on some paths, and dialling it would fail
+  /// silently at the very worst moment.
+  String? get callNumber {
+    final emergency = emergencyPhone?.trim();
+    if (emergency != null && emergency.isNotEmpty) return emergency;
+    final general = phone?.trim();
+    if (general != null && general.isNotEmpty) return general;
+    return null;
+  }
+
+  /// Whether the card has an insurer number worth leading with.
+  bool get hasCallNumber => callNumber != null;
 
   bool get isExpired {
     if (expiryDate == null) return false;
@@ -50,16 +83,26 @@ class DiverInsurance extends Equatable {
     String? provider,
     String? policyNumber,
     DateTime? expiryDate,
+    String? emergencyPhone,
+    String? phone,
   }) {
     return DiverInsurance(
       provider: provider ?? this.provider,
       policyNumber: policyNumber ?? this.policyNumber,
       expiryDate: expiryDate ?? this.expiryDate,
+      emergencyPhone: emergencyPhone ?? this.emergencyPhone,
+      phone: phone ?? this.phone,
     );
   }
 
   @override
-  List<Object?> get props => [provider, policyNumber, expiryDate];
+  List<Object?> get props => [
+    provider,
+    policyNumber,
+    expiryDate,
+    emergencyPhone,
+    phone,
+  ];
 }
 
 /// Diver profile entity

--- a/lib/features/divers/domain/entities/diver.dart
+++ b/lib/features/divers/domain/entities/diver.dart
@@ -35,12 +35,13 @@ class DiverInsurance extends Equatable {
   /// an insured diver is meant to call first: their own assistance provider
   /// authorises the evacuation and coordinates the chamber referral, which is
   /// the role the emergency card otherwise attributes to the regional diver
-  /// hotline. Preferred by [callNumber].
+  /// hotline. Exposed as [assistanceLine].
   final String? emergencyPhone;
 
-  /// The insurer's general or office line. Answers during business hours only
-  /// for most providers, so it is a fallback for [callNumber], never the
-  /// number a card leads with when [emergencyPhone] is known.
+  /// The insurer's general or office line, exposed as [officeLine]. For most
+  /// providers this answers during business hours only, so it is never what
+  /// the emergency card leads with: an unanswered number at 2am is worse
+  /// than the regional hotline, which does answer.
   final String? phone;
 
   const DiverInsurance({
@@ -51,19 +52,28 @@ class DiverInsurance extends Equatable {
     this.phone,
   });
 
-  /// The insurer number to dial, or null when the diver recorded neither.
-  /// Blank strings are treated as absent: an emptied text field round-trips
-  /// through the database as `''` on some paths, and dialling it would fail
-  /// silently at the very worst moment.
-  String? get callNumber {
-    final emergency = emergencyPhone?.trim();
-    if (emergency != null && emergency.isNotEmpty) return emergency;
-    final general = phone?.trim();
-    if (general != null && general.isNotEmpty) return general;
-    return null;
+  /// Trims a stored number and reports a blank one as absent. An emptied text
+  /// field round-trips through the database as `''` on some paths, and
+  /// dialling that would fail silently at the very worst moment.
+  static String? _dialable(String? value) {
+    final trimmed = value?.trim();
+    return (trimmed == null || trimmed.isEmpty) ? null : trimmed;
   }
 
-  /// Whether the card has an insurer number worth leading with.
+  /// The 24-hour assistance line, ready to dial, or null if not recorded.
+  /// This is the only insurer number the emergency card will lead with.
+  String? get assistanceLine => _dialable(emergencyPhone);
+
+  /// The office line, ready to dial, or null if not recorded.
+  String? get officeLine => _dialable(phone);
+
+  /// An insurer number to dial at all, preferring the assistance line. Used to
+  /// decide whether the insurance block has anything to show; deciding what
+  /// the card *leads* with is [assistanceLine]'s job, because a number that
+  /// only answers in business hours must not be presented as a first call.
+  String? get callNumber => assistanceLine ?? officeLine;
+
+  /// Whether the diver recorded any insurer number at all.
   bool get hasCallNumber => callNumber != null;
 
   bool get isExpired {

--- a/lib/features/divers/domain/entities/diver.dart
+++ b/lib/features/divers/domain/entities/diver.dart
@@ -108,7 +108,11 @@ class DiverInsurance extends Equatable {
     return expiryDate!.isBefore(thirtyDaysFromNow) && !isExpired;
   }
 
-  bool get isValid => provider != null && provider!.isNotEmpty && !isExpired;
+  /// Goes through [providerLabel] so a whitespace-only provider is "not
+  /// recorded" here too. Every presence question about insurance has to give
+  /// the same answer, or the dashboard calls a policy valid that the emergency
+  /// card refuses to show.
+  bool get isValid => providerLabel != null && !isExpired;
 
   DiverInsurance copyWith({
     String? provider,

--- a/lib/features/safety/presentation/pages/emergency_card_page.dart
+++ b/lib/features/safety/presentation/pages/emergency_card_page.dart
@@ -304,15 +304,16 @@ class _DiverSection extends StatelessWidget {
       required String? number,
       required IconData icon,
     }) {
-      final trimmed = number?.trim();
-      if (trimmed == null || trimmed.isEmpty) return const SizedBox.shrink();
+      // Callers pass the entity's already-normalized getters, so a blank is
+      // null by the time it arrives here.
+      if (number == null) return const SizedBox.shrink();
       return ListTile(
         contentPadding: EdgeInsets.zero,
         leading: Icon(icon),
         title: Text(label, style: big),
-        subtitle: Text(trimmed),
+        subtitle: Text(number),
         trailing: const Icon(Icons.phone, size: 20),
-        onTap: () => onCall(trimmed),
+        onTap: () => onCall(number),
       );
     }
 
@@ -346,12 +347,12 @@ class _DiverSection extends StatelessWidget {
             ),
           insurerNumber(
             label: l10n.emergencyCard_insuranceEmergencyLine,
-            number: diver.insurance.emergencyPhone,
+            number: diver.insurance.assistanceLine,
             icon: Icons.emergency_share_outlined,
           ),
           insurerNumber(
             label: l10n.emergencyCard_insuranceOfficeLine,
-            number: diver.insurance.phone,
+            number: diver.insurance.officeLine,
             icon: Icons.phone_outlined,
           ),
           // No 24h assistance line is the state issue #1522 describes: the

--- a/lib/features/safety/presentation/pages/emergency_card_page.dart
+++ b/lib/features/safety/presentation/pages/emergency_card_page.dart
@@ -380,6 +380,11 @@ class _DiverSection extends StatelessWidget {
 
 /// Whether the insurance block has anything worth a section header. A diver
 /// who saved only an assistance number still gets the section.
+///
+/// Deliberately narrower than [DiverInsurance.hasAnyDetail], which also counts
+/// the expiry date: the card does not render an expiry, so keying off it would
+/// print a header over an empty block. Persistence and export use the wider
+/// one.
 bool _hasInsuranceDetails(DiverInsurance insurance) {
   final provider = insurance.provider?.trim();
   if (provider != null && provider.isNotEmpty) return true;

--- a/lib/features/safety/presentation/pages/emergency_card_page.dart
+++ b/lib/features/safety/presentation/pages/emergency_card_page.dart
@@ -96,11 +96,10 @@ class _CardBody extends ConsumerWidget {
             style: theme.textTheme.bodyMedium,
             textAlign: TextAlign.center,
           ),
-          if (insurance.policyNumber != null &&
-              insurance.policyNumber!.isNotEmpty) ...[
+          if (insurance.policyLabel != null) ...[
             const SizedBox(height: 4),
             Text(
-              l10n.emergencyCard_insurancePolicy(insurance.policyNumber!),
+              l10n.emergencyCard_insurancePolicy(insurance.policyLabel!),
               style: theme.textTheme.bodyMedium?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
@@ -211,9 +210,7 @@ class _CardBody extends ConsumerWidget {
   /// What the lead button calls the insurer. A diver can save a number
   /// without naming the provider, and "Call" on its own is not a button.
   String _insurerName(AppLocalizations l10n, DiverInsurance insurance) {
-    final provider = insurance.provider?.trim();
-    if (provider != null && provider.isNotEmpty) return provider;
-    return l10n.emergencyCard_insuranceSection;
+    return insurance.providerLabel ?? l10n.emergencyCard_insuranceSection;
   }
 }
 
@@ -340,12 +337,11 @@ class _DiverSection extends StatelessWidget {
         if (_hasInsuranceDetails(diver.insurance)) ...[
           const SizedBox(height: 16),
           _SectionHeader(title: l10n.emergencyCard_insuranceSection),
-          if (diver.insurance.provider != null &&
-              diver.insurance.provider!.isNotEmpty)
-            Text(diver.insurance.provider!, style: big),
-          if (diver.insurance.policyNumber != null)
+          if (diver.insurance.providerLabel != null)
+            Text(diver.insurance.providerLabel!, style: big),
+          if (diver.insurance.policyLabel != null)
             Text(
-              l10n.emergencyCard_insurancePolicy(diver.insurance.policyNumber!),
+              l10n.emergencyCard_insurancePolicy(diver.insurance.policyLabel!),
               style: big,
             ),
           insurerNumber(
@@ -386,11 +382,9 @@ class _DiverSection extends StatelessWidget {
 /// print a header over an empty block. Persistence and export use the wider
 /// one.
 bool _hasInsuranceDetails(DiverInsurance insurance) {
-  final provider = insurance.provider?.trim();
-  if (provider != null && provider.isNotEmpty) return true;
-  final policy = insurance.policyNumber?.trim();
-  if (policy != null && policy.isNotEmpty) return true;
-  return insurance.hasCallNumber;
+  return insurance.providerLabel != null ||
+      insurance.policyLabel != null ||
+      insurance.hasCallNumber;
 }
 
 class _SectionHeader extends StatelessWidget {

--- a/lib/features/safety/presentation/pages/emergency_card_page.dart
+++ b/lib/features/safety/presentation/pages/emergency_card_page.dart
@@ -6,6 +6,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/safety/presentation/widgets/chamber_tile.dart';
 import 'package:submersion/features/safety/presentation/providers/emergency_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// The offline emergency card: one screen readable by a stranger under
@@ -64,32 +65,70 @@ class _CardBody extends ConsumerWidget {
     final l10n = context.l10n;
     final theme = Theme.of(context);
     final diver = data.diver;
+    final insurance = diver?.insurance;
+
+    // The diver's own insurer is the first call when they recorded a number:
+    // that is who authorizes the evacuation and coordinates the chamber
+    // referral, which is the role this card otherwise hands to the regional
+    // hotline. Leading with a hotline the diver is not a member of is the
+    // complaint in issue #1522. With no insurer number recorded the regional
+    // hotline leads, exactly as before.
+    final insurerNumber = insurance?.callNumber;
 
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
-        // Call DAN: always first and biggest.
-        FilledButton.icon(
-          style: FilledButton.styleFrom(
-            padding: const EdgeInsets.symmetric(vertical: 20),
-            textStyle: theme.textTheme.titleLarge?.copyWith(
-              fontWeight: FontWeight.bold,
-            ),
+        if (insurerNumber != null) ...[
+          _CallAction(
+            emphasis: _CallEmphasis.primary,
+            label: l10n.emergencyCard_callDan(_insurerName(l10n, insurance!)),
+            number: insurerNumber,
+            onCall: _call,
           ),
-          icon: const Icon(Icons.phone, size: 28),
-          label: Text(
-            '${l10n.emergencyCard_callDan(data.hotline.name)}\n'
-            '${data.hotline.phone}',
+          const SizedBox(height: 8),
+          Text(
+            l10n.emergencyCard_callInsurer_subtitle,
+            style: theme.textTheme.bodyMedium,
             textAlign: TextAlign.center,
           ),
-          onPressed: () => _call(data.hotline.phone),
-        ),
-        const SizedBox(height: 8),
-        Text(
-          l10n.emergencyCard_callDan_subtitle,
-          style: theme.textTheme.bodyMedium,
-          textAlign: TextAlign.center,
-        ),
+          if (insurance.policyNumber != null &&
+              insurance.policyNumber!.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              l10n.emergencyCard_insurancePolicy(insurance.policyNumber!),
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+          const SizedBox(height: 20),
+          _CallAction(
+            emphasis: _CallEmphasis.secondary,
+            label: l10n.emergencyCard_callDan(data.hotline.name),
+            number: data.hotline.phone,
+            onCall: _call,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            l10n.emergencyCard_hotlineSecondary_subtitle,
+            style: theme.textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+        ] else ...[
+          _CallAction(
+            emphasis: _CallEmphasis.primary,
+            label: l10n.emergencyCard_callDan(data.hotline.name),
+            number: data.hotline.phone,
+            onCall: _call,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            l10n.emergencyCard_callDan_subtitle,
+            style: theme.textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+        ],
         const SizedBox(height: 4),
         Text(
           data.countryCode != null
@@ -163,6 +202,72 @@ class _CardBody extends ConsumerWidget {
       await launchUrl(uri);
     }
   }
+
+  /// What the lead button calls the insurer. A diver can save a number
+  /// without naming the provider, and "Call" on its own is not a button.
+  String _insurerName(AppLocalizations l10n, DiverInsurance insurance) {
+    final provider = insurance.provider?.trim();
+    if (provider != null && provider.isNotEmpty) return provider;
+    return l10n.emergencyCard_insuranceSection;
+  }
+}
+
+/// How loud a call button is. The card has at most one [primary]: two buttons
+/// of equal weight is the same "which do I press?" problem under stress as no
+/// button at all.
+enum _CallEmphasis { primary, secondary }
+
+/// A tap-to-call button showing who answers and the number that will be
+/// dialled, so the number stays readable to someone reading it aloud to
+/// a bystander rather than tapping it.
+class _CallAction extends StatelessWidget {
+  final _CallEmphasis emphasis;
+  final String label;
+  final String number;
+  final Future<void> Function(String) onCall;
+
+  const _CallAction({
+    required this.emphasis,
+    required this.label,
+    required this.number,
+    required this.onCall,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isPrimary = emphasis == _CallEmphasis.primary;
+    final child = Text('$label\n$number', textAlign: TextAlign.center);
+    final icon = Icon(Icons.phone, size: isPrimary ? 28 : 24);
+
+    void handleTap() => onCall(number);
+
+    if (isPrimary) {
+      return FilledButton.icon(
+        style: FilledButton.styleFrom(
+          padding: const EdgeInsets.symmetric(vertical: 20),
+          textStyle: theme.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        icon: icon,
+        label: child,
+        onPressed: handleTap,
+      );
+    }
+
+    return FilledButton.tonalIcon(
+      style: FilledButton.styleFrom(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        textStyle: theme.textTheme.titleMedium?.copyWith(
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      icon: icon,
+      label: child,
+      onPressed: handleTap,
+    );
+  }
 }
 
 class _DiverSection extends StatelessWidget {
@@ -192,6 +297,23 @@ class _DiverSection extends StatelessWidget {
       );
     }
 
+    Widget insurerNumber({
+      required String label,
+      required String? number,
+      required IconData icon,
+    }) {
+      final trimmed = number?.trim();
+      if (trimmed == null || trimmed.isEmpty) return const SizedBox.shrink();
+      return ListTile(
+        contentPadding: EdgeInsets.zero,
+        leading: Icon(icon),
+        title: Text(label, style: big),
+        subtitle: Text(trimmed),
+        trailing: const Icon(Icons.phone, size: 20),
+        onTap: () => onCall(trimmed),
+      );
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -210,20 +332,54 @@ class _DiverSection extends StatelessWidget {
         _SectionHeader(title: l10n.emergencyCard_contactsSection),
         contact(diver.emergencyContact),
         contact(diver.emergencyContact2),
-        if (diver.insurance.provider != null &&
-            diver.insurance.provider!.isNotEmpty) ...[
+        if (_hasInsuranceDetails(diver.insurance)) ...[
           const SizedBox(height: 16),
           _SectionHeader(title: l10n.emergencyCard_insuranceSection),
-          Text(diver.insurance.provider!, style: big),
+          if (diver.insurance.provider != null &&
+              diver.insurance.provider!.isNotEmpty)
+            Text(diver.insurance.provider!, style: big),
           if (diver.insurance.policyNumber != null)
             Text(
               l10n.emergencyCard_insurancePolicy(diver.insurance.policyNumber!),
               style: big,
             ),
+          insurerNumber(
+            label: l10n.emergencyCard_insuranceEmergencyLine,
+            number: diver.insurance.emergencyPhone,
+            icon: Icons.emergency_share_outlined,
+          ),
+          insurerNumber(
+            label: l10n.emergencyCard_insuranceOfficeLine,
+            number: diver.insurance.phone,
+            icon: Icons.phone_outlined,
+          ),
+          // A provider with no number is the state issue #1522 describes:
+          // the card cannot lead with the insurer, so say why rather than
+          // leaving the diver to wonder where their number went.
+          if (!diver.insurance.hasCallNumber)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                l10n.emergencyCard_insuranceNoPhone,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
         ],
       ],
     );
   }
+}
+
+/// Whether the insurance block has anything worth a section header. A diver
+/// who saved only an assistance number still gets the section.
+bool _hasInsuranceDetails(DiverInsurance insurance) {
+  final provider = insurance.provider?.trim();
+  if (provider != null && provider.isNotEmpty) return true;
+  final policy = insurance.policyNumber?.trim();
+  if (policy != null && policy.isNotEmpty) return true;
+  return insurance.hasCallNumber;
 }
 
 class _SectionHeader extends StatelessWidget {

--- a/lib/features/safety/presentation/pages/emergency_card_page.dart
+++ b/lib/features/safety/presentation/pages/emergency_card_page.dart
@@ -67,13 +67,18 @@ class _CardBody extends ConsumerWidget {
     final diver = data.diver;
     final insurance = diver?.insurance;
 
-    // The diver's own insurer is the first call when they recorded a number:
-    // that is who authorizes the evacuation and coordinates the chamber
-    // referral, which is the role this card otherwise hands to the regional
-    // hotline. Leading with a hotline the diver is not a member of is the
-    // complaint in issue #1522. With no insurer number recorded the regional
-    // hotline leads, exactly as before.
-    final insurerNumber = insurance?.callNumber;
+    // The diver's own insurer is the first call when they recorded a 24h
+    // assistance line: that is who authorizes the evacuation and coordinates
+    // the chamber referral, which is the role this card otherwise hands to the
+    // regional hotline. Leading with a hotline the diver is not a member of is
+    // the complaint in issue #1522.
+    //
+    // Only the assistance line qualifies. An insurer's office line typically
+    // answers in business hours only, so promoting it would promise a first
+    // call that rings an empty desk at 2am -- worse than the regional hotline,
+    // which does answer. The office line stays in the insurance block below,
+    // and the block nudges the diver to record the 24h number.
+    final insurerNumber = insurance?.assistanceLine;
 
     return ListView(
       padding: const EdgeInsets.all(16),
@@ -353,10 +358,11 @@ class _DiverSection extends StatelessWidget {
             number: diver.insurance.phone,
             icon: Icons.phone_outlined,
           ),
-          // A provider with no number is the state issue #1522 describes:
-          // the card cannot lead with the insurer, so say why rather than
-          // leaving the diver to wonder where their number went.
-          if (!diver.insurance.hasCallNumber)
+          // No 24h assistance line is the state issue #1522 describes: the
+          // card cannot lead with the insurer, so say why rather than leaving
+          // the diver to wonder. An office line alone still lands here, since
+          // it is not a number this card will promote.
+          if (diver.insurance.assistanceLine == null)
             Padding(
               padding: const EdgeInsets.only(top: 8),
               child: Text(

--- a/lib/features/settings/presentation/pages/diver_profile_hub_page.dart
+++ b/lib/features/settings/presentation/pages/diver_profile_hub_page.dart
@@ -371,20 +371,21 @@ class DiverProfileHubPage extends ConsumerWidget {
 
   String _insuranceSubtitle(BuildContext context, Diver diver) {
     final insurance = diver.insurance;
-    if (insurance.provider == null || insurance.provider!.isEmpty) {
+    final provider = insurance.providerLabel;
+    if (provider == null) {
       return context.l10n.settings_profileHub_insurance_notSet;
     }
 
     if (insurance.isExpired) {
-      return '${insurance.provider} - ${context.l10n.settings_profileHub_insurance_expired}';
+      return '$provider - ${context.l10n.settings_profileHub_insurance_expired}';
     }
 
     if (insurance.expiryDate != null) {
       final formatted = DateFormat.yMMMd().format(insurance.expiryDate!);
-      return '${insurance.provider} - $formatted';
+      return '$provider - $formatted';
     }
 
-    return insurance.provider!;
+    return provider;
   }
 
   String _notesSubtitle(BuildContext context, Diver diver) {

--- a/lib/features/settings/presentation/pages/insurance_edit_page.dart
+++ b/lib/features/settings/presentation/pages/insurance_edit_page.dart
@@ -20,6 +20,8 @@ class _InsuranceEditPageState extends ConsumerState<InsuranceEditPage> {
   final _formKey = GlobalKey<FormState>();
   final _providerCtrl = TextEditingController();
   final _policyCtrl = TextEditingController();
+  final _emergencyPhoneCtrl = TextEditingController();
+  final _phoneCtrl = TextEditingController();
 
   DateTime? _insuranceExpiry;
   bool _populated = false;
@@ -31,6 +33,8 @@ class _InsuranceEditPageState extends ConsumerState<InsuranceEditPage> {
     super.initState();
     _providerCtrl.addListener(_onFieldChanged);
     _policyCtrl.addListener(_onFieldChanged);
+    _emergencyPhoneCtrl.addListener(_onFieldChanged);
+    _phoneCtrl.addListener(_onFieldChanged);
   }
 
   void _onFieldChanged() {
@@ -43,6 +47,8 @@ class _InsuranceEditPageState extends ConsumerState<InsuranceEditPage> {
   void dispose() {
     _providerCtrl.dispose();
     _policyCtrl.dispose();
+    _emergencyPhoneCtrl.dispose();
+    _phoneCtrl.dispose();
     super.dispose();
   }
 
@@ -51,6 +57,8 @@ class _InsuranceEditPageState extends ConsumerState<InsuranceEditPage> {
     _populated = true;
     _providerCtrl.text = diver.insurance.provider ?? '';
     _policyCtrl.text = diver.insurance.policyNumber ?? '';
+    _emergencyPhoneCtrl.text = diver.insurance.emergencyPhone ?? '';
+    _phoneCtrl.text = diver.insurance.phone ?? '';
     _insuranceExpiry = diver.insurance.expiryDate;
     _hasChanges = false;
   }
@@ -71,6 +79,8 @@ class _InsuranceEditPageState extends ConsumerState<InsuranceEditPage> {
           provider: _trimOrNull(_providerCtrl),
           policyNumber: _trimOrNull(_policyCtrl),
           expiryDate: _insuranceExpiry,
+          emergencyPhone: _trimOrNull(_emergencyPhoneCtrl),
+          phone: _trimOrNull(_phoneCtrl),
         ),
         updatedAt: DateTime.now(),
       );
@@ -215,6 +225,35 @@ class _InsuranceEditPageState extends ConsumerState<InsuranceEditPage> {
                       decoration: InputDecoration(
                         labelText: context.l10n.divers_edit_policyNumberLabel,
                         prefixIcon: const Icon(Icons.numbers),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    // The assistance line comes before the office line: it is
+                    // the one the emergency card leads with, so it is the one
+                    // a diver filling this in should not skip.
+                    TextFormField(
+                      controller: _emergencyPhoneCtrl,
+                      keyboardType: TextInputType.phone,
+                      decoration: InputDecoration(
+                        labelText: context
+                            .l10n
+                            .divers_edit_insuranceEmergencyPhoneLabel,
+                        prefixIcon: const Icon(Icons.emergency_share_outlined),
+                        hintText: context
+                            .l10n
+                            .divers_edit_insuranceEmergencyPhoneHint,
+                        helperText: context
+                            .l10n
+                            .divers_edit_insuranceEmergencyPhoneHelper,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    TextFormField(
+                      controller: _phoneCtrl,
+                      keyboardType: TextInputType.phone,
+                      decoration: InputDecoration(
+                        labelText: context.l10n.divers_edit_insurancePhoneLabel,
+                        prefixIcon: const Icon(Icons.phone_outlined),
                       ),
                     ),
                     const SizedBox(height: 16),

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -3122,6 +3122,10 @@
   "divers_edit_errorSaving": "خطأ في حفظ الغواص: {error}",
   "divers_edit_expiryDateNotSet": "غير محدد",
   "divers_edit_expiryDateTitle": "تاريخ الانتهاء",
+  "divers_edit_insuranceEmergencyPhoneHelper": "يظهر أولاً في بطاقة الطوارئ الخاصة بك.",
+  "divers_edit_insuranceEmergencyPhoneHint": "مثال: +1 919 684 9111",
+  "divers_edit_insuranceEmergencyPhoneLabel": "رقم المساعدة الطارئة على مدار 24 ساعة",
+  "divers_edit_insurancePhoneLabel": "رقم مكتب شركة التأمين",
   "divers_edit_insuranceProviderHint": "مثال: DAN، DiveAssure",
   "divers_edit_insuranceProviderLabel": "مزود التأمين",
   "divers_edit_insuranceSection": "تأمين الغوص",
@@ -7549,6 +7553,11 @@
     }
   },
   "emergencyCard_callDan_subtitle": "خط طوارئ الغواصين. اتصل به أولاً: فهم ينسقون الإخلاء والإحالة إلى غرفة الضغط.",
+  "emergencyCard_callInsurer_subtitle": "خط الطوارئ الخاص بتأمين الغوص. اتصل به أولاً: شركة التأمين تعتمد الإخلاء وتنسق الإحالة إلى غرفة الضغط.",
+  "emergencyCard_hotlineSecondary_subtitle": "خط طوارئ الغواصين الإقليمي. اتصل به إذا لم يرد خط شركة التأمين.",
+  "emergencyCard_insuranceEmergencyLine": "خط الطوارئ على مدار 24 ساعة",
+  "emergencyCard_insuranceOfficeLine": "خط المكتب",
+  "emergencyCard_insuranceNoPhone": "لم يتم حفظ رقم طوارئ شركة التأمين. أضفه في إعدادات ملف الغواص لتبدأ هذه البطاقة به.",
   "emergencyCard_ems": "خدمات الطوارئ المحلية: {number}",
   "@emergencyCard_ems": {
     "placeholders": {

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -3122,6 +3122,10 @@
   "divers_edit_errorSaving": "Fehler beim Speichern des Tauchers: {error}",
   "divers_edit_expiryDateNotSet": "Nicht festgelegt",
   "divers_edit_expiryDateTitle": "Ablaufdatum",
+  "divers_edit_insuranceEmergencyPhoneHelper": "Wird auf deiner Notfallkarte zuerst angezeigt.",
+  "divers_edit_insuranceEmergencyPhoneHint": "z.B. +1 919 684 9111",
+  "divers_edit_insuranceEmergencyPhoneLabel": "24-h-Notrufnummer der Versicherung",
+  "divers_edit_insurancePhoneLabel": "Bürotelefon der Versicherung",
   "divers_edit_insuranceProviderHint": "z.B. DAN, DiveAssure",
   "divers_edit_insuranceProviderLabel": "Versicherungsanbieter",
   "divers_edit_insuranceSection": "Tauchversicherung",
@@ -7549,6 +7553,11 @@
     }
   },
   "emergencyCard_callDan_subtitle": "Taucher-Notfallhotline. Zuerst anrufen: sie koordiniert Evakuierung und Kammerzuweisung.",
+  "emergencyCard_callInsurer_subtitle": "Notfallnummer deiner Tauchversicherung. Zuerst anrufen: dein Versicherer genehmigt die Evakuierung und koordiniert die Kammerzuweisung.",
+  "emergencyCard_hotlineSecondary_subtitle": "Regionale Taucher-Notfallhotline. Anrufen, wenn die Nummer deines Versicherers nicht erreichbar ist.",
+  "emergencyCard_insuranceEmergencyLine": "24-h-Notrufnummer",
+  "emergencyCard_insuranceOfficeLine": "Bürotelefon",
+  "emergencyCard_insuranceNoPhone": "Keine Notrufnummer des Versicherers gespeichert. Trage sie im Taucherprofil ein, damit diese Karte damit beginnt.",
   "emergencyCard_ems": "Örtlicher Notruf: {number}",
   "@emergencyCard_ems": {
     "placeholders": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -5680,6 +5680,10 @@
   "divers_edit_errorSaving": "Error saving diver: {error}",
   "divers_edit_expiryDateNotSet": "Not set",
   "divers_edit_expiryDateTitle": "Expiry Date",
+  "divers_edit_insuranceEmergencyPhoneHelper": "Shown first on your emergency card.",
+  "divers_edit_insuranceEmergencyPhoneHint": "e.g., +1 919 684 9111",
+  "divers_edit_insuranceEmergencyPhoneLabel": "24h Emergency Assistance Number",
+  "divers_edit_insurancePhoneLabel": "Insurance Office Number",
   "divers_edit_insuranceProviderHint": "e.g., DAN, DiveAssure",
   "divers_edit_insuranceProviderLabel": "Insurance Provider",
   "divers_edit_insuranceSection": "Dive Insurance",
@@ -16328,6 +16332,11 @@
     }
   },
   "emergencyCard_callDan_subtitle": "Diver emergency hotline. Call first: they coordinate evacuation and chamber referral.",
+  "emergencyCard_callInsurer_subtitle": "Your dive insurance emergency line. Call first: your insurer authorizes the evacuation and coordinates the chamber referral.",
+  "emergencyCard_hotlineSecondary_subtitle": "Regional diver emergency hotline. Call this if your insurer's line does not answer.",
+  "emergencyCard_insuranceEmergencyLine": "24h emergency line",
+  "emergencyCard_insuranceOfficeLine": "Office line",
+  "emergencyCard_insuranceNoPhone": "No insurer emergency number saved. Add it in Diver Profile settings so this card can lead with it.",
   "emergencyCard_ems": "Local emergency services: {number}",
   "@emergencyCard_ems": {
     "placeholders": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -3122,6 +3122,10 @@
   "divers_edit_errorSaving": "Error al guardar buceador: {error}",
   "divers_edit_expiryDateNotSet": "No establecida",
   "divers_edit_expiryDateTitle": "Fecha de vencimiento",
+  "divers_edit_insuranceEmergencyPhoneHelper": "Se muestra primero en tu tarjeta de emergencia.",
+  "divers_edit_insuranceEmergencyPhoneHint": "ej., +1 919 684 9111",
+  "divers_edit_insuranceEmergencyPhoneLabel": "Número de asistencia de emergencia 24 h",
+  "divers_edit_insurancePhoneLabel": "Teléfono de oficina del seguro",
   "divers_edit_insuranceProviderHint": "ej., DAN, DiveAssure",
   "divers_edit_insuranceProviderLabel": "Proveedor de seguro",
   "divers_edit_insuranceSection": "Seguro de buceo",
@@ -7549,6 +7553,11 @@
     }
   },
   "emergencyCard_callDan_subtitle": "Línea de emergencias para buceadores. Llama primero: coordinan la evacuación y la derivación a cámara.",
+  "emergencyCard_callInsurer_subtitle": "Línea de emergencia de tu seguro de buceo. Llama primero: tu aseguradora autoriza la evacuación y coordina la derivación a cámara.",
+  "emergencyCard_hotlineSecondary_subtitle": "Línea regional de emergencias para buceadores. Llama aquí si la línea de tu aseguradora no responde.",
+  "emergencyCard_insuranceEmergencyLine": "Línea de emergencia 24 h",
+  "emergencyCard_insuranceOfficeLine": "Teléfono de oficina",
+  "emergencyCard_insuranceNoPhone": "No hay número de emergencia de la aseguradora guardado. Añádelo en los ajustes del perfil de buceador para que esta tarjeta lo muestre primero.",
   "emergencyCard_ems": "Emergencias locales: {number}",
   "@emergencyCard_ems": {
     "placeholders": {

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -3038,6 +3038,10 @@
   "divers_edit_errorSaving": "Erreur lors de l'enregistrement du plongeur : {error}",
   "divers_edit_expiryDateNotSet": "Non defini",
   "divers_edit_expiryDateTitle": "Date d'expiration",
+  "divers_edit_insuranceEmergencyPhoneHelper": "Affiché en premier sur votre carte d'urgence.",
+  "divers_edit_insuranceEmergencyPhoneHint": "ex. +1 919 684 9111",
+  "divers_edit_insuranceEmergencyPhoneLabel": "Numéro d'assistance d'urgence 24 h",
+  "divers_edit_insurancePhoneLabel": "Téléphone du bureau de l'assurance",
   "divers_edit_insuranceProviderHint": "ex. DAN, DiveAssure",
   "divers_edit_insuranceProviderLabel": "Assureur",
   "divers_edit_insuranceSection": "Assurance plongee",
@@ -7549,6 +7553,11 @@
     }
   },
   "emergencyCard_callDan_subtitle": "Ligne d'urgence plongeurs. Appelez d'abord : ils coordonnent l'évacuation et l'orientation vers un caisson.",
+  "emergencyCard_callInsurer_subtitle": "Ligne d'urgence de votre assurance plongée. Appelez d'abord : votre assureur autorise l'évacuation et coordonne l'orientation vers un caisson.",
+  "emergencyCard_hotlineSecondary_subtitle": "Ligne d'urgence plongeurs régionale. Appelez-la si la ligne de votre assureur ne répond pas.",
+  "emergencyCard_insuranceEmergencyLine": "Ligne d'urgence 24 h",
+  "emergencyCard_insuranceOfficeLine": "Ligne de bureau",
+  "emergencyCard_insuranceNoPhone": "Aucun numéro d'urgence de l'assureur enregistré. Ajoutez-le dans les réglages du profil plongeur pour que cette carte le place en premier.",
   "emergencyCard_ems": "Secours locaux : {number}",
   "@emergencyCard_ems": {
     "placeholders": {

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -3038,6 +3038,10 @@
   "divers_edit_errorSaving": "שגיאה בשמירת צולל: {error}",
   "divers_edit_expiryDateNotSet": "לא הוגדר",
   "divers_edit_expiryDateTitle": "תאריך תפוגה",
+  "divers_edit_insuranceEmergencyPhoneHelper": "מוצג ראשון בכרטיס החירום שלך.",
+  "divers_edit_insuranceEmergencyPhoneHint": "לדוגמה, +1 919 684 9111",
+  "divers_edit_insuranceEmergencyPhoneLabel": "מספר סיוע חירום 24 שעות",
+  "divers_edit_insurancePhoneLabel": "מספר משרד חברת הביטוח",
   "divers_edit_insuranceProviderHint": "לדוגמה, DAN, DiveAssure",
   "divers_edit_insuranceProviderLabel": "ספק ביטוח",
   "divers_edit_insuranceSection": "ביטוח צלילה",
@@ -7549,6 +7553,11 @@
     }
   },
   "emergencyCard_callDan_subtitle": "קו חירום לצוללים. התקשר אליו קודם: הם מתאמים פינוי והפניה לתא לחץ.",
+  "emergencyCard_callInsurer_subtitle": "קו החירום של ביטוח הצלילה שלך. התקשר אליו קודם: המבטח מאשר את הפינוי ומתאם את ההפניה לתא לחץ.",
+  "emergencyCard_hotlineSecondary_subtitle": "קו חירום אזורי לצוללים. התקשר אליו אם קו המבטח אינו עונה.",
+  "emergencyCard_insuranceEmergencyLine": "קו חירום 24 שעות",
+  "emergencyCard_insuranceOfficeLine": "קו המשרד",
+  "emergencyCard_insuranceNoPhone": "לא נשמר מספר חירום של המבטח. הוסף אותו בהגדרות פרופיל הצולל כדי שהכרטיס יתחיל בו.",
   "emergencyCard_ems": "שירותי חירום מקומיים: {number}",
   "@emergencyCard_ems": {
     "placeholders": {

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -3038,6 +3038,10 @@
   "divers_edit_errorSaving": "Hiba a merülo mentesekor: {error}",
   "divers_edit_expiryDateNotSet": "Nincs megadva",
   "divers_edit_expiryDateTitle": "Lejarat datuma",
+  "divers_edit_insuranceEmergencyPhoneHelper": "Elsőként jelenik meg a vészhelyzeti kártyán.",
+  "divers_edit_insuranceEmergencyPhoneHint": "pl. +1 919 684 9111",
+  "divers_edit_insuranceEmergencyPhoneLabel": "24 órás segélyhívó szám",
+  "divers_edit_insurancePhoneLabel": "Biztosító irodai telefonszáma",
   "divers_edit_insuranceProviderHint": "pl. DAN, DiveAssure",
   "divers_edit_insuranceProviderLabel": "Biztosito",
   "divers_edit_insuranceSection": "Merülesi biztositas",
@@ -7549,6 +7553,11 @@
     }
   },
   "emergencyCard_callDan_subtitle": "Búvár segélyvonal. Először ezt hívd: ők koordinálják az evakuálást és a kamrába irányítást.",
+  "emergencyCard_callInsurer_subtitle": "A búvárbiztosításod segélyvonala. Először ezt hívd: a biztosító engedélyezi az evakuálást és koordinálja a kamrába irányítást.",
+  "emergencyCard_hotlineSecondary_subtitle": "Regionális búvár segélyvonal. Akkor hívd, ha a biztosító vonala nem válaszol.",
+  "emergencyCard_insuranceEmergencyLine": "24 órás segélyvonal",
+  "emergencyCard_insuranceOfficeLine": "Irodai vonal",
+  "emergencyCard_insuranceNoPhone": "Nincs mentve a biztosító segélyhívó száma. Add meg a búvárprofil beállításaiban, hogy ez a kártya azzal kezdjen.",
   "emergencyCard_ems": "Helyi segélyhívó: {number}",
   "@emergencyCard_ems": {
     "placeholders": {

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -3038,6 +3038,10 @@
   "divers_edit_errorSaving": "Errore nel salvataggio del subacqueo: {error}",
   "divers_edit_expiryDateNotSet": "Non impostata",
   "divers_edit_expiryDateTitle": "Data di scadenza",
+  "divers_edit_insuranceEmergencyPhoneHelper": "Mostrato per primo sulla tua scheda di emergenza.",
+  "divers_edit_insuranceEmergencyPhoneHint": "es. +1 919 684 9111",
+  "divers_edit_insuranceEmergencyPhoneLabel": "Numero di assistenza di emergenza 24 h",
+  "divers_edit_insurancePhoneLabel": "Telefono dell'ufficio assicurativo",
   "divers_edit_insuranceProviderHint": "es. DAN, DiveAssure",
   "divers_edit_insuranceProviderLabel": "Fornitore assicurazione",
   "divers_edit_insuranceSection": "Assicurazione subacquea",
@@ -7549,6 +7553,11 @@
     }
   },
   "emergencyCard_callDan_subtitle": "Linea di emergenza subacquei. Chiama prima: coordinano evacuazione e invio in camera iperbarica.",
+  "emergencyCard_callInsurer_subtitle": "Linea di emergenza della tua assicurazione subacquea. Chiama prima: il tuo assicuratore autorizza l'evacuazione e coordina l'invio in camera iperbarica.",
+  "emergencyCard_hotlineSecondary_subtitle": "Linea di emergenza subacquei regionale. Chiamala se la linea del tuo assicuratore non risponde.",
+  "emergencyCard_insuranceEmergencyLine": "Linea di emergenza 24 h",
+  "emergencyCard_insuranceOfficeLine": "Linea ufficio",
+  "emergencyCard_insuranceNoPhone": "Nessun numero di emergenza dell'assicuratore salvato. Aggiungilo nelle impostazioni del profilo subacqueo così questa scheda potrà mostrarlo per primo.",
   "emergencyCard_ems": "Emergenze locali: {number}",
   "@emergencyCard_ems": {
     "placeholders": {

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -16202,6 +16202,30 @@ abstract class AppLocalizations {
   /// **'Expiry Date'**
   String get divers_edit_expiryDateTitle;
 
+  /// No description provided for @divers_edit_insuranceEmergencyPhoneHelper.
+  ///
+  /// In en, this message translates to:
+  /// **'Shown first on your emergency card.'**
+  String get divers_edit_insuranceEmergencyPhoneHelper;
+
+  /// No description provided for @divers_edit_insuranceEmergencyPhoneHint.
+  ///
+  /// In en, this message translates to:
+  /// **'e.g., +1 919 684 9111'**
+  String get divers_edit_insuranceEmergencyPhoneHint;
+
+  /// No description provided for @divers_edit_insuranceEmergencyPhoneLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'24h Emergency Assistance Number'**
+  String get divers_edit_insuranceEmergencyPhoneLabel;
+
+  /// No description provided for @divers_edit_insurancePhoneLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Insurance Office Number'**
+  String get divers_edit_insurancePhoneLabel;
+
   /// No description provided for @divers_edit_insuranceProviderHint.
   ///
   /// In en, this message translates to:
@@ -41848,6 +41872,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Diver emergency hotline. Call first: they coordinate evacuation and chamber referral.'**
   String get emergencyCard_callDan_subtitle;
+
+  /// No description provided for @emergencyCard_callInsurer_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Your dive insurance emergency line. Call first: your insurer authorizes the evacuation and coordinates the chamber referral.'**
+  String get emergencyCard_callInsurer_subtitle;
+
+  /// No description provided for @emergencyCard_hotlineSecondary_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Regional diver emergency hotline. Call this if your insurer\'s line does not answer.'**
+  String get emergencyCard_hotlineSecondary_subtitle;
+
+  /// No description provided for @emergencyCard_insuranceEmergencyLine.
+  ///
+  /// In en, this message translates to:
+  /// **'24h emergency line'**
+  String get emergencyCard_insuranceEmergencyLine;
+
+  /// No description provided for @emergencyCard_insuranceOfficeLine.
+  ///
+  /// In en, this message translates to:
+  /// **'Office line'**
+  String get emergencyCard_insuranceOfficeLine;
+
+  /// No description provided for @emergencyCard_insuranceNoPhone.
+  ///
+  /// In en, this message translates to:
+  /// **'No insurer emergency number saved. Add it in Diver Profile settings so this card can lead with it.'**
+  String get emergencyCard_insuranceNoPhone;
 
   /// No description provided for @emergencyCard_ems.
   ///

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -9502,6 +9502,20 @@ class AppLocalizationsAr extends AppLocalizations {
   String get divers_edit_expiryDateTitle => 'تاريخ الانتهاء';
 
   @override
+  String get divers_edit_insuranceEmergencyPhoneHelper =>
+      'يظهر أولاً في بطاقة الطوارئ الخاصة بك.';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneHint => 'مثال: +1 919 684 9111';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneLabel =>
+      'رقم المساعدة الطارئة على مدار 24 ساعة';
+
+  @override
+  String get divers_edit_insurancePhoneLabel => 'رقم مكتب شركة التأمين';
+
+  @override
   String get divers_edit_insuranceProviderHint => 'مثال: DAN، DiveAssure';
 
   @override
@@ -24887,6 +24901,25 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get emergencyCard_callDan_subtitle =>
       'خط طوارئ الغواصين. اتصل به أولاً: فهم ينسقون الإخلاء والإحالة إلى غرفة الضغط.';
+
+  @override
+  String get emergencyCard_callInsurer_subtitle =>
+      'خط الطوارئ الخاص بتأمين الغوص. اتصل به أولاً: شركة التأمين تعتمد الإخلاء وتنسق الإحالة إلى غرفة الضغط.';
+
+  @override
+  String get emergencyCard_hotlineSecondary_subtitle =>
+      'خط طوارئ الغواصين الإقليمي. اتصل به إذا لم يرد خط شركة التأمين.';
+
+  @override
+  String get emergencyCard_insuranceEmergencyLine =>
+      'خط الطوارئ على مدار 24 ساعة';
+
+  @override
+  String get emergencyCard_insuranceOfficeLine => 'خط المكتب';
+
+  @override
+  String get emergencyCard_insuranceNoPhone =>
+      'لم يتم حفظ رقم طوارئ شركة التأمين. أضفه في إعدادات ملف الغواص لتبدأ هذه البطاقة به.';
 
   @override
   String emergencyCard_ems(String number) {

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -9682,6 +9682,20 @@ class AppLocalizationsDe extends AppLocalizations {
   String get divers_edit_expiryDateTitle => 'Ablaufdatum';
 
   @override
+  String get divers_edit_insuranceEmergencyPhoneHelper =>
+      'Wird auf deiner Notfallkarte zuerst angezeigt.';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneHint => 'z.B. +1 919 684 9111';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneLabel =>
+      '24-h-Notrufnummer der Versicherung';
+
+  @override
+  String get divers_edit_insurancePhoneLabel => 'Bürotelefon der Versicherung';
+
+  @override
   String get divers_edit_insuranceProviderHint => 'z.B. DAN, DiveAssure';
 
   @override
@@ -25296,6 +25310,24 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get emergencyCard_callDan_subtitle =>
       'Taucher-Notfallhotline. Zuerst anrufen: sie koordiniert Evakuierung und Kammerzuweisung.';
+
+  @override
+  String get emergencyCard_callInsurer_subtitle =>
+      'Notfallnummer deiner Tauchversicherung. Zuerst anrufen: dein Versicherer genehmigt die Evakuierung und koordiniert die Kammerzuweisung.';
+
+  @override
+  String get emergencyCard_hotlineSecondary_subtitle =>
+      'Regionale Taucher-Notfallhotline. Anrufen, wenn die Nummer deines Versicherers nicht erreichbar ist.';
+
+  @override
+  String get emergencyCard_insuranceEmergencyLine => '24-h-Notrufnummer';
+
+  @override
+  String get emergencyCard_insuranceOfficeLine => 'Bürotelefon';
+
+  @override
+  String get emergencyCard_insuranceNoPhone =>
+      'Keine Notrufnummer des Versicherers gespeichert. Trage sie im Taucherprofil ein, damit diese Karte damit beginnt.';
 
   @override
   String emergencyCard_ems(String number) {

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -9520,6 +9520,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get divers_edit_expiryDateTitle => 'Expiry Date';
 
   @override
+  String get divers_edit_insuranceEmergencyPhoneHelper =>
+      'Shown first on your emergency card.';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneHint => 'e.g., +1 919 684 9111';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneLabel =>
+      '24h Emergency Assistance Number';
+
+  @override
+  String get divers_edit_insurancePhoneLabel => 'Insurance Office Number';
+
+  @override
   String get divers_edit_insuranceProviderHint => 'e.g., DAN, DiveAssure';
 
   @override
@@ -24921,6 +24935,24 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get emergencyCard_callDan_subtitle =>
       'Diver emergency hotline. Call first: they coordinate evacuation and chamber referral.';
+
+  @override
+  String get emergencyCard_callInsurer_subtitle =>
+      'Your dive insurance emergency line. Call first: your insurer authorizes the evacuation and coordinates the chamber referral.';
+
+  @override
+  String get emergencyCard_hotlineSecondary_subtitle =>
+      'Regional diver emergency hotline. Call this if your insurer\'s line does not answer.';
+
+  @override
+  String get emergencyCard_insuranceEmergencyLine => '24h emergency line';
+
+  @override
+  String get emergencyCard_insuranceOfficeLine => 'Office line';
+
+  @override
+  String get emergencyCard_insuranceNoPhone =>
+      'No insurer emergency number saved. Add it in Diver Profile settings so this card can lead with it.';
 
   @override
   String emergencyCard_ems(String number) {

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -9681,6 +9681,21 @@ class AppLocalizationsEs extends AppLocalizations {
   String get divers_edit_expiryDateTitle => 'Fecha de vencimiento';
 
   @override
+  String get divers_edit_insuranceEmergencyPhoneHelper =>
+      'Se muestra primero en tu tarjeta de emergencia.';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneHint => 'ej., +1 919 684 9111';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneLabel =>
+      'Número de asistencia de emergencia 24 h';
+
+  @override
+  String get divers_edit_insurancePhoneLabel =>
+      'Teléfono de oficina del seguro';
+
+  @override
   String get divers_edit_insuranceProviderHint => 'ej., DAN, DiveAssure';
 
   @override
@@ -25364,6 +25379,24 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get emergencyCard_callDan_subtitle =>
       'Línea de emergencias para buceadores. Llama primero: coordinan la evacuación y la derivación a cámara.';
+
+  @override
+  String get emergencyCard_callInsurer_subtitle =>
+      'Línea de emergencia de tu seguro de buceo. Llama primero: tu aseguradora autoriza la evacuación y coordina la derivación a cámara.';
+
+  @override
+  String get emergencyCard_hotlineSecondary_subtitle =>
+      'Línea regional de emergencias para buceadores. Llama aquí si la línea de tu aseguradora no responde.';
+
+  @override
+  String get emergencyCard_insuranceEmergencyLine => 'Línea de emergencia 24 h';
+
+  @override
+  String get emergencyCard_insuranceOfficeLine => 'Teléfono de oficina';
+
+  @override
+  String get emergencyCard_insuranceNoPhone =>
+      'No hay número de emergencia de la aseguradora guardado. Añádelo en los ajustes del perfil de buceador para que esta tarjeta lo muestre primero.';
 
   @override
   String emergencyCard_ems(String number) {

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -9716,6 +9716,21 @@ class AppLocalizationsFr extends AppLocalizations {
   String get divers_edit_expiryDateTitle => 'Date d\'expiration';
 
   @override
+  String get divers_edit_insuranceEmergencyPhoneHelper =>
+      'Affiché en premier sur votre carte d\'urgence.';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneHint => 'ex. +1 919 684 9111';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneLabel =>
+      'Numéro d\'assistance d\'urgence 24 h';
+
+  @override
+  String get divers_edit_insurancePhoneLabel =>
+      'Téléphone du bureau de l\'assurance';
+
+  @override
   String get divers_edit_insuranceProviderHint => 'ex. DAN, DiveAssure';
 
   @override
@@ -25429,6 +25444,24 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get emergencyCard_callDan_subtitle =>
       'Ligne d\'urgence plongeurs. Appelez d\'abord : ils coordonnent l\'évacuation et l\'orientation vers un caisson.';
+
+  @override
+  String get emergencyCard_callInsurer_subtitle =>
+      'Ligne d\'urgence de votre assurance plongée. Appelez d\'abord : votre assureur autorise l\'évacuation et coordonne l\'orientation vers un caisson.';
+
+  @override
+  String get emergencyCard_hotlineSecondary_subtitle =>
+      'Ligne d\'urgence plongeurs régionale. Appelez-la si la ligne de votre assureur ne répond pas.';
+
+  @override
+  String get emergencyCard_insuranceEmergencyLine => 'Ligne d\'urgence 24 h';
+
+  @override
+  String get emergencyCard_insuranceOfficeLine => 'Ligne de bureau';
+
+  @override
+  String get emergencyCard_insuranceNoPhone =>
+      'Aucun numéro d\'urgence de l\'assureur enregistré. Ajoutez-le dans les réglages du profil plongeur pour que cette carte le place en premier.';
 
   @override
   String emergencyCard_ems(String number) {

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -9446,6 +9446,21 @@ class AppLocalizationsHe extends AppLocalizations {
   String get divers_edit_expiryDateTitle => 'תאריך תפוגה';
 
   @override
+  String get divers_edit_insuranceEmergencyPhoneHelper =>
+      'מוצג ראשון בכרטיס החירום שלך.';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneHint =>
+      'לדוגמה, +1 919 684 9111';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneLabel =>
+      'מספר סיוע חירום 24 שעות';
+
+  @override
+  String get divers_edit_insurancePhoneLabel => 'מספר משרד חברת הביטוח';
+
+  @override
   String get divers_edit_insuranceProviderHint => 'לדוגמה, DAN, DiveAssure';
 
   @override
@@ -24718,6 +24733,24 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get emergencyCard_callDan_subtitle =>
       'קו חירום לצוללים. התקשר אליו קודם: הם מתאמים פינוי והפניה לתא לחץ.';
+
+  @override
+  String get emergencyCard_callInsurer_subtitle =>
+      'קו החירום של ביטוח הצלילה שלך. התקשר אליו קודם: המבטח מאשר את הפינוי ומתאם את ההפניה לתא לחץ.';
+
+  @override
+  String get emergencyCard_hotlineSecondary_subtitle =>
+      'קו חירום אזורי לצוללים. התקשר אליו אם קו המבטח אינו עונה.';
+
+  @override
+  String get emergencyCard_insuranceEmergencyLine => 'קו חירום 24 שעות';
+
+  @override
+  String get emergencyCard_insuranceOfficeLine => 'קו המשרד';
+
+  @override
+  String get emergencyCard_insuranceNoPhone =>
+      'לא נשמר מספר חירום של המבטח. הוסף אותו בהגדרות פרופיל הצולל כדי שהכרטיס יתחיל בו.';
 
   @override
   String emergencyCard_ems(String number) {

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -9657,6 +9657,20 @@ class AppLocalizationsHu extends AppLocalizations {
   String get divers_edit_expiryDateTitle => 'Lejarat datuma';
 
   @override
+  String get divers_edit_insuranceEmergencyPhoneHelper =>
+      'Elsőként jelenik meg a vészhelyzeti kártyán.';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneHint => 'pl. +1 919 684 9111';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneLabel =>
+      '24 órás segélyhívó szám';
+
+  @override
+  String get divers_edit_insurancePhoneLabel => 'Biztosító irodai telefonszáma';
+
+  @override
   String get divers_edit_insuranceProviderHint => 'pl. DAN, DiveAssure';
 
   @override
@@ -25239,6 +25253,24 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get emergencyCard_callDan_subtitle =>
       'Búvár segélyvonal. Először ezt hívd: ők koordinálják az evakuálást és a kamrába irányítást.';
+
+  @override
+  String get emergencyCard_callInsurer_subtitle =>
+      'A búvárbiztosításod segélyvonala. Először ezt hívd: a biztosító engedélyezi az evakuálást és koordinálja a kamrába irányítást.';
+
+  @override
+  String get emergencyCard_hotlineSecondary_subtitle =>
+      'Regionális búvár segélyvonal. Akkor hívd, ha a biztosító vonala nem válaszol.';
+
+  @override
+  String get emergencyCard_insuranceEmergencyLine => '24 órás segélyvonal';
+
+  @override
+  String get emergencyCard_insuranceOfficeLine => 'Irodai vonal';
+
+  @override
+  String get emergencyCard_insuranceNoPhone =>
+      'Nincs mentve a biztosító segélyhívó száma. Add meg a búvárprofil beállításaiban, hogy ez a kártya azzal kezdjen.';
 
   @override
   String emergencyCard_ems(String number) {

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -9681,6 +9681,21 @@ class AppLocalizationsIt extends AppLocalizations {
   String get divers_edit_expiryDateTitle => 'Data di scadenza';
 
   @override
+  String get divers_edit_insuranceEmergencyPhoneHelper =>
+      'Mostrato per primo sulla tua scheda di emergenza.';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneHint => 'es. +1 919 684 9111';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneLabel =>
+      'Numero di assistenza di emergenza 24 h';
+
+  @override
+  String get divers_edit_insurancePhoneLabel =>
+      'Telefono dell\'ufficio assicurativo';
+
+  @override
   String get divers_edit_insuranceProviderHint => 'es. DAN, DiveAssure';
 
   @override
@@ -25345,6 +25360,24 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get emergencyCard_callDan_subtitle =>
       'Linea di emergenza subacquei. Chiama prima: coordinano evacuazione e invio in camera iperbarica.';
+
+  @override
+  String get emergencyCard_callInsurer_subtitle =>
+      'Linea di emergenza della tua assicurazione subacquea. Chiama prima: il tuo assicuratore autorizza l\'evacuazione e coordina l\'invio in camera iperbarica.';
+
+  @override
+  String get emergencyCard_hotlineSecondary_subtitle =>
+      'Linea di emergenza subacquei regionale. Chiamala se la linea del tuo assicuratore non risponde.';
+
+  @override
+  String get emergencyCard_insuranceEmergencyLine => 'Linea di emergenza 24 h';
+
+  @override
+  String get emergencyCard_insuranceOfficeLine => 'Linea ufficio';
+
+  @override
+  String get emergencyCard_insuranceNoPhone =>
+      'Nessun numero di emergenza dell\'assicuratore salvato. Aggiungilo nelle impostazioni del profilo subacqueo così questa scheda potrà mostrarlo per primo.';
 
   @override
   String emergencyCard_ems(String number) {

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -9606,6 +9606,20 @@ class AppLocalizationsNl extends AppLocalizations {
   String get divers_edit_expiryDateTitle => 'Vervaldatum';
 
   @override
+  String get divers_edit_insuranceEmergencyPhoneHelper =>
+      'Wordt als eerste op je noodkaart getoond.';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneHint => 'bijv. +1 919 684 9111';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneLabel =>
+      '24-uurs noodhulpnummer';
+
+  @override
+  String get divers_edit_insurancePhoneLabel => 'Kantoornummer verzekering';
+
+  @override
   String get divers_edit_insuranceProviderHint => 'bijv. DAN, DiveAssure';
 
   @override
@@ -25152,6 +25166,24 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get emergencyCard_callDan_subtitle =>
       'Noodlijn voor duikers. Bel eerst: zij coördineren evacuatie en doorverwijzing naar een kamer.';
+
+  @override
+  String get emergencyCard_callInsurer_subtitle =>
+      'Noodlijn van je duikverzekering. Bel eerst: je verzekeraar autoriseert de evacuatie en coördineert de doorverwijzing naar een kamer.';
+
+  @override
+  String get emergencyCard_hotlineSecondary_subtitle =>
+      'Regionale noodlijn voor duikers. Bel deze als de lijn van je verzekeraar niet opneemt.';
+
+  @override
+  String get emergencyCard_insuranceEmergencyLine => '24-uurs noodlijn';
+
+  @override
+  String get emergencyCard_insuranceOfficeLine => 'Kantoornummer';
+
+  @override
+  String get emergencyCard_insuranceNoPhone =>
+      'Geen noodnummer van de verzekeraar opgeslagen. Voeg het toe in de duikerprofielinstellingen zodat deze kaart ermee begint.';
 
   @override
   String emergencyCard_ems(String number) {

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -9683,6 +9683,21 @@ class AppLocalizationsPt extends AppLocalizations {
   String get divers_edit_expiryDateTitle => 'Data de Validade';
 
   @override
+  String get divers_edit_insuranceEmergencyPhoneHelper =>
+      'Aparece primeiro no seu cartão de emergência.';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneHint => 'ex., +1 919 684 9111';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneLabel =>
+      'Número de assistência de emergência 24 h';
+
+  @override
+  String get divers_edit_insurancePhoneLabel =>
+      'Telefone do escritório do seguro';
+
+  @override
   String get divers_edit_insuranceProviderHint => 'ex., DAN, DiveAssure';
 
   @override
@@ -25343,6 +25358,24 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get emergencyCard_callDan_subtitle =>
       'Linha de emergência para mergulhadores. Ligue primeiro: eles coordenam a evacuação e o encaminhamento para câmara.';
+
+  @override
+  String get emergencyCard_callInsurer_subtitle =>
+      'Linha de emergência do seu seguro de mergulho. Ligue primeiro: a seguradora autoriza a evacuação e coordena o encaminhamento para câmara.';
+
+  @override
+  String get emergencyCard_hotlineSecondary_subtitle =>
+      'Linha regional de emergência para mergulhadores. Ligue se a linha da sua seguradora não atender.';
+
+  @override
+  String get emergencyCard_insuranceEmergencyLine => 'Linha de emergência 24 h';
+
+  @override
+  String get emergencyCard_insuranceOfficeLine => 'Linha do escritório';
+
+  @override
+  String get emergencyCard_insuranceNoPhone =>
+      'Nenhum número de emergência da seguradora guardado. Adicione-o nas definições do perfil de mergulhador para que este cartão o mostre primeiro.';
 
   @override
   String emergencyCard_ems(String number) {

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -9218,6 +9218,18 @@ class AppLocalizationsZh extends AppLocalizations {
   String get divers_edit_expiryDateTitle => '到期日';
 
   @override
+  String get divers_edit_insuranceEmergencyPhoneHelper => '在紧急卡片上优先显示。';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneHint => '例如 +1 919 684 9111';
+
+  @override
+  String get divers_edit_insuranceEmergencyPhoneLabel => '24 小时紧急救援电话';
+
+  @override
+  String get divers_edit_insurancePhoneLabel => '保险公司办公电话';
+
+  @override
   String get divers_edit_insuranceProviderHint => '例如 DAN、DiveAssure';
 
   @override
@@ -24044,6 +24056,24 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get emergencyCard_callDan_subtitle => '潜水员紧急热线。请先拨打:他们负责协调撤离和减压舱转诊。';
+
+  @override
+  String get emergencyCard_callInsurer_subtitle =>
+      '你的潜水保险紧急专线。请先拨打:保险公司负责批准撤离并协调减压舱转诊。';
+
+  @override
+  String get emergencyCard_hotlineSecondary_subtitle =>
+      '区域潜水员紧急热线。若保险公司专线无人接听,请拨打此号码。';
+
+  @override
+  String get emergencyCard_insuranceEmergencyLine => '24 小时紧急专线';
+
+  @override
+  String get emergencyCard_insuranceOfficeLine => '办公电话';
+
+  @override
+  String get emergencyCard_insuranceNoPhone =>
+      '尚未保存保险公司紧急电话。请在潜水员资料设置中添加,以便此卡优先显示该号码。';
 
   @override
   String emergencyCard_ems(String number) {

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -3122,6 +3122,10 @@
   "divers_edit_errorSaving": "Fout bij opslaan van duiker: {error}",
   "divers_edit_expiryDateNotSet": "Niet ingesteld",
   "divers_edit_expiryDateTitle": "Vervaldatum",
+  "divers_edit_insuranceEmergencyPhoneHelper": "Wordt als eerste op je noodkaart getoond.",
+  "divers_edit_insuranceEmergencyPhoneHint": "bijv. +1 919 684 9111",
+  "divers_edit_insuranceEmergencyPhoneLabel": "24-uurs noodhulpnummer",
+  "divers_edit_insurancePhoneLabel": "Kantoornummer verzekering",
   "divers_edit_insuranceProviderHint": "bijv. DAN, DiveAssure",
   "divers_edit_insuranceProviderLabel": "Verzekeraar",
   "divers_edit_insuranceSection": "Duikverzekering",
@@ -7549,6 +7553,11 @@
     }
   },
   "emergencyCard_callDan_subtitle": "Noodlijn voor duikers. Bel eerst: zij coördineren evacuatie en doorverwijzing naar een kamer.",
+  "emergencyCard_callInsurer_subtitle": "Noodlijn van je duikverzekering. Bel eerst: je verzekeraar autoriseert de evacuatie en coördineert de doorverwijzing naar een kamer.",
+  "emergencyCard_hotlineSecondary_subtitle": "Regionale noodlijn voor duikers. Bel deze als de lijn van je verzekeraar niet opneemt.",
+  "emergencyCard_insuranceEmergencyLine": "24-uurs noodlijn",
+  "emergencyCard_insuranceOfficeLine": "Kantoornummer",
+  "emergencyCard_insuranceNoPhone": "Geen noodnummer van de verzekeraar opgeslagen. Voeg het toe in de duikerprofielinstellingen zodat deze kaart ermee begint.",
   "emergencyCard_ems": "Lokale hulpdiensten: {number}",
   "@emergencyCard_ems": {
     "placeholders": {

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -3122,6 +3122,10 @@
   "divers_edit_errorSaving": "Erro ao salvar mergulhador: {error}",
   "divers_edit_expiryDateNotSet": "Nao definida",
   "divers_edit_expiryDateTitle": "Data de Validade",
+  "divers_edit_insuranceEmergencyPhoneHelper": "Aparece primeiro no seu cartão de emergência.",
+  "divers_edit_insuranceEmergencyPhoneHint": "ex., +1 919 684 9111",
+  "divers_edit_insuranceEmergencyPhoneLabel": "Número de assistência de emergência 24 h",
+  "divers_edit_insurancePhoneLabel": "Telefone do escritório do seguro",
   "divers_edit_insuranceProviderHint": "ex., DAN, DiveAssure",
   "divers_edit_insuranceProviderLabel": "Seguradora",
   "divers_edit_insuranceSection": "Seguro de Mergulho",
@@ -7549,6 +7553,11 @@
     }
   },
   "emergencyCard_callDan_subtitle": "Linha de emergência para mergulhadores. Ligue primeiro: eles coordenam a evacuação e o encaminhamento para câmara.",
+  "emergencyCard_callInsurer_subtitle": "Linha de emergência do seu seguro de mergulho. Ligue primeiro: a seguradora autoriza a evacuação e coordena o encaminhamento para câmara.",
+  "emergencyCard_hotlineSecondary_subtitle": "Linha regional de emergência para mergulhadores. Ligue se a linha da sua seguradora não atender.",
+  "emergencyCard_insuranceEmergencyLine": "Linha de emergência 24 h",
+  "emergencyCard_insuranceOfficeLine": "Linha do escritório",
+  "emergencyCard_insuranceNoPhone": "Nenhum número de emergência da seguradora guardado. Adicione-o nas definições do perfil de mergulhador para que este cartão o mostre primeiro.",
   "emergencyCard_ems": "Emergência local: {number}",
   "@emergencyCard_ems": {
     "placeholders": {

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -3255,6 +3255,10 @@
   "divers_edit_errorSaving": "保存潜水员出错：{error}",
   "divers_edit_expiryDateNotSet": "未设置",
   "divers_edit_expiryDateTitle": "到期日",
+  "divers_edit_insuranceEmergencyPhoneHelper": "在紧急卡片上优先显示。",
+  "divers_edit_insuranceEmergencyPhoneHint": "例如 +1 919 684 9111",
+  "divers_edit_insuranceEmergencyPhoneLabel": "24 小时紧急救援电话",
+  "divers_edit_insurancePhoneLabel": "保险公司办公电话",
   "divers_edit_insuranceProviderHint": "例如 DAN、DiveAssure",
   "divers_edit_insuranceProviderLabel": "保险提供商",
   "divers_edit_insuranceSection": "潜水保险",
@@ -7549,6 +7553,11 @@
     }
   },
   "emergencyCard_callDan_subtitle": "潜水员紧急热线。请先拨打:他们负责协调撤离和减压舱转诊。",
+  "emergencyCard_callInsurer_subtitle": "你的潜水保险紧急专线。请先拨打:保险公司负责批准撤离并协调减压舱转诊。",
+  "emergencyCard_hotlineSecondary_subtitle": "区域潜水员紧急热线。若保险公司专线无人接听,请拨打此号码。",
+  "emergencyCard_insuranceEmergencyLine": "24 小时紧急专线",
+  "emergencyCard_insuranceOfficeLine": "办公电话",
+  "emergencyCard_insuranceNoPhone": "尚未保存保险公司紧急电话。请在潜水员资料设置中添加,以便此卡优先显示该号码。",
   "emergencyCard_ems": "当地急救电话:{number}",
   "@emergencyCard_ems": {
     "placeholders": {

--- a/test/core/database/migration_v187_session_item_overdue_services_test.dart
+++ b/test/core/database/migration_v187_session_item_overdue_services_test.dart
@@ -50,8 +50,10 @@ void main() {
     expect(row.data['overdue_services'], isNull);
   });
 
-  test('v187 is the current schema version and is in the ladder', () {
-    expect(AppDatabase.currentSchemaVersion, 187);
+  test('migration list includes v187 and schema is at least 187', () {
+    // Relaxed from an exact match when v188 landed: the exact assertion is
+    // the newest rung's job, and it moves with it.
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(187));
     expect(AppDatabase.migrationVersions, contains(187));
   });
 

--- a/test/core/database/migration_v188_insurance_phone_test.dart
+++ b/test/core/database/migration_v188_insurance_phone_test.dart
@@ -1,0 +1,131 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// Pre-v188 divers shape: insurance provider, policy and expiry, but no way
+/// to record the insurer's own phone numbers (issue #1522).
+const _preV188Divers = '''
+  CREATE TABLE divers (
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+    medical_notes TEXT NOT NULL DEFAULT '',
+    insurance_provider TEXT,
+    insurance_policy_number TEXT,
+    insurance_expiry_date INTEGER,
+    notes TEXT NOT NULL DEFAULT '',
+    is_default INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  )
+''';
+
+const _seedDiver =
+    "INSERT INTO divers "
+    "(id, name, insurance_provider, insurance_policy_number, "
+    "created_at, updated_at) "
+    "VALUES ('d1', 'Alice Alpha', 'ARENA', 'POL-1', 100, 100)";
+
+void main() {
+  test('v188 adds both insurance phone columns, preserving rows', () async {
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 187');
+        rawDb.execute(_preV188Divers);
+        rawDb.execute(_seedDiver);
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    final cols = await db.customSelect("PRAGMA table_info('divers')").get();
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    expect(names, contains('insurance_emergency_phone'));
+    expect(names, contains('insurance_phone'));
+
+    final row = await db
+        .customSelect(
+          'SELECT name, insurance_provider, insurance_emergency_phone, '
+          "insurance_phone FROM divers WHERE id = 'd1'",
+        )
+        .getSingle();
+    expect(row.data['name'], 'Alice Alpha');
+    expect(row.data['insurance_provider'], 'ARENA');
+    expect(
+      row.data['insurance_emergency_phone'],
+      isNull,
+      reason: 'nothing in an old database can tell us the insurer hotline',
+    );
+    expect(row.data['insurance_phone'], isNull);
+  });
+
+  test('v188 is the current schema version and is in the ladder', () {
+    expect(AppDatabase.currentSchemaVersion, 188);
+    expect(AppDatabase.migrationVersions, contains(188));
+  });
+
+  test('v188 is idempotent when both columns already exist', () async {
+    // An interrupted upgrade, or a database that reached this version number
+    // from a parallel branch, leaves the columns already added. The PRAGMA
+    // guard must skip the ALTER rather than fail on a duplicate column.
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 187');
+        rawDb.execute(_preV188Divers);
+        rawDb.execute(
+          'ALTER TABLE divers ADD COLUMN insurance_emergency_phone TEXT',
+        );
+        rawDb.execute('ALTER TABLE divers ADD COLUMN insurance_phone TEXT');
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    final names = (await db.customSelect("PRAGMA table_info('divers')").get())
+        .map((c) => c.read<String>('name'))
+        .toList();
+    expect(names.where((n) => n == 'insurance_emergency_phone'), hasLength(1));
+    expect(names.where((n) => n == 'insurance_phone'), hasLength(1));
+  });
+
+  test('v188 adds the missing column when only one landed', () async {
+    // The two ALTERs are guarded independently, so an upgrade interrupted
+    // between them must still finish on the next open.
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 187');
+        rawDb.execute(_preV188Divers);
+        rawDb.execute(
+          'ALTER TABLE divers ADD COLUMN insurance_emergency_phone TEXT',
+        );
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    final names = (await db.customSelect("PRAGMA table_info('divers')").get())
+        .map((c) => c.read<String>('name'))
+        .toSet();
+    expect(names, contains('insurance_emergency_phone'));
+    expect(names, contains('insurance_phone'));
+  });
+
+  test('the helper no-ops when divers is absent', () async {
+    // Partial-schema case: migration tests instantiate databases without
+    // unrelated tables, and unguarded DDL would fail with "no such table".
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 187');
+        // Deliberately no divers table at all.
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    final result = await db.customSelect('SELECT 1 AS ok').getSingle();
+    expect(result.data['ok'], 1);
+  });
+}

--- a/test/core/services/export/uddf/uddf_owner_insurance_export_test.dart
+++ b/test/core/services/export/uddf/uddf_owner_insurance_export_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xml/xml.dart';
+import 'package:submersion/core/services/export/uddf/uddf_export_builders.dart';
+import 'package:submersion/core/services/export/uddf/uddf_import_parsers.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+
+/// The `<insurance>` element lives under the non-standard `<ownerextended>`
+/// block, so these tests pin our own contract for it: what gets written, and
+/// that the parser reads back what the builder wrote.
+void main() {
+  final epoch = DateTime.utc(2026, 1, 1);
+
+  Diver ownerWith(DiverInsurance insurance) => Diver(
+    id: 'diver-1',
+    name: 'Alice Alpha',
+    createdAt: epoch,
+    updatedAt: epoch,
+    insurance: insurance,
+  );
+
+  XmlElement? insuranceOf(Diver owner) {
+    final builder = XmlBuilder();
+    builder.element(
+      'root',
+      nest: () =>
+          UddfExportBuilders.buildApplicationData(builder, owner: owner),
+    );
+    return builder.buildDocument().findAllElements('insurance').firstOrNull;
+  }
+
+  group('UDDF owner insurance export', () {
+    test('writes both phone numbers alongside the provider', () {
+      final insurance = insuranceOf(
+        ownerWith(
+          const DiverInsurance(
+            provider: 'ARENA',
+            policyNumber: 'A-777',
+            emergencyPhone: '+49-30-555-0100',
+            phone: '+49-30-555-0199',
+          ),
+        ),
+      );
+
+      expect(insurance, isNotNull);
+      expect(insurance!.getElement('provider')?.innerText, 'ARENA');
+      expect(insurance.getElement('policynumber')?.innerText, 'A-777');
+      expect(
+        insurance.getElement('emergencyphone')?.innerText,
+        '+49-30-555-0100',
+      );
+      expect(insurance.getElement('phone')?.innerText, '+49-30-555-0199');
+    });
+
+    test('exports an assistance line saved without a provider name', () {
+      // The card supports a number with no provider name, so gating the
+      // element on the provider would drop it on export and lose it on
+      // re-import.
+      final insurance = insuranceOf(
+        ownerWith(const DiverInsurance(emergencyPhone: '+49-30-555-0100')),
+      );
+
+      expect(insurance, isNotNull);
+      expect(insurance!.getElement('provider'), isNull);
+      expect(
+        insurance.getElement('emergencyphone')?.innerText,
+        '+49-30-555-0100',
+      );
+    });
+
+    test('exports a policy number saved without a provider name', () {
+      final insurance = insuranceOf(
+        ownerWith(const DiverInsurance(policyNumber: 'A-777')),
+      );
+
+      expect(insurance, isNotNull);
+      expect(insurance!.getElement('policynumber')?.innerText, 'A-777');
+    });
+
+    test('writes no insurance element when nothing was recorded', () {
+      expect(insuranceOf(ownerWith(const DiverInsurance())), isNull);
+    });
+
+    test('round-trips both numbers back through the parser', () {
+      final owner = ownerWith(
+        const DiverInsurance(
+          provider: 'ARENA',
+          emergencyPhone: '+49-30-555-0100',
+          phone: '+49-30-555-0199',
+        ),
+      );
+
+      final builder = XmlBuilder();
+      builder.element(
+        'root',
+        nest: () =>
+            UddfExportBuilders.buildApplicationData(builder, owner: owner),
+      );
+      final extended = builder
+          .buildDocument()
+          .findAllElements('ownerextended')
+          .first;
+
+      final parsed = <String, dynamic>{};
+      UddfImportParsers.parseOwnerExtended(extended, parsed);
+
+      expect(parsed['insuranceProvider'], 'ARENA');
+      expect(parsed['insuranceEmergencyPhone'], '+49-30-555-0100');
+      expect(parsed['insurancePhone'], '+49-30-555-0199');
+    });
+  });
+}

--- a/test/features/dive_import/uddf_import_oceanic_plus_profile_test.dart
+++ b/test/features/dive_import/uddf_import_oceanic_plus_profile_test.dart
@@ -172,6 +172,11 @@ void main() {
         expect(dive.runtime, isNotNull);
         expect(dive.runtime!.inSeconds, greaterThan(1000));
       }
-    });
+      // Imports nine real dives of 99-250 samples each through the entity
+      // importer and a database round trip, then reads every one back. That
+      // costs ~18s on an idle machine, which leaves almost no headroom under
+      // the 30s default and times out on a loaded CI shard (seen on PR #1530,
+      // shard 3, where the file passes on its own).
+    }, timeout: const Timeout(Duration(minutes: 2)));
   });
 }

--- a/test/features/divers/data/repositories/diver_repository_additional_test.dart
+++ b/test/features/divers/data/repositories/diver_repository_additional_test.dart
@@ -120,6 +120,8 @@ void main() {
           provider: 'DAN',
           policyNumber: 'P-123',
           expiryDate: insDate,
+          emergencyPhone: '+1-919-684-9111',
+          phone: '+1-919-684-2948',
         ),
         createdAt: DateTime(2024),
         updatedAt: DateTime(2024),
@@ -141,6 +143,8 @@ void main() {
         read.insurance.expiryDate?.millisecondsSinceEpoch,
         equals(insDate.millisecondsSinceEpoch),
       );
+      expect(read.insurance.emergencyPhone, equals('+1-919-684-9111'));
+      expect(read.insurance.phone, equals('+1-919-684-2948'));
     });
   });
 

--- a/test/features/divers/domain/entities/diver_insurance_test.dart
+++ b/test/features/divers/domain/entities/diver_insurance_test.dart
@@ -7,8 +7,31 @@ void main() {
       const insurance = DiverInsurance(provider: 'ARENA');
       expect(insurance.emergencyPhone, isNull);
       expect(insurance.phone, isNull);
+      expect(insurance.assistanceLine, isNull);
+      expect(insurance.officeLine, isNull);
       expect(insurance.callNumber, isNull);
       expect(insurance.hasCallNumber, isFalse);
+    });
+
+    test('assistanceLine is null when only an office line is recorded', () {
+      // The emergency card leads with assistanceLine and nothing else, so
+      // this null is what keeps a business-hours number out of the primary
+      // button.
+      const insurance = DiverInsurance(
+        provider: 'ARENA',
+        phone: '+49-30-111-111',
+      );
+      expect(insurance.assistanceLine, isNull);
+      expect(insurance.officeLine, '+49-30-111-111');
+    });
+
+    test('both lines are trimmed, and blanks read as absent', () {
+      const insurance = DiverInsurance(
+        emergencyPhone: '  +49-30-000-000  ',
+        phone: '   ',
+      );
+      expect(insurance.assistanceLine, '+49-30-000-000');
+      expect(insurance.officeLine, isNull);
     });
 
     test('callNumber prefers the 24h assistance line over the office line', () {

--- a/test/features/divers/domain/entities/diver_insurance_test.dart
+++ b/test/features/divers/domain/entities/diver_insurance_test.dart
@@ -25,6 +25,28 @@ void main() {
       expect(insurance.officeLine, '+49-30-111-111');
     });
 
+    test('provider and policy labels trim, and blanks read as absent', () {
+      const blank = DiverInsurance(provider: '   ', policyNumber: '');
+      expect(blank.providerLabel, isNull);
+      expect(blank.policyLabel, isNull);
+      expect(blank.hasAnyDetail, isFalse);
+
+      const padded = DiverInsurance(
+        provider: '  ARENA  ',
+        policyNumber: '  A-777  ',
+      );
+      expect(padded.providerLabel, 'ARENA');
+      expect(padded.policyLabel, 'A-777');
+      expect(padded.hasAnyDetail, isTrue);
+    });
+
+    test('hasAnyDetail counts an expiry date on its own', () {
+      // Export keys off this, so an expiry-only record must still round-trip.
+      final insurance = DiverInsurance(expiryDate: DateTime.utc(2030));
+      expect(insurance.hasAnyDetail, isTrue);
+      expect(insurance.hasCallNumber, isFalse);
+    });
+
     test('both lines are trimmed, and blanks read as absent', () {
       const insurance = DiverInsurance(
         emergencyPhone: '  +49-30-000-000  ',

--- a/test/features/divers/domain/entities/diver_insurance_test.dart
+++ b/test/features/divers/domain/entities/diver_insurance_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+
+void main() {
+  group('DiverInsurance emergency contact details', () {
+    test('defaults both numbers to null', () {
+      const insurance = DiverInsurance(provider: 'ARENA');
+      expect(insurance.emergencyPhone, isNull);
+      expect(insurance.phone, isNull);
+      expect(insurance.callNumber, isNull);
+      expect(insurance.hasCallNumber, isFalse);
+    });
+
+    test('callNumber prefers the 24h assistance line over the office line', () {
+      const insurance = DiverInsurance(
+        provider: 'ARENA',
+        emergencyPhone: '+49-30-000-000',
+        phone: '+49-30-111-111',
+      );
+      expect(insurance.callNumber, '+49-30-000-000');
+      expect(insurance.hasCallNumber, isTrue);
+    });
+
+    test('callNumber falls back to the office line', () {
+      const insurance = DiverInsurance(
+        provider: 'ARENA',
+        phone: '+49-30-111-111',
+      );
+      expect(insurance.callNumber, '+49-30-111-111');
+      expect(insurance.hasCallNumber, isTrue);
+    });
+
+    test('a blank number is not a call number', () {
+      const insurance = DiverInsurance(
+        provider: 'ARENA',
+        emergencyPhone: '   ',
+        phone: '',
+      );
+      expect(insurance.callNumber, isNull);
+      expect(insurance.hasCallNumber, isFalse);
+    });
+
+    test('copyWith carries the numbers and can replace them', () {
+      const insurance = DiverInsurance(
+        provider: 'ARENA',
+        emergencyPhone: '+49-30-000-000',
+        phone: '+49-30-111-111',
+      );
+      expect(
+        insurance.copyWith(policyNumber: 'P-1').emergencyPhone,
+        '+49-30-000-000',
+      );
+      expect(
+        insurance.copyWith(emergencyPhone: '+49-30-222-222').emergencyPhone,
+        '+49-30-222-222',
+      );
+    });
+
+    test('the numbers take part in equality', () {
+      expect(
+        const DiverInsurance(provider: 'ARENA', emergencyPhone: '1'),
+        isNot(const DiverInsurance(provider: 'ARENA', emergencyPhone: '2')),
+      );
+      expect(
+        const DiverInsurance(provider: 'ARENA', phone: '1'),
+        isNot(const DiverInsurance(provider: 'ARENA', phone: '2')),
+      );
+    });
+  });
+}

--- a/test/features/divers/domain/entities/diver_insurance_test.dart
+++ b/test/features/divers/domain/entities/diver_insurance_test.dart
@@ -40,6 +40,18 @@ void main() {
       expect(padded.hasAnyDetail, isTrue);
     });
 
+    test('a whitespace-only provider is not valid insurance', () {
+      // isValid feeds Diver.hasValidInsurance, the dashboard gauge strip and
+      // the profile hub. If it disagreed with providerLabel, the dashboard
+      // would call a policy valid that the emergency card refuses to show.
+      const blank = DiverInsurance(provider: '   ');
+      expect(blank.isValid, isFalse);
+      expect(blank.providerLabel, isNull);
+
+      const named = DiverInsurance(provider: '  ARENA  ');
+      expect(named.isValid, isTrue);
+    });
+
     test('hasAnyDetail counts an expiry date on its own', () {
       // Export keys off this, so an expiry-only record must still round-trip.
       final insurance = DiverInsurance(expiryDate: DateTime.utc(2030));

--- a/test/features/safety/presentation/pages/emergency_card_page_test.dart
+++ b/test/features/safety/presentation/pages/emergency_card_page_test.dart
@@ -409,6 +409,27 @@ void main() {
       );
     });
 
+    testWidgets('a whitespace-only policy number prints no policy line', (
+      tester,
+    ) async {
+      // A blank "Policy" line is noise on a screen read under stress.
+      await tester.binding.setSurfaceSize(const Size(500, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pump(
+        tester,
+        diverOverride: diver.copyWith(
+          insurance: const DiverInsurance(
+            provider: 'ARENA',
+            policyNumber: '   ',
+            emergencyPhone: '+49-30-555-0100',
+          ),
+        ),
+      );
+
+      expect(find.textContaining('Policy'), findsNothing);
+    });
+
     testWidgets('the office line stays reachable in the insurance block', (
       tester,
     ) async {

--- a/test/features/safety/presentation/pages/emergency_card_page_test.dart
+++ b/test/features/safety/presentation/pages/emergency_card_page_test.dart
@@ -1,5 +1,12 @@
 import 'package:flutter/material.dart'
-    show IconButton, Icons, Locale, MaterialApp, PopupMenuButton, Size;
+    show
+        FilledButton,
+        IconButton,
+        Icons,
+        Locale,
+        MaterialApp,
+        PopupMenuButton,
+        Size;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -67,6 +74,7 @@ void main() {
   Future<void> pump(
     WidgetTester tester, {
     bool includeDiver = true,
+    Diver? diverOverride,
     List<EmergencyChamber>? chambers,
     List<ChamberListing>? listings,
     int? totalChamberCount,
@@ -83,7 +91,7 @@ void main() {
               countryCode: 'AU',
               hotline: hotline,
               emsNumber: '000',
-              diver: includeDiver ? diver : null,
+              diver: includeDiver ? (diverOverride ?? diver) : null,
               nearbyChambers:
                   listings ??
                   [
@@ -305,5 +313,141 @@ void main() {
       find.textContaining('Not confirmed with the facility'),
       findsOneWidget,
     );
+  });
+
+  group('issue #1522: the insurer leads when the diver recorded a number', () {
+    final insured = diver.copyWith(
+      insurance: const DiverInsurance(
+        provider: 'ARENA',
+        policyNumber: 'A-777',
+        emergencyPhone: '+49-30-555-0100',
+        phone: '+49-30-555-0199',
+      ),
+    );
+
+    testWidgets('the primary button calls the insurer, not the hotline', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(500, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pump(tester, diverOverride: insured);
+
+      final primary = tester.widget<FilledButton>(
+        find.byType(FilledButton).first,
+      );
+      expect(
+        find.descendant(
+          of: find.byWidget(primary),
+          matching: find.textContaining('Call ARENA'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byWidget(primary),
+          matching: find.textContaining('+49-30-555-0100'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Your dive insurance emergency line'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('the regional hotline stays on the card as the fallback', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(500, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pump(tester, diverOverride: insured);
+
+      expect(find.textContaining('DES Australia'), findsOneWidget);
+      expect(find.textContaining('1800-088-200'), findsOneWidget);
+      expect(
+        find.textContaining('Call this if your insurer'),
+        findsOneWidget,
+        reason: 'the hotline must say why it is now the second call',
+      );
+    });
+
+    testWidgets('the office line is used only when there is no 24h line', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(500, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pump(
+        tester,
+        diverOverride: diver.copyWith(
+          insurance: const DiverInsurance(
+            provider: 'ARENA',
+            phone: '+49-30-555-0199',
+          ),
+        ),
+      );
+
+      final primary = tester.widget<FilledButton>(
+        find.byType(FilledButton).first,
+      );
+      expect(
+        find.descendant(
+          of: find.byWidget(primary),
+          matching: find.textContaining('+49-30-555-0199'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('both insurer numbers are listed and tappable', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(500, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pump(tester, diverOverride: insured);
+
+      expect(find.text('24h emergency line'), findsOneWidget);
+      expect(find.text('Office line'), findsOneWidget);
+      expect(find.text('+49-30-555-0199'), findsOneWidget);
+    });
+
+    testWidgets('the hotline still leads when no insurer number is stored', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(500, 2000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pump(tester);
+
+      final primary = tester.widget<FilledButton>(
+        find.byType(FilledButton).first,
+      );
+      expect(
+        find.descendant(
+          of: find.byWidget(primary),
+          matching: find.textContaining('DES Australia'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Diver emergency hotline. Call first'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('a provider with no number explains why it cannot lead', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(500, 2000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pump(tester);
+
+      expect(
+        find.textContaining('No insurer emergency number saved'),
+        findsOneWidget,
+      );
+    });
   });
 }

--- a/test/features/safety/presentation/pages/emergency_card_page_test.dart
+++ b/test/features/safety/presentation/pages/emergency_card_page_test.dart
@@ -373,9 +373,12 @@ void main() {
       );
     });
 
-    testWidgets('the office line is used only when there is no 24h line', (
+    testWidgets('an office line alone never displaces the 24h hotline', (
       tester,
     ) async {
+      // An insurer's office line typically answers in business hours only.
+      // Promoting it would promise a first call that rings an empty desk at
+      // 2am, which is worse than the regional hotline that does answer.
       await tester.binding.setSurfaceSize(const Size(500, 2400));
       addTearDown(() => tester.binding.setSurfaceSize(null));
 
@@ -395,9 +398,39 @@ void main() {
       expect(
         find.descendant(
           of: find.byWidget(primary),
-          matching: find.textContaining('+49-30-555-0199'),
+          matching: find.textContaining('DES Australia'),
         ),
         findsOneWidget,
+      );
+      expect(
+        find.textContaining('Your dive insurance emergency line'),
+        findsNothing,
+        reason: 'an office line must not be described as an emergency line',
+      );
+    });
+
+    testWidgets('the office line stays reachable in the insurance block', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(500, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pump(
+        tester,
+        diverOverride: diver.copyWith(
+          insurance: const DiverInsurance(
+            provider: 'ARENA',
+            phone: '+49-30-555-0199',
+          ),
+        ),
+      );
+
+      expect(find.text('Office line'), findsOneWidget);
+      expect(find.text('+49-30-555-0199'), findsOneWidget);
+      expect(
+        find.textContaining('No insurer emergency number saved'),
+        findsOneWidget,
+        reason: 'an office line alone still needs the 24h number nudge',
       );
     });
 

--- a/test/features/safety/presentation/pages/emergency_card_page_test.dart
+++ b/test/features/safety/presentation/pages/emergency_card_page_test.dart
@@ -409,6 +409,41 @@ void main() {
       );
     });
 
+    testWidgets('an unnamed insurer still leads, under a generic label', (
+      tester,
+    ) async {
+      // A diver can save the number off their card without typing the
+      // insurer's name. "Call" on its own is not a button, so the section
+      // heading stands in for the name.
+      await tester.binding.setSurfaceSize(const Size(500, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pump(
+        tester,
+        diverOverride: diver.copyWith(
+          insurance: const DiverInsurance(emergencyPhone: '+49-30-555-0100'),
+        ),
+      );
+
+      final primary = tester.widget<FilledButton>(
+        find.byType(FilledButton).first,
+      );
+      expect(
+        find.descendant(
+          of: find.byWidget(primary),
+          matching: find.textContaining('Call Dive insurance'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byWidget(primary),
+          matching: find.textContaining('+49-30-555-0100'),
+        ),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('a whitespace-only policy number prints no policy line', (
       tester,
     ) async {

--- a/test/features/settings/presentation/pages/insurance_edit_page_test.dart
+++ b/test/features/settings/presentation/pages/insurance_edit_page_test.dart
@@ -201,4 +201,72 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(DatePickerDialog), findsNothing);
   });
+
+  testWidgets('populates both insurer phone numbers (#1522)', (tester) async {
+    await pump(
+      tester,
+      makeDiver(
+        insurance: const DiverInsurance(
+          provider: 'ARENA',
+          emergencyPhone: '+49-30-555-0100',
+          phone: '+49-30-555-0199',
+        ),
+      ),
+    );
+
+    expect(find.text('+49-30-555-0100'), findsOneWidget);
+    expect(find.text('+49-30-555-0199'), findsOneWidget);
+  });
+
+  testWidgets('saving persists the trimmed insurer phone numbers (#1522)', (
+    tester,
+  ) async {
+    final notifier = await pump(tester, makeDiver());
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, '24h Emergency Assistance Number'),
+      '  +49-30-555-0100  ',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Insurance Office Number'),
+      '+49-30-555-0199',
+    );
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.insurance.emergencyPhone, '+49-30-555-0100');
+    expect(notifier.updated!.insurance.phone, '+49-30-555-0199');
+  });
+
+  testWidgets('clearing an insurer phone number persists null (#1522)', (
+    tester,
+  ) async {
+    final notifier = await pump(
+      tester,
+      makeDiver(
+        insurance: const DiverInsurance(
+          provider: 'ARENA',
+          emergencyPhone: '+49-30-555-0100',
+          phone: '+49-30-555-0199',
+        ),
+      ),
+    );
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, '24h Emergency Assistance Number'),
+      '',
+    );
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.updated, isNotNull);
+    expect(notifier.updated!.insurance.emergencyPhone, isNull);
+    expect(
+      notifier.updated!.insurance.phone,
+      '+49-30-555-0199',
+      reason: 'clearing one number must not clear the other',
+    );
+  });
 }


### PR DESCRIPTION
## Summary

Fixes #1522.

The emergency card hard-coded the regional diver hotline (DAN/DES) as its single large call button. As the issue puts it, that "does not make a lot of sense if you don't have DAN": for a diver insured by anyone else, their own assistance provider is who authorizes the evacuation and coordinates the chamber referral, which is exactly the role the card's own subtitle claims for the hotline.

Insurance now carries phone numbers, and the card leads with them when they exist.

## Changes

- `DiverInsurance` gains `emergencyPhone` (24h assistance line) and `phone` (office line), plus a `callNumber` getter that prefers the assistance line and treats blank strings as absent. This mirrors the existing `EmergencyChamber.phone` / `emergencyPhone` / `callNumber` trio, which already models the same distinction elsewhere in the feature.
- **Emergency card**: when a number is recorded, the insurer becomes the primary button with the policy number repeated directly beneath it (it is the first thing an assistance line asks for), and the regional hotline drops to a tonal secondary button labelled as the fallback for when the insurer's line does not answer. With no number recorded the card renders exactly as before. A provider saved with no number now explains why it cannot lead.
- The insurance section lower down lists both numbers as tap-to-call rows.
- **Insurance edit page**: two new phone fields, assistance line first, with helper text saying it leads on the emergency card.
- **Schema v188**: `divers.insurance_emergency_phone` and `divers.insurance_phone`. Column-only rung, no backfill (nothing in an existing database can tell us an insurer's hotline). Both ALTERs are guarded independently, so an upgrade interrupted between them finishes on the next open, and the helper is also called from the `beforeOpen` backstop because a database arriving by restore or sync-adopt never runs `onUpgrade` and every diver read selects the whole row.
- Numbers round-trip through the repository and UDDF export/import. Sync needed no change: `sync_data_serializer` maps diver rows generically, so new columns ride along.
- New l10n keys translated across all 11 locales.
- Relaxes the v187 rung test's exact `currentSchemaVersion` assertion to `greaterThanOrEqualTo`, matching v184 through v186. Pinning the exact value is the newest rung's job and it moves with it; v188 now holds the pin.

## Test Plan

- [x] `flutter test` passes (23,988 tests)
- [x] `flutter analyze` passes (no issues)
- [x] Manual testing on: none. Verification is automated only, see below.

New coverage:

- `diver_insurance_test.dart`: `callNumber` preference order, blank-string handling, `copyWith`, equality.
- `migration_v188_insurance_phone_test.dart`: column creation with rows preserved, idempotency, the one-column-landed partial case, and the absent-table no-op.
- `emergency_card_page_test.dart`: six tests asserting the insurer leads, the hotline survives as a labelled fallback, the office line is used only without a 24h line, both numbers are listed, and the no-insurer path is unchanged.
- `insurance_edit_page_test.dart`: population, trimmed save, and clearing one number without clearing the other.

## Screenshots

Not captured. The layout change is: the insurer's `FilledButton` (with policy number beneath) takes the position and weight the hotline button had, and the hotline becomes a `FilledButton.tonalIcon` below it. Both subtitles state which call is which. Nothing moves when no insurer number is stored.

## Notes for review

Two judgment calls worth a second opinion:

1. **Ordering.** I put the insurer ahead of the regional hotline whenever a number exists. The reasoning is that the insurer is the party that authorizes evacuation and payment, and DAN is itself an insurer, so for DAN members the two collapse into one number anyway. If you would rather both buttons stay equally prominent, that is a small change to `_CallEmphasis`.
2. **Two fields or one.** The issue said "phone number ( or phone numbers )", and insurers universally publish a 24h assistance line separately from the office line, so I modelled both. The office field is easy to drop if you would rather keep the edit form to a single number.

The policy number deliberately appears twice when the insurer leads: once beside the call button, once in the insurance section.
