### PR TITLE
fix(sync): stop Google Drive sync using a closed HTTP client

### DIFF
--- a/lib/core/services/cloud_storage/google_drive/desktop_oauth_authenticator.dart
+++ b/lib/core/services/cloud_storage/google_drive/desktop_oauth_authenticator.dart
@@ -171,8 +171,28 @@ class DesktopOAuthAuthenticator implements GoogleDriveAuthenticator {
     }
   }
 
+  /// Single-flights [attemptSilentAuth]: the `_authClient != null` guard is
+  /// read before the token-store await, so two concurrent callers would both
+  /// get past it and both install. The second install closes the client the
+  /// first already published to the provider and the media store, and nothing
+  /// rebuilds from a still-non-null authClient -- so every later Drive call
+  /// failed with "HTTP request failed. Client is already closed." until the
+  /// process restarted.
+  ///
+  /// Two callers is the ordinary case: the Cloud Sync page fires an unawaited
+  /// refreshState() -> isAuthenticated() while a launch sync sits inside its
+  /// own isAuthenticated().
+  Future<bool>? _silentAuthInFlight;
+
   @override
-  Future<bool> attemptSilentAuth() async {
+  Future<bool> attemptSilentAuth() {
+    if (_authClient != null) return Future.value(true);
+    return _silentAuthInFlight ??= _runSilentAuth().whenComplete(
+      () => _silentAuthInFlight = null,
+    );
+  }
+
+  Future<bool> _runSilentAuth() async {
     try {
       if (_authClient != null) return true;
 

--- a/lib/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart
+++ b/lib/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart
@@ -54,8 +54,28 @@ class GoogleSignInAuthenticator implements GoogleDriveAuthenticator {
     _initialized = true;
   }
 
+  /// Single-flights [attemptSilentAuth]: the `_authClient != null` guard is
+  /// read before the SDK round trip, so two concurrent callers would both get
+  /// past it and both install. The second install closes the client the first
+  /// already published to the provider and the media store, and nothing
+  /// rebuilds from a still-non-null authClient -- so every later Drive call
+  /// failed with "HTTP request failed. Client is already closed." until the
+  /// process restarted.
+  ///
+  /// Two callers is the ordinary case: the Cloud Sync page fires an unawaited
+  /// refreshState() -> isAuthenticated() while a launch sync sits inside its
+  /// own isAuthenticated().
+  Future<bool>? _silentAuthInFlight;
+
   @override
-  Future<bool> attemptSilentAuth() async {
+  Future<bool> attemptSilentAuth() {
+    if (_authClient != null) return Future.value(true);
+    return _silentAuthInFlight ??= _runSilentAuth().whenComplete(
+      () => _silentAuthInFlight = null,
+    );
+  }
+
+  Future<bool> _runSilentAuth() async {
     try {
       if (_authClient != null) return true;
 

--- a/lib/core/services/cloud_storage/google_drive_storage_provider.dart
+++ b/lib/core/services/cloud_storage/google_drive_storage_provider.dart
@@ -56,6 +56,10 @@ class GoogleDriveStorageProvider
 
   final GoogleDriveAuthenticator _authenticator;
   drive.DriveApi? _driveApi;
+
+  /// The client [_driveApi] was built over, compared by identity so a client
+  /// swapped underneath us is never kept in use.
+  http.Client? _driveApiClient;
   drive.DriveApi? _injectedApi;
   String? _syncFolderId;
 
@@ -114,6 +118,13 @@ class GoogleDriveStorageProvider
   /// when not authenticated. Rebuilt lazily so a re-auth (new client)
   /// transparently produces a new API instance.
   ///
+  /// The cache is keyed on the client's IDENTITY, not merely on its
+  /// nullness. A re-auth closes the client it replaces, and an api cached
+  /// over that closed client kept sending through it -- "HTTP request
+  /// failed. Client is already closed." on every Drive call for the rest of
+  /// the process, while isAuthenticated() went on answering true because
+  /// authClient was non-null the whole time.
+  ///
   /// An api injected by [debugSetDriveApi] wins outright: tests exercise the
   /// transfer paths with no authenticator at all, so deriving from
   /// [GoogleDriveAuthenticator.authClient] would resolve to null and every
@@ -125,9 +136,14 @@ class GoogleDriveStorageProvider
     final client = _authenticator.authClient;
     if (client == null) {
       _driveApi = null;
+      _driveApiClient = null;
       return null;
     }
-    return _driveApi ??= drive.DriveApi(client);
+    if (_driveApi == null || !identical(client, _driveApiClient)) {
+      _driveApi = drive.DriveApi(client);
+      _driveApiClient = client;
+    }
+    return _driveApi;
   }
 
   drive.DriveApi get _requireApi {

--- a/test/core/services/cloud_storage/google_drive/desktop_oauth_authenticator_test.dart
+++ b/test/core/services/cloud_storage/google_drive/desktop_oauth_authenticator_test.dart
@@ -155,6 +155,34 @@ void main() {
     });
   });
 
+  group('silent sign-in', () {
+    test('two concurrent callers install one client and close none', () async {
+      // The `_authClient != null` guard is read BEFORE the token store await,
+      // so without single-flighting both callers get past it, both install,
+      // and the second install closes the client the first one already handed
+      // to GoogleDriveStorageProvider (and to the media store). Every later
+      // Drive call then fails with "Client is already closed" for the life of
+      // the process, because authClient is still non-null so nothing rebuilds.
+      //
+      // Two callers is the ordinary case, not a corner: the Cloud Sync page
+      // fires an unawaited refreshState() -> isAuthenticated() while a launch
+      // sync is already inside its own isAuthenticated().
+      store.stored = creds(refreshToken: 'rt-1');
+      final built = <_FakeRefreshingClient>[];
+      final auth = authenticator(builtClients: built);
+
+      final results = await Future.wait([
+        auth.attemptSilentAuth(),
+        auth.attemptSilentAuth(),
+      ]);
+
+      expect(results, [true, true]);
+      expect(built, hasLength(1), reason: 'the second caller must reuse');
+      expect(built.single.closed, isFalse);
+      expect(auth.authClient, same(built.single));
+    });
+  });
+
   group('client credentials', () {
     // Google rejects the token exchange for Desktop-app clients with
     // `invalid_request: client_secret is missing`, with or without PKCE and

--- a/test/core/services/cloud_storage/google_drive/google_sign_in_authenticator_test.dart
+++ b/test/core/services/cloud_storage/google_drive/google_sign_in_authenticator_test.dart
@@ -63,10 +63,17 @@ class _FakePlatform extends GoogleSignInPlatform
   @override
   bool authorizationRequiresUserInteraction() => false;
 
+  /// How many times a scope authorization was requested. One per installed
+  /// client, so it counts clients without reaching into the authenticator.
+  int authorizationCalls = 0;
+
   @override
   Future<ClientAuthorizationTokenData?> clientAuthorizationTokensForScopes(
     ClientAuthorizationTokensForScopesParameters params,
-  ) async => authorizationToken;
+  ) async {
+    authorizationCalls++;
+    return authorizationToken;
+  }
 
   @override
   Future<ServerAuthorizationTokenData?> serverAuthorizationTokensForScopes(
@@ -148,6 +155,30 @@ void main() {
       expect(await auth.attemptSilentAuth(), isTrue);
       expect(auth.authClient, same(first));
     });
+
+    test(
+      'two concurrent callers authorize once and install one client',
+      () async {
+        // The reuse guard above is read BEFORE the SDK round trip, so without
+        // single-flighting both callers install and the second _installClient
+        // closes the client the first already handed to the provider and to the
+        // media store. Nothing rebuilds from a still-non-null authClient, so
+        // every later Drive call fails with "Client is already closed" for the
+        // rest of the process.
+        platform.lightweightResult = _FakePlatform.resultsFor(
+          'diver@example.com',
+        );
+
+        final results = await Future.wait([
+          auth.attemptSilentAuth(),
+          auth.attemptSilentAuth(),
+        ]);
+
+        expect(results, [true, true]);
+        expect(platform.authorizationCalls, 1);
+        expect(auth.authClient, isNotNull);
+      },
+    );
 
     test('swallows platform errors and reports failure', () async {
       GoogleSignInPlatform.instance = _ThrowingInitPlatform();

--- a/test/core/services/cloud_storage/google_drive_storage_provider_auth_test.dart
+++ b/test/core/services/cloud_storage/google_drive_storage_provider_auth_test.dart
@@ -31,6 +31,9 @@ class _FakeAuthenticator implements GoogleDriveAuthenticator {
   @override
   http.Client? get authClient => _client;
 
+  /// Swaps the published client, the way a re-auth does.
+  set authClient(http.Client? client) => _client = client;
+
   @override
   Future<void> authenticate() async => authenticateCalls++;
 
@@ -177,6 +180,28 @@ void main() {
       authenticator: _FakeAuthenticator(null)..silentAuthResult = false,
     );
     expect(await unauthenticated.isAuthenticated(), isFalse);
+  });
+
+  test('a swapped auth client rebuilds the Drive api', () async {
+    // The api cache was keyed on nothing: it was dropped only when authClient
+    // read back NULL, never when it read back a DIFFERENT client. A re-auth
+    // closes the old client, so the cached api went on sending through a
+    // closed transport -- "HTTP request failed. Client is already closed." on
+    // every Drive call for the rest of the process, with isAuthenticated()
+    // still answering true.
+    await provider.listFiles(folderId: 'folder-7');
+    expect(drive_.requests, isNotEmpty);
+
+    final reauthenticated = _FakeDrive();
+    auth.authClient = reauthenticated.client();
+
+    await provider.listFiles(folderId: 'folder-7');
+
+    expect(
+      reauthenticated.requests,
+      isNotEmpty,
+      reason: 'the api must follow the authenticator to the new client',
+    );
   });
 
   test('getUserEmail delegates to the authenticator', () async {


### PR DESCRIPTION
## Summary

Google Drive sync failed permanently with the same error on every attempt:

```
Library replace failed: CloudStorageException: Get/create sync folder failed:
ClientException: HTTP request failed. Client is already closed.
```

It fired on the FIRST Drive HTTP call of an operation, kept firing until the app was
restarted, and did it while the Cloud Sync tile still showed the account as connected.
Two stacked defects produced that, and each one is why the other was invisible.

**1. `attemptSilentAuth()` was not single-flight.** Both concrete authenticators open
with `if (_authClient != null) return true;` and then await a slow round trip: the
secure-storage token load on the loopback flow, the SDK call on google_sign_in. The
guard is read before that await, so two concurrent callers both got past it, both
reached `_installClient`, and the second one's teardown closed the client the first had
already published to `GoogleDriveStorageProvider` and to the media store.

Two concurrent callers is the ordinary case here, not a corner. `cloud_sync_page.dart`
fires an unawaited `refreshState()` from a post-frame callback (which reaches
`isSyncAvailable()` and then `isAuthenticated()`), while a launch sync or a pending
Replace intent sits inside its own `isAuthenticated()`. Both hit a cold
`_authClient == null`.

**2. The provider's `DriveApi` cache had no identity key.** `_api` did
`return _driveApi ??= drive.DriveApi(client)`, which keys on the cache's own nullness
and never on the client it was derived from. The cache was dropped only when
`authClient` read back null, never when it read back a different client. So the closed
transport stayed in use for the rest of the process, and `isAuthenticated()` went on
answering true the whole time because the authenticator's client was non-null.

Fixing only the first would leave the second latent: sign-out and the 401 retry
legitimately replace the client mid-session, so the cache has to notice regardless.

## Changes

- `desktop_oauth_authenticator.dart` and `google_sign_in_authenticator.dart`: memoise
  the in-flight silent-auth future so concurrent callers share one resolution and one
  installed client. `KeychainGatedAuthenticator` already memoised its delegate
  resolution, so the macOS gate inherits this through its delegate.
- `google_drive_storage_provider.dart`: record the client `_driveApi` was built over
  and compare it with `identical()`, so a client swapped underneath is never kept in
  use. Defense in depth for any path that replaces the client, including a re-auth
  racing an in-flight call.
- Three regression tests, each watched failing first for the right reason: two clients
  built where one was expected, two SDK authorizations where one was expected, and zero
  requests reaching a swapped-in client.

## Test Plan

- [x] `flutter test` passes
- [x] `flutter analyze` passes
- [x] Manual testing on: not manually reproduced, see below

Run locally in this worktree:

- `flutter test test/core/services/cloud_storage/ test/core/services/media_store/
  test/core/services/accounts/` gives 576 passed, 1 skipped
- `flutter test test/core/services/sync/ test/features/settings/` gives 2035 passed,
  2 skipped
- `flutter analyze lib test` finds no issues, `dart format .` applied
- The pre-push hook's format, analyze, generated-l10n and affected-test checks all
  passed. That hook runs a ranked affected-test selection rather than the whole suite,
  so CI's full run is the remaining check.

The failure is a timing race, so it is not reliably reproducible by hand: the tests are
the reproduction. Each new test fails on `main` for the exact mechanism described above
and passes with the fix.

## Notes for the reviewer

The `whenComplete(() => _silentAuthInFlight = null)` on the memoised future is
deliberate. The memo has to clear when the attempt settles, so a failed silent auth
does not pin a permanent `false` and block a later retry, while still collapsing every
caller that arrives during one attempt.

A sibling defect reaches the same closed client through a different door and is left
for a separate change: `GoogleDriveMediaObjectStore` captures the client at
construction, and `mediaStoreRuntimeProvider` is invalidated only on store connect and
disconnect, so a legitimate re-auth (the 401 retry most routinely) still orphans the
client the media store is holding. Filed as #1531; the fix there is a client supplier
rather than a captured client.
