### PR TITLE
fix(media-store): resolve the Google Drive client per request, not at construction

### DIFF
--- a/lib/core/services/accounts/adapters/google_drive_account_adapter.dart
+++ b/lib/core/services/accounts/adapters/google_drive_account_adapter.dart
@@ -48,8 +48,13 @@ class GoogleDriveAccountAdapter extends AccountProviderAdapter
   Future<MediaObjectStore?> mediaObjectStore(
     domain.ConnectedAccount account,
   ) async {
-    final client = await _provider.mediaHttpClient();
-    if (client == null) return null;
-    return GoogleDriveMediaObjectStore(client: client);
+    // Probe once so an unusable Google session still yields null here,
+    // then hand the store the supplier rather than the client: the
+    // authenticator closes and replaces its client on every re-auth, and
+    // the media store runtime holding this store outlives that.
+    if (await _provider.mediaHttpClient() == null) return null;
+    return GoogleDriveMediaObjectStore(
+      clientSupplier: _provider.mediaHttpClient,
+    );
   }
 }

--- a/lib/core/services/media_store/google_drive_media_object_store.dart
+++ b/lib/core/services/media_store/google_drive_media_object_store.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:http/http.dart' as http;
 
 import 'package:submersion/core/services/media_store/media_object_store.dart';
@@ -13,15 +14,40 @@ import 'package:submersion/core/services/media_store/media_object_store.dart';
 /// photos and videos - with resume via the `Content-Range: bytes */total`
 /// probe. [chunkSizeBytes] must be a multiple of 256 KiB (Drive rule).
 class GoogleDriveMediaObjectStore implements MediaObjectStore {
+  /// [clientSupplier] is asked for the authenticator's *current* client on
+  /// every request. It must not be replaced by a captured client: the
+  /// Google authenticators close and replace theirs on every re-auth
+  /// (GoogleSignInAuthenticator._installClient / signOut /
+  /// handleAuthFailure, DesktopOAuthAuthenticator._teardownClient), and
+  /// the runtime holding this store outlives all of them, so a captured
+  /// client goes dead at the first token refresh and every later transfer
+  /// throws "Client is already closed". Null means no Google session is
+  /// available right now.
   GoogleDriveMediaObjectStore({
-    required http.Client client,
+    required Future<http.Client?> Function() clientSupplier,
     this.folderName = 'submersion-media',
     this.chunkSizeBytes = 8 * 1024 * 1024,
     String apiBase = 'https://www.googleapis.com',
-  }) : _client = client,
+  }) : _clientSupplier = clientSupplier,
        _apiBase = apiBase;
 
-  final http.Client _client;
+  /// For tests and any caller that owns the client's lifetime outright.
+  /// Production callers must use the default constructor so the store
+  /// follows re-auth.
+  @visibleForTesting
+  GoogleDriveMediaObjectStore.withClient(
+    http.Client client, {
+    String folderName = 'submersion-media',
+    int chunkSizeBytes = 8 * 1024 * 1024,
+    String apiBase = 'https://www.googleapis.com',
+  }) : this(
+         clientSupplier: () async => client,
+         folderName: folderName,
+         chunkSizeBytes: chunkSizeBytes,
+         apiBase: apiBase,
+       );
+
+  final Future<http.Client?> Function() _clientSupplier;
   final String folderName;
   final int chunkSizeBytes;
   final String _apiBase;
@@ -333,8 +359,9 @@ class GoogleDriveMediaObjectStore implements MediaObjectStore {
   }
 
   Future<http.Response> _send(http.Request request) async {
+    final client = await _resolveClient();
     try {
-      return await http.Response.fromStream(await _client.send(request));
+      return await http.Response.fromStream(await client.send(request));
     } on Exception catch (e) {
       throw MediaStoreException(
         'Could not reach Google Drive',
@@ -342,6 +369,29 @@ class GoogleDriveMediaObjectStore implements MediaObjectStore {
         cause: e,
       );
     }
+  }
+
+  /// The authenticator's client as of right now. Resolved per request so a
+  /// re-auth that swapped the client is picked up transparently; see the
+  /// constructor.
+  Future<http.Client> _resolveClient() async {
+    final http.Client? client;
+    try {
+      client = await _clientSupplier();
+    } on Exception catch (e) {
+      throw MediaStoreException(
+        'Could not reach Google Drive',
+        kind: MediaStoreErrorKind.transient,
+        cause: e,
+      );
+    }
+    if (client == null) {
+      throw const MediaStoreException(
+        'No Google Drive session; sign in again',
+        kind: MediaStoreErrorKind.auth,
+      );
+    }
+    return client;
   }
 
   MediaStoreException _forStatus(

--- a/lib/features/media_store/data/media_store_service.dart
+++ b/lib/features/media_store/data/media_store_service.dart
@@ -57,9 +57,14 @@ Future<MediaObjectStore?> buildMediaObjectStore(
       final provider =
           cloudProviderInstanceFor(CloudProviderType.googledrive)
               as GoogleDriveStorageProvider;
-      final client = await provider.mediaHttpClient();
-      if (client == null) return null;
-      return GoogleDriveMediaObjectStore(client: client);
+      // Probe once for "is there a session at all", then let the store
+      // resolve the client per request: the authenticator closes and
+      // replaces its client on every re-auth and this store is cached in a
+      // long-lived runtime.
+      if (await provider.mediaHttpClient() == null) return null;
+      return GoogleDriveMediaObjectStore(
+        clientSupplier: provider.mediaHttpClient,
+      );
     case CloudProviderType.icloud:
       final availability = await ICloudNativeService.getAvailability();
       if (availability != ICloudAvailability.available) return null;

--- a/test/core/services/accounts/adapters/google_drive_account_adapter_test.dart
+++ b/test/core/services/accounts/adapters/google_drive_account_adapter_test.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/accounts/adapters/google_drive_account_adapter.dart';
+import 'package:submersion/core/services/accounts/connected_account.dart'
+    as domain;
+import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_authenticator.dart';
+import 'package:submersion/core/services/cloud_storage/google_drive_storage_provider.dart';
+
+import '../../../../helpers/fake_drive_server.dart';
+import '../../../../helpers/revocable_client.dart';
+
+/// Covers the media-store half of the adapter: that it declines when there
+/// is no Google session, and that the store it hands back keeps working
+/// after the authenticator swaps its client.
+class _FakeAuthenticator implements GoogleDriveAuthenticator {
+  _FakeAuthenticator(this.client);
+
+  /// The currently published client, replaced wholesale on re-auth exactly
+  /// as GoogleSignInAuthenticator._installClient does.
+  http.Client? client;
+  bool silentAuthResult = true;
+
+  @override
+  http.Client? get authClient => client;
+
+  @override
+  Future<void> authenticate() async {}
+
+  @override
+  Future<bool> attemptSilentAuth() async => silentAuthResult;
+
+  @override
+  Future<void> handleAuthFailure() async {}
+
+  @override
+  Future<void> signOut() async => client = null;
+
+  @override
+  Future<String?> get userEmail async => 'diver@example.com';
+}
+
+void main() {
+  late Directory tmp;
+  late FakeDriveServer server;
+  late _FakeAuthenticator authenticator;
+  late GoogleDriveAccountAdapter adapter;
+
+  final account = domain.ConnectedAccount(
+    id: 'acc-gd',
+    kind: AccountKind.googledrive,
+    label: 'Google Drive',
+    createdAt: DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+    updatedAt: DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+  );
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('gdrive_adapter_test');
+    server = FakeDriveServer();
+    authenticator = _FakeAuthenticator(RevocableClient(server.client));
+    adapter = GoogleDriveAccountAdapter(
+      provider: GoogleDriveStorageProvider(authenticator: authenticator),
+    );
+  });
+
+  tearDown(() => tmp.delete(recursive: true));
+
+  test('mediaObjectStore declines when there is no Google session', () async {
+    authenticator
+      ..client = null
+      ..silentAuthResult = false;
+    expect(await adapter.mediaObjectStore(account), isNull);
+  });
+
+  test('the store it returns survives a re-auth that swaps the '
+      'client', () async {
+    final store = (await adapter.mediaObjectStore(account))!;
+    final src = File('${tmp.path}/a.jpg')..writeAsBytesSync([1, 2, 3]);
+    await store.putFile(
+      'smv1/objects/aa/before.jpg',
+      src,
+      contentType: 'image/jpeg',
+    );
+
+    // The 401 retry path: the old client is closed, a fresh one published.
+    // A store that captured the client at construction dies here.
+    authenticator.client!.close();
+    authenticator.client = RevocableClient(server.client);
+
+    await store.putFile(
+      'smv1/objects/aa/after.jpg',
+      src,
+      contentType: 'image/jpeg',
+    );
+
+    expect(
+      server.filesById.values.map((f) => f.name),
+      containsAll(<String>[
+        'smv1/objects/aa/before.jpg',
+        'smv1/objects/aa/after.jpg',
+      ]),
+    );
+  });
+}

--- a/test/core/services/media_store/google_drive_media_object_store_test.dart
+++ b/test/core/services/media_store/google_drive_media_object_store_test.dart
@@ -4,10 +4,12 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
 import 'package:http/http.dart' as http;
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/media_store/google_drive_media_object_store.dart';
 import 'package:submersion/core/services/media_store/media_object_store.dart';
 
 import '../../../helpers/fake_drive_server.dart';
+import '../../../helpers/revocable_client.dart';
 import 'media_object_store_contract.dart';
 
 void main() {
@@ -229,7 +231,7 @@ void main() {
 
   test('a re-auth that closes and replaces the client is followed on the '
       'next request', () async {
-    var live = _RevocableClient(server.client);
+    var live = RevocableClient(server.client);
     final store = GoogleDriveMediaObjectStore(
       clientSupplier: () async => live,
       apiBase: 'https://fake.googleapis.test',
@@ -245,7 +247,7 @@ void main() {
     // the routine trigger): close the published client, then publish a
     // fresh one for the same account.
     live.close();
-    live = _RevocableClient(server.client);
+    live = RevocableClient(server.client);
 
     await store.putFile(
       'smv1/objects/aa/after.jpg',
@@ -259,6 +261,48 @@ void main() {
         'smv1/objects/aa/before.jpg',
         'smv1/objects/aa/after.jpg',
       ]),
+    );
+  });
+
+  test('a client closed with no replacement surfaces as a transient '
+      'transport failure', () async {
+    // The re-auth that never lands: the authenticator tore its client down
+    // and no fresh one arrived. This is the exact shape of the bug the
+    // supplier exists to prevent, so pin the symptom as well as the kind.
+    final dead = RevocableClient(server.client)..close();
+    final store = GoogleDriveMediaObjectStore(
+      clientSupplier: () async => dead,
+      apiBase: 'https://fake.googleapis.test',
+    );
+    await expectLater(
+      store.head('smv1/objects/aa/x.jpg'),
+      throwsA(
+        isA<MediaStoreException>()
+            .having((e) => e.kind, 'kind', MediaStoreErrorKind.transient)
+            .having(
+              (e) => (e.cause as http.ClientException).message,
+              'cause',
+              contains('Client is already closed'),
+            ),
+      ),
+    );
+  });
+
+  test('a supplier that fails to produce a client is transient', () async {
+    final store = GoogleDriveMediaObjectStore(
+      clientSupplier: () async =>
+          throw const CloudStorageException('silent auth exploded'),
+      apiBase: 'https://fake.googleapis.test',
+    );
+    await expectLater(
+      store.head('smv1/objects/aa/x.jpg'),
+      throwsA(
+        isA<MediaStoreException>().having(
+          (e) => e.kind,
+          'kind',
+          MediaStoreErrorKind.transient,
+        ),
+      ),
     );
   });
 
@@ -278,32 +322,4 @@ void main() {
       ),
     );
   });
-}
-
-/// A transport with the real `IOClient` lifecycle: every request after
-/// [close] throws, exactly as the authenticator's client does once a
-/// re-auth has torn it down. `MockClient` alone cannot model this - its
-/// inherited `close` is a no-op, so a closed one keeps answering.
-class _RevocableClient extends http.BaseClient {
-  _RevocableClient(this._inner);
-
-  final http.Client _inner;
-  bool _closed = false;
-
-  @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) {
-    if (_closed) {
-      throw http.ClientException(
-        'HTTP request failed. Client is already closed.',
-        request.url,
-      );
-    }
-    return _inner.send(request);
-  }
-
-  @override
-  void close() {
-    _closed = true;
-    _inner.close();
-  }
 }

--- a/test/core/services/media_store/google_drive_media_object_store_test.dart
+++ b/test/core/services/media_store/google_drive_media_object_store_test.dart
@@ -15,8 +15,8 @@ void main() {
   late FakeDriveServer server;
 
   GoogleDriveMediaObjectStore build({int? chunkSizeBytes}) {
-    return GoogleDriveMediaObjectStore(
-      client: server.client,
+    return GoogleDriveMediaObjectStore.withClient(
+      server.client,
       chunkSizeBytes: chunkSizeBytes ?? 8 * 1024 * 1024,
       apiBase: 'https://fake.googleapis.test',
     );
@@ -173,8 +173,8 @@ void main() {
 
   test('a 5xx from Drive surfaces as MediaStoreException on every '
       'verb', () async {
-    final store = GoogleDriveMediaObjectStore(
-      client: MockClient(
+    final store = GoogleDriveMediaObjectStore.withClient(
+      MockClient(
         (_) async => http.Response('{"error":{"message":"boom"}}', 500),
       ),
       apiBase: 'https://fake.googleapis.test',
@@ -226,4 +226,84 @@ void main() {
       0,
     );
   });
+
+  test('a re-auth that closes and replaces the client is followed on the '
+      'next request', () async {
+    var live = _RevocableClient(server.client);
+    final store = GoogleDriveMediaObjectStore(
+      clientSupplier: () async => live,
+      apiBase: 'https://fake.googleapis.test',
+    );
+    final src = File('${tmp.path}/reauth.jpg')..writeAsBytesSync([7, 7, 7]);
+    await store.putFile(
+      'smv1/objects/aa/before.jpg',
+      src,
+      contentType: 'image/jpeg',
+    );
+
+    // What the authenticator does on every re-auth (the 401 retry being
+    // the routine trigger): close the published client, then publish a
+    // fresh one for the same account.
+    live.close();
+    live = _RevocableClient(server.client);
+
+    await store.putFile(
+      'smv1/objects/aa/after.jpg',
+      src,
+      contentType: 'image/jpeg',
+    );
+
+    expect(
+      server.filesById.values.map((f) => f.name),
+      containsAll(<String>[
+        'smv1/objects/aa/before.jpg',
+        'smv1/objects/aa/after.jpg',
+      ]),
+    );
+  });
+
+  test('a supplier with no Google session fails as an auth error', () async {
+    final store = GoogleDriveMediaObjectStore(
+      clientSupplier: () async => null,
+      apiBase: 'https://fake.googleapis.test',
+    );
+    await expectLater(
+      store.head('smv1/objects/aa/x.jpg'),
+      throwsA(
+        isA<MediaStoreException>().having(
+          (e) => e.kind,
+          'kind',
+          MediaStoreErrorKind.auth,
+        ),
+      ),
+    );
+  });
+}
+
+/// A transport with the real `IOClient` lifecycle: every request after
+/// [close] throws, exactly as the authenticator's client does once a
+/// re-auth has torn it down. `MockClient` alone cannot model this - its
+/// inherited `close` is a no-op, so a closed one keeps answering.
+class _RevocableClient extends http.BaseClient {
+  _RevocableClient(this._inner);
+
+  final http.Client _inner;
+  bool _closed = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    if (_closed) {
+      throw http.ClientException(
+        'HTTP request failed. Client is already closed.',
+        request.url,
+      );
+    }
+    return _inner.send(request);
+  }
+
+  @override
+  void close() {
+    _closed = true;
+    _inner.close();
+  }
 }

--- a/test/helpers/revocable_client.dart
+++ b/test/helpers/revocable_client.dart
@@ -1,0 +1,35 @@
+import 'package:http/http.dart' as http;
+
+/// A transport with the real [http.IOClient] lifecycle: every request after
+/// [close] throws, exactly as an authenticator's client does once a re-auth
+/// has torn it down.
+///
+/// `MockClient` cannot model this on its own. It does not override `close`,
+/// so it inherits `BaseClient`'s no-op and a "closed" MockClient keeps
+/// answering requests - which would let a captured-client bug pass a test
+/// silently. Wrap the fake in one of these and close the wrapper instead.
+class RevocableClient extends http.BaseClient {
+  RevocableClient(this._inner);
+
+  final http.Client _inner;
+  bool _closed = false;
+
+  bool get isClosed => _closed;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    if (_closed) {
+      throw http.ClientException(
+        'HTTP request failed. Client is already closed.',
+        request.url,
+      );
+    }
+    return _inner.send(request);
+  }
+
+  @override
+  void close() {
+    _closed = true;
+    _inner.close();
+  }
+}


### PR DESCRIPTION
## Summary

`GoogleDriveMediaObjectStore` captured the Google authenticator's shared auth client at construction (`required http.Client client` stored in `final http.Client _client`) and held it for the store's lifetime. That client is replaceable state, not a stable dependency: the authenticators close and replace theirs on every re-auth, in `GoogleSignInAuthenticator._installClient` / `signOut` / `handleAuthFailure` and `DesktopOAuthAuthenticator._teardownClient`. The routine trigger is the 401 retry in `GoogleDriveStorageProvider._run`, which calls `handleAuthFailure()` and then installs a fresh client.

The store outlives all of that. `mediaStoreRuntimeProvider` is documented as imperatively invalidated only on store connect and disconnect, so after any re-auth the cached runtime kept sending through a closed transport, and every Drive media transfer failed with `ClientException: HTTP request failed. Client is already closed.` until the provider was invalidated or the app restarted.

The store now takes a `Future<http.Client?> Function()` supplier and resolves it in `_send`, so it always follows the authenticator's current client. This mirrors `DropboxApiClient`, which resolves its bearer through a `getAccessToken` callback for exactly the same reason; `S3MediaObjectStore` has no equivalent problem because it builds its own client from static config.

This is the media-store half of the problem. The sibling bug (concurrent `attemptSilentAuth()` installing two clients and closing one that was already published, plus `GoogleDriveStorageProvider`'s DriveApi cache not being keyed to client identity) is fixed separately on `claude/submersion-google-drive-sync-82573d`.

## Changes

- `lib/core/services/media_store/google_drive_media_object_store.dart`: `_client` becomes `_clientSupplier`, resolved per request by a new `_resolveClient()` that `_send` calls. A `.withClient` named constructor, marked `@visibleForTesting`, keeps the fixed-client shape available to tests and makes a production caller that captures a client fail analysis.
- A supplier that yields no session is now an `auth`-kind `MediaStoreException` instead of a transport error wrapped as `transient`. That reclassification matters: `transient` is the retry-forever bucket, so a dead client used to wedge the transfer queue rather than surfacing "sign in again".
- `lib/core/services/accounts/adapters/google_drive_account_adapter.dart` and `lib/features/media_store/data/media_store_service.dart`: both keep their "no session, no store" probe, then pass the `provider.mediaHttpClient` tear-off instead of a resolved client.
- `test/core/services/media_store/google_drive_media_object_store_test.dart`: two new tests plus a `_RevocableClient` helper; existing constructions moved to `.withClient`.

## Notes for reviewers

**The probe is still cheap on the hot path.** `mediaHttpClient()` calls `isAuthenticated()`, which short-circuits on `_api != null`, so a healthy session is a field read. Only a torn-down authenticator pays for `attemptSilentAuth()`, which is the right thing to do at that point anyway: it either recovers the session or reports an auth failure, both strictly better than sending through a dead client.

**Re-auth is now picked up mid-upload.** Large uploads chunk through `_send`, so a token refresh between chunks is followed transparently. That composes correctly with Drive's resumable protocol: the session URI is pre-authorized and independent of the bearer, so only the credential changes and the byte offset survives.

**Test approach.** `MockClient.close()` is a no-op (it inherits `BaseClient.close()`); only `IOClient` throws `'HTTP request failed. Client is already closed.'` afterwards. A test that just called `close()` on a `MockClient` would therefore pass against the buggy code. The new test drives a `_RevocableClient` wrapper reproducing the real `IOClient` lifecycle, closes and swaps it the way a re-auth does, and asserts the next request reaches the new client. The same `FakeDriveServer` stays behind the wrapper across the swap so a stale `_folderId` cache cannot confound the assertion.

Written test-first: the reproduction was confirmed red against the old API with the real production failure (`MediaStoreException(transient): Could not reach Google Drive`, thrown from `_findByKey` -> `_query` -> `_send`, since `putFile` opens with a metadata query and dies before a byte moves), then red again as a compile failure against the new API, then green.

**Left alone as out of scope:** `_folderId` is still cached for the store's lifetime. That is correct across a re-auth (same account, same folder), and a sign-out invalidates the runtime so a new store is built, but it does mean the cache's correctness depends on that invalidation, which is the same coupling that caused this bug.

## Test Plan

- [x] `flutter test` passes: 23971 passed, 21 skipped, 0 failed
- [x] `flutter analyze` passes: no issues found
- [x] Manual testing on: not run. The failure path needs a live Google session and a token refresh (or a forced 401) to reproduce, so it is covered by the automated re-auth test rather than by hand.
