### PR TITLE
fix(ui): respect the diver's date format everywhere (#1512)

### DIFF
--- a/lib/core/utils/unit_formatter.dart
+++ b/lib/core/utils/unit_formatter.dart
@@ -509,6 +509,26 @@ class UnitFormatter {
   static String weekdayMonthDayPattern(DateFormatPreference dateFormat) =>
       'EEE, ${monthDayPattern(dateFormat)}';
 
+  /// Narrow all-numeric month and day, in [dateFormat]'s order and with its
+  /// own separator: 'M/d', 'd/M', 'M-d' or 'd.M'.
+  ///
+  /// For the cramped surfaces that cannot afford a spelled month, above all a
+  /// chart axis, where a wide label is what crowds the ticks. Derived from the
+  /// pattern rather than from [DateFormatPreference.isDayFirst], which is also
+  /// true for the ISO preference: reading that flag alone hands an ISO diver a
+  /// day-first '8/10' and drops the dotted preference's dots.
+  static String numericMonthDayPattern(DateFormatPreference dateFormat) =>
+      dateFormat.pattern
+          // The year and the separator that binds it to its neighbour.
+          .replaceFirst(RegExp(r'y+[^A-Za-z]+'), '')
+          .replaceFirst(RegExp(r'[^A-Za-z]+y+$'), '')
+          // Narrowest numeric form of whichever tokens are left.
+          .replaceFirst(RegExp(r'M+'), 'M')
+          .replaceFirst(RegExp(r'd+'), 'd')
+          // A space or comma is what the spelled-out preferences separate
+          // with, and neither reads as a date once the month is a digit.
+          .replaceFirst(RegExp(r'[,\s]+'), '/');
+
   /// `DateFormat` pattern for a bare month and year in [dateFormat]'s shape.
   ///
   /// Derived by dropping the day token and the separator that binds it to its

--- a/lib/core/utils/unit_formatter.dart
+++ b/lib/core/utils/unit_formatter.dart
@@ -509,6 +509,26 @@ class UnitFormatter {
   static String weekdayMonthDayPattern(DateFormatPreference dateFormat) =>
       'EEE, ${monthDayPattern(dateFormat)}';
 
+  /// `DateFormat` pattern for a bare month and year in [dateFormat]'s shape.
+  ///
+  /// Derived by dropping the day token and the separator that binds it to its
+  /// neighbour, so every preference keeps its own punctuation and ordering:
+  /// 'MM/dd/yyyy' and 'dd/MM/yyyy' both collapse to 'MM/yyyy', 'yyyy-MM-dd' to
+  /// 'yyyy-MM', and the spelled-out forms to 'MMM yyyy'.
+  static String monthYearPattern(DateFormatPreference dateFormat) => dateFormat
+      .pattern
+      // A day followed by its separator: 'dd/', 'd ', 'd, '.
+      .replaceFirst(RegExp(r'd+[^A-Za-z]+'), '')
+      // Or a trailing day preceded by its separator: '-dd'.
+      .replaceFirst(RegExp(r'[^A-Za-z]+d+$'), '');
+
+  /// Format month and year only, in the diver's date shape.
+  /// Example: "Mar 2026", "03/2026" or "2026-03"
+  String formatMonthYear(DateTime? dateTime) {
+    if (dateTime == null) return '--';
+    return DateFormat(monthYearPattern(settings.dateFormat)).format(dateTime);
+  }
+
   /// Format month and day only (respects day-first vs month-first preference)
   /// Example: "Jan 15" or "15 Jan"
   String formatMonthDay(DateTime? dateTime) {

--- a/lib/features/backup/presentation/widgets/backup_history_tile.dart
+++ b/lib/features/backup/presentation/widgets/backup_history_tile.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/features/backup/presentation/widgets/pre_migration_badge.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Renders a single row in the backup history list.
 ///
-/// Pure presentation + callbacks; no Riverpod/provider coupling, so it
-/// can be tested in isolation.
-class BackupHistoryTile extends StatelessWidget {
+/// Presentation + callbacks only. It reads [settingsProvider] so the backup
+/// timestamp honours the diver's date and time format preferences, so a
+/// `ProviderScope` must be in the tree above it.
+class BackupHistoryTile extends ConsumerWidget {
   final BackupRecord record;
   final IconData leadingIcon;
   final VoidCallback onPinToggle;
@@ -27,9 +30,9 @@ class BackupHistoryTile extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
-    final dateFormat = DateFormat.yMMMd().add_jm();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return ListTile(
       leading: Icon(leadingIcon),
@@ -38,7 +41,7 @@ class BackupHistoryTile extends StatelessWidget {
         children: [
           Flexible(
             child: Text(
-              dateFormat.format(record.timestamp),
+              units.formatDateTime(record.timestamp, l10n: context.l10n),
               overflow: TextOverflow.ellipsis,
             ),
           ),

--- a/lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart
+++ b/lib/features/backup/presentation/widgets/restore_confirmation_dialog.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Confirmation dialog shown before restoring from a backup.
@@ -14,7 +16,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// replacing the library everywhere; Replace requires a second confirmation.
 /// For pre-migration backups, branches on schema version compatibility
 /// (those emergency flows always restore in merge mode).
-class RestoreConfirmationDialog extends StatefulWidget {
+class RestoreConfirmationDialog extends ConsumerStatefulWidget {
   final BackupRecord record;
   final int currentSchemaVersion;
   final bool offerReplace;
@@ -44,11 +46,12 @@ class RestoreConfirmationDialog extends StatefulWidget {
   }
 
   @override
-  State<RestoreConfirmationDialog> createState() =>
+  ConsumerState<RestoreConfirmationDialog> createState() =>
       _RestoreConfirmationDialogState();
 }
 
-class _RestoreConfirmationDialogState extends State<RestoreConfirmationDialog> {
+class _RestoreConfirmationDialogState
+    extends ConsumerState<RestoreConfirmationDialog> {
   RestoreMode _mode = RestoreMode.merge;
 
   @override
@@ -61,7 +64,7 @@ class _RestoreConfirmationDialogState extends State<RestoreConfirmationDialog> {
 
   Widget _buildManual(BuildContext context) {
     final theme = Theme.of(context);
-    final dateFormat = DateFormat.yMMMd().add_jm();
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final record = widget.record;
 
     return AlertDialog(
@@ -82,7 +85,7 @@ class _RestoreConfirmationDialogState extends State<RestoreConfirmationDialog> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    dateFormat.format(record.timestamp),
+                    units.formatDateTime(record.timestamp, l10n: context.l10n),
                     style: theme.textTheme.titleSmall,
                   ),
                   const SizedBox(height: 4),
@@ -239,13 +242,13 @@ class _RestoreConfirmationDialogState extends State<RestoreConfirmationDialog> {
   Widget _buildPreMigration(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
-    final dateFormat = DateFormat.yMMMd().add_jm();
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final record = widget.record;
     final fromSchemaVersion = record.fromSchemaVersion;
     final toSchemaVersion = record.toSchemaVersion;
     final appVersion =
         record.appVersion ?? l10n.backup_restore_preMigration_unknownVersion;
-    final timestamp = dateFormat.format(record.timestamp);
+    final timestamp = units.formatDateTime(record.timestamp, l10n: l10n);
 
     if (fromSchemaVersion == null || toSchemaVersion == null) {
       return AlertDialog(

--- a/lib/features/buddies/presentation/pages/buddy_detail_page.dart
+++ b/lib/features/buddies/presentation/pages/buddy_detail_page.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:submersion/shared/widgets/profile_photo/profile_avatar.dart';
 import 'package:submersion/features/certifications/domain/certification_title.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/export_destination_sheet.dart';
@@ -120,6 +120,7 @@ class _BuddyDetailContent extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final statsAsync = ref.watch(buddyStatsProvider(buddy.id));
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     final body = SingleChildScrollView(
       controller: DetailScrollController.maybeOf(context),
@@ -143,7 +144,7 @@ class _BuddyDetailContent extends ConsumerWidget {
           const SizedBox(height: 24),
 
           // Statistics
-          _buildStatsSection(context, statsAsync),
+          _buildStatsSection(context, statsAsync, units),
           const SizedBox(height: 24),
 
           // Notes
@@ -512,6 +513,7 @@ class _BuddyDetailContent extends ConsumerWidget {
   Widget _buildStatsSection(
     BuildContext context,
     AsyncValue<BuddyStats> statsAsync,
+    UnitFormatter units,
   ) {
     return Card(
       child: Padding(
@@ -538,13 +540,13 @@ class _BuddyDetailContent extends ConsumerWidget {
                     _StatRow(
                       icon: Icons.first_page,
                       label: context.l10n.buddies_stat_firstDive,
-                      value: DateFormat.yMMMd().format(stats.firstDive!),
+                      value: units.formatDate(stats.firstDive),
                     ),
                   if (stats.lastDive != null)
                     _StatRow(
                       icon: Icons.last_page,
                       label: context.l10n.buddies_stat_lastDive,
-                      value: DateFormat.yMMMd().format(stats.lastDive!),
+                      value: units.formatDate(stats.lastDive),
                     ),
                   if (stats.favoriteSite != null)
                     _StatRow(
@@ -592,7 +594,7 @@ class _BuddyDetailContent extends ConsumerWidget {
     final theme = Theme.of(context);
     // Includes the year: shared dives routinely span several years, so a bare
     // "Mar 28" is ambiguous (#982). Matches the stats card above.
-    final dateFormat = DateFormat.yMMMd();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Card(
       child: Padding(
@@ -696,7 +698,7 @@ class _BuddyDetailContent extends ConsumerWidget {
                                     ),
                                     const SizedBox(height: 2),
                                     Text(
-                                      dateFormat.format(dive.dateTime),
+                                      units.formatDate(dive.dateTime),
                                       style: theme.textTheme.bodySmall
                                           ?.copyWith(
                                             color: theme

--- a/lib/features/certifications/domain/constants/certification_field.dart
+++ b/lib/features/certifications/domain/constants/certification_field.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart' show DateFormat;
 
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -181,8 +180,6 @@ class CertificationFieldAdapter
     return map;
   }();
 
-  static final DateFormat _dateFormat = DateFormat.yMMMd();
-
   @override
   List<CertificationField> get allFields => _allFields;
 
@@ -220,8 +217,8 @@ class CertificationFieldAdapter
       // displayName, not name: the latter is the enum identifier, so the
       // column read "openWater" rather than "Open Water".
       CertificationField.level => (value as CertificationLevel).displayName,
-      CertificationField.issueDate => _dateFormat.format(value as DateTime),
-      CertificationField.expiryDate => _dateFormat.format(value as DateTime),
+      CertificationField.issueDate => units.formatDate(value as DateTime),
+      CertificationField.expiryDate => units.formatDate(value as DateTime),
       _ => value is String ? (value.isEmpty ? '--' : value) : value.toString(),
     };
   }

--- a/lib/features/certifications/presentation/pages/certification_detail_page.dart
+++ b/lib/features/certifications/presentation/pages/certification_detail_page.dart
@@ -3,9 +3,10 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
@@ -119,6 +120,7 @@ class _CertificationDetailContent extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final body = SingleChildScrollView(
       controller: DetailScrollController.maybeOf(context),
       padding: const EdgeInsets.all(16),
@@ -126,7 +128,7 @@ class _CertificationDetailContent extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // Status banner
-          _buildStatusBanner(context),
+          _buildStatusBanner(context, units),
           const SizedBox(height: 24),
 
           // Header with agency logo
@@ -138,7 +140,7 @@ class _CertificationDetailContent extends ConsumerWidget {
           const SizedBox(height: 16),
 
           // Dates
-          _buildDatesSection(context),
+          _buildDatesSection(context, units),
           const SizedBox(height: 16),
 
           // Instructor info
@@ -325,11 +327,11 @@ class _CertificationDetailContent extends ConsumerWidget {
     }
   }
 
-  Widget _buildStatusBanner(BuildContext context) {
+  Widget _buildStatusBanner(BuildContext context, UnitFormatter units) {
     if (certification.isExpired) {
       return Semantics(
         label:
-            'Warning: This certification has expired${certification.expiryDate != null ? ' on ${DateFormat.yMMMd().format(certification.expiryDate!)}' : ''}',
+            'Warning: This certification has expired${certification.expiryDate != null ? ' on ${units.formatDate(certification.expiryDate)}' : ''}',
         child: Container(
           width: double.infinity,
           padding: const EdgeInsets.all(12),
@@ -356,7 +358,7 @@ class _CertificationDetailContent extends ConsumerWidget {
                     if (certification.expiryDate != null)
                       Text(
                         context.l10n.certifications_detail_status_expiredOn(
-                          DateFormat.yMMMd().format(certification.expiryDate!),
+                          units.formatDate(certification.expiryDate),
                         ),
                         style: TextStyle(
                           color: Colors.red.withValues(alpha: 0.8),
@@ -374,7 +376,7 @@ class _CertificationDetailContent extends ConsumerWidget {
       final days = certification.daysUntilExpiry ?? 0;
       return Semantics(
         label:
-            'Warning: Certification expires in $days days${certification.expiryDate != null ? ' on ${DateFormat.yMMMd().format(certification.expiryDate!)}' : ''}',
+            'Warning: Certification expires in $days days${certification.expiryDate != null ? ' on ${units.formatDate(certification.expiryDate)}' : ''}',
         child: Container(
           width: double.infinity,
           padding: const EdgeInsets.all(12),
@@ -403,7 +405,7 @@ class _CertificationDetailContent extends ConsumerWidget {
                     if (certification.expiryDate != null)
                       Text(
                         context.l10n.certifications_detail_status_expiresOn(
-                          DateFormat.yMMMd().format(certification.expiryDate!),
+                          units.formatDate(certification.expiryDate),
                         ),
                         style: TextStyle(
                           color: Colors.orange.withValues(alpha: 0.8),
@@ -511,7 +513,7 @@ class _CertificationDetailContent extends ConsumerWidget {
     );
   }
 
-  Widget _buildDatesSection(BuildContext context) {
+  Widget _buildDatesSection(BuildContext context, UnitFormatter units) {
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -529,13 +531,13 @@ class _CertificationDetailContent extends ConsumerWidget {
               _InfoRow(
                 icon: Icons.event_available,
                 label: context.l10n.certifications_detail_label_issueDate,
-                value: DateFormat.yMMMd().format(certification.issueDate!),
+                value: units.formatDate(certification.issueDate),
               ),
             if (certification.expiryDate != null)
               _InfoRow(
                 icon: Icons.event_busy,
                 label: context.l10n.certifications_detail_label_expiryDate,
-                value: DateFormat.yMMMd().format(certification.expiryDate!),
+                value: units.formatDate(certification.expiryDate),
                 valueColor: certification.isExpired
                     ? Colors.red
                     : certification.expiresWithin(90)

--- a/lib/features/certifications/presentation/pages/certification_edit_page.dart
+++ b/lib/features/certifications/presentation/pages/certification_edit_page.dart
@@ -5,8 +5,9 @@ import 'package:image_picker/image_picker.dart';
 import 'package:submersion/core/services/images/profile_photo_codec.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/core/constants/certification_levels.dart';
 import 'package:submersion/core/constants/enums.dart';
@@ -1044,7 +1045,7 @@ class _CertificationEditPageState extends ConsumerState<CertificationEditPage> {
   }
 }
 
-class _DatePickerField extends StatelessWidget {
+class _DatePickerField extends ConsumerWidget {
   final String label;
   final DateTime? value;
   final IconData icon;
@@ -1060,14 +1061,15 @@ class _DatePickerField extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final units = UnitFormatter(ref.watch(settingsProvider));
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Semantics(
           button: true,
           label: value != null
-              ? '$label: ${DateFormat.yMMMd().format(value!)}. Tap to change'
+              ? '$label: ${units.formatDate(value)}. Tap to change'
               : '$label: not set. Tap to select',
           child: InkWell(
             onTap: () => _pickDate(context),
@@ -1086,7 +1088,7 @@ class _DatePickerField extends StatelessWidget {
               ),
               child: Text(
                 value != null
-                    ? DateFormat.yMMMd().format(value!)
+                    ? units.formatDate(value)
                     : context.l10n.certifications_edit_datePicker_tapToSelect,
                 style: TextStyle(
                   color: value != null

--- a/lib/features/certifications/presentation/widgets/certification_ecard_front.dart
+++ b/lib/features/certifications/presentation/widgets/certification_ecard_front.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:submersion/core/utils/unit_formatter.dart';
-import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/certifications/domain/entities/certification.dart';
 import 'package:submersion/features/certifications/domain/certification_title.dart';
@@ -12,7 +10,7 @@ import 'package:submersion/features/certifications/presentation/widgets/certific
 ///
 /// Shows the uploaded front photo when the diver captured one, otherwise a
 /// generated card in the issuing agency's colours.
-class CertificationEcardFront extends ConsumerWidget {
+class CertificationEcardFront extends StatelessWidget {
   /// The certification to display.
   final Certification certification;
 
@@ -26,8 +24,7 @@ class CertificationEcardFront extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final units = UnitFormatter(ref.watch(settingsProvider));
+  Widget build(BuildContext context) {
     final photo = certification.photoFront;
     if (photo != null) {
       return CertificationCardPhoto(
@@ -36,7 +33,7 @@ class CertificationEcardFront extends ConsumerWidget {
         infoLines: _buildInfoLines(),
       );
     }
-    return _buildGeneratedFront(context, units);
+    return _buildGeneratedFront(context);
   }
 
   /// Lines repeated over a photographed card.
@@ -62,7 +59,7 @@ class CertificationEcardFront extends ConsumerWidget {
     return [if (headline.isNotEmpty) headline, if (detail.isNotEmpty) detail];
   }
 
-  Widget _buildGeneratedFront(BuildContext context, UnitFormatter units) {
+  Widget _buildGeneratedFront(BuildContext context) {
     final agency = certification.agency;
 
     return Container(
@@ -107,7 +104,7 @@ class CertificationEcardFront extends ConsumerWidget {
                 // narrow phone. The header and grid are the facts a dive
                 // operator reads, so they keep their intrinsic height.
                 Flexible(child: _buildHero()),
-                _buildFieldGrid(context, units),
+                _buildFieldGrid(context),
               ],
             ),
           ),
@@ -181,8 +178,8 @@ class CertificationEcardFront extends ConsumerWidget {
   /// Cells with no value are dropped rather than rendered blank, and the
   /// remaining cells reflow two per row, so a bare certification produces a
   /// tighter card instead of a grid of holes.
-  Widget _buildFieldGrid(BuildContext context, UnitFormatter units) {
-    final cells = _buildFieldCells(context, units);
+  Widget _buildFieldGrid(BuildContext context) {
+    final cells = _buildFieldCells(context);
     if (cells.isEmpty) return const SizedBox.shrink();
 
     final rows = <List<_CardField>>[];
@@ -215,8 +212,9 @@ class CertificationEcardFront extends ConsumerWidget {
     );
   }
 
-  List<_CardField> _buildFieldCells(BuildContext context, UnitFormatter units) {
+  List<_CardField> _buildFieldCells(BuildContext context) {
     final l10n = context.l10n;
+    final dateFormat = DateFormat.yMMM();
     final cardNumber = certification.cardNumber;
 
     return [
@@ -233,12 +231,12 @@ class CertificationEcardFront extends ConsumerWidget {
       if (certification.issueDate != null)
         _CardField(
           label: l10n.certifications_ecard_label_issued,
-          value: units.formatMonthYear(certification.issueDate),
+          value: dateFormat.format(certification.issueDate!),
         ),
       if (certification.expiryDate != null)
         _CardField(
           label: l10n.certifications_ecard_label_validUntil,
-          value: units.formatMonthYear(certification.expiryDate),
+          value: dateFormat.format(certification.expiryDate!),
           valueColor: _expiryColor(),
         ),
     ];

--- a/lib/features/certifications/presentation/widgets/certification_ecard_front.dart
+++ b/lib/features/certifications/presentation/widgets/certification_ecard_front.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/certifications/domain/entities/certification.dart';
 import 'package:submersion/features/certifications/domain/certification_title.dart';
@@ -10,7 +12,7 @@ import 'package:submersion/features/certifications/presentation/widgets/certific
 ///
 /// Shows the uploaded front photo when the diver captured one, otherwise a
 /// generated card in the issuing agency's colours.
-class CertificationEcardFront extends StatelessWidget {
+class CertificationEcardFront extends ConsumerWidget {
   /// The certification to display.
   final Certification certification;
 
@@ -24,7 +26,8 @@ class CertificationEcardFront extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final photo = certification.photoFront;
     if (photo != null) {
       return CertificationCardPhoto(
@@ -33,7 +36,7 @@ class CertificationEcardFront extends StatelessWidget {
         infoLines: _buildInfoLines(),
       );
     }
-    return _buildGeneratedFront(context);
+    return _buildGeneratedFront(context, units);
   }
 
   /// Lines repeated over a photographed card.
@@ -59,7 +62,7 @@ class CertificationEcardFront extends StatelessWidget {
     return [if (headline.isNotEmpty) headline, if (detail.isNotEmpty) detail];
   }
 
-  Widget _buildGeneratedFront(BuildContext context) {
+  Widget _buildGeneratedFront(BuildContext context, UnitFormatter units) {
     final agency = certification.agency;
 
     return Container(
@@ -104,7 +107,7 @@ class CertificationEcardFront extends StatelessWidget {
                 // narrow phone. The header and grid are the facts a dive
                 // operator reads, so they keep their intrinsic height.
                 Flexible(child: _buildHero()),
-                _buildFieldGrid(context),
+                _buildFieldGrid(context, units),
               ],
             ),
           ),
@@ -178,8 +181,8 @@ class CertificationEcardFront extends StatelessWidget {
   /// Cells with no value are dropped rather than rendered blank, and the
   /// remaining cells reflow two per row, so a bare certification produces a
   /// tighter card instead of a grid of holes.
-  Widget _buildFieldGrid(BuildContext context) {
-    final cells = _buildFieldCells(context);
+  Widget _buildFieldGrid(BuildContext context, UnitFormatter units) {
+    final cells = _buildFieldCells(context, units);
     if (cells.isEmpty) return const SizedBox.shrink();
 
     final rows = <List<_CardField>>[];
@@ -212,9 +215,8 @@ class CertificationEcardFront extends StatelessWidget {
     );
   }
 
-  List<_CardField> _buildFieldCells(BuildContext context) {
+  List<_CardField> _buildFieldCells(BuildContext context, UnitFormatter units) {
     final l10n = context.l10n;
-    final dateFormat = DateFormat.yMMM();
     final cardNumber = certification.cardNumber;
 
     return [
@@ -231,12 +233,12 @@ class CertificationEcardFront extends StatelessWidget {
       if (certification.issueDate != null)
         _CardField(
           label: l10n.certifications_ecard_label_issued,
-          value: dateFormat.format(certification.issueDate!),
+          value: units.formatMonthYear(certification.issueDate),
         ),
       if (certification.expiryDate != null)
         _CardField(
           label: l10n.certifications_ecard_label_validUntil,
-          value: dateFormat.format(certification.expiryDate!),
+          value: units.formatMonthYear(certification.expiryDate),
           valueColor: _expiryColor(),
         ),
     ];

--- a/lib/features/certifications/presentation/widgets/certification_list_content.dart
+++ b/lib/features/certifications/presentation/widgets/certification_list_content.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/constants/sort_options_display.dart';
 import 'package:submersion/features/certifications/domain/certification_title.dart';
@@ -713,7 +712,7 @@ class _CertificationListContentState
 }
 
 /// List item widget for displaying a certification
-class CertificationListTile extends StatelessWidget {
+class CertificationListTile extends ConsumerWidget {
   final Certification certification;
   final bool isSelected;
   final VoidCallback? onTap;
@@ -732,8 +731,9 @@ class CertificationListTile extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     final statusLabel = certification.isExpired
         ? ', Expired'
@@ -741,7 +741,7 @@ class CertificationListTile extends StatelessWidget {
         ? ', Expiring in ${certification.daysUntilExpiry} days'
         : '';
     final issueDateLabel = certification.issueDate != null
-        ? ', issued ${DateFormat.yMMMd().format(certification.issueDate!)}'
+        ? ', issued ${units.formatDate(certification.issueDate)}'
         : '';
     // Only non-null when a custom name owns the title, so the level is spoken
     // exactly once either way.
@@ -770,7 +770,7 @@ class CertificationListTile extends StatelessWidget {
             child: _buildLeadingIcon(context),
           ),
           title: Text(certificationTitle(certification)),
-          subtitle: _buildSubtitle(context),
+          subtitle: _buildSubtitle(context, units),
           trailing: _buildTrailing(context),
         ),
       ),
@@ -803,13 +803,13 @@ class CertificationListTile extends StatelessWidget {
     );
   }
 
-  Widget? _buildSubtitle(BuildContext context) {
+  Widget? _buildSubtitle(BuildContext context, UnitFormatter units) {
     final parts = <String>[];
     // Carries the level too when the title is a custom name, which is the
     // only place the level can show on this tile.
     parts.add(certificationAgencyAndLevel(certification));
     if (certification.issueDate != null) {
-      parts.add(DateFormat.yMMMd().format(certification.issueDate!));
+      parts.add(units.formatDate(certification.issueDate));
     }
     return Text(parts.join(' - '));
   }

--- a/lib/features/certifications/presentation/widgets/certification_picker.dart
+++ b/lib/features/certifications/presentation/widgets/certification_picker.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/certifications/domain/certification_title.dart';
 import 'package:submersion/features/certifications/domain/entities/certification.dart';
@@ -186,7 +187,7 @@ class CertificationPickerSheet extends ConsumerWidget {
                 itemBuilder: (context, index) {
                   final cert = sortedCerts[index];
                   final isSelected = selectedCertification?.id == cert.id;
-                  final dateFormat = DateFormat.yMMMd();
+                  final units = UnitFormatter(ref.watch(settingsProvider));
 
                   // Only non-null when a custom name owns the title, so the
                   // level is spoken exactly once either way.
@@ -199,7 +200,7 @@ class CertificationPickerSheet extends ConsumerWidget {
                       '${cert.agency.displayName} '
                       '${certificationTitle(cert)}$levelLabel';
                   final certLabel = cert.issueDate != null
-                      ? '$certName, issued ${dateFormat.format(cert.issueDate!)}${isSelected ? ', selected' : ''}${cert.isExpired ? ', expired' : ''}'
+                      ? '$certName, issued ${units.formatDate(cert.issueDate)}${isSelected ? ', selected' : ''}${cert.isExpired ? ', expired' : ''}'
                       : '$certName${isSelected ? ', selected' : ''}${cert.isExpired ? ', expired' : ''}';
 
                   return Semantics(
@@ -228,7 +229,7 @@ class CertificationPickerSheet extends ConsumerWidget {
                       title: Text(certificationTitle(cert)),
                       subtitle: Text(
                         cert.issueDate != null
-                            ? '${certificationAgencyAndLevel(cert)} - ${dateFormat.format(cert.issueDate!)}'
+                            ? '${certificationAgencyAndLevel(cert)} - ${units.formatDate(cert.issueDate)}'
                             : certificationAgencyAndLevel(cert),
                       ),
                       trailing: isSelected

--- a/lib/features/checklists/presentation/widgets/checklist_item_edit_sheet.dart
+++ b/lib/features/checklists/presentation/widgets/checklist_item_edit_sheet.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/checklists/domain/entities/trip_checklist_item.dart';
 import 'package:submersion/features/checklists/presentation/providers/checklist_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 
@@ -113,6 +114,7 @@ class _ChecklistItemEditSheetState
 
   @override
   Widget build(BuildContext context) {
+    final units = UnitFormatter(ref.watch(settingsProvider));
     return Padding(
       padding: EdgeInsets.only(
         left: 16,
@@ -185,7 +187,7 @@ class _ChecklistItemEditSheetState
               contentPadding: EdgeInsets.zero,
               title: Text(context.l10n.checklists_item_dueDateLabel),
               subtitle: Text(
-                _dueDate == null ? '-' : DateFormat.yMMMd().format(_dueDate!),
+                _dueDate == null ? '-' : units.formatDate(_dueDate),
               ),
               trailing: _dueDate == null
                   ? const Icon(Icons.calendar_today)

--- a/lib/features/checklists/presentation/widgets/checklist_item_tile.dart
+++ b/lib/features/checklists/presentation/widgets/checklist_item_tile.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/checklists/domain/entities/trip_checklist_item.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// A single checklist row: checkbox, title, optional due chip, edit/delete.
-class ChecklistItemTile extends StatelessWidget {
+class ChecklistItemTile extends ConsumerWidget {
   final TripChecklistItem item;
 
   /// Whether overdue styling applies (false for past trips - they never nag).
@@ -24,8 +26,9 @@ class ChecklistItemTile extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final isOverdue = showOverdue && item.isOverdue(DateTime.now());
     final due = item.dueDate;
 
@@ -58,7 +61,7 @@ class ChecklistItemTile extends StatelessWidget {
               label: Text(
                 isOverdue
                     ? context.l10n.checklists_item_overdue
-                    : DateFormat.MMMd().format(due),
+                    : units.formatMonthDay(due),
                 style: theme.textTheme.labelSmall?.copyWith(
                   color: isOverdue
                       ? theme.colorScheme.onErrorContainer

--- a/lib/features/courses/presentation/widgets/requirement_tile.dart
+++ b/lib/features/courses/presentation/widgets/requirement_tile.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/courses/domain/entities/course_progress.dart';
 import 'package:submersion/features/courses/domain/entities/course_requirement.dart';
 import 'package:submersion/features/courses/presentation/providers/course_requirement_providers.dart';
 import 'package:submersion/features/courses/presentation/widgets/add_requirement_sheet.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 /// One requirement row: a checkbox for checklist items, a progress count
 /// plus expandable credited-dive list for dive requirements. Unsatisfied
@@ -101,9 +102,9 @@ class _DiveRequirementTile extends ConsumerWidget {
   final CourseRequirementProgress progress;
   final List<RequirementDiveSummary> suggestions;
 
-  String _diveLabel(RequirementDiveSummary dive) {
+  String _diveLabel(RequirementDiveSummary dive, UnitFormatter units) {
     final number = dive.diveNumber != null ? '#${dive.diveNumber}' : '';
-    final date = DateFormat.MMMd().format(dive.dateTime);
+    final date = units.formatMonthDay(dive.dateTime);
     final site = dive.siteName;
     return [number, date, ?site].where((part) => part.isNotEmpty).join(' · ');
   }
@@ -113,6 +114,7 @@ class _DiveRequirementTile extends ConsumerWidget {
     final requirement = progress.requirement;
     final theme = Theme.of(context);
     final satisfied = progress.isSatisfied;
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return ExpansionTile(
       leading: satisfied
@@ -136,7 +138,7 @@ class _DiveRequirementTile extends ConsumerWidget {
           ListTile(
             dense: true,
             leading: const Icon(Icons.link, size: 18),
-            title: Text(_diveLabel(dive)),
+            title: Text(_diveLabel(dive, units)),
             trailing: IconButton(
               tooltip: context.l10n.courses_action_unlinkDive,
               icon: const Icon(Icons.link_off, size: 18),
@@ -167,7 +169,7 @@ class _DiveRequirementTile extends ConsumerWidget {
                   children: [
                     for (final dive in suggestions)
                       ActionChip(
-                        label: Text(_diveLabel(dive)),
+                        label: Text(_diveLabel(dive, units)),
                         onPressed: () async {
                           await ref
                               .read(courseRequirementRepositoryProvider)

--- a/lib/features/dashboard/presentation/widgets/gauge_strip.dart
+++ b/lib/features/dashboard/presentation/widgets/gauge_strip.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 
 import 'package:submersion/features/dashboard/presentation/providers/gauge_providers.dart';
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
@@ -63,6 +63,7 @@ class GaugeStrip extends ConsumerWidget {
     Set<String> hidden,
   ) {
     final l10n = context.l10n;
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final chips = <_Chip>[];
 
     // Gear, insurance and the flight window are hardened: an alert-tone chip
@@ -171,9 +172,7 @@ class GaugeStrip extends ConsumerWidget {
             context,
             icon: Icons.health_and_safety_outlined,
             label: l10n.dashboard_gauges_insuranceExpires(
-              DateFormat.yMMMd(
-                Localizations.localeOf(context).toString(),
-              ).format(policy.expiryDate!),
+              units.formatDate(policy.expiryDate),
             ),
             tone: _Tone.warn,
             onTap: () => context.push('/settings/diver-profile/insurance'),

--- a/lib/features/dashboard/presentation/widgets/hero_header.dart
+++ b/lib/features/dashboard/presentation/widgets/hero_header.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/presentation/widgets/ocean_background.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
 import 'package:submersion/features/statistics/domain/career_totals.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/statistics/presentation/providers/career_totals_provider.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
@@ -28,6 +29,7 @@ class HeroHeader extends ConsumerWidget {
     final careerAsync = ref.watch(careerTotalsProvider);
     final theme = Theme.of(context);
     final isDesktop = ResponsiveBreakpoints.isDesktop(context);
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Semantics(
       label: context.l10n.dashboard_semantics_greetingBanner,
@@ -85,9 +87,7 @@ class HeroHeader extends ConsumerWidget {
                     const SizedBox(height: 4),
                     if (isDesktop)
                       Text(
-                        DateFormat.yMMMMd(
-                          Localizations.localeOf(context).toString(),
-                        ).format(DateTime.now()),
+                        units.formatDate(DateTime.now()),
                         style: theme.textTheme.bodyMedium?.copyWith(
                           color: Colors.white.withValues(alpha: 0.75),
                         ),

--- a/lib/features/dive_computer/presentation/pages/device_detail_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/log_failure.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_computer/presentation/utils/last_download_formatter.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -13,6 +14,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 /// Page displaying details about a specific dive computer.
 class DeviceDetailPage extends ConsumerWidget {
@@ -57,6 +59,7 @@ class DeviceDetailPage extends ConsumerWidget {
     ThemeData theme,
   ) {
     final colorScheme = theme.colorScheme;
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Scaffold(
       appBar: AppBar(
@@ -114,7 +117,7 @@ class DeviceDetailPage extends ConsumerWidget {
             _buildDuplicateBanner(context, ref, computer),
             _buildInfoCard(context, computer, colorScheme),
             const SizedBox(height: 16),
-            _buildStatsCard(context, computer, colorScheme),
+            _buildStatsCard(context, computer, colorScheme, units),
             const SizedBox(height: 16),
             _buildActionsCard(context, ref, computer, colorScheme),
             if (computer.notes.isNotEmpty) ...[
@@ -289,6 +292,7 @@ class DeviceDetailPage extends ConsumerWidget {
     BuildContext context,
     DiveComputer computer,
     ColorScheme colorScheme,
+    UnitFormatter units,
   ) {
     final theme = Theme.of(context);
 
@@ -318,7 +322,11 @@ class DeviceDetailPage extends ConsumerWidget {
                   child: _buildStatItem(
                     context,
                     Icons.download,
-                    formatLastDownload(context, computer.lastDownload),
+                    formatLastDownload(
+                      context,
+                      computer.lastDownload,
+                      units: units,
+                    ),
                     context.l10n.diveComputer_detail_lastDownload,
                     colorScheme,
                   ),

--- a/lib/features/dive_computer/presentation/pages/device_list_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_list_page.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_computer/presentation/utils/last_download_formatter.dart';
 import 'package:submersion/features/dive_computer/presentation/widgets/dive_computer_merge_sheet.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/selection/bulk_action.dart';
 import 'package:submersion/shared/selection/selectable_list_scope.dart';
@@ -335,7 +337,7 @@ class _DeviceListPageState extends ConsumerState<DeviceListPage> {
 }
 
 /// Card widget displaying a single dive computer.
-class _ComputerCard extends StatelessWidget {
+class _ComputerCard extends ConsumerWidget {
   final DiveComputer computer;
   final VoidCallback onTap;
   final VoidCallback onDownload;
@@ -353,9 +355,10 @@ class _ComputerCard extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -450,7 +453,11 @@ class _ComputerCard extends StatelessWidget {
                           ),
                           const SizedBox(width: 4),
                           Text(
-                            formatLastDownload(context, computer.lastDownload),
+                            formatLastDownload(
+                              context,
+                              computer.lastDownload,
+                              units: units,
+                            ),
                             style: theme.textTheme.bodySmall?.copyWith(
                               color: colorScheme.onSurfaceVariant,
                             ),

--- a/lib/features/dive_computer/presentation/utils/last_download_formatter.dart
+++ b/lib/features/dive_computer/presentation/utils/last_download_formatter.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:intl/intl.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Localized relative "last download" label for a dive computer (#152).
@@ -8,7 +8,14 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// no [BuildContext] and therefore structurally could not localize -- it
 /// leaked hardcoded English (and a fixed M/D/Y date) into the Transfer,
 /// device list, and device detail screens on every locale.
-String formatLastDownload(BuildContext context, DateTime? lastDownload) {
+///
+/// [units] carries the diver's date preference, so downloads older than a week
+/// render in the shape chosen under Manage > Units rather than the locale's.
+String formatLastDownload(
+  BuildContext context,
+  DateTime? lastDownload, {
+  required UnitFormatter units,
+}) {
   final l10n = context.l10n;
   if (lastDownload == null) return l10n.transfer_computers_lastDownloadNever;
 
@@ -29,8 +36,7 @@ String formatLastDownload(BuildContext context, DateTime? lastDownload) {
     return l10n.transfer_computers_lastDownloadDaysAgo(diff.inDays);
   }
 
-  // Older downloads: a locale-appropriate numeric date instead of the old
+  // Older downloads: the diver's preferred date shape instead of the old
   // hardcoded month/day/year.
-  final locale = Localizations.localeOf(context).toString();
-  return DateFormat.yMd(locale).format(lastDownload);
+  return units.formatDate(lastDownload);
 }

--- a/lib/features/dive_computer/presentation/widgets/download_step_widget.dart
+++ b/lib/features/dive_computer/presentation/widgets/download_step_widget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/features/dive_computer/domain/entities/device_model.dart';
@@ -10,6 +9,8 @@ import 'package:submersion/features/dive_computer/presentation/widgets/pin_code_
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 import 'package:submersion/core/utils/log_failure.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 /// Widget for the download step of the discovery wizard.
 class DownloadStepWidget extends ConsumerStatefulWidget {
@@ -336,7 +337,9 @@ class _DownloadStepWidgetState extends ConsumerState<DownloadStepWidget> {
   Widget _buildCutoffPrompt(BuildContext context) {
     final theme = Theme.of(context);
     final cutoff = _cutoff!;
-    final dateLabel = DateFormat.yMMMd().format(cutoff);
+    final dateLabel = UnitFormatter(
+      ref.watch(settingsProvider),
+    ).formatDate(cutoff);
 
     return Padding(
       padding: const EdgeInsets.all(24),
@@ -595,11 +598,10 @@ class _DownloadStepWidgetState extends ConsumerState<DownloadStepWidget> {
     ThemeData theme,
     ColorScheme colorScheme,
   ) {
-    final date = dive.startTime;
-    final dateStr =
-        '${date.month}/${date.day}/${date.year} '
-        '${date.hour.toString().padLeft(2, '0')}:'
-        '${date.minute.toString().padLeft(2, '0')}';
+    // #1512: hand-rolled M/D/YYYY with a 24-hour clock ignored both the date
+    // and the time preference.
+    final units = UnitFormatter(ref.watch(settingsProvider));
+    final dateStr = units.formatDateTimeBullet(dive.startTime);
     final durationMin = dive.durationSeconds ~/ 60;
 
     // Build detail chips

--- a/lib/features/dive_import/presentation/widgets/imported_dive_card.dart
+++ b/lib/features/dive_import/presentation/widgets/imported_dive_card.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_import/domain/entities/imported_dive.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Card displaying an imported dive for selection in the import wizard.
-class ImportedDiveCard extends StatelessWidget {
+class ImportedDiveCard extends ConsumerWidget {
   const ImportedDiveCard({
     super.key,
     required this.dive,
@@ -19,9 +21,10 @@ class ImportedDiveCard extends StatelessWidget {
   final ImportMatchStatus? matchStatus;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Card(
       elevation: isSelected ? 2 : 0,
@@ -44,7 +47,7 @@ class ImportedDiveCard extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      _buildHeader(context),
+                      _buildHeader(context, units),
                       const SizedBox(height: 8),
                       _buildMetrics(context),
                       if (matchStatus != null) ...[
@@ -82,22 +85,20 @@ class ImportedDiveCard extends StatelessWidget {
     );
   }
 
-  Widget _buildHeader(BuildContext context) {
+  Widget _buildHeader(BuildContext context, UnitFormatter units) {
     final theme = Theme.of(context);
-    final dateFormat = DateFormat.yMMMd();
-    final timeFormat = DateFormat.jm();
 
     return Row(
       children: [
         Text(
-          dateFormat.format(dive.startTime),
+          units.formatDate(dive.startTime),
           style: theme.textTheme.titleMedium?.copyWith(
             fontWeight: FontWeight.w600,
           ),
         ),
         const SizedBox(width: 8),
         Text(
-          timeFormat.format(dive.startTime),
+          units.formatTime(dive.startTime),
           style: theme.textTheme.bodyMedium?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),

--- a/lib/features/equipment/presentation/pages/equipment_edit_page.dart
+++ b/lib/features/equipment/presentation/pages/equipment_edit_page.dart
@@ -574,8 +574,12 @@ class _EquipmentEditPageState extends ConsumerState<EquipmentEditPage> {
               onPressed: _selectPurchaseDate,
               icon: const Icon(Icons.calendar_today),
               label: Text(
+                // #1512: hand-rolled M/D/YYYY ignored the diver's preference,
+                // which the detail page for the same field already honours.
                 _purchaseDate != null
-                    ? '${_purchaseDate!.month}/${_purchaseDate!.day}/${_purchaseDate!.year}'
+                    ? UnitFormatter(
+                        ref.watch(settingsProvider),
+                      ).formatDate(_purchaseDate)
                     : context.l10n.equipment_edit_selectDate,
               ),
               style: OutlinedButton.styleFrom(

--- a/lib/features/equipment/presentation/widgets/service_clocks_card.dart
+++ b/lib/features/equipment/presentation/widgets/service_clocks_card.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
 import 'package:submersion/features/equipment/presentation/widgets/service_schedule_dialogs.dart';
 import 'package:submersion/features/equipment/presentation/widgets/service_trigger_text.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// The Service clocks card on the equipment detail page: one row per
@@ -34,16 +36,20 @@ class ServiceClocksCard extends ConsumerWidget {
     };
   }
 
-  String _triggerText(BuildContext context, ServiceClockStatus status) =>
-      formatServiceTriggerText(
-        context,
-        now: status.now,
-        dueDate: status.dueDate,
-        divesSinceAnchor: status.divesSinceAnchor,
-        divesRemaining: status.divesRemaining,
-        hoursSinceAnchor: status.hoursSinceAnchor,
-        hoursRemaining: status.hoursRemaining,
-      );
+  String _triggerText(
+    BuildContext context,
+    UnitFormatter units,
+    ServiceClockStatus status,
+  ) => formatServiceTriggerText(
+    context,
+    units: units,
+    now: status.now,
+    dueDate: status.dueDate,
+    divesSinceAnchor: status.divesSinceAnchor,
+    divesRemaining: status.divesRemaining,
+    hoursSinceAnchor: status.hoursSinceAnchor,
+    hoursRemaining: status.hoursRemaining,
+  );
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -52,6 +58,7 @@ class ServiceClocksCard extends ConsumerWidget {
       serviceSchedulesForEquipmentProvider(equipmentId),
     );
     final kindsAsync = ref.watch(serviceKindsProvider);
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final l10n = context.l10n;
 
     return Card(
@@ -133,7 +140,7 @@ class ServiceClocksCard extends ConsumerWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            Text(_triggerText(context, status)),
+                            Text(_triggerText(context, units, status)),
                             // An hours clock accrues from logged dive
                             // duration, which approximates but is not
                             // identical to rebreather loop time. Say so

--- a/lib/features/equipment/presentation/widgets/service_schedule_dialogs.dart
+++ b/lib/features/equipment/presentation/widgets/service_schedule_dialogs.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/currency.dart';
 import 'package:submersion/core/utils/number_input.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/equipment/domain/entities/service_kind.dart';
 import 'package:submersion/features/equipment/domain/entities/service_schedule.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 
@@ -127,7 +130,7 @@ Future<void> showScheduleOverrideDialog(
   );
 }
 
-class _ScheduleOverrideDialog extends StatefulWidget {
+class _ScheduleOverrideDialog extends ConsumerStatefulWidget {
   final ServiceSchedule schedule;
   final ServiceKind kind;
   final WidgetRef ref;
@@ -139,11 +142,12 @@ class _ScheduleOverrideDialog extends StatefulWidget {
   });
 
   @override
-  State<_ScheduleOverrideDialog> createState() =>
+  ConsumerState<_ScheduleOverrideDialog> createState() =>
       _ScheduleOverrideDialogState();
 }
 
-class _ScheduleOverrideDialogState extends State<_ScheduleOverrideDialog> {
+class _ScheduleOverrideDialogState
+    extends ConsumerState<_ScheduleOverrideDialog> {
   late final TextEditingController _days;
   late final TextEditingController _dives;
   late final TextEditingController _hours;
@@ -322,9 +326,9 @@ class _ScheduleOverrideDialogState extends State<_ScheduleOverrideDialog> {
                     child: Text(
                       _anchorDate == null
                           ? '-'
-                          : MaterialLocalizations.of(
-                              context,
-                            ).formatShortDate(_anchorDate!),
+                          : UnitFormatter(
+                              ref.watch(settingsProvider),
+                            ).formatDate(_anchorDate),
                     ),
                   ),
                 ),

--- a/lib/features/equipment/presentation/widgets/service_trigger_text.dart
+++ b/lib/features/equipment/presentation/widgets/service_trigger_text.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Formats the "Due {date}" / "Overdue since {date}" / "N of M dives left" /
@@ -9,6 +10,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// summaries), so both read the exact same wording.
 String formatServiceTriggerText(
   BuildContext context, {
+  required UnitFormatter units,
   required DateTime now,
   DateTime? dueDate,
   int? divesSinceAnchor,
@@ -19,9 +21,7 @@ String formatServiceTriggerText(
   final l10n = context.l10n;
   final parts = <String>[];
   if (dueDate != null) {
-    final formatted = MaterialLocalizations.of(
-      context,
-    ).formatShortDate(dueDate);
+    final formatted = units.formatDate(dueDate);
     parts.add(
       // Strict isAfter: at the exact due instant (now == dueDate) the engine
       // treats the date trigger as due-soon, not overdue, so render "Due

--- a/lib/features/gps_log/presentation/widgets/gps_track_date_filter_action.dart
+++ b/lib/features/gps_log/presentation/widgets/gps_track_date_filter_action.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/gps_log/presentation/providers/gps_track_map_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 
@@ -31,6 +32,7 @@ class GpsTrackDateFilterAction extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     final range = ref.watch(trackDateFilterProvider);
+    final units = UnitFormatter(ref.watch(settingsProvider));
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -40,8 +42,8 @@ class GpsTrackDateFilterAction extends ConsumerWidget {
           label: Text(
             range == null
                 ? l10n.gpsTrack_filter_all
-                : '${DateFormat.yMd().format(range.start)} - '
-                      '${DateFormat.yMd().format(range.end)}',
+                : '${units.formatDate(range.start)} - '
+                      '${units.formatDate(range.end)}',
           ),
           onPressed: () => _pickRange(context, ref),
         ),

--- a/lib/features/import_wizard/data/adapters/dive_computer_adapter.dart
+++ b/lib/features/import_wizard/data/adapters/dive_computer_adapter.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/domain/models/incoming_dive_data.dart';
@@ -650,16 +649,13 @@ class DiveComputerAdapter implements ImportSourceAdapter {
   // Helpers
   // ---------------------------------------------------------------------------
 
-  static final _dateFormatter = DateFormat('MMM d, yyyy');
-  static final _timeFormatter = DateFormat('h:mm a');
-
   EntityItem _diveToEntityItem(DownloadedDive dive) {
-    final dateStr = _dateFormatter.format(dive.startTime);
-    final timeStr = _timeFormatter.format(dive.startTime);
-    final title = '$dateStr \u2014 $timeStr';
-
     final settings = _ref?.read(settingsProvider) ?? const AppSettings();
     final units = UnitFormatter(settings);
+
+    final dateStr = units.formatDate(dive.startTime);
+    final timeStr = units.formatTime(dive.startTime);
+    final title = '$dateStr \u2014 $timeStr';
     final durationMin = dive.duration.inMinutes;
     final tempStr = dive.minTemperature != null
         ? ' \u00b7 ${units.formatTemperature(dive.minTemperature!, decimals: 1)}'

--- a/lib/features/import_wizard/data/adapters/healthkit_adapter.dart
+++ b/lib/features/import_wizard/data/adapters/healthkit_adapter.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/domain/models/incoming_dive_data.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -320,15 +319,12 @@ class HealthKitAdapter implements ImportSourceAdapter {
     return 0;
   }
 
-  static final _dateFormatter = DateFormat('MMM d, yyyy');
-  static final _timeFormatter = DateFormat('h:mm a');
-
   EntityItem _diveToEntityItem(ImportedDive dive) {
-    final dateStr = _dateFormatter.format(dive.startTime);
-    final timeStr = _timeFormatter.format(dive.startTime);
-    final title = '$dateStr \u2014 $timeStr';
-
     final units = UnitFormatter(_settings);
+
+    final dateStr = units.formatDate(dive.startTime);
+    final timeStr = units.formatTime(dive.startTime);
+    final title = '$dateStr \u2014 $timeStr';
     final durationMin = dive.duration.inMinutes;
     final tempStr = dive.minTemperature != null
         ? ' \u00b7 ${units.formatTemperature(dive.minTemperature!, decimals: 1)}'

--- a/lib/features/import_wizard/data/adapters/suunto_cloud_adapter.dart
+++ b/lib/features/import_wizard/data/adapters/suunto_cloud_adapter.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/domain/models/incoming_dive_data.dart';
@@ -483,18 +482,15 @@ class SuuntoCloudAdapter implements ImportSourceAdapter {
   // Helpers -- entity item conversion
   // ---------------------------------------------------------------------------
 
-  static final _dateFormatter = DateFormat('MMM d, yyyy');
-  static final _timeFormatter = DateFormat('h:mm a');
-
   EntityItem _diveToEntityItem(SuuntoParsedDive parsed) {
     final dive = parsed.dive;
     final localStart = dive.startTime.toLocal();
-    final dateStr = _dateFormatter.format(localStart);
-    final timeStr = _timeFormatter.format(localStart);
-    final title = '$dateStr — $timeStr';
-
     final settings = _ref?.read(settingsProvider) ?? const AppSettings();
     final units = UnitFormatter(settings);
+
+    final dateStr = units.formatDate(localStart);
+    final timeStr = units.formatTime(localStart);
+    final title = '$dateStr — $timeStr';
     final durationMin = dive.duration.inMinutes;
     final tempStr = dive.minTemperature != null
         ? ' · ${units.formatTemperature(dive.minTemperature!, decimals: 1)}'

--- a/lib/features/import_wizard/data/adapters/universal_adapter.dart
+++ b/lib/features/import_wizard/data/adapters/universal_adapter.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/domain/models/incoming_dive_data.dart';
@@ -814,8 +813,9 @@ class UniversalAdapter implements ImportSourceAdapter {
   // Helpers — entity item conversion
   // ---------------------------------------------------------------------------
 
-  static final _dateFormatter = DateFormat('MMM d, yyyy');
-  static final _timeFormatter = DateFormat('h:mm a');
+  /// Formatter for the review list's dates and times, built from the active
+  /// diver's unit settings so the wizard matches the rest of the app.
+  UnitFormatter get _units => UnitFormatter(_ref.read(settingsProvider));
 
   void _addGroupIfNotEmpty(
     Map<wizard.ImportEntityType, EntityGroup> groups,
@@ -837,10 +837,12 @@ class UniversalAdapter implements ImportSourceAdapter {
         data['siteName'] as String? ??
         (data['site'] as Map<String, dynamic>?)?['name'] as String?;
 
+    final units = _units;
+
     String title;
     if (dateTime != null) {
-      final dateStr = _dateFormatter.format(dateTime);
-      final timeStr = _timeFormatter.format(dateTime);
+      final dateStr = units.formatDate(dateTime);
+      final timeStr = units.formatTime(dateTime);
       title = '$dateStr \u2014 $timeStr';
     } else {
       title = 'Unknown date';
@@ -849,8 +851,6 @@ class UniversalAdapter implements ImportSourceAdapter {
     final parts = <String>[];
     if (siteName != null && siteName.isNotEmpty) parts.add(siteName);
     if (maxDepth != null) {
-      final settings = _ref.read(settingsProvider);
-      final units = UnitFormatter(settings);
       parts.add('${units.formatDepth(maxDepth)} max');
     }
     if (effectiveDuration != null) {
@@ -923,13 +923,14 @@ class UniversalAdapter implements ImportSourceAdapter {
     final startDate = data['startDate'] as DateTime?;
     final endDate = data['endDate'] as DateTime?;
 
+    final units = _units;
     String subtitle;
     if (startDate != null && endDate != null) {
       subtitle =
-          '${_dateFormatter.format(startDate)} - '
-          '${_dateFormatter.format(endDate)}';
+          '${units.formatDate(startDate)} - '
+          '${units.formatDate(endDate)}';
     } else if (startDate != null) {
-      subtitle = _dateFormatter.format(startDate);
+      subtitle = units.formatDate(startDate);
     } else {
       subtitle = '';
     }

--- a/lib/features/import_wizard/presentation/widgets/garmin_cloud_dive_list.dart
+++ b/lib/features/import_wizard/presentation/widgets/garmin_cloud_dive_list.dart
@@ -1,12 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/services/garmin_connect/garmin_dive_mapper.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
-
-final _dateFormatter = DateFormat('MMM d, yyyy');
-final _timeFormatter = DateFormat('h:mm a');
 
 /// Builds the same title/subtitle text shown for a Garmin dive both in the
 /// fetch step's inline selection list and in the shared Review step, so the
@@ -17,10 +13,10 @@ final _timeFormatter = DateFormat('h:mm a');
 ) {
   final dive = parsed.dive;
   final localStart = dive.startTime.toLocal();
-  final title =
-      '${_dateFormatter.format(localStart)} — ${_timeFormatter.format(localStart)}';
-
   final units = UnitFormatter(settings);
+  final title =
+      '${units.formatDate(localStart)} — ${units.formatTime(localStart)}';
+
   final durationMin = dive.duration.inMinutes;
   final tempStr = dive.minTemperature != null
       ? ' · ${units.formatTemperature(dive.minTemperature!, decimals: 1)}'

--- a/lib/features/import_wizard/presentation/widgets/healthkit_adapter_steps.dart
+++ b/lib/features/import_wizard/presentation/widgets/healthkit_adapter_steps.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_import/domain/entities/imported_dive.dart';
 import 'package:submersion/features/dive_import/domain/services/health_import_service.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 
 /// Riverpod [StateProvider] signalling whether HealthKit permissions have been
@@ -318,7 +319,7 @@ class _HealthKitDateRangeStepState
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final dateFormat = DateFormat.yMMMd();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Padding(
       padding: const EdgeInsets.all(24),
@@ -344,7 +345,7 @@ class _HealthKitDateRangeStepState
                 child: DatePickerButton(
                   label: context.l10n.diveImport_healthkit_dateFrom,
                   date: _startDate,
-                  dateText: dateFormat.format(_startDate),
+                  dateText: units.formatDate(_startDate),
                   onTap: _selectStartDate,
                 ),
               ),
@@ -353,7 +354,7 @@ class _HealthKitDateRangeStepState
                 child: DatePickerButton(
                   label: context.l10n.diveImport_healthkit_dateTo,
                   date: _endDate,
-                  dateText: dateFormat.format(_endDate),
+                  dateText: units.formatDate(_endDate),
                   onTap: _selectEndDate,
                 ),
               ),

--- a/lib/features/maps/presentation/pages/offline_maps_page.dart
+++ b/lib/features/maps/presentation/pages/offline_maps_page.dart
@@ -613,10 +613,10 @@ class _OfflineMapsPageState extends ConsumerState<OfflineMapsPage> {
     );
   }
 
-  String _formatDate(DateTime date) {
-    return '${date.year}-${date.month.toString().padLeft(2, '0')}-'
-        '${date.day.toString().padLeft(2, '0')}';
-  }
+  // Shown to the diver, so it follows Manage - Units rather than a fixed
+  // ISO stamp (#1512).
+  String _formatDate(DateTime date) =>
+      UnitFormatter(ref.watch(settingsProvider)).formatDate(date);
 
   Future<void> _confirmDeleteRegion(
     BuildContext context,

--- a/lib/features/media/presentation/pages/media_repair_history_view.dart
+++ b/lib/features/media/presentation/pages/media_repair_history_view.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/media/data/repositories/media_repair_log_repository.dart';
 import 'package:submersion/features/media/presentation/providers/media_repair_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// The repair audit trail (Media section Phase 5).
@@ -46,9 +47,7 @@ class MediaRepairHistoryView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final entries = ref.watch(repairHistoryProvider).value ?? const [];
-    final format = DateFormat.yMMMd(
-      Localizations.localeOf(context).toString(),
-    ).add_jm();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Scaffold(
       appBar: AppBar(title: Text(context.l10n.media_repairHistory_title)),
@@ -72,7 +71,7 @@ class MediaRepairHistoryView extends ConsumerWidget {
                         overflow: TextOverflow.ellipsis,
                       ),
                       Text(
-                        '${format.format(entry.occurredAt)} '
+                        '${units.formatDateTime(entry.occurredAt, l10n: context.l10n)} '
                         '${context.l10n.media_repairHistory_source(_sourceLabel(context, entry.source))}',
                         style: subtitleStyle,
                       ),

--- a/lib/features/media/presentation/pages/media_sources_section_view.dart
+++ b/lib/features/media/presentation/pages/media_sources_section_view.dart
@@ -1,14 +1,15 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/media/data/services/repair/watched_folder_scanner.dart';
 import 'package:submersion/features/media/domain/entities/media_library_filter.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media/presentation/helpers/media_source_labels.dart';
 import 'package:submersion/features/media/presentation/providers/media_library_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_watcher_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Counts per source type for the browse list.
@@ -101,7 +102,6 @@ class MediaSourcesSectionView extends ConsumerWidget {
     final counts = ref.watch(sourceCountsProvider).value ?? const {};
     final roots = ref.watch(watchedRootsProvider).value ?? const [];
     final autoApply = ref.watch(watcherAutoApplyProvider);
-    final locale = Localizations.localeOf(context).toString();
 
     return ListView(
       children: [
@@ -131,7 +131,7 @@ class MediaSourcesSectionView extends ConsumerWidget {
             style: Theme.of(context).textTheme.titleSmall,
           ),
         ),
-        for (final root in roots) _WatchedRootTile(root: root, locale: locale),
+        for (final root in roots) _WatchedRootTile(root: root),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8),
           child: Row(
@@ -163,14 +163,14 @@ class MediaSourcesSectionView extends ConsumerWidget {
 }
 
 class _WatchedRootTile extends ConsumerWidget {
-  const _WatchedRootTile({required this.root, required this.locale});
+  const _WatchedRootTile({required this.root});
 
   final String root;
-  final String locale;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final stamp = ref.watch(watchedRootLastScanProvider(root)).value;
+    final units = UnitFormatter(ref.watch(settingsProvider));
     return ListTile(
       leading: const Icon(Icons.folder_outlined),
       title: Text(root, maxLines: 1, overflow: TextOverflow.ellipsis),
@@ -178,7 +178,7 @@ class _WatchedRootTile extends ConsumerWidget {
         stamp == null
             ? context.l10n.media_sources_neverScanned
             : context.l10n.media_sources_lastScanned(
-                DateFormat.yMMMd(locale).add_jm().format(stamp),
+                units.formatDateTime(stamp, l10n: context.l10n),
               ),
       ),
       trailing: IconButton(

--- a/lib/features/media/presentation/pages/media_viewer_page.dart
+++ b/lib/features/media/presentation/pages/media_viewer_page.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:intl/intl.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -1514,8 +1513,6 @@ class _BottomMetadataOverlay extends StatelessWidget {
         item.enrichment?.isWithinDiveWindow(profileLengthSeconds) ?? false;
     final enrichment = positioned ? item.enrichment : null;
     final formatter = UnitFormatter(settings);
-    final timeFormat = DateFormat.jm();
-    final dateFormat = DateFormat.yMMMd();
 
     return Positioned(
       bottom: 0,
@@ -1619,7 +1616,7 @@ class _BottomMetadataOverlay extends StatelessWidget {
                 Row(
                   children: [
                     Text(
-                      '${dateFormat.format(item.takenAt)} at ${timeFormat.format(item.takenAt)}',
+                      formatter.formatDateTime(item.takenAt, l10n: l10n),
                       style: TextStyle(
                         color: Colors.white.withValues(alpha: 0.8),
                         fontSize: 14,

--- a/lib/features/media/presentation/pages/photo_picker_page.dart
+++ b/lib/features/media/presentation/pages/photo_picker_page.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:photo_manager/photo_manager.dart' as pm;
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/presentation/providers/files_tab_providers.dart';
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/files_tab.dart';
 import 'package:submersion/features/media/presentation/widgets/url_tab.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/drag_select_grid_view.dart';
 import 'package:submersion/core/utils/log_failure.dart';
@@ -338,19 +339,18 @@ class _PhotoPickerPageState extends ConsumerState<PhotoPickerPage> {
 }
 
 /// Header showing the date range being browsed.
-class _DateRangeHeader extends StatelessWidget {
+class _DateRangeHeader extends ConsumerWidget {
   final DateTime startTime;
   final DateTime endTime;
 
   const _DateRangeHeader({required this.startTime, required this.endTime});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
 
-    final dateFormat = DateFormat.MMMd();
-    final timeFormat = DateFormat.jm();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     final sameDay =
         startTime.day == endTime.day &&
@@ -360,10 +360,10 @@ class _DateRangeHeader extends StatelessWidget {
     String rangeText;
     if (sameDay) {
       rangeText =
-          '${dateFormat.format(startTime)}, ${timeFormat.format(startTime)} to ${timeFormat.format(endTime)}';
+          '${units.formatMonthDay(startTime)}, ${units.formatTime(startTime)} to ${units.formatTime(endTime)}';
     } else {
       rangeText =
-          '${dateFormat.format(startTime)} ${timeFormat.format(startTime)} to ${dateFormat.format(endTime)} ${timeFormat.format(endTime)}';
+          '${units.formatMonthDay(startTime)} ${units.formatTime(startTime)} to ${units.formatMonthDay(endTime)} ${units.formatTime(endTime)}';
     }
 
     return Container(
@@ -579,18 +579,17 @@ class _PhotoThumbnail extends ConsumerWidget {
 }
 
 /// View shown when no photos are found in the date range.
-class _EmptyStateView extends StatelessWidget {
+class _EmptyStateView extends ConsumerWidget {
   final DateTime startTime;
   final DateTime endTime;
 
   const _EmptyStateView({required this.startTime, required this.endTime});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final dateFormat = DateFormat.MMMd();
-    final timeFormat = DateFormat.jm();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Center(
       child: Padding(
@@ -611,10 +610,10 @@ class _EmptyStateView extends StatelessWidget {
             const SizedBox(height: 8),
             Text(
               context.l10n.media_photoPicker_emptyMessage(
-                dateFormat.format(startTime),
-                timeFormat.format(startTime),
-                dateFormat.format(endTime),
-                timeFormat.format(endTime),
+                units.formatMonthDay(startTime),
+                units.formatTime(startTime),
+                units.formatMonthDay(endTime),
+                units.formatTime(endTime),
               ),
               textAlign: TextAlign.center,
               style: textTheme.bodyMedium?.copyWith(

--- a/lib/features/media/presentation/pages/site_media_viewer_page.dart
+++ b/lib/features/media/presentation/pages/site_media_viewer_page.dart
@@ -1,18 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:intl/intl.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/share_anchor.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/media/data/services/media_share_temp_file.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media/presentation/providers/site_media_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
 import 'package:submersion/features/media/presentation/widgets/media_nav_arrows.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Which list of site-related media backs the viewer's pager.
@@ -408,15 +409,14 @@ class _TopOverlay extends StatelessWidget {
 }
 
 /// Bottom overlay showing capture time and caption for the current item.
-class _BottomMetadataOverlay extends StatelessWidget {
+class _BottomMetadataOverlay extends ConsumerWidget {
   final MediaItem item;
 
   const _BottomMetadataOverlay({required this.item});
 
   @override
-  Widget build(BuildContext context) {
-    final timeFormat = DateFormat.jm();
-    final dateFormat = DateFormat.yMMMd();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Positioned(
       bottom: 0,
@@ -452,7 +452,7 @@ class _BottomMetadataOverlay extends StatelessWidget {
                   const SizedBox(height: 8),
                 ],
                 Text(
-                  '${dateFormat.format(item.takenAt)} at ${timeFormat.format(item.takenAt)}',
+                  units.formatDateTime(item.takenAt, l10n: context.l10n),
                   style: TextStyle(
                     color: Colors.white.withValues(alpha: 0.8),
                     fontSize: 14,

--- a/lib/features/media/presentation/widgets/ambiguous_dive_sheet.dart
+++ b/lib/features/media/presentation/widgets/ambiguous_dive_sheet.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 /// Lets the user pick between the dives an ambiguous timestamp match
 /// offered, closest entry first. Resolves to the dive id, or null.
@@ -41,7 +42,7 @@ class AmbiguousDiveTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final dive = ref.watch(diveProvider(diveId)).value;
-    final locale = Localizations.localeOf(context).toString();
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final parts = dive == null
         ? const <String>[]
         : [
@@ -56,9 +57,7 @@ class AmbiguousDiveTile extends ConsumerWidget {
     final label = parts.isEmpty ? diveId : parts.join(' ');
     return ListTile(
       title: Text(label),
-      subtitle: dive == null
-          ? null
-          : Text(DateFormat.yMMMd(locale).format(dive.dateTime)),
+      subtitle: dive == null ? null : Text(units.formatDate(dive.dateTime)),
       onTap: onTap,
     );
   }

--- a/lib/features/media/presentation/widgets/dive_picker_sheet.dart
+++ b/lib/features/media/presentation/widgets/dive_picker_sheet.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/core/utils/log_failure.dart';
 
@@ -63,7 +64,7 @@ class _DivePickerSheetState extends ConsumerState<_DivePickerSheet> {
 
   @override
   Widget build(BuildContext context) {
-    final locale = Localizations.localeOf(context).toString();
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final dives = _dives;
     final visible = dives?.where(_matches).toList();
 
@@ -108,9 +109,7 @@ class _DivePickerSheetState extends ConsumerState<_DivePickerSheet> {
                           final dive = visible[index];
                           return ListTile(
                             title: Text(_label(dive)),
-                            subtitle: Text(
-                              DateFormat.yMMMd(locale).format(dive.dateTime),
-                            ),
+                            subtitle: Text(units.formatDate(dive.dateTime)),
                             onTap: () => Navigator.of(context).pop(dive.id),
                           );
                         },

--- a/lib/features/media/presentation/widgets/file_review_card.dart
+++ b/lib/features/media/presentation/widgets/file_review_card.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/media/domain/value_objects/extracted_file.dart';
 import 'package:submersion/features/media/domain/value_objects/taken_at_source.dart';
 import 'package:submersion/features/media/domain/value_objects/unmatched_diagnostic.dart';
 import 'package:submersion/features/media/presentation/providers/files_tab_providers.dart';
 import 'package:submersion/features/media/presentation/utils/capture_time_offset_format.dart';
 import 'package:submersion/features/media/presentation/widgets/dive_picker_sheet.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// A single row in the [FileReviewPane], representing one [ExtractedFile]
@@ -66,6 +67,7 @@ class FileReviewCard extends ConsumerWidget {
     final canAssign =
         allowDiveAssignment && assignTo != null && assignTo != targetDiveId;
     final reason = diagnostic;
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return ListTile(
       isThreeLine: reason != null,
@@ -79,7 +81,7 @@ class FileReviewCard extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(_timeLine(context)),
+          Text(_timeLine(context, units)),
           if (reason != null)
             Text(
               _reasonLine(context, reason),
@@ -132,7 +134,7 @@ class FileReviewCard extends ConsumerWidget {
   /// When a session offset is in effect the corrected time leads and the value
   /// actually read from the file follows in parentheses, so a diver can see
   /// what was changed on their behalf before committing.
-  String _timeLine(BuildContext context) {
+  String _timeLine(BuildContext context, UnitFormatter units) {
     final l10n = context.l10n;
     final source = switch (file.metadata.takenAtSource) {
       TakenAtSource.nativeExif => l10n.media_photoPicker_files_sourceExif,
@@ -146,9 +148,9 @@ class FileReviewCard extends ConsumerWidget {
     final takenAt = file.metadata.takenAt;
     if (takenAt == null) return source;
 
-    final original = _format(takenAt);
+    final original = _format(units, takenAt);
     if (captureTimeOffset == Duration.zero) return '$original ($source)';
-    final shifted = _format(takenAt.add(captureTimeOffset));
+    final shifted = _format(units, takenAt.add(captureTimeOffset));
     return '${l10n.media_photoPicker_files_shiftedTime(shifted, original)} '
         '($source)';
   }
@@ -171,8 +173,13 @@ class FileReviewCard extends ConsumerWidget {
   /// `takenAt` is wall-clock-UTC by codebase convention, so format its UTC
   /// components directly. Running it through a local-timezone formatter would
   /// re-introduce the host-offset skew the convention exists to avoid.
-  String _format(DateTime value) =>
-      DateFormat('yyyy-MM-dd HH:mm').format(value.toUtc());
+  ///
+  /// The shape comes from the diver's date and time preferences rather than a
+  /// fixed pattern; only the UTC normalisation is fixed here.
+  String _format(UnitFormatter units, DateTime value) {
+    final utc = value.toUtc();
+    return '${units.formatDate(utc)} ${units.formatTime(utc)}';
+  }
 
   /// A 48x48 leading preview. Videos can't be decoded by [Image.file], so they
   /// get an explicit video icon rather than the broken-image error fallback.

--- a/lib/features/media/presentation/widgets/media_library_active_filter_chips.dart
+++ b/lib/features/media/presentation/widgets/media_library_active_filter_chips.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/marine_life/presentation/providers/species_providers.dart';
 import 'package:submersion/features/marine_life/presentation/species_display.dart';
@@ -11,6 +12,7 @@ import 'package:submersion/features/media/presentation/providers/media_library_p
 import 'package:submersion/features/media/presentation/providers/media_smart_album_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/media_library_filter_labels.dart';
 import 'package:submersion/features/media/presentation/widgets/media_smart_album_name_dialog.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -49,6 +51,7 @@ class MediaLibraryActiveFilterChips extends ConsumerWidget {
     final sites = ref.watch(sitesProvider).value ?? const [];
     final trips = ref.watch(allTripsProvider).value ?? const [];
     final species = ref.watch(allSpeciesProvider).value ?? const [];
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     Widget chip(String label, VoidCallback onClear) {
       return InputChip(
@@ -108,7 +111,7 @@ class MediaLibraryActiveFilterChips extends ConsumerWidget {
     if (filter.fromDate != null || filter.toDate != null) {
       chips.add(
         chip(
-          formatFilterDateRange(context, filter.fromDate, filter.toDate),
+          formatFilterDateRange(units, filter.fromDate, filter.toDate),
           () => _update(ref, (f) => f.copyWith(fromDate: null, toDate: null)),
         ),
       );

--- a/lib/features/media/presentation/widgets/media_library_filter_labels.dart
+++ b/lib/features/media/presentation/widgets/media_library_filter_labels.dart
@@ -1,19 +1,17 @@
-import 'package:flutter/widgets.dart';
-import 'package:intl/intl.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 
 /// Renders a filter date range for display. Shared by the filter sheet and
 /// the active-chip strip so the same range never reads two different ways.
 ///
-/// Locale-aware by construction: the format comes from the active locale
-/// rather than a hard-coded pattern.
+/// Takes the caller's [UnitFormatter] so the range honours the diver's date
+/// format preference rather than the locale default.
 String formatFilterDateRange(
-  BuildContext context,
+  UnitFormatter units,
   DateTime? from,
   DateTime? to,
 ) {
-  final format = DateFormat.yMMMd(Localizations.localeOf(context).toString());
   if (from != null && to != null) {
-    return '${format.format(from)} - ${format.format(to)}';
+    return '${units.formatDate(from)} - ${units.formatDate(to)}';
   }
-  return format.format(from ?? to!);
+  return units.formatDate(from ?? to!);
 }

--- a/lib/features/media/presentation/widgets/media_library_filter_sheet.dart
+++ b/lib/features/media/presentation/widgets/media_library_filter_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/marine_life/domain/entities/species.dart';
 import 'package:submersion/features/marine_life/presentation/providers/species_providers.dart';
@@ -10,6 +11,7 @@ import 'package:submersion/features/media/domain/entities/media_library_filter.d
 import 'package:submersion/features/media/presentation/providers/media_library_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_smart_album_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/media_library_filter_labels.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
@@ -213,6 +215,7 @@ class _MediaLibraryFilterSheetState
     ]..sort((a, b) => a.$2.toLowerCase().compareTo(b.$2.toLowerCase()));
     final albums = ref.watch(mediaSmartAlbumsProvider).value ?? const [];
     final missingCount = ref.watch(missingCountProvider).value ?? 0;
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     final siteName = _siteId == null
         ? null
@@ -355,7 +358,7 @@ class _MediaLibraryFilterSheetState
                           _fromDate == null && _toDate == null
                               ? anyLabel
                               : formatFilterDateRange(
-                                  context,
+                                  units,
                                   _fromDate,
                                   _toDate,
                                 ),

--- a/lib/features/media/presentation/widgets/media_library_grouped_list.dart
+++ b/lib/features/media/presentation/widgets/media_library_grouped_list.dart
@@ -1,16 +1,18 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
+import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/router/section_navigation.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/media/domain/entities/media_library_filter.dart';
 import 'package:submersion/features/media/presentation/widgets/media_library_grid.dart';
 import 'package:submersion/features/media/presentation/widgets/media_library_groupers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Sectioned presentation shared by the by-dive and timeline modes: group
 /// headers over non-scrolling thumbnail grids inside one scrolling list,
 /// with the same near-end load-more contract as the flat grid.
-class MediaLibraryGroupedList extends StatelessWidget {
+class MediaLibraryGroupedList extends ConsumerWidget {
   const MediaLibraryGroupedList({
     super.key,
     required this.groups,
@@ -35,7 +37,11 @@ class MediaLibraryGroupedList extends StatelessWidget {
 
   static const double _loadMoreThreshold = 400;
 
-  String _diveHeaderLabel(BuildContext context, DiveGroupHeader header) {
+  String _diveHeaderLabel(
+    BuildContext context,
+    UnitFormatter units,
+    DiveGroupHeader header,
+  ) {
     if (header.diveId == null) {
       return context.l10n.media_library_unlinkedHeader;
     }
@@ -47,8 +53,7 @@ class MediaLibraryGroupedList extends StatelessWidget {
     if (parts.isEmpty) {
       final date = header.diveDateTime;
       if (date != null) {
-        final locale = Localizations.localeOf(context).toString();
-        return DateFormat.yMMMd(locale).format(date);
+        return units.formatDate(date);
       }
       // A linked dive with no number, site or date still needs a visible
       // label: the header is this view's only route to that dive, and an
@@ -59,8 +64,8 @@ class MediaLibraryGroupedList extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
-    final locale = Localizations.localeOf(context).toString();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     final rows = <Widget>[];
     DateTime? lastMonth;
@@ -73,7 +78,7 @@ class MediaLibraryGroupedList extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.fromLTRB(12, 16, 12, 4),
               child: Text(
-                DateFormat.yMMMM(locale).format(header.monthStart),
+                units.formatMonthYear(header.monthStart),
                 style: Theme.of(context).textTheme.titleMedium,
               ),
             ),
@@ -83,13 +88,13 @@ class MediaLibraryGroupedList extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
             child: Text(
-              DateFormat.MMMEd(locale).format(header.dayStart),
+              units.formatWeekdayMonthDay(header.dayStart),
               style: Theme.of(context).textTheme.labelLarge,
             ),
           ),
         );
       } else if (header is DiveGroupHeader) {
-        final label = _diveHeaderLabel(context, header);
+        final label = _diveHeaderLabel(context, units, header);
         final diveId = header.diveId;
         // Inert while a selection is in progress, matching the tiles below it:
         // a tap landing a few pixels high must not navigate away from a

--- a/lib/features/media/presentation/widgets/scan_results_dialog.dart
+++ b/lib/features/media/presentation/widgets/scan_results_dialog.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Result returned from the scan results dialog.
@@ -31,16 +33,16 @@ class ScanDialogResult {
 ///
 /// Displays photos matched to dives with checkboxes to select which
 /// dives' photos should be linked. All dives are checked by default.
-class ScanResultsDialog extends StatefulWidget {
+class ScanResultsDialog extends ConsumerStatefulWidget {
   final ScanResult scanResult;
 
   const ScanResultsDialog({super.key, required this.scanResult});
 
   @override
-  State<ScanResultsDialog> createState() => _ScanResultsDialogState();
+  ConsumerState<ScanResultsDialog> createState() => _ScanResultsDialogState();
 }
 
-class _ScanResultsDialogState extends State<ScanResultsDialog> {
+class _ScanResultsDialogState extends ConsumerState<ScanResultsDialog> {
   /// Track which dives are selected for linking.
   late Map<Dive, bool> _selectedDives;
 
@@ -178,8 +180,7 @@ class _ScanResultsDialogState extends State<ScanResultsDialog> {
   }
 
   List<Widget> _buildDiveItems(ColorScheme colorScheme, TextTheme textTheme) {
-    final dateFormat = DateFormat.yMMMd();
-    final timeFormat = DateFormat.jm();
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final sortedDives = widget.scanResult.matchedByDive.keys.toList()
       ..sort((a, b) => a.dateTime.compareTo(b.dateTime));
 
@@ -190,8 +191,8 @@ class _ScanResultsDialogState extends State<ScanResultsDialog> {
       // Build dive subtitle
       final siteName =
           dive.site?.name ?? context.l10n.media_scanResults_unknownSite;
-      final dateStr = dateFormat.format(dive.dateTime);
-      final timeStr = timeFormat.format(dive.effectiveEntryTime);
+      final dateStr = units.formatDate(dive.dateTime);
+      final timeStr = units.formatTime(dive.effectiveEntryTime);
 
       return CheckboxListTile(
         value: isSelected,

--- a/lib/features/planner/domain/services/plan_name_generator.dart
+++ b/lib/features/planner/domain/services/plan_name_generator.dart
@@ -1,21 +1,21 @@
-import 'package:intl/intl.dart';
-
 /// Builds the default name offered when a dive plan is saved for the first
 /// time.
 ///
 /// Kept free of Flutter and Riverpod so it can be unit tested without a
-/// provider container. Unit conversion happens in the caller: [depthLabel] is
-/// already formatted in the diver's depth unit (for example `40m` or `130ft`),
-/// which means the generated name freezes that unit into the stored string.
-/// That is intentional. The name is a user-editable label, so regenerating it
-/// after a unit switch would overwrite names the diver typed deliberately.
+/// provider container. Formatting happens in the caller: [depthLabel] is
+/// already in the diver's depth unit (for example `40m` or `130ft`) and
+/// [dateLabel] is already in the diver's date order (for example `Jul 25` or
+/// `25 Jul`), which means the generated name freezes both into the stored
+/// string. That is intentional. The name is a user-editable label, so
+/// regenerating it after a preference switch would overwrite names the diver
+/// typed deliberately.
 ///
 /// [fallbackLabel] is the localized word for a plan (for example `Dive Plan`)
 /// and is used only when neither a site nor a depth is available.
 String generateDefaultPlanName({
   String? siteName,
   String? depthLabel,
-  required DateTime date,
+  required String dateLabel,
   required String fallbackLabel,
 }) {
   final site = siteName?.trim();
@@ -27,5 +27,5 @@ String generateDefaultPlanName({
   ];
   if (parts.isEmpty) parts.add(fallbackLabel);
 
-  return '${parts.join(' ')} - ${DateFormat.MMMd().format(date)}';
+  return '${parts.join(' ')} - $dateLabel';
 }

--- a/lib/features/planner/presentation/pages/plan_canvas_page.dart
+++ b/lib/features/planner/presentation/pages/plan_canvas_page.dart
@@ -644,7 +644,9 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
           depthLabel: suggestedDepth > 0
               ? units.formatDepth(suggestedDepth)
               : null,
-          date: planState.startDateTime ?? DateTime.now(),
+          dateLabel: units.formatMonthDay(
+            planState.startDateTime ?? DateTime.now(),
+          ),
           fallbackLabel: l10n.plannerCanvas_name_defaultFallback,
         ),
         title: l10n.plannerCanvas_name_dialogTitle,

--- a/lib/features/planner/presentation/widgets/follow_dive_sheet.dart
+++ b/lib/features/planner/presentation/widgets/follow_dive_sheet.dart
@@ -86,9 +86,7 @@ class _FollowDiveSheetState extends ConsumerState<FollowDiveSheet> {
   }
 
   Widget _diveTile(Dive dive, UnitFormatter units) {
-    final date = MaterialLocalizations.of(
-      context,
-    ).formatShortDate(dive.entryTime ?? dive.dateTime);
+    final date = units.formatDate(dive.entryTime ?? dive.dateTime);
     final subtitleParts = <String>[
       date,
       if (dive.maxDepth != null) units.formatDepth(dive.maxDepth!),

--- a/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
+++ b/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
@@ -217,9 +217,7 @@ class _PlanTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final date = MaterialLocalizations.of(
-      context,
-    ).formatShortDate(summary.updatedAt);
+    final date = units.formatDate(summary.updatedAt);
     final subtitleParts = <String>[
       date,
       if (summary.maxDepth != null) units.formatDepth(summary.maxDepth!),

--- a/lib/features/pre_dive/presentation/pages/pre_dive_session_runner_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_session_runner_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/number_input.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/equipment/domain/entities/overdue_service_entry.dart';
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
@@ -9,6 +10,7 @@ import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.da
 import 'package:submersion/features/pre_dive/domain/services/checklist_session_engine.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
 import 'package:submersion/features/pre_dive/presentation/widgets/session_item_tile.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Runs (or, once locked, displays) a pre-dive checklist session. Every tap
@@ -295,7 +297,7 @@ class PreDiveSessionRunnerPage extends ConsumerWidget {
               child: Text(
                 '${l10n.preDive_runner_locked} - '
                 '${_statusLabel(context, session.status)}'
-                '${session.completedAt == null ? '' : ' - ${MaterialLocalizations.of(context).formatMediumDate(session.completedAt!)}'}',
+                '${session.completedAt == null ? '' : ' - ${UnitFormatter(ref.watch(settingsProvider)).formatDate(session.completedAt)}'}',
                 style: theme.textTheme.bodyMedium,
               ),
             ),

--- a/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
 import 'package:submersion/features/pre_dive/domain/models/pre_dive_session_filter.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
@@ -189,7 +190,7 @@ class _ActiveFilterBar extends ConsumerWidget {
       PreDiveSessionStatus.aborted => l10n.preDive_sessions_statusAborted,
     };
 
-    final materialL10n = MaterialLocalizations.of(context);
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
@@ -233,9 +234,9 @@ class _ActiveFilterBar extends ConsumerWidget {
                 if (filter.dateRange != null)
                   Chip(
                     label: Text(
-                      '${materialL10n.formatMediumDate(filter.dateRange!.start)}'
+                      '${units.formatDate(filter.dateRange!.start)}'
                       ' - '
-                      '${materialL10n.formatMediumDate(filter.dateRange!.end)}',
+                      '${units.formatDate(filter.dateRange!.end)}',
                     ),
                     visualDensity: VisualDensity.compact,
                     deleteIcon: const Icon(Icons.close, size: 16),
@@ -400,9 +401,9 @@ class _SessionTile extends ConsumerWidget {
     final theme = Theme.of(context);
     final flagged =
         ref.watch(preDiveSessionStatsProvider).value?[session.id]?.flagged ?? 0;
-    final startedDate = MaterialLocalizations.of(
-      context,
-    ).formatMediumDate(session.startedAt);
+    final startedDate = UnitFormatter(
+      ref.watch(settingsProvider),
+    ).formatDate(session.startedAt);
 
     final hasLinkedDive = session.diveId != null;
 

--- a/lib/features/pre_dive/presentation/widgets/link_dive_picker.dart
+++ b/lib/features/pre_dive/presentation/widgets/link_dive_picker.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/debounced_search_results.dart';
 
@@ -138,22 +140,20 @@ class _RecentDives extends ConsumerWidget {
   }
 }
 
-class _DiveList extends StatelessWidget {
+class _DiveList extends ConsumerWidget {
   final List<DiveSummary> dives;
 
   const _DiveList({required this.dives});
 
   @override
-  Widget build(BuildContext context) {
-    final materialL10n = MaterialLocalizations.of(context);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return ListView.builder(
       itemCount: dives.length,
       itemBuilder: (context, index) {
         final dive = dives[index];
-        final date = materialL10n.formatMediumDate(
-          dive.entryTime ?? dive.dateTime,
-        );
+        final date = units.formatDate(dive.entryTime ?? dive.dateTime);
         // Number and site identify the dive; the date is the fallback identity
         // for a dive that has neither, so it must not also be the title then.
         final parts = [

--- a/lib/features/pre_dive/presentation/widgets/link_session_picker.dart
+++ b/lib/features/pre_dive/presentation/widgets/link_session_picker.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Picks the checklist run to attach to a dive (#1066), from the dive's own
@@ -49,14 +51,14 @@ class _LinkSessionPicker extends ConsumerWidget {
   }
 }
 
-class _SessionList extends StatelessWidget {
+class _SessionList extends ConsumerWidget {
   final List<PreDiveSession> sessions;
 
   const _SessionList({required this.sessions});
 
   @override
-  Widget build(BuildContext context) {
-    final materialL10n = MaterialLocalizations.of(context);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return ListView.builder(
       itemCount: sessions.length,
@@ -75,8 +77,7 @@ class _SessionList extends StatelessWidget {
           }),
           title: Text(session.templateName),
           subtitle: Text(
-            '${materialL10n.formatMediumDate(when)} - '
-            '${TimeOfDay.fromDateTime(when).format(context)}',
+            '${units.formatDate(when)} - ${units.formatTime(when)}',
           ),
           onTap: () => Navigator.of(context).pop(session.id),
         );

--- a/lib/features/pre_dive/presentation/widgets/pre_dive_session_filter_sheet.dart
+++ b/lib/features/pre_dive/presentation/widgets/pre_dive_session_filter_sheet.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
 import 'package:submersion/features/pre_dive/domain/models/pre_dive_session_filter.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 
@@ -85,6 +87,7 @@ class _PreDiveSessionFilterSheetState
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final templateNames = ref.watch(preDiveSessionTemplateNamesProvider);
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return DraggableScrollableSheet(
       initialChildSize: 0.7,
@@ -188,9 +191,9 @@ class _PreDiveSessionFilterSheetState
                         title: Text(
                           _dateRange == null
                               ? l10n.preDive_sessions_filterAnyDate
-                              : '${MaterialLocalizations.of(context).formatMediumDate(_dateRange!.start)}'
+                              : '${units.formatDate(_dateRange!.start)}'
                                     ' - '
-                                    '${MaterialLocalizations.of(context).formatMediumDate(_dateRange!.end)}',
+                                    '${units.formatDate(_dateRange!.end)}',
                         ),
                         trailing: _dateRange == null
                             ? null

--- a/lib/features/pre_dive/presentation/widgets/session_item_tile.dart
+++ b/lib/features/pre_dive/presentation/widgets/session_item_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/equipment/domain/entities/overdue_service_entry.dart';
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
@@ -8,6 +9,7 @@ import 'package:submersion/features/equipment/presentation/widgets/service_trigg
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_checklist_template.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
 import 'package:submersion/features/pre_dive/domain/services/checklist_session_engine.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// One checklist row in the session runner: large tap target, state icon,
@@ -139,7 +141,7 @@ class SessionItemTile extends ConsumerWidget {
         for (final entry in overdueEntries)
           Text(
             '${entry.kindName}: '
-            '${formatServiceTriggerText(context, now: overdueAsOf, dueDate: entry.dueDate, divesSinceAnchor: entry.divesSinceAnchor, divesRemaining: entry.divesRemaining, hoursSinceAnchor: entry.hoursSinceAnchor, hoursRemaining: entry.hoursRemaining)}',
+            '${formatServiceTriggerText(context, units: UnitFormatter(ref.watch(settingsProvider)), now: overdueAsOf, dueDate: entry.dueDate, divesSinceAnchor: entry.divesSinceAnchor, divesRemaining: entry.divesRemaining, hoursSinceAnchor: entry.hoursSinceAnchor, hoursRemaining: entry.hoursRemaining)}',
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.error,
             ),
@@ -150,7 +152,9 @@ class SessionItemTile extends ConsumerWidget {
       // text-bearing there eats into the item title (issue #935).
       if (item.completedAt != null)
         Text(
-          TimeOfDay.fromDateTime(item.completedAt!).format(context),
+          UnitFormatter(
+            ref.watch(settingsProvider),
+          ).formatTime(item.completedAt),
           style: theme.textTheme.bodySmall,
         ),
     ];

--- a/lib/features/reef/presentation/widgets/water_conditions_card.dart
+++ b/lib/features/reef/presentation/widgets/water_conditions_card.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart' show DateFormat;
 
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/reef/domain/entities/reef_data_status.dart';
 import 'package:submersion/features/reef/domain/entities/reef_habitat.dart';
 import 'package:submersion/features/reef/domain/entities/reef_health.dart';
@@ -68,6 +68,7 @@ class WaterConditionsCard extends ConsumerWidget {
 
     final data = health.value!;
     final tempUnit = ref.watch(temperatureUnitProvider);
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     final lines = <String>[];
     if (_reefPossible) {
@@ -108,9 +109,7 @@ class WaterConditionsCard extends ConsumerWidget {
     // day at the extremes of the timezone range, reporting an observation
     // date the dataset never had.
     lines.add(
-      context.l10n.reef_health_asOf(
-        DateFormat.yMMMd().format(data.observedAt.toUtc()),
-      ),
+      context.l10n.reef_health_asOf(units.formatDate(data.observedAt.toUtc())),
     );
 
     return tile(lines.join('\n'), isThreeLine: lines.length > 2);

--- a/lib/features/safety/presentation/pages/incident_edit_page.dart
+++ b/lib/features/safety/presentation/pages/incident_edit_page.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/safety/domain/entities/incident.dart';
 import 'package:submersion/features/safety/presentation/formatters/incident_labels.dart';
 import 'package:submersion/features/safety/presentation/providers/incident_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 
@@ -92,6 +93,7 @@ class _IncidentEditPageState extends ConsumerState<IncidentEditPage> {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    final units = UnitFormatter(ref.watch(settingsProvider));
     if (!_loaded) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
@@ -172,7 +174,7 @@ class _IncidentEditPageState extends ConsumerState<IncidentEditPage> {
               title: Text(l10n.incidentEdit_date),
               // Format the wall-clock UTC components directly (no toLocal), so
               // the shown day is identical on every synced device.
-              subtitle: Text(DateFormat.yMMMd().format(_occurredAt)),
+              subtitle: Text(units.formatDate(_occurredAt)),
               onTap: _pickDate,
             ),
             TextFormField(

--- a/lib/features/safety/presentation/pages/incidents_list_page.dart
+++ b/lib/features/safety/presentation/pages/incidents_list_page.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/safety/domain/entities/incident.dart';
 import 'package:submersion/features/safety/presentation/formatters/incident_labels.dart';
 import 'package:submersion/features/safety/presentation/providers/incident_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// The near-miss log: newest first, deliberately quiet styling.
@@ -70,7 +71,8 @@ class _IncidentTile extends ConsumerWidget {
     final theme = Theme.of(context);
     // occurredAt is a wall-clock UTC date; format its components directly (no
     // toLocal) so the shown day is stable across synced devices/timezones.
-    final dateText = DateFormat.yMMMd().format(incident.occurredAt);
+    final units = UnitFormatter(ref.watch(settingsProvider));
+    final dateText = units.formatDate(incident.occurredAt);
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),

--- a/lib/features/safety/presentation/pages/no_fly_page.dart
+++ b/lib/features/safety/presentation/pages/no_fly_page.dart
@@ -5,12 +5,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import 'package:submersion/core/providers/async_value_extensions.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:submersion/features/safety/presentation/formatters/no_fly_format.dart';
 import 'package:submersion/features/safety/presentation/providers/flight_window_providers.dart';
 import 'package:submersion/features/safety/presentation/providers/no_fly_providers.dart';
 import 'package:submersion/features/planning/presentation/widgets/planning_tool_pane.dart';
 import 'package:submersion/features/safety/presentation/widgets/flight_window_card.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -102,13 +104,13 @@ class _NoFlyPageState extends ConsumerState<NoFlyPage> {
 }
 
 /// The no-fly countdown card (also usable on other surfaces).
-class NoFlyStatusCard extends StatelessWidget {
+class NoFlyStatusCard extends ConsumerWidget {
   final NoFlyStatus? status;
 
   const NoFlyStatusCard({required this.status, super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     final theme = Theme.of(context);
     final now = DateTime.now().toUtc();
@@ -126,7 +128,11 @@ class NoFlyStatusCard extends StatelessWidget {
 
     final remaining = status!.remaining(now);
     final untilLocal = status!.until.toLocal();
-    final untilText = DateFormat.E().add_jm().format(untilLocal);
+    // The weekday has no ordering to respect, so it stays locale-derived; the
+    // clock half goes through the diver's 12h/24h preference.
+    final units = UnitFormatter(ref.watch(settingsProvider));
+    final untilText =
+        '${DateFormat.E().format(untilLocal)} ${units.formatTime(untilLocal)}';
 
     return Card(
       child: Padding(

--- a/lib/features/safety/presentation/widgets/chamber_tile.dart
+++ b/lib/features/safety/presentation/widgets/chamber_tile.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/safety/domain/entities/chamber_listing.dart';
@@ -50,7 +49,7 @@ class ChamberTile extends ConsumerWidget {
     final provenance = [
       if (chamber.lastVerified != null)
         l10n.emergencyCard_chamberVerified(
-          DateFormat.yMMM().format(chamber.lastVerified!),
+          units.formatMonthYear(chamber.lastVerified),
         ),
       if (chamber.verifiedVia == ChamberVerification.registry)
         l10n.emergencyCard_chamberUnverified,

--- a/lib/features/safety/presentation/widgets/flight_window_card.dart
+++ b/lib/features/safety/presentation/widgets/flight_window_card.dart
@@ -1,26 +1,34 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:submersion/features/safety/presentation/formatters/no_fly_format.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Presentational card for a [FlightWindowStatus]. Parents own the ticking:
 /// re-build (NoFlyPage's minute timer, the trip story wrapper's timer) and
 /// the countdown re-renders against the current wall-clock.
-class FlightWindowCard extends StatelessWidget {
+class FlightWindowCard extends ConsumerWidget {
   final FlightWindowStatus status;
 
   const FlightWindowCard({super.key, required this.status});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     final scheme = Theme.of(context).colorScheme;
     final now = NoFlyService.wallClockNowUtc();
     // Wall-clock-as-UTC values format their components directly -- no
-    // toLocal(), matching how dive times are displayed everywhere.
-    final timeFormat = DateFormat.E().add_jm();
+    // toLocal(), matching how dive times are displayed everywhere. The weekday
+    // has no ordering to respect, so it stays locale-derived; the clock half
+    // goes through the diver's 12h/24h preference.
+    final units = UnitFormatter(ref.watch(settingsProvider));
+    final weekdayFormat = DateFormat.E();
+    String formatWhen(DateTime value) =>
+        '${weekdayFormat.format(value)} ${units.formatTime(value)}';
 
     final (
       IconData icon,
@@ -34,19 +42,19 @@ class FlightWindowCard extends StatelessWidget {
         l10n.flightWindow_openTitle(
           formatNoFlyRemaining(status.remaining(now)),
         ),
-        l10n.flightWindow_surfaceBy(timeFormat.format(status.deadline)),
+        l10n.flightWindow_surfaceBy(formatWhen(status.deadline)),
       ),
       FlightWindowState.closed => (
         Icons.airplanemode_inactive,
         scheme.tertiary,
         l10n.flightWindow_closed,
-        l10n.flightWindow_departs(timeFormat.format(status.flightAt)),
+        l10n.flightWindow_departs(formatWhen(status.flightAt)),
       ),
       FlightWindowState.conflict => (
         Icons.warning_amber,
         scheme.error,
         l10n.flightWindow_conflict,
-        l10n.flightWindow_departs(timeFormat.format(status.flightAt)),
+        l10n.flightWindow_departs(formatWhen(status.flightAt)),
       ),
     };
 

--- a/lib/features/settings/presentation/pages/body_weight_edit_page.dart
+++ b/lib/features/settings/presentation/pages/body_weight_edit_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/number_input.dart';
@@ -90,7 +89,7 @@ class BodyWeightEditPage extends ConsumerWidget {
                   Expanded(
                     child: Text(
                       '${dialogContext.l10n.bodyWeight_dateLabel}: '
-                      '${DateFormat.yMMMd().format(measuredAt)}',
+                      '${units.formatDate(measuredAt)}',
                     ),
                   ),
                   IconButton(
@@ -189,9 +188,9 @@ class BodyWeightEditPage extends ConsumerWidget {
                 title: Text(units.formatWeight(entry.weightKg)),
                 subtitle: Text(
                   entry.heightCm != null
-                      ? '${DateFormat.yMMMd().format(entry.measuredAt)} · '
+                      ? '${units.formatDate(entry.measuredAt)} · '
                             '${units.formatHeight(entry.heightCm)}'
-                      : DateFormat.yMMMd().format(entry.measuredAt),
+                      : units.formatDate(entry.measuredAt),
                 ),
                 trailing: IconButton(
                   icon: const Icon(Icons.delete_outline),

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -1489,7 +1489,9 @@ class _CloudSyncPageState extends ConsumerState<CloudSyncPage> {
     } else if (difference.inDays < 7) {
       return l10n.settings_cloudSync_time_daysAgo(difference.inDays);
     } else {
-      return UnitFormatter(ref.read(settingsProvider)).formatDate(dateTime);
+      // watch, not read: both callers render this into the widget tree, so a
+      // preference change while the page is open must repaint it.
+      return UnitFormatter(ref.watch(settingsProvider)).formatDate(dateTime);
     }
   }
 }

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType;
@@ -11,9 +10,11 @@ import 'package:submersion/core/services/cloud_storage/dropbox/dropbox_auth_stor
 import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
 import 'package:submersion/core/services/sync/library_moved.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/divers/data/repositories/diver_merge_repository.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/storage_providers.dart'
     show StoragePlatformCapabilities, storagePlatformCapabilitiesProvider;
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
@@ -1488,7 +1489,7 @@ class _CloudSyncPageState extends ConsumerState<CloudSyncPage> {
     } else if (difference.inDays < 7) {
       return l10n.settings_cloudSync_time_daysAgo(difference.inDays);
     } else {
-      return DateFormat.yMMMd().format(dateTime);
+      return UnitFormatter(ref.read(settingsProvider)).formatDate(dateTime);
     }
   }
 }

--- a/lib/features/settings/presentation/pages/diver_profile_hub_page.dart
+++ b/lib/features/settings/presentation/pages/diver_profile_hub_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 import 'package:submersion/shared/widgets/profile_photo/profile_photo_picker.dart';
 import 'package:submersion/shared/widgets/profile_photo/profile_avatar.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -70,7 +69,7 @@ class DiverProfileHubPage extends ConsumerWidget {
             children: [
               _buildActiveDiverCard(context, ref, diver),
               const SizedBox(height: 16),
-              _buildSectionTilesCard(context, diver),
+              _buildSectionTilesCard(context, ref, diver),
               const SizedBox(height: 16),
               _buildManagementTilesCard(context, diver),
               const SizedBox(height: 32),
@@ -208,7 +207,11 @@ class DiverProfileHubPage extends ConsumerWidget {
     );
   }
 
-  Widget _buildSectionTilesCard(BuildContext context, Diver diver) {
+  Widget _buildSectionTilesCard(
+    BuildContext context,
+    WidgetRef ref,
+    Diver diver,
+  ) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Card(
@@ -251,7 +254,7 @@ class DiverProfileHubPage extends ConsumerWidget {
               context,
               icon: Icons.health_and_safety,
               title: context.l10n.settings_profileHub_insurance,
-              subtitle: _insuranceSubtitle(context, diver),
+              subtitle: _insuranceSubtitle(context, ref, diver),
               route: '/settings/diver-profile/insurance',
             ),
             const Divider(height: 1),
@@ -369,7 +372,7 @@ class DiverProfileHubPage extends ConsumerWidget {
     return context.l10n.settings_profileHub_medicalInfo_notSet;
   }
 
-  String _insuranceSubtitle(BuildContext context, Diver diver) {
+  String _insuranceSubtitle(BuildContext context, WidgetRef ref, Diver diver) {
     final insurance = diver.insurance;
     if (insurance.provider == null || insurance.provider!.isEmpty) {
       return context.l10n.settings_profileHub_insurance_notSet;
@@ -380,7 +383,9 @@ class DiverProfileHubPage extends ConsumerWidget {
     }
 
     if (insurance.expiryDate != null) {
-      final formatted = DateFormat.yMMMd().format(insurance.expiryDate!);
+      final formatted = UnitFormatter(
+        ref.watch(settingsProvider),
+      ).formatDate(insurance.expiryDate);
       return '${insurance.provider} - $formatted';
     }
 

--- a/lib/features/settings/presentation/pages/fix_dive_times_page.dart
+++ b/lib/features/settings/presentation/pages/fix_dive_times_page.dart
@@ -112,8 +112,11 @@ class _FixDiveTimesPageState extends ConsumerState<FixDiveTimesPage> {
     if (picked == null) return;
     setState(() {
       _rangeStart = DateTime.utc(picked.year, picked.month, picked.day);
-      _rangeStartController.text =
-          '${picked.year}-${picked.month.toString().padLeft(2, '0')}-${picked.day.toString().padLeft(2, '0')}';
+      // Read-only display of the picked bound: the real value lives in
+      // _rangeStart, so this follows Manage - Units (#1512).
+      _rangeStartController.text = UnitFormatter(
+        ref.read(settingsProvider),
+      ).formatDate(picked);
     });
     await _loadDives();
   }
@@ -136,8 +139,9 @@ class _FixDiveTimesPageState extends ConsumerState<FixDiveTimesPage> {
         59,
         59,
       );
-      _rangeEndController.text =
-          '${picked.year}-${picked.month.toString().padLeft(2, '0')}-${picked.day.toString().padLeft(2, '0')}';
+      _rangeEndController.text = UnitFormatter(
+        ref.read(settingsProvider),
+      ).formatDate(picked);
     });
     await _loadDives();
   }

--- a/lib/features/settings/presentation/pages/insurance_edit_page.dart
+++ b/lib/features/settings/presentation/pages/insurance_edit_page.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
@@ -236,7 +237,9 @@ class _InsuranceEditPageState extends ConsumerState<InsuranceEditPage> {
       title: Text(context.l10n.divers_edit_expiryDateTitle),
       subtitle: Text(
         _insuranceExpiry != null
-            ? DateFormat.yMMMd().format(_insuranceExpiry!)
+            ? UnitFormatter(
+                ref.watch(settingsProvider),
+              ).formatDate(_insuranceExpiry)
             : context.l10n.divers_edit_expiryDateNotSet,
       ),
       trailing: Row(

--- a/lib/features/settings/presentation/pages/lightroom_settings_page.dart
+++ b/lib/features/settings/presentation/pages/lightroom_settings_page.dart
@@ -12,9 +12,11 @@ import 'package:submersion/core/services/lightroom/adobe_ims_auth_manager.dart';
 import 'package:submersion/core/services/lightroom/lightroom_auth_store.dart';
 import 'package:submersion/core/services/lightroom/lightroom_embedded_connect.dart';
 import 'package:submersion/core/services/lightroom/lightroom_models.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/media/presentation/helpers/lightroom_scan_helper.dart';
 import 'package:submersion/features/media/presentation/providers/lightroom_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/widgets/lightroom_connect_dialog.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -389,9 +391,9 @@ class _LightroomSettingsPageState extends ConsumerState<LightroomSettingsPage> {
               if (last == null) return const SizedBox.shrink();
               return Text(
                 l10n.settings_lightroom_lastPoll(
-                  MaterialLocalizations.of(
-                    context,
-                  ).formatShortDate(last.toLocal()),
+                  UnitFormatter(
+                    ref.watch(settingsProvider),
+                  ).formatDate(last.toLocal()),
                 ),
               );
             },

--- a/lib/features/settings/presentation/pages/medical_info_edit_page.dart
+++ b/lib/features/settings/presentation/pages/medical_info_edit_page.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
@@ -280,7 +281,9 @@ class _MedicalInfoEditPageState extends ConsumerState<MedicalInfoEditPage> {
           Expanded(
             child: Text(
               _medicalClearanceExpiry != null
-                  ? DateFormat.yMMMd().format(_medicalClearanceExpiry!)
+                  ? UnitFormatter(
+                      ref.watch(settingsProvider),
+                    ).formatDate(_medicalClearanceExpiry)
                   : context.l10n.divers_edit_medicalClearanceNotSet,
             ),
           ),

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -3251,11 +3251,12 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
       ),
     };
 
+    // #1512: this stamp was hand-rolled as M/D/YYYY with a 24-hour clock, so
+    // it ignored both the date and the time preference.
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final lastCheck = prefs.lastCheckTime;
     final lastCheckText = lastCheck != null
-        ? '${lastCheck.month}/${lastCheck.day}/${lastCheck.year} '
-              '${lastCheck.hour.toString().padLeft(2, '0')}:'
-              '${lastCheck.minute.toString().padLeft(2, '0')}'
+        ? units.formatDateTime(lastCheck, l10n: context.l10n)
         : context.l10n.settings_updates_never;
 
     return Card(

--- a/lib/features/settings/presentation/pages/sync_devices_page.dart
+++ b/lib/features/settings/presentation/pages/sync_devices_page.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
 import 'package:submersion/core/services/sync/sync_device_footprint.dart';
 import 'package:submersion/core/utils/byte_format.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_device_providers.dart';
 import 'package:submersion/features/settings/presentation/widgets/sync_maintenance_progress_dialog.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
@@ -182,7 +183,9 @@ class _DeviceTile extends ConsumerWidget {
                 : l10n.settings_syncDevices_tile_filesSizeSeen(
                     device.fileCount,
                     size,
-                    DateFormat.yMMMd().add_jm().format(when.toLocal()),
+                    UnitFormatter(
+                      ref.watch(settingsProvider),
+                    ).formatDateTime(when.toLocal(), l10n: context.l10n),
                   ),
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,

--- a/lib/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart
+++ b/lib/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/sync/library_epoch.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/features/settings/presentation/widgets/sync_maintenance_progress_dialog.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -20,8 +21,9 @@ Future<void> showAdoptReplacedLibraryDialog(
 ) async {
   final l10n = context.l10n;
   final date = marker.replacedAt > 0
-      ? DateFormat.yMMMd().add_jm().format(
+      ? UnitFormatter(ref.read(settingsProvider)).formatDateTime(
           DateTime.fromMillisecondsSinceEpoch(marker.replacedAt),
+          l10n: l10n,
         )
       : '?';
   final confirmed = await showDialog<bool>(

--- a/lib/features/signatures/presentation/widgets/buddy_signature_card.dart
+++ b/lib/features/signatures/presentation/widgets/buddy_signature_card.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/signatures/domain/entities/signature.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/dive_roles/presentation/dive_role_display.dart';
 
 /// Card displaying a buddy's signature status
-class BuddySignatureCard extends StatelessWidget {
+class BuddySignatureCard extends ConsumerWidget {
   final BuddyWithRole buddyWithRole;
   final Signature? signature;
   final VoidCallback? onRequestSignature;
@@ -24,9 +26,10 @@ class BuddySignatureCard extends StatelessWidget {
   bool get hasSigned => signature != null;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colorScheme = Theme.of(context).colorScheme;
     final buddy = buddyWithRole.buddy;
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 4),
@@ -81,7 +84,7 @@ class BuddySignatureCard extends StatelessWidget {
                         const SizedBox(height: 4),
                         Text(
                           context.l10n.signatures_signedDate(
-                            DateFormat.yMMMd().format(signature!.signedAt),
+                            units.formatDate(signature!.signedAt),
                           ),
                           style: Theme.of(context).textTheme.bodySmall
                               ?.copyWith(color: colorScheme.primary),

--- a/lib/features/signatures/presentation/widgets/signature_display_widget.dart
+++ b/lib/features/signatures/presentation/widgets/signature_display_widget.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/signatures/domain/entities/signature.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Widget to display a saved instructor signature
-class SignatureDisplayWidget extends StatelessWidget {
+class SignatureDisplayWidget extends ConsumerWidget {
   final Signature signature;
   final VoidCallback? onTap;
   final VoidCallback? onDelete;
@@ -20,9 +22,9 @@ class SignatureDisplayWidget extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colorScheme = Theme.of(context).colorScheme;
-    final dateFormat = DateFormat.yMMMd().add_jm();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Card(
       child: Semantics(
@@ -99,7 +101,10 @@ class SignatureDisplayWidget extends StatelessWidget {
                     const SizedBox(width: 4),
                     Text(
                       context.l10n.signatures_signedDate(
-                        dateFormat.format(signature.signedAt),
+                        units.formatDateTime(
+                          signature.signedAt,
+                          l10n: context.l10n,
+                        ),
                       ),
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                         color: colorScheme.onSurfaceVariant,
@@ -176,15 +181,15 @@ class SignatureDisplayWidget extends StatelessWidget {
 }
 
 /// Full-view dialog for signature
-class SignatureFullViewDialog extends StatelessWidget {
+class SignatureFullViewDialog extends ConsumerWidget {
   final Signature signature;
 
   const SignatureFullViewDialog({super.key, required this.signature});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colorScheme = Theme.of(context).colorScheme;
-    final dateFormat = DateFormat.yMMMd().add_jm();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Dialog(
       child: Container(
@@ -257,7 +262,10 @@ class SignatureFullViewDialog extends StatelessWidget {
                   const SizedBox(width: 4),
                   Text(
                     context.l10n.signatures_signedDate(
-                      dateFormat.format(signature.signedAt),
+                      units.formatDateTime(
+                        signature.signedAt,
+                        l10n: context.l10n,
+                      ),
                     ),
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       color: colorScheme.onSurfaceVariant,

--- a/lib/features/statistics/presentation/pages/statistics_progression_page.dart
+++ b/lib/features/statistics/presentation/pages/statistics_progression_page.dart
@@ -217,6 +217,7 @@ class StatisticsProgressionPage extends ConsumerWidget {
         // controls, because a mean of a running total says nothing.
         data: (data) => DiveTrendChart(
           points: data,
+          dateFormat: ref.watch(dateFormatProvider),
           pointColor: Colors.green,
           valueFormatter: (value) => value.toStringAsFixed(0),
         ),

--- a/lib/features/statistics/presentation/widgets/date_axis.dart
+++ b/lib/features/statistics/presentation/widgets/date_axis.dart
@@ -12,6 +12,7 @@ library;
 
 import 'package:intl/intl.dart';
 import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 
 enum DateAxisGranularity { day, month, quarter, year }
 
@@ -109,8 +110,7 @@ class DateAxis {
       case DateAxisGranularity.month:
         return "${DateFormat.MMM().format(date)} '${_shortYear(date)}";
       case DateAxisGranularity.day:
-        final md = dateFormat.isDayFirst ? 'd/M' : 'M/d';
-        return "${DateFormat(md).format(date)} '${_shortYear(date)}";
+        return "${DateFormat(UnitFormatter.numericMonthDayPattern(dateFormat)).format(date)} '${_shortYear(date)}";
     }
   }
 

--- a/lib/features/statistics/presentation/widgets/date_axis.dart
+++ b/lib/features/statistics/presentation/widgets/date_axis.dart
@@ -5,9 +5,14 @@
 /// and stay honest, so they plot real timestamps and need ticks chosen from the
 /// span rather than from the point count (issue #299).
 ///
-/// Deliberately free of Flutter and of ambient locale: labels are formatted
-/// from the diver's own [DateFormatPreference], which the widget threads in.
-/// This file only decides where ticks go.
+/// Deliberately free of Flutter and Riverpod: the widget threads in the
+/// diver's [DateFormatPreference], and this file only decides where ticks go.
+///
+/// Free of the ambient locale only where the reading order is ambiguous, which
+/// is the numeric day label. The month and year labels still go through intl's
+/// named constructors and so resolve against `Intl.defaultLocale`, which is
+/// what makes "Mar" read as "mars" on a French UI. That is the intended split:
+/// the preference owns the order, the locale owns the words.
 library;
 
 import 'package:intl/intl.dart';

--- a/lib/features/statistics/presentation/widgets/date_axis.dart
+++ b/lib/features/statistics/presentation/widgets/date_axis.dart
@@ -5,11 +5,13 @@
 /// and stay honest, so they plot real timestamps and need ticks chosen from the
 /// span rather than from the point count (issue #299).
 ///
-/// Deliberately free of Flutter and of locale: labels are formatted by the
-/// widget, which has a BuildContext. This file only decides where ticks go.
+/// Deliberately free of Flutter and of ambient locale: labels are formatted
+/// from the diver's own [DateFormatPreference], which the widget threads in.
+/// This file only decides where ticks go.
 library;
 
 import 'package:intl/intl.dart';
+import 'package:submersion/core/constants/units.dart';
 
 enum DateAxisGranularity { day, month, quarter, year }
 
@@ -20,6 +22,7 @@ class DateAxis {
     required this.ticks,
     required this.granularity,
     required this.labelInterval,
+    this.dateFormat = DateFormatPreference.mmmDYYYY,
   });
 
   /// Lower bound, as `millisecondsSinceEpoch`, for fl_chart's `minX`.
@@ -32,6 +35,10 @@ class DateAxis {
   final List<DateTime> ticks;
 
   final DateAxisGranularity granularity;
+
+  /// The diver's date order, which only the day-granularity label reads: a
+  /// numeric "10/8" is the one label here that is ambiguous (#1512).
+  final DateFormatPreference dateFormat;
 
   /// Spacing, in milliseconds, to hand fl_chart as `SideTitles.interval`.
   ///
@@ -102,7 +109,8 @@ class DateAxis {
       case DateAxisGranularity.month:
         return "${DateFormat.MMM().format(date)} '${_shortYear(date)}";
       case DateAxisGranularity.day:
-        return "${DateFormat.Md().format(date)} '${_shortYear(date)}";
+        final md = dateFormat.isDayFirst ? 'd/M' : 'M/d';
+        return "${DateFormat(md).format(date)} '${_shortYear(date)}";
     }
   }
 
@@ -113,7 +121,11 @@ class DateAxis {
   ///
   /// A degenerate range (one dive, or several on one day) is widened to a day
   /// so fl_chart has a non-zero axis to draw.
-  factory DateAxis.forRange(DateTime first, DateTime last) {
+  factory DateAxis.forRange(
+    DateTime first,
+    DateTime last, {
+    DateFormatPreference dateFormat = DateFormatPreference.mmmDYYYY,
+  }) {
     final start = first;
     var end = last;
     if (!end.isAfter(start)) {
@@ -140,6 +152,7 @@ class DateAxis {
       ticks: ticks,
       granularity: granularity,
       labelInterval: (maxMs - minMs) / steps,
+      dateFormat: dateFormat,
     );
   }
 

--- a/lib/features/statistics/presentation/widgets/dive_trend_chart.dart
+++ b/lib/features/statistics/presentation/widgets/dive_trend_chart.dart
@@ -5,6 +5,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/presentation/widgets/chart_zoom_controls.dart';
 import 'package:submersion/core/ui/chart_viewport.dart';
 import 'package:submersion/core/ui/trackpad_zoom_recognizer.dart';
@@ -46,10 +47,16 @@ class DiveTrendChart extends StatefulWidget {
     this.yAxisFormatter,
     this.chartId,
     this.onDiveSelected,
+    this.dateFormat = DateFormatPreference.mmmDYYYY,
   });
 
   /// Raw per-dive points, in any order. Never pre-aggregated by the caller.
   final List<TrendDataPoint> points;
+
+  /// The diver's date order, threaded in by the caller rather than read from
+  /// the ambient locale, so the axis and the tooltip match Manage - Units
+  /// (#1512).
+  final DateFormatPreference dateFormat;
 
   final TrendAggregation aggregation;
   final bool showRollingMean;
@@ -332,6 +339,7 @@ class _DiveTrendChartState extends State<DiveTrendChart> {
     final dateAxis = DateAxis.forRange(
       DateTime.fromMillisecondsSinceEpoch(visibleMin.toInt(), isUtc: true),
       DateTime.fromMillisecondsSinceEpoch(visibleMax.toInt(), isUtc: true),
+      dateFormat: widget.dateFormat,
     );
 
     // The fits can run outside the bucket range, so the axis has to see them.
@@ -608,7 +616,7 @@ class _DiveTrendChartState extends State<DiveTrendChart> {
             for (var i = 0; i < touchedSpots.length; i++)
               if (i == 0)
                 LineTooltipItem(
-                  DateFormat.yMMMd().format(date),
+                  DateFormat(widget.dateFormat.pattern).format(date),
                   style,
                   children: [
                     for (final spot in touchedSpots)

--- a/lib/features/statistics/presentation/widgets/trend_chart_section.dart
+++ b/lib/features/statistics/presentation/widgets/trend_chart_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
 
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/statistics/domain/trend_aggregation.dart';
 import 'package:submersion/features/statistics/presentation/providers/trend_chart_settings_provider.dart';
 import 'package:submersion/features/statistics/presentation/widgets/dive_trend_chart.dart';
@@ -75,6 +76,7 @@ class TrendChartSection extends ConsumerWidget {
               DiveTrendChart(
                 chartId: chartId,
                 points: points,
+                dateFormat: ref.watch(dateFormatProvider),
                 onDiveSelected: onDiveSelected,
                 aggregation: settings.aggregation,
                 showRollingMean: settings.showRollingMean,

--- a/lib/features/transfer/presentation/pages/transfer_page.dart
+++ b/lib/features/transfer/presentation/pages/transfer_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_computer/presentation/utils/last_download_formatter.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/master_detail/master_detail_scaffold.dart';
@@ -12,6 +13,7 @@ import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.d
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/export_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/transfer/presentation/widgets/csv_export_dialog.dart';
 import 'package:submersion/features/transfer/presentation/widgets/pdf_export_dialog.dart';
 import 'package:submersion/features/transfer/presentation/widgets/transfer_list_content.dart';
@@ -610,6 +612,7 @@ class _ComputersSectionContent extends ConsumerWidget {
     final computersAsync = ref.watch(allDiveComputersProvider);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
@@ -687,6 +690,7 @@ class _ComputersSectionContent extends ConsumerWidget {
                       computer,
                       theme,
                       colorScheme,
+                      units,
                     ),
                   ),
                 ],
@@ -728,6 +732,7 @@ class _ComputersSectionContent extends ConsumerWidget {
     DiveComputer computer,
     ThemeData theme,
     ColorScheme colorScheme,
+    UnitFormatter units,
   ) {
     return Card(
       margin: const EdgeInsets.only(bottom: 8),
@@ -809,7 +814,11 @@ class _ComputersSectionContent extends ConsumerWidget {
                         ),
                         const SizedBox(width: 4),
                         Text(
-                          formatLastDownload(context, computer.lastDownload),
+                          formatLastDownload(
+                            context,
+                            computer.lastDownload,
+                            units: units,
+                          ),
                           style: theme.textTheme.bodySmall?.copyWith(
                             color: colorScheme.onSurfaceVariant,
                             fontSize: 11,

--- a/lib/features/trips/domain/constants/trip_field.dart
+++ b/lib/features/trips/domain/constants/trip_field.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart' show DateFormat;
 
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -195,8 +194,6 @@ class TripFieldAdapter extends EntityFieldAdapter<TripWithStats, TripField> {
     return map;
   }();
 
-  static final DateFormat _dateFormat = DateFormat.yMMMd();
-
   @override
   List<TripField> get allFields => _allFields;
 
@@ -226,8 +223,8 @@ class TripFieldAdapter extends EntityFieldAdapter<TripWithStats, TripField> {
   String formatValue(TripField field, dynamic value, UnitFormatter units) {
     if (value == null) return '--';
     return switch (field) {
-      TripField.startDate => _dateFormat.format(value as DateTime),
-      TripField.endDate => _dateFormat.format(value as DateTime),
+      TripField.startDate => units.formatDate(value as DateTime),
+      TripField.endDate => units.formatDate(value as DateTime),
       TripField.durationDays => '${value as int} days',
       TripField.tripType => (value as TripType).name,
       TripField.diveCount => (value as int).toString(),

--- a/lib/features/trips/presentation/pages/trip_detail_page.dart
+++ b/lib/features/trips/presentation/pages/trip_detail_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
@@ -260,7 +259,6 @@ class _TripDetailContent extends ConsumerWidget {
     final settings = ref.watch(settingsProvider);
     final units = UnitFormatter(settings);
     final theme = Theme.of(context);
-    final dateFormat = DateFormat.MMMd();
 
     return divesAsync.when(
       data: (dives) {
@@ -313,7 +311,7 @@ class _TripDetailContent extends ConsumerWidget {
                           ),
                           const SizedBox(height: 2),
                           Text(
-                            dateFormat.format(dive.dateTime),
+                            units.formatMonthDay(dive.dateTime),
                             style: theme.textTheme.bodySmall?.copyWith(
                               color: theme.colorScheme.onSurfaceVariant,
                             ),
@@ -364,7 +362,7 @@ class _TripDetailContent extends ConsumerWidget {
 
   Widget _buildEmbeddedHeader(BuildContext context, WidgetRef ref, Trip trip) {
     final colorScheme = Theme.of(context).colorScheme;
-    final dateFormat = DateFormat.MMMd();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -399,7 +397,7 @@ class _TripDetailContent extends ConsumerWidget {
                   overflow: TextOverflow.ellipsis,
                 ),
                 Text(
-                  '${dateFormat.format(trip.startDate)} - ${dateFormat.format(trip.endDate)}',
+                  '${units.formatMonthDay(trip.startDate)} - ${units.formatMonthDay(trip.endDate)}',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: colorScheme.onSurfaceVariant,
                   ),

--- a/lib/features/trips/presentation/pages/trip_edit_page.dart
+++ b/lib/features/trips/presentation/pages/trip_edit_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/trips/data/repositories/itinerary_day_repository.dart';
@@ -180,7 +180,7 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
 
   @override
   Widget build(BuildContext context) {
-    final dateFormat = DateFormat.yMMMd();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     final body = _isLoading
         ? const Center(child: CircularProgressIndicator())
@@ -252,11 +252,11 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
                   Semantics(
                     button: true,
                     label:
-                        '${context.l10n.trips_edit_label_startDate}: ${dateFormat.format(_startDate)}. Tap to change',
+                        '${context.l10n.trips_edit_label_startDate}: ${units.formatDate(_startDate)}. Tap to change',
                     child: ListTile(
                       leading: const Icon(Icons.calendar_today),
                       title: Text(context.l10n.trips_edit_label_startDate),
-                      subtitle: Text(dateFormat.format(_startDate)),
+                      subtitle: Text(units.formatDate(_startDate)),
                       onTap: () => _selectDate(context, true),
                       contentPadding: EdgeInsets.zero,
                       trailing: const Icon(Icons.edit),
@@ -267,11 +267,11 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
                   Semantics(
                     button: true,
                     label:
-                        '${context.l10n.trips_edit_label_endDate}: ${dateFormat.format(_endDate)}. Tap to change',
+                        '${context.l10n.trips_edit_label_endDate}: ${units.formatDate(_endDate)}. Tap to change',
                     child: ListTile(
                       leading: const Icon(Icons.event),
                       title: Text(context.l10n.trips_edit_label_endDate),
-                      subtitle: Text(dateFormat.format(_endDate)),
+                      subtitle: Text(units.formatDate(_endDate)),
                       onTap: () => _selectDate(context, false),
                       contentPadding: EdgeInsets.zero,
                       trailing: const Icon(Icons.edit),
@@ -300,7 +300,7 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
                       subtitle: Text(
                         _returnFlightAt == null
                             ? context.l10n.trips_edit_returnFlightNotSet
-                            : '${dateFormat.format(_returnFlightAt!)}, '
+                            : '${units.formatDate(_returnFlightAt)}, '
                                   '${TimeOfDay.fromDateTime(_returnFlightAt!).format(context)}',
                       ),
                       trailing: _returnFlightAt == null

--- a/lib/features/trips/presentation/pages/trip_edit_page.dart
+++ b/lib/features/trips/presentation/pages/trip_edit_page.dart
@@ -300,8 +300,11 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
                       subtitle: Text(
                         _returnFlightAt == null
                             ? context.l10n.trips_edit_returnFlightNotSet
+                            // TimeOfDay.format reads MediaQuery's
+                            // alwaysUse24HourFormat, which is the platform
+                            // setting, not the diver's TimeFormat (#1512).
                             : '${units.formatDate(_returnFlightAt)}, '
-                                  '${TimeOfDay.fromDateTime(_returnFlightAt!).format(context)}',
+                                  '${units.formatTime(_returnFlightAt)}',
                       ),
                       trailing: _returnFlightAt == null
                           ? const Icon(Icons.edit)

--- a/lib/features/trips/presentation/pages/trip_gallery_page.dart
+++ b/lib/features/trips/presentation/pages/trip_gallery_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
@@ -11,6 +11,7 @@ import 'package:submersion/features/media/presentation/providers/media_providers
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
 import 'package:submersion/features/media/presentation/widgets/scan_results_dialog.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_media_providers.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
@@ -283,7 +284,7 @@ class _GalleryContent extends StatelessWidget {
 }
 
 /// ExpansionTile section for photos from a single dive.
-class _DivePhotoSection extends StatelessWidget {
+class _DivePhotoSection extends ConsumerWidget {
   final String tripId;
   final Dive dive;
   final List<MediaItem> media;
@@ -295,8 +296,8 @@ class _DivePhotoSection extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
-    final dateFormat = DateFormat.MMMd();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final siteName =
         dive.site?.name ?? context.l10n.trips_detail_dives_unknownSite;
     final diveNumber = dive.diveNumber ?? '-';
@@ -314,7 +315,7 @@ class _DivePhotoSection extends StatelessWidget {
         ),
         subtitle: Text(
           context.l10n.trips_gallery_diveSection_subtitle(
-            dateFormat.format(dive.dateTime),
+            units.formatMonthDay(dive.dateTime),
             photoCount,
             photoLabel,
           ),

--- a/lib/features/trips/presentation/widgets/compact_trip_list_tile.dart
+++ b/lib/features/trips/presentation/widgets/compact_trip_list_tile.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/selection/selection_checkbox_slot.dart';
@@ -9,7 +11,7 @@ import 'package:submersion/shared/selection/selection_checkbox_slot.dart';
 ///
 /// Line 1: Trip name (expanded) | Date range (secondary text) | Chevron
 /// Line 2: Dive count with scuba icon | Total bottom time with timer icon
-class CompactTripListTile extends StatelessWidget {
+class CompactTripListTile extends ConsumerWidget {
   final TripWithStats tripWithStats;
   final bool isSelected;
   final VoidCallback? onTap;
@@ -30,7 +32,7 @@ class CompactTripListTile extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final trip = tripWithStats.trip;
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
@@ -38,9 +40,10 @@ class CompactTripListTile extends StatelessWidget {
         ? colorScheme.primaryContainer.withValues(alpha: 0.5)
         : null;
     final secondaryTextColor = colorScheme.onSurfaceVariant;
-    final dateFormat = DateFormat.yMMMd();
+    // Ordered by the diver's date format preference (#1512).
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final dateRangeStr =
-        '${dateFormat.format(trip.startDate)} - ${dateFormat.format(trip.endDate)}';
+        '${units.formatDate(trip.startDate)} - ${units.formatDate(trip.endDate)}';
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),

--- a/lib/features/trips/presentation/widgets/dive_assignment_dialog.dart
+++ b/lib/features/trips/presentation/widgets/dive_assignment_dialog.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/trips/domain/entities/dive_candidate.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -22,16 +24,17 @@ Future<List<String>?> showDiveAssignmentDialog({
 /// assignment status (unassigned vs on-other-trips).
 ///
 /// Returns the selected dive IDs on confirm, or null on cancel.
-class DiveAssignmentDialog extends StatefulWidget {
+class DiveAssignmentDialog extends ConsumerStatefulWidget {
   final List<DiveCandidate> candidates;
 
   const DiveAssignmentDialog({super.key, required this.candidates});
 
   @override
-  State<DiveAssignmentDialog> createState() => _DiveAssignmentDialogState();
+  ConsumerState<DiveAssignmentDialog> createState() =>
+      _DiveAssignmentDialogState();
 }
 
-class _DiveAssignmentDialogState extends State<DiveAssignmentDialog> {
+class _DiveAssignmentDialogState extends ConsumerState<DiveAssignmentDialog> {
   late final Set<String> _selectedIds;
   late final List<DiveCandidate> _unassigned;
   late final List<DiveCandidate> _otherTrip;
@@ -236,14 +239,14 @@ class _DiveAssignmentDialogState extends State<DiveAssignmentDialog> {
     TextTheme textTheme, {
     required bool showTripName,
   }) {
-    final dateFormat = DateFormat.yMMMd();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return candidates.map((candidate) {
       final dive = candidate.dive;
       final isSelected = _selectedIds.contains(dive.id);
       final siteName =
           dive.site?.name ?? context.l10n.trips_diveScan_unknownSite;
-      final dateStr = dateFormat.format(dive.dateTime);
+      final dateStr = units.formatDate(dive.dateTime);
       final depthStr = dive.maxDepth != null
           ? '${dive.maxDepth!.toStringAsFixed(1)}m'
           : '';

--- a/lib/features/trips/presentation/widgets/dive_assignment_dialog.dart
+++ b/lib/features/trips/presentation/widgets/dive_assignment_dialog.dart
@@ -247,8 +247,10 @@ class _DiveAssignmentDialogState extends ConsumerState<DiveAssignmentDialog> {
       final siteName =
           dive.site?.name ?? context.l10n.trips_diveScan_unknownSite;
       final dateStr = units.formatDate(dive.dateTime);
+      // Metres were hardcoded here, so an imperial diver read the wrong
+      // unit; the formatter is already in scope for the date.
       final depthStr = dive.maxDepth != null
-          ? '${dive.maxDepth!.toStringAsFixed(1)}m'
+          ? units.formatDepth(dive.maxDepth)
           : '';
 
       return InkWell(

--- a/lib/features/trips/presentation/widgets/story/trip_story_day_header.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_day_header.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -89,7 +88,9 @@ class TripStoryDayHeader extends ConsumerWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      DateFormat.MMMEd().format(day.date),
+                      UnitFormatter(
+                        ref.watch(settingsProvider),
+                      ).formatWeekdayMonthDay(day.date),
                       style: theme.textTheme.titleMedium?.copyWith(
                         fontWeight: FontWeight.bold,
                       ),

--- a/lib/features/trips/presentation/widgets/story/trip_story_hero.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_hero.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/trips/domain/entities/itinerary_day.dart';
 import 'package:submersion/features/trips/domain/entities/trip_story.dart';
 import 'package:submersion/features/trips/presentation/providers/liveaboard_providers.dart';
@@ -21,7 +22,7 @@ class TripStoryHero extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final trip = story.trip;
     final theme = Theme.of(context);
-    final dateFormat = DateFormat.yMMMd();
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final hasItinerary = story.days.any((d) => d.itineraryDay != null);
 
     return Column(
@@ -46,8 +47,8 @@ class TripStoryHero extends ConsumerWidget {
         ),
         const SizedBox(height: 4),
         Text(
-          '${dateFormat.format(trip.startDate)}'
-          ' - ${dateFormat.format(trip.endDate)}'
+          '${units.formatDate(trip.startDate)}'
+          ' - ${units.formatDate(trip.endDate)}'
           ' (${context.l10n.trips_detail_durationDays(trip.durationDays)})',
           style: theme.textTheme.bodyMedium?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
@@ -96,19 +97,19 @@ class TripStoryHero extends ConsumerWidget {
   }
 }
 
-class _ChecklistCard extends StatelessWidget {
+class _ChecklistCard extends ConsumerWidget {
   final TripStory story;
 
   const _ChecklistCard({required this.story});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final checklist = story.checklist;
     final progress = checklist.total == 0
         ? 0.0
         : checklist.done / checklist.total;
-    final dateFormat = DateFormat.MMMd();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Card(
       child: Padding(
@@ -151,7 +152,7 @@ class _ChecklistCard extends StatelessWidget {
                     ),
                     if (item.dueDate != null)
                       Text(
-                        dateFormat.format(item.dueDate!),
+                        units.formatMonthDay(item.dueDate),
                         style: theme.textTheme.labelSmall?.copyWith(
                           color: theme.colorScheme.primary,
                         ),

--- a/lib/features/trips/presentation/widgets/trip_itinerary_tab.dart
+++ b/lib/features/trips/presentation/widgets/trip_itinerary_tab.dart
@@ -109,7 +109,6 @@ class _ItineraryDayCard extends ConsumerWidget {
     final units = UnitFormatter(settings);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final dateFormat = DateFormat.MMMEd();
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
@@ -162,7 +161,7 @@ class _ItineraryDayCard extends ConsumerWidget {
                             ),
                           ),
                           Text(
-                            dateFormat.format(day.date),
+                            units.formatWeekdayMonthDay(day.date),
                             style: theme.textTheme.bodySmall?.copyWith(
                               color: colorScheme.onSurfaceVariant,
                             ),

--- a/lib/features/trips/presentation/widgets/trip_list_content.dart
+++ b/lib/features/trips/presentation/widgets/trip_list_content.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/constants/sort_options.dart';
@@ -784,7 +783,7 @@ class _TripListContentState extends ConsumerState<TripListContent> {
 }
 
 /// List item widget for displaying a trip
-class TripListTile extends StatelessWidget {
+class TripListTile extends ConsumerWidget {
   final TripWithStats tripWithStats;
   final bool isSelected;
   final VoidCallback? onTap;
@@ -805,9 +804,9 @@ class TripListTile extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final trip = tripWithStats.trip;
-    final dateFormat = DateFormat.yMMMd();
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final theme = Theme.of(context);
 
     final subtitleStr = trip.subtitle != null ? ', ${trip.subtitle}' : '';
@@ -821,7 +820,7 @@ class TripListTile extends StatelessWidget {
     // to match the compact tile and because a translated "to" would need an
     // ARB key per locale to read correctly.
     final dateRangeStr =
-        '${dateFormat.format(trip.startDate)} - ${dateFormat.format(trip.endDate)}';
+        '${units.formatDate(trip.startDate)} - ${units.formatDate(trip.endDate)}';
     final tripLabel =
         '${trip.name}, $dateRangeStr$subtitleStr, $diveCountStr$runtimeStr';
 
@@ -899,7 +898,7 @@ class TripListTile extends StatelessWidget {
               // Date range takes the subtitle role from the ListTile above,
               // matching the dive card's date line.
               Text(
-                '${dateFormat.format(trip.startDate)} - ${dateFormat.format(trip.endDate)}',
+                '${units.formatDate(trip.startDate)} - ${units.formatDate(trip.endDate)}',
               ),
               if (trip.subtitle != null)
                 Text(
@@ -1050,7 +1049,7 @@ class TripSearchDelegate extends SearchDelegate<Trip?> {
               itemCount: trips.length,
               itemBuilder: (context, index) {
                 final trip = trips[index];
-                final dateFormat = DateFormat.yMMMd();
+                final units = UnitFormatter(ref.watch(settingsProvider));
                 return ListTile(
                   // Same text theme roles as TripListTile so search results do
                   // not fall back to ListTile's bodyLarge title default.
@@ -1085,7 +1084,7 @@ class TripSearchDelegate extends SearchDelegate<Trip?> {
                   ),
                   title: Text(trip.name),
                   subtitle: Text(
-                    '${dateFormat.format(trip.startDate)} - ${dateFormat.format(trip.endDate)}',
+                    '${units.formatDate(trip.startDate)} - ${units.formatDate(trip.endDate)}',
                   ),
                   onTap: () {
                     close(context, trip);

--- a/lib/features/trips/presentation/widgets/trip_picker.dart
+++ b/lib/features/trips/presentation/widgets/trip_picker.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
@@ -68,8 +69,8 @@ class _TripPickerState extends ConsumerState<TripPicker> {
   }
 
   String _formatTripDates(Trip trip) {
-    final dateFormat = DateFormat.yMMMd();
-    return '${dateFormat.format(trip.startDate)} - ${dateFormat.format(trip.endDate)}';
+    final units = UnitFormatter(ref.watch(settingsProvider));
+    return '${units.formatDate(trip.startDate)} - ${units.formatDate(trip.endDate)}';
   }
 
   Widget _buildSuggestedTrip() {
@@ -248,18 +249,18 @@ class TripPickerSheet extends ConsumerWidget {
                 itemBuilder: (context, index) {
                   final trip = trips[index];
                   final isSelected = selectedTrip?.id == trip.id;
-                  final dateFormat = DateFormat.yMMMd();
+                  final units = UnitFormatter(ref.watch(settingsProvider));
 
                   final tripLabel = isSelected
                       ? context.l10n.trips_picker_tileSemanticsSelected(
                           trip.name,
-                          dateFormat.format(trip.startDate),
-                          dateFormat.format(trip.endDate),
+                          units.formatDate(trip.startDate),
+                          units.formatDate(trip.endDate),
                         )
                       : context.l10n.trips_picker_tileSemantics(
                           trip.name,
-                          dateFormat.format(trip.startDate),
-                          dateFormat.format(trip.endDate),
+                          units.formatDate(trip.startDate),
+                          units.formatDate(trip.endDate),
                         );
 
                   return Semantics(
@@ -282,7 +283,7 @@ class TripPickerSheet extends ConsumerWidget {
                       ),
                       title: Text(trip.name),
                       subtitle: Text(
-                        '${dateFormat.format(trip.startDate)} - ${dateFormat.format(trip.endDate)}',
+                        '${units.formatDate(trip.startDate)} - ${units.formatDate(trip.endDate)}',
                       ),
                       trailing: isSelected
                           ? Icon(

--- a/lib/features/trips/presentation/widgets/trip_service_alert_banner.dart
+++ b/lib/features/trips/presentation/widgets/trip_service_alert_banner.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -43,7 +45,11 @@ class TripServiceAlertBanner extends ConsumerWidget {
       button: true,
       label: context.l10n.trips_serviceAlert_count(itemCount),
       child: InkWell(
-        onTap: () => _showAlertSheet(context, alerts),
+        onTap: () => _showAlertSheet(
+          context,
+          UnitFormatter(ref.read(settingsProvider)),
+          alerts,
+        ),
         child: Container(
           width: double.infinity,
           color: background,
@@ -69,7 +75,11 @@ class TripServiceAlertBanner extends ConsumerWidget {
     );
   }
 
-  void _showAlertSheet(BuildContext context, List<DueClock> alerts) {
+  void _showAlertSheet(
+    BuildContext context,
+    UnitFormatter units,
+    List<DueClock> alerts,
+  ) {
     showModalBottomSheet<void>(
       context: context,
       builder: (sheetContext) => SafeArea(
@@ -91,7 +101,9 @@ class TripServiceAlertBanner extends ConsumerWidget {
                           : Theme.of(sheetContext).colorScheme.tertiary,
                     ),
                     title: Text(alert.item.name),
-                    subtitle: Text(_alertSubtitle(sheetContext, alert.status)),
+                    subtitle: Text(
+                      _alertSubtitle(sheetContext, units, alert.status),
+                    ),
                     onTap: () {
                       Navigator.pop(sheetContext);
                       context.push('/equipment/${alert.item.id}');
@@ -105,7 +117,11 @@ class TripServiceAlertBanner extends ConsumerWidget {
     );
   }
 
-  String _alertSubtitle(BuildContext context, ServiceClockStatus status) {
+  String _alertSubtitle(
+    BuildContext context,
+    UnitFormatter units,
+    ServiceClockStatus status,
+  ) {
     // Key off severity, not now-vs-dueDate: a clock overdue on dives/hours can
     // still have a future (or null) date trigger, and must read as "overdue".
     // Non-overdue alerts only reach the banner with a concrete future dueDate
@@ -116,7 +132,7 @@ class TripServiceAlertBanner extends ConsumerWidget {
     }
     return context.l10n.trips_serviceAlert_dueBefore(
       status.kind.name,
-      MaterialLocalizations.of(context).formatShortDate(dueDate),
+      units.formatDate(dueDate),
     );
   }
 }

--- a/lib/features/trips/presentation/widgets/trip_summary_widget.dart
+++ b/lib/features/trips/presentation/widgets/trip_summary_widget.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 /// Summary widget shown when no trip is selected.
 class TripSummaryWidget extends ConsumerWidget {
@@ -23,7 +24,7 @@ class TripSummaryWidget extends ConsumerWidget {
             _buildHeader(context),
             const SizedBox(height: 24),
             tripsAsync.when(
-              data: (trips) => _buildOverview(context, trips),
+              data: (trips) => _buildOverview(context, ref, trips),
               loading: () => const Center(child: CircularProgressIndicator()),
               error: (e, _) =>
                   Center(child: Text('${context.l10n.common_label_error}: $e')),
@@ -68,7 +69,7 @@ class TripSummaryWidget extends ConsumerWidget {
     );
   }
 
-  Widget _buildOverview(BuildContext context, List trips) {
+  Widget _buildOverview(BuildContext context, WidgetRef ref, List trips) {
     // Calculate stats
     num totalDives = 0;
     num totalDays = 0;
@@ -139,11 +140,11 @@ class TripSummaryWidget extends ConsumerWidget {
         ),
         if (trips.isNotEmpty) ...[
           const SizedBox(height: 24),
-          _buildTripListPreview(context, trips),
+          _buildTripListPreview(context, ref, trips),
         ],
         if (upcomingTrips.isNotEmpty) ...[
           const SizedBox(height: 24),
-          _buildUpcomingTrips(context, upcomingTrips),
+          _buildUpcomingTrips(context, ref, upcomingTrips),
         ],
       ],
     );
@@ -198,12 +199,16 @@ class TripSummaryWidget extends ConsumerWidget {
     );
   }
 
-  Widget _buildTripListPreview(BuildContext context, List trips) {
+  Widget _buildTripListPreview(
+    BuildContext context,
+    WidgetRef ref,
+    List trips,
+  ) {
     // Sort by start date descending and take recent 3
     final sortedTrips = List.from(trips)
       ..sort((a, b) => b.trip.startDate.compareTo(a.trip.startDate));
     final previewTrips = sortedTrips.take(3).toList();
-    final dateFormat = DateFormat.yMMMd();
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -231,7 +236,7 @@ class TripSummaryWidget extends ConsumerWidget {
                 ),
                 title: Text(trip.name),
                 subtitle: Text(
-                  '${dateFormat.format(trip.startDate)} • ${tripWithStats.diveCount} dives',
+                  '${units.formatDate(trip.startDate)} • ${tripWithStats.diveCount} dives',
                 ),
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () {
@@ -247,8 +252,12 @@ class TripSummaryWidget extends ConsumerWidget {
     );
   }
 
-  Widget _buildUpcomingTrips(BuildContext context, List upcomingTrips) {
-    final dateFormat = DateFormat.yMMMd();
+  Widget _buildUpcomingTrips(
+    BuildContext context,
+    WidgetRef ref,
+    List upcomingTrips,
+  ) {
+    final units = UnitFormatter(ref.watch(settingsProvider));
     final nextTrip = upcomingTrips.first;
     final daysUntil = nextTrip.trip.startDate.difference(DateTime.now()).inDays;
 
@@ -282,7 +291,7 @@ class TripSummaryWidget extends ConsumerWidget {
               ),
             ),
             subtitle: Text(
-              '${dateFormat.format(nextTrip.trip.startDate)} • In $daysUntil days',
+              '${units.formatDate(nextTrip.trip.startDate)} • In $daysUntil days',
               style: TextStyle(
                 color: Theme.of(context).colorScheme.onPrimaryContainer,
               ),

--- a/test/architecture/preference_aware_date_format_test.dart
+++ b/test/architecture/preference_aware_date_format_test.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Presentation code must render dates through `UnitFormatter`, which reads the
+/// diver's `DateFormatPreference` from Manage - Units, and never through a
+/// locale-derived `DateFormat` named constructor.
+///
+/// `DateFormat.yMMMd()` resolves against `Intl.defaultLocale`, so on an English
+/// UI it always renders "Jan 6, 1983". A diver who picked D MMM YYYY sees the
+/// wrong order and there is nothing in the widget to hint at it, which is how
+/// #1512 reached a release across Trips, Certifications, the update check and
+/// the equipment editor at once. This scan is the ratchet: every offender was
+/// converted, so any new one is a regression.
+///
+/// The `UnitFormatter` replacements are `formatDate`, `formatDateTime`,
+/// `formatDateTimeBullet`, `formatMonthDay`, `formatWeekdayMonthDay`,
+/// `formatMonthDayWithYear` and `formatMonthYear`.
+void main() {
+  /// Directories whose whole job is drawing the UI.
+  const scannedRoots = ['lib/core/presentation', 'lib/shared', 'lib/features'];
+
+  /// Only presentation code is scanned inside `lib/features`; parsers,
+  /// serialisers and repositories legitimately pin a machine format.
+  bool isScanned(String path) {
+    if (!path.startsWith('lib/features/')) return true;
+    return path.contains('/presentation/');
+  }
+
+  /// Files that keep a fixed format on purpose, each with the reason.
+  const allowed = <String, String>{
+    // Timestamps that end up in a filename, which must sort and must not
+    // contain a slash.
+    'lib/features/settings/presentation/pages/storage_settings_page.dart':
+        'export filename stamp',
+    // The Material date picker's own manual-entry hint, already derived from
+    // the preference by showAppDatePicker.
+    'lib/shared/widgets/app_date_picker.dart':
+        'picker hint, preference-derived',
+    // Fixed two-character month/year printed inside the CR80 card art, where
+    // the width budget is the constraint rather than the reading order.
+    'lib/features/certifications/presentation/services/certification_card_renderer.dart':
+        'CR80 card art, fixed width budget',
+  };
+
+  /// A named constructor is ambiguous when it carries a day, or a month
+  /// alongside a year: "10/8" and "Jun 2024" both read differently to a diver
+  /// on a day-first or ISO preference. A bare weekday (`E`), a bare month name
+  /// (`MMMM`), a bare year (`y`) and the time constructors have no order to
+  /// get wrong.
+  bool isAmbiguous(String constructorName) =>
+      constructorName.contains('d') ||
+      (constructorName.contains('y') && constructorName.contains('M'));
+
+  final namedConstructor = RegExp(r'\bDateFormat\.([A-Za-z]+)\s*\(');
+
+  // '${date.month}/${date.day}/${date.year}': a hand-rolled M/D/YYYY cannot
+  // honour any preference at all. Slash-separated only, so a dash-joined map
+  // key such as '$y-$m-$d' stays out of it: that is a machine string, and an
+  // ISO ordering is unambiguous anyway.
+  final handRolled = RegExp(r'\.month\}/\$\{[A-Za-z_.!?]*\.day\}');
+
+  test('presentation code formats dates from the diver preference', () {
+    final violations = <String>[];
+
+    for (final root in scannedRoots) {
+      final dir = Directory(root);
+      if (!dir.existsSync()) continue;
+      for (final entity in dir.listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        final path = entity.path;
+        if (!isScanned(path) || allowed.containsKey(path)) continue;
+
+        final lines = entity.readAsLinesSync();
+        for (var i = 0; i < lines.length; i++) {
+          final line = lines[i];
+          for (final match in namedConstructor.allMatches(line)) {
+            final name = match.group(1)!;
+            if (isAmbiguous(name)) {
+              violations.add('$path:${i + 1}  DateFormat.$name()');
+            }
+          }
+          if (handRolled.hasMatch(line)) {
+            violations.add('$path:${i + 1}  hand-rolled M/D/Y interpolation');
+          }
+        }
+      }
+    }
+
+    expect(
+      violations,
+      isEmpty,
+      reason:
+          'These render a date from the ambient locale instead of the diver\'s '
+          'DateFormatPreference (#1512). Use UnitFormatter, reached with '
+          'UnitFormatter(ref.watch(settingsProvider)). If a fixed format is '
+          'genuinely required, add the file to the allowlist above with its '
+          'reason.\n${violations.join('\n')}',
+    );
+  });
+}

--- a/test/architecture/preference_aware_date_format_test.dart
+++ b/test/architecture/preference_aware_date_format_test.dart
@@ -41,6 +41,14 @@ void main() {
     // the width budget is the constraint rather than the reading order.
     'lib/features/certifications/presentation/services/certification_card_renderer.dart':
         'CR80 card art, fixed width budget',
+    // The printed card face imitates a physical certification card, so it
+    // keeps that card's compact month/year whatever the diver picked. There is
+    // no day to reorder; the spoken Semantics label carries the full date in
+    // the diver's own order instead. Pinned by
+    // certification_ecard_test.dart, "keeps the card face month/year under a
+    // day-first preference".
+    'lib/features/certifications/presentation/widgets/certification_ecard_front.dart':
+        'card face imitates the physical card',
   };
 
   /// A named constructor is ambiguous when it carries a day, or a month

--- a/test/architecture/preference_aware_date_format_test.dart
+++ b/test/architecture/preference_aware_date_format_test.dart
@@ -71,7 +71,9 @@ void main() {
   // honour any preference at all. Slash-separated only, so a dash-joined map
   // key such as '$y-$m-$d' stays out of it: that is a machine string, and an
   // ISO ordering is unambiguous anyway.
-  final handRolled = RegExp(r'\.month\}/\$\{[A-Za-z_.!?]*\.day\}');
+  final handRolled = RegExp(
+    r'\.month\}/[^A-Za-z]{0,6}\$\{[A-Za-z_.!?]*\.day\}',
+  );
 
   // MaterialLocalizations formats from the resolved UI locale, which is the
   // same defect as DateFormat.yMMMd() wearing different clothes: it was how
@@ -84,7 +86,7 @@ void main() {
   // receiver on the same line.
   final materialDate = RegExp(r'\.format(Medium|Full|Compact|Short)Date\b');
   final materialMonthYear = RegExp(
-    r'MaterialLocalizations[\s\S]*formatMonthYear\b',
+    r'MaterialLocalizations[^;]{0,200}formatMonthYear\b',
   );
 
   // TimeOfDay.format reads MediaQuery's alwaysUse24HourFormat, the platform
@@ -92,6 +94,19 @@ void main() {
   final timeOfDay = RegExp(
     r'\bTimeOfDay[^;\n]*\.format\(context\)|\.formatTimeOfDay\b',
   );
+
+  /// Joins [lines] into one string, trimmed and space-separated, appending
+  /// each line's start offset to [lineStarts] so a match can be mapped back to
+  /// the line its call began on.
+  String flatten(List<String> lines, [List<int>? lineStarts]) {
+    final flat = StringBuffer();
+    for (final line in lines) {
+      lineStarts?.add(flat.length);
+      flat.write(line.trim());
+      flat.write(' ');
+    }
+    return flat.toString();
+  }
 
   test('presentation code formats dates from the diver preference', () {
     final violations = <String>[];
@@ -107,25 +122,54 @@ void main() {
         final path = entity.path.replaceAll('\\', '/');
         if (!isScanned(path) || allowed.containsKey(path)) continue;
 
+        // Scan the file as one flattened string, not line by line. dart
+        // format splits a chain the moment it runs long, and
+        // `MaterialLocalizations.of(\n  context,\n).formatShortDate(x)` is the
+        // shape it produces for exactly the calls this scan hunts. A per-line
+        // test sees three fragments and matches none of them.
+        //
+        // Each line is trimmed and joined with a single space, so the patterns
+        // below tolerate the whitespace the join introduces. `lineStarts`
+        // maps a match offset back to the line the call began on.
         final lines = entity.readAsLinesSync();
-        for (var i = 0; i < lines.length; i++) {
-          final line = lines[i];
-          for (final match in namedConstructor.allMatches(line)) {
-            final name = match.group(1)!;
-            if (isAmbiguous(name)) {
-              violations.add('$path:${i + 1}  DateFormat.$name()');
+        final lineStarts = <int>[];
+        final text = flatten(lines, lineStarts);
+
+        int lineOf(int offset) {
+          var low = 0;
+          var high = lineStarts.length - 1;
+          while (low < high) {
+            final mid = (low + high + 1) ~/ 2;
+            if (lineStarts[mid] <= offset) {
+              low = mid;
+            } else {
+              high = mid - 1;
             }
           }
-          if (handRolled.hasMatch(line)) {
-            violations.add('$path:${i + 1}  hand-rolled M/D/Y interpolation');
-          }
-          if (materialDate.hasMatch(line) || materialMonthYear.hasMatch(line)) {
-            violations.add('$path:${i + 1}  MaterialLocalizations date');
-          }
-          if (timeOfDay.hasMatch(line)) {
-            violations.add('$path:${i + 1}  TimeOfDay.format(context)');
+          return low + 1;
+        }
+
+        void report(
+          RegExp pattern,
+          String what, {
+          bool Function(RegExpMatch)? when,
+        }) {
+          for (final match in pattern.allMatches(text)) {
+            if (when != null && !when(match)) continue;
+            violations.add('$path:${lineOf(match.start)}  $what');
           }
         }
+
+        for (final match in namedConstructor.allMatches(text)) {
+          final name = match.group(1)!;
+          if (isAmbiguous(name)) {
+            violations.add('$path:${lineOf(match.start)}  DateFormat.$name()');
+          }
+        }
+        report(handRolled, 'hand-rolled M/D/Y interpolation');
+        report(materialDate, 'MaterialLocalizations date');
+        report(materialMonthYear, 'MaterialLocalizations date');
+        report(timeOfDay, 'TimeOfDay.format(context)');
       }
     }
 
@@ -138,6 +182,76 @@ void main() {
           'UnitFormatter(ref.watch(settingsProvider)). If a fixed format is '
           'genuinely required, add the file to the allowlist above with its '
           'reason.\n${violations.join('\n')}',
+    );
+  });
+
+  // The scan is only worth trusting if it survives dart format. Each sample
+  // below is the shape the formatter produces once the call runs long, which
+  // is precisely when a line-by-line scan stops seeing it.
+  test('the patterns survive a call split across lines', () {
+    expect(
+      materialDate.hasMatch(
+        flatten([
+          'final formatted = MaterialLocalizations.of(',
+          '  context,',
+          ').formatShortDate(dueDate);',
+        ]),
+      ),
+      isTrue,
+    );
+
+    expect(
+      materialMonthYear.hasMatch(
+        flatten([
+          'final label = MaterialLocalizations.of(',
+          '  context,',
+          ').formatMonthYear(when);',
+        ]),
+      ),
+      isTrue,
+    );
+
+    expect(
+      timeOfDay.hasMatch(
+        flatten([
+          'final t = TimeOfDay.fromDateTime(',
+          '  value,',
+          ').format(context);',
+        ]),
+      ),
+      isTrue,
+    );
+
+    expect(
+      handRolled.hasMatch(
+        flatten(["final s = '\${d.month}/'", "    '\${d.day}/\${d.year}';"]),
+      ),
+      isTrue,
+    );
+
+    expect(
+      namedConstructor
+          .allMatches(flatten(['DateFormat', '  .yMMMd()', '  .format(x);']))
+          .isEmpty,
+      isTrue,
+      reason:
+          'a receiver split before the dot is not a shape dart format emits, '
+          'and matching it would need a parser rather than a regex',
+    );
+
+    // The two shapes that must stay quiet: an ISO map key, and
+    // UnitFormatter's own formatMonthYear.
+    expect(
+      handRolled.hasMatch(
+        flatten(["return '\${d.year}-\${d.month}-\${d.day}';"]),
+      ),
+      isFalse,
+    );
+    expect(
+      materialMonthYear.hasMatch(
+        flatten(['units.formatMonthYear(header.monthStart),']),
+      ),
+      isFalse,
     );
   });
 }

--- a/test/architecture/preference_aware_date_format_test.dart
+++ b/test/architecture/preference_aware_date_format_test.dart
@@ -41,6 +41,11 @@ void main() {
     // the width budget is the constraint rather than the reading order.
     'lib/features/certifications/presentation/services/certification_card_renderer.dart':
         'CR80 card art, fixed width budget',
+    // The terminal startup-failure screen renders when the database could not
+    // be opened, so the diver's saved preferences are not readable at all and
+    // the resolved system locale is the only source of formatting there.
+    'lib/core/presentation/widgets/startup_failure_view.dart':
+        'renders before settings are readable',
     // The printed card face imitates a physical certification card, so it
     // keeps that card's compact month/year whatever the diver picked. There is
     // no day to reorder; the spoken Semantics label carries the full date in
@@ -68,6 +73,26 @@ void main() {
   // ISO ordering is unambiguous anyway.
   final handRolled = RegExp(r'\.month\}/\$\{[A-Za-z_.!?]*\.day\}');
 
+  // MaterialLocalizations formats from the resolved UI locale, which is the
+  // same defect as DateFormat.yMMMd() wearing different clothes: it was how
+  // the pre-dive, planner and equipment surfaces still ignored the preference
+  // after the first sweep, because no search for "DateFormat" reaches them.
+  //
+  // Only the four `format*Date` names are matched unconditionally: they exist
+  // nowhere else. `formatMonthYear` is also a UnitFormatter method, and the
+  // correct one, so it counts only alongside the MaterialLocalizations
+  // receiver on the same line.
+  final materialDate = RegExp(r'\.format(Medium|Full|Compact|Short)Date\b');
+  final materialMonthYear = RegExp(
+    r'MaterialLocalizations[\s\S]*formatMonthYear\b',
+  );
+
+  // TimeOfDay.format reads MediaQuery's alwaysUse24HourFormat, the platform
+  // setting, rather than the diver's TimeFormat.
+  final timeOfDay = RegExp(
+    r'\bTimeOfDay[^;\n]*\.format\(context\)|\.formatTimeOfDay\b',
+  );
+
   test('presentation code formats dates from the diver preference', () {
     final violations = <String>[];
 
@@ -93,6 +118,12 @@ void main() {
           }
           if (handRolled.hasMatch(line)) {
             violations.add('$path:${i + 1}  hand-rolled M/D/Y interpolation');
+          }
+          if (materialDate.hasMatch(line) || materialMonthYear.hasMatch(line)) {
+            violations.add('$path:${i + 1}  MaterialLocalizations date');
+          }
+          if (timeOfDay.hasMatch(line)) {
+            violations.add('$path:${i + 1}  TimeOfDay.format(context)');
           }
         }
       }

--- a/test/architecture/preference_aware_date_format_test.dart
+++ b/test/architecture/preference_aware_date_format_test.dart
@@ -76,7 +76,10 @@ void main() {
       if (!dir.existsSync()) continue;
       for (final entity in dir.listSync(recursive: true)) {
         if (entity is! File || !entity.path.endsWith('.dart')) continue;
-        final path = entity.path;
+        // Normalise separators: Directory.listSync yields platform paths, so
+        // on Windows every 'lib/features/' prefix and allowlist key below
+        // would miss and the scan would report phantom violations.
+        final path = entity.path.replaceAll('\\', '/');
         if (!isScanned(path) || allowed.containsKey(path)) continue;
 
         final lines = entity.readAsLinesSync();

--- a/test/core/utils/unit_formatter_date_test.dart
+++ b/test/core/utils/unit_formatter_date_test.dart
@@ -1,9 +1,31 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 void main() {
+  // These assertions are formatted by intl, which resolves against
+  // Intl.defaultLocale: a process global that app.dart sets from the app
+  // locale. There is no MaterialApp here to pin it, so without this the
+  // spelled months and the digits would ride on intl's implicit en_US
+  // fallback. Pin it, and restore it so the global stays contained.
+  //
+  // Setting the global explicitly means intl stops using its built-in fallback
+  // and demands real symbol data, so the locale must be initialized first.
+  late String? previousLocale;
+
+  // Symbol data does not depend on per-test state, so load it once.
+  setUpAll(() => initializeDateFormatting('en'));
+
+  setUp(() {
+    previousLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en';
+  });
+
+  tearDown(() => Intl.defaultLocale = previousLocale);
+
   const monthFirst = UnitFormatter(
     AppSettings(dateFormat: DateFormatPreference.mmddyyyy),
   );

--- a/test/core/utils/unit_formatter_date_test.dart
+++ b/test/core/utils/unit_formatter_date_test.dart
@@ -127,6 +127,38 @@ void main() {
       );
     });
 
+    // #1512 follow-up: the chart axis first derived this from `isDayFirst`,
+    // which is true for the ISO preference too, so an ISO diver got a
+    // day-first "8/10" and the dotted preference lost its dots.
+    test('numericMonthDayPattern keeps the order and the separator', () {
+      expect(
+        UnitFormatter.numericMonthDayPattern(DateFormatPreference.mmddyyyy),
+        'M/d',
+      );
+      expect(
+        UnitFormatter.numericMonthDayPattern(DateFormatPreference.ddmmyyyy),
+        'd/M',
+      );
+      expect(
+        UnitFormatter.numericMonthDayPattern(DateFormatPreference.yyyymmdd),
+        'M-d',
+      );
+      expect(
+        UnitFormatter.numericMonthDayPattern(DateFormatPreference.ddmmyyyyDots),
+        'd.M',
+      );
+      // The spelled-out preferences separate with a space or a comma, which
+      // does not read as a date on a cramped axis, so they take a slash.
+      expect(
+        UnitFormatter.numericMonthDayPattern(DateFormatPreference.mmmDYYYY),
+        'M/d',
+      );
+      expect(
+        UnitFormatter.numericMonthDayPattern(DateFormatPreference.dMMMYYYY),
+        'd/M',
+      );
+    });
+
     test('monthYearPattern removes the day and its separator', () {
       expect(
         UnitFormatter.monthYearPattern(DateFormatPreference.mmddyyyy),

--- a/test/core/utils/unit_formatter_date_test.dart
+++ b/test/core/utils/unit_formatter_date_test.dart
@@ -78,6 +78,43 @@ void main() {
     });
   });
 
+  group('formatMonthYear', () {
+    final date = DateTime(2026, 3, 15);
+
+    test('drops the day from the diver preference, keeping its shape', () {
+      expect(monthFirst.formatMonthYear(date), '03/2026');
+      expect(dayFirst.formatMonthYear(date), '03/2026');
+      expect(
+        const UnitFormatter(
+          AppSettings(dateFormat: DateFormatPreference.yyyymmdd),
+        ).formatMonthYear(date),
+        '2026-03',
+      );
+      expect(
+        const UnitFormatter(
+          AppSettings(dateFormat: DateFormatPreference.mmmDYYYY),
+        ).formatMonthYear(date),
+        'Mar 2026',
+      );
+      expect(
+        const UnitFormatter(
+          AppSettings(dateFormat: DateFormatPreference.dMMMYYYY),
+        ).formatMonthYear(date),
+        'Mar 2026',
+      );
+      expect(
+        const UnitFormatter(
+          AppSettings(dateFormat: DateFormatPreference.ddmmyyyyDots),
+        ).formatMonthYear(date),
+        '03.2026',
+      );
+    });
+
+    test('renders the placeholder for a null date', () {
+      expect(monthFirst.formatMonthYear(null), '--');
+    });
+  });
+
   group('static patterns', () {
     test('monthDayPattern follows the day-first preference', () {
       expect(
@@ -87,6 +124,33 @@ void main() {
       expect(
         UnitFormatter.monthDayPattern(DateFormatPreference.ddmmyyyy),
         'd MMM',
+      );
+    });
+
+    test('monthYearPattern removes the day and its separator', () {
+      expect(
+        UnitFormatter.monthYearPattern(DateFormatPreference.mmddyyyy),
+        'MM/yyyy',
+      );
+      expect(
+        UnitFormatter.monthYearPattern(DateFormatPreference.ddmmyyyy),
+        'MM/yyyy',
+      );
+      expect(
+        UnitFormatter.monthYearPattern(DateFormatPreference.yyyymmdd),
+        'yyyy-MM',
+      );
+      expect(
+        UnitFormatter.monthYearPattern(DateFormatPreference.mmmDYYYY),
+        'MMM yyyy',
+      );
+      expect(
+        UnitFormatter.monthYearPattern(DateFormatPreference.dMMMYYYY),
+        'MMM yyyy',
+      );
+      expect(
+        UnitFormatter.monthYearPattern(DateFormatPreference.ddmmyyyyDots),
+        'MM.yyyy',
       );
     });
 

--- a/test/features/backup/presentation/widgets/backup_history_tile_test.dart
+++ b/test/features/backup/presentation/widgets/backup_history_tile_test.dart
@@ -2,13 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../../../../helpers/mock_providers.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/features/backup/presentation/widgets/backup_history_tile.dart';
 import 'package:submersion/features/backup/presentation/widgets/pre_migration_badge.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
 
 BackupRecord _manual({
   bool pinned = false,

--- a/test/features/backup/presentation/widgets/backup_history_tile_test.dart
+++ b/test/features/backup/presentation/widgets/backup_history_tile_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
@@ -48,10 +49,12 @@ BackupRecord _preMigration({
 }
 
 Widget _wrap(Widget child) {
-  return MaterialApp(
-    localizationsDelegates: AppLocalizations.localizationsDelegates,
-    supportedLocales: AppLocalizations.supportedLocales,
-    home: Scaffold(body: child),
+  return ProviderScope(
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    ),
   );
 }
 

--- a/test/features/backup/presentation/widgets/backup_history_tile_test.dart
+++ b/test/features/backup/presentation/widgets/backup_history_tile_test.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../helpers/mock_providers.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/features/backup/presentation/widgets/backup_history_tile.dart';
 import 'package:submersion/features/backup/presentation/widgets/pre_migration_badge.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 BackupRecord _manual({
@@ -50,6 +52,10 @@ BackupRecord _preMigration({
 
 Widget _wrap(Widget child) {
   return ProviderScope(
+    // The tile watches settingsProvider for the diver's date format. The real
+    // notifier reaches for DiverSettingsRepository and a DatabaseService this
+    // harness never starts, so stand in with the shared mock.
+    overrides: [settingsProvider.overrideWith((ref) => MockSettingsNotifier())],
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,

--- a/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
+++ b/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import '../../../../helpers/mock_providers.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_confirmation_dialog.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
 
 BackupRecord _preMigration({
   required int fromVersion,

--- a/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
+++ b/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
@@ -26,10 +27,12 @@ BackupRecord _preMigration({
 }
 
 Widget _wrap(Widget child) {
-  return MaterialApp(
-    localizationsDelegates: AppLocalizations.localizationsDelegates,
-    supportedLocales: AppLocalizations.supportedLocales,
-    home: Scaffold(body: child),
+  return ProviderScope(
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    ),
   );
 }
 
@@ -115,21 +118,17 @@ void main() {
     ) async {
       RestoreMode? result;
       await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: Builder(
-              builder: (ctx) => TextButton(
-                onPressed: () async {
-                  result = await RestoreConfirmationDialog.show(
-                    ctx,
-                    record,
-                    currentSchemaVersion: currentSchemaVersion,
-                  );
-                },
-                child: const Text('open'),
-              ),
+        _wrap(
+          Builder(
+            builder: (ctx) => TextButton(
+              onPressed: () async {
+                result = await RestoreConfirmationDialog.show(
+                  ctx,
+                  record,
+                  currentSchemaVersion: currentSchemaVersion,
+                );
+              },
+              child: const Text('open'),
             ),
           ),
         ),

--- a/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
+++ b/test/features/backup/presentation/widgets/restore_confirmation_dialog_compat_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import '../../../../helpers/mock_providers.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
 import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_confirmation_dialog.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 BackupRecord _preMigration({
@@ -28,6 +30,10 @@ BackupRecord _preMigration({
 
 Widget _wrap(Widget child) {
   return ProviderScope(
+    // The dialog watches settingsProvider for the diver's date format. The real
+    // notifier reaches for DiverSettingsRepository and a DatabaseService this
+    // harness never starts, so stand in with the shared mock.
+    overrides: [settingsProvider.overrideWith((ref) => MockSettingsNotifier())],
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,

--- a/test/features/backup/presentation/widgets/restore_confirmation_dialog_test.dart
+++ b/test/features/backup/presentation/widgets/restore_confirmation_dialog_test.dart
@@ -2,12 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../../../../helpers/mock_providers.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_confirmation_dialog.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
 
 void main() {
   final record = BackupRecord(

--- a/test/features/backup/presentation/widgets/restore_confirmation_dialog_test.dart
+++ b/test/features/backup/presentation/widgets/restore_confirmation_dialog_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
@@ -26,21 +27,23 @@ void main() {
     RestoreMode? result;
     var completed = false;
     await tester.pumpWidget(
-      MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: Builder(
-          builder: (context) => ElevatedButton(
-            onPressed: () async {
-              result = await RestoreConfirmationDialog.show(
-                context,
-                record,
-                currentSchemaVersion: 80,
-                offerReplace: offerReplace,
-              );
-              completed = true;
-            },
-            child: const Text('open'),
+      ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                result = await RestoreConfirmationDialog.show(
+                  context,
+                  record,
+                  currentSchemaVersion: 80,
+                  offerReplace: offerReplace,
+                );
+                completed = true;
+              },
+              child: const Text('open'),
+            ),
           ),
         ),
       ),

--- a/test/features/backup/presentation/widgets/restore_confirmation_dialog_test.dart
+++ b/test/features/backup/presentation/widgets/restore_confirmation_dialog_test.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../helpers/mock_providers.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_confirmation_dialog.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 void main() {
@@ -28,6 +30,12 @@ void main() {
     var completed = false;
     await tester.pumpWidget(
       ProviderScope(
+        // The dialog watches settingsProvider for the diver's date format. The
+        // real notifier reaches for DiverSettingsRepository and a DatabaseService
+        // this harness never starts, so stand in with the shared mock.
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,

--- a/test/features/certifications/domain/constants/certification_field_test.dart
+++ b/test/features/certifications/domain/constants/certification_field_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -8,6 +10,26 @@ import 'package:submersion/features/certifications/domain/entities/certification
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 void main() {
+  // These assertions are formatted by intl, which resolves against
+  // Intl.defaultLocale: a process global that app.dart sets from the app
+  // locale. There is no MaterialApp here to pin it, so without this the
+  // spelled months and the digits would ride on intl's implicit en_US
+  // fallback. Pin it, and restore it so the global stays contained.
+  //
+  // Setting the global explicitly means intl stops using its built-in fallback
+  // and demands real symbol data, so the locale must be initialized first.
+  late String? previousLocale;
+
+  // Symbol data does not depend on per-test state, so load it once.
+  setUpAll(() => initializeDateFormatting('en'));
+
+  setUp(() {
+    previousLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en';
+  });
+
+  tearDown(() => Intl.defaultLocale = previousLocale);
+
   // A UnitFormatter backed by metric default settings.
   const units = UnitFormatter(AppSettings());
 

--- a/test/features/certifications/domain/constants/certification_field_test.dart
+++ b/test/features/certifications/domain/constants/certification_field_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl/intl.dart' show DateFormat;
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/certifications/domain/constants/certification_field.dart';
 import 'package:submersion/features/certifications/domain/entities/certification.dart';
@@ -27,8 +27,10 @@ void main() {
     updatedAt: DateTime(2023, 6, 15),
   );
 
-  // DateFormat used by the adapter for formatting dates.
-  final dateFormat = DateFormat.yMMMd();
+  // A diver who picked DD/MM/YYYY in Manage - Units (#1512).
+  const dayFirstUnits = UnitFormatter(
+    AppSettings(dateFormat: DateFormatPreference.ddmmyyyy),
+  );
 
   group('CertificationFieldAdapter.allFields', () {
     test('has expected count matching CertificationField.values', () {
@@ -357,19 +359,30 @@ void main() {
       );
     });
 
-    test('formats issue date using DateFormat.yMMMd()', () {
+    // #1512: the certification list read 'Jun 15, 2023' whatever the diver
+    // picked, because the adapter formatted dates from a fixed pattern
+    // instead of the UnitFormatter it is already handed.
+    test('formats issue date using the diver date format', () {
       final date = DateTime(2023, 6, 15);
       expect(
         adapter.formatValue(CertificationField.issueDate, date, units),
-        equals(dateFormat.format(date)),
+        equals(units.formatDate(date)),
+      );
+      expect(
+        adapter.formatValue(CertificationField.issueDate, date, dayFirstUnits),
+        equals('15/06/2023'),
       );
     });
 
-    test('formats expiry date using DateFormat.yMMMd()', () {
+    test('formats expiry date using the diver date format', () {
       final date = DateTime(2026, 6, 15);
       expect(
         adapter.formatValue(CertificationField.expiryDate, date, units),
-        equals(dateFormat.format(date)),
+        equals(units.formatDate(date)),
+      );
+      expect(
+        adapter.formatValue(CertificationField.expiryDate, date, dayFirstUnits),
+        equals('15/06/2026'),
       );
     });
 

--- a/test/features/certifications/presentation/widgets/certification_list_tile_date_format_test.dart
+++ b/test/features/certifications/presentation/widgets/certification_list_tile_date_format_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/certifications/domain/entities/certification.dart';
+import 'package:submersion/features/certifications/presentation/widgets/certification_list_content.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// #1512: the certification tile dated its subtitle with `DateFormat.yMMMd()`,
+/// so a diver on DD/MM/YYYY still read "Jun 15, 2023".
+
+/// The tile watches [settingsProvider]; the real notifier reaches for the
+/// database, so stand in with a fixed [AppSettings].
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier(super.initial);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+// `Override` is sealed and not re-exported, so the helper stays dynamic,
+// matching `testApp`'s `overrides` parameter.
+List<dynamic> _overridesFor(DateFormatPreference format) => [
+  settingsProvider.overrideWith(
+    (ref) => _TestSettingsNotifier(AppSettings(dateFormat: format)),
+  ),
+];
+
+Certification _certification() => Certification(
+  id: 'cert-1',
+  diverId: 'diver-1',
+  name: '',
+  agency: CertificationAgency.padi,
+  level: CertificationLevel.openWater,
+  issueDate: DateTime(2023, 6, 15),
+  createdAt: DateTime(2023, 6, 15),
+  updatedAt: DateTime(2023, 6, 15),
+);
+
+void main() {
+  group('CertificationListTile honours the diver date format', () {
+    testWidgets('subtitle carries the day-first issue date', (tester) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: _overridesFor(DateFormatPreference.ddmmyyyy),
+          child: CertificationListTile(certification: _certification()),
+        ),
+      );
+
+      expect(
+        find.textContaining('15/06/2023'),
+        findsOneWidget,
+        reason: 'the subtitle must follow Manage - Units, not the UI locale',
+      );
+      expect(find.textContaining('Jun 15, 2023'), findsNothing);
+    });
+
+    testWidgets('subtitle carries the ISO issue date', (tester) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: _overridesFor(DateFormatPreference.yyyymmdd),
+          child: CertificationListTile(certification: _certification()),
+        ),
+      );
+
+      expect(find.textContaining('2023-06-15'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/certifications/presentation/widgets/certification_list_tile_date_format_test.dart
+++ b/test/features/certifications/presentation/widgets/certification_list_tile_date_format_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/units.dart';
@@ -10,6 +11,10 @@ import '../../../../helpers/test_app.dart';
 
 /// #1512: the certification tile dated its subtitle with `DateFormat.yMMMd()`,
 /// so a diver on DD/MM/YYYY still read "Jun 15, 2023".
+///
+/// Both hosts pin `Locale('en')`. These assertions are numeric, but intl
+/// renders digits in the locale's own numbering system, so an unpinned host
+/// could produce Arabic-Indic digits on an `ar` machine.
 
 /// The tile watches [settingsProvider]; the real notifier reaches for the
 /// database, so stand in with a fixed [AppSettings].
@@ -45,6 +50,7 @@ void main() {
     testWidgets('subtitle carries the day-first issue date', (tester) async {
       await tester.pumpWidget(
         testApp(
+          locale: const Locale('en'),
           overrides: _overridesFor(DateFormatPreference.ddmmyyyy),
           child: CertificationListTile(certification: _certification()),
         ),
@@ -61,6 +67,7 @@ void main() {
     testWidgets('subtitle carries the ISO issue date', (tester) async {
       await tester.pumpWidget(
         testApp(
+          locale: const Locale('en'),
           overrides: _overridesFor(DateFormatPreference.yyyymmdd),
           child: CertificationListTile(certification: _certification()),
         ),

--- a/test/features/checklists/presentation/widgets/checklist_item_tile_test.dart
+++ b/test/features/checklists/presentation/widgets/checklist_item_tile_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
-import '../../../../helpers/mock_providers.dart';
 import 'package:submersion/features/checklists/domain/entities/trip_checklist_item.dart';
 import 'package:submersion/features/checklists/presentation/widgets/checklist_item_tile.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
+import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/test_app.dart';
 
 TripChecklistItem _item({

--- a/test/features/checklists/presentation/widgets/checklist_item_tile_test.dart
+++ b/test/features/checklists/presentation/widgets/checklist_item_tile_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
+import '../../../../helpers/mock_providers.dart';
 import 'package:submersion/features/checklists/domain/entities/trip_checklist_item.dart';
 import 'package:submersion/features/checklists/presentation/widgets/checklist_item_tile.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 import '../../../../helpers/test_app.dart';
 
@@ -22,6 +24,14 @@ TripChecklistItem _item({
   updatedAt: DateTime(2026),
 );
 
+// The tile watches settingsProvider for the diver's date format. The real
+// notifier reaches for DiverSettingsRepository and a DatabaseService this
+// harness never starts, and its constructor load is unlistened, so a failure
+// would escape to the zone and fail whichever test is running at the time.
+List<dynamic> _settingsOverrides() => [
+  settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+];
+
 void main() {
   testWidgets('tapping the checkbox invokes onToggle with the new value', (
     tester,
@@ -29,6 +39,7 @@ void main() {
     bool? toggledTo;
     await tester.pumpWidget(
       testApp(
+        overrides: _settingsOverrides(),
         child: ChecklistItemTile(
           item: _item(),
           showOverdue: true,
@@ -48,6 +59,7 @@ void main() {
   ) async {
     await tester.pumpWidget(
       testApp(
+        overrides: _settingsOverrides(),
         child: ChecklistItemTile(
           item: _item(isDone: true),
           showOverdue: true,
@@ -63,6 +75,7 @@ void main() {
   testWidgets('shows notes as a subtitle when present', (tester) async {
     await tester.pumpWidget(
       testApp(
+        overrides: _settingsOverrides(),
         child: ChecklistItemTile(
           item: _item(notes: 'bring backup mask'),
           showOverdue: true,
@@ -77,6 +90,7 @@ void main() {
   testWidgets('omits the subtitle when notes are empty', (tester) async {
     await tester.pumpWidget(
       testApp(
+        overrides: _settingsOverrides(),
         child: ChecklistItemTile(
           item: _item(),
           showOverdue: true,
@@ -95,6 +109,7 @@ void main() {
     var edited = false;
     await tester.pumpWidget(
       testApp(
+        overrides: _settingsOverrides(),
         child: ChecklistItemTile(
           item: _item(),
           showOverdue: true,
@@ -119,6 +134,7 @@ void main() {
     var deleted = false;
     await tester.pumpWidget(
       testApp(
+        overrides: _settingsOverrides(),
         child: ChecklistItemTile(
           item: _item(),
           showOverdue: true,
@@ -142,6 +158,7 @@ void main() {
   ) async {
     await tester.pumpWidget(
       testApp(
+        overrides: _settingsOverrides(),
         child: ChecklistItemTile(
           item: _item(
             dueDate: DateTime.now().subtract(const Duration(days: 3)),
@@ -160,6 +177,7 @@ void main() {
   ) async {
     await tester.pumpWidget(
       testApp(
+        overrides: _settingsOverrides(),
         child: ChecklistItemTile(
           item: _item(dueDate: DateTime(2026, 8, 1)),
           showOverdue: false,

--- a/test/features/dive_computer/presentation/utils/last_download_formatter_test.dart
+++ b/test/features/dive_computer/presentation/utils/last_download_formatter_test.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_computer/presentation/utils/last_download_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 /// The formatter replaced a domain getter that could not localize (#152), so
@@ -24,6 +27,7 @@ void main() {
     WidgetTester tester,
     DateTime? lastDownload, {
     Locale locale = const Locale('en'),
+    AppSettings settings = const AppSettings(),
   }) async {
     late String output;
     await tester.pumpWidget(
@@ -33,7 +37,11 @@ void main() {
         supportedLocales: AppLocalizations.supportedLocales,
         home: Builder(
           builder: (context) {
-            output = formatLastDownload(context, lastDownload);
+            output = formatLastDownload(
+              context,
+              lastDownload,
+              units: UnitFormatter(settings),
+            );
             return Text(output);
           },
         ),
@@ -81,11 +89,25 @@ void main() {
     );
   });
 
-  testWidgets('downloads older than a week fall back to a numeric date', (
+  testWidgets('downloads older than a week fall back to a full date', (
     tester,
   ) async {
     final old = DateTime(2026, 1, 15);
-    expect(await render(tester, old), DateFormat.yMd('en').format(old));
+    expect(await render(tester, old), 'Jan 15, 2026');
+  });
+
+  testWidgets('the fallback date honours the diver\'s date preference', (
+    tester,
+  ) async {
+    final old = DateTime(2026, 1, 15);
+    expect(
+      await render(
+        tester,
+        old,
+        settings: const AppSettings(dateFormat: DateFormatPreference.ddmmyyyy),
+      ),
+      '15/01/2026',
+    );
   });
 
   testWidgets('a future timestamp does not render a negative duration', (

--- a/test/features/equipment/presentation/widgets/service_trigger_text_test.dart
+++ b/test/features/equipment/presentation/widgets/service_trigger_text_test.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/equipment/presentation/widgets/service_trigger_text.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 void main() {
   Future<String> format(
     WidgetTester tester, {
     required DateTime now,
+    AppSettings settings = const AppSettings(),
     DateTime? dueDate,
     int? divesSinceAnchor,
     int? divesRemaining,
@@ -23,6 +27,7 @@ void main() {
           builder: (context) {
             result = formatServiceTriggerText(
               context,
+              units: UnitFormatter(settings),
               now: now,
               dueDate: dueDate,
               divesSinceAnchor: divesSinceAnchor,
@@ -45,6 +50,18 @@ void main() {
       dueDate: DateTime(2026, 1, 1),
     );
     expect(text, contains('Overdue since'));
+  });
+
+  // #1512: the due date came from MaterialLocalizations.formatShortDate, which
+  // follows the UI locale rather than the diver's date preference.
+  testWidgets('the due date follows the diver date format', (tester) async {
+    final text = await format(
+      tester,
+      settings: const AppSettings(dateFormat: DateFormatPreference.ddmmyyyy),
+      now: DateTime(2026, 1, 1),
+      dueDate: DateTime(2026, 6, 15),
+    );
+    expect(text, contains('15/06/2026'));
   });
 
   testWidgets('future date trigger reads "Due"', (tester) async {

--- a/test/features/media/presentation/media_library_grouped_list_test.dart
+++ b/test/features/media/presentation/media_library_grouped_list_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../../helpers/mock_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_provenance_providers.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 import 'package:go_router/go_router.dart';
@@ -13,6 +12,8 @@ import 'package:submersion/features/media/presentation/widgets/media_library_gro
 import 'package:submersion/features/media/presentation/widgets/media_library_groupers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../helpers/mock_providers.dart';
 
 MediaLibraryEntry entry(String id) => MediaLibraryEntry(
   item: MediaItem(

--- a/test/features/media/presentation/media_library_grouped_list_test.dart
+++ b/test/features/media/presentation/media_library_grouped_list_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../helpers/mock_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_provenance_providers.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 import 'package:go_router/go_router.dart';
@@ -10,6 +11,7 @@ import 'package:submersion/features/media/domain/entities/media_source_type.dart
 import 'package:submersion/features/media/presentation/widgets/media_library_grid.dart';
 import 'package:submersion/features/media/presentation/widgets/media_library_grouped_list.dart';
 import 'package:submersion/features/media/presentation/widgets/media_library_groupers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 MediaLibraryEntry entry(String id) => MediaLibraryEntry(
@@ -51,6 +53,11 @@ MediaLibraryGroup diveGroup({
 List<dynamic> _badgeOverrides() => [
   mediaStoreAttachedProvider.overrideWith((ref) async => false),
   mediaQueueFactsProvider.overrideWith((ref, id) => Stream.value(null)),
+  // The list watches settingsProvider for its date headers. The real notifier
+  // reaches for DiverSettingsRepository and a DatabaseService this harness
+  // never starts, and its constructor load is unlistened, so a failure would
+  // escape to the zone and fail whichever test is running at the time.
+  settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
 ];
 
 void main() {

--- a/test/features/media/presentation/media_repair_history_test.dart
+++ b/test/features/media/presentation/media_repair_history_test.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import '../../../helpers/mock_providers.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/data/repositories/media_repair_log_repository.dart';
 import 'package:submersion/features/media/presentation/pages/media_repair_history_view.dart';
 import 'package:submersion/features/media/presentation/providers/media_repair_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../helpers/mock_providers.dart';
 
 RepairLogEntry logEntry(
   String id, {

--- a/test/features/media/presentation/media_repair_history_test.dart
+++ b/test/features/media/presentation/media_repair_history_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import '../../../helpers/mock_providers.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/data/repositories/media_repair_log_repository.dart';
 import 'package:submersion/features/media/presentation/pages/media_repair_history_view.dart';
 import 'package:submersion/features/media/presentation/providers/media_repair_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 RepairLogEntry logEntry(
@@ -26,7 +28,14 @@ RepairLogEntry logEntry(
 void main() {
   Widget host(List<RepairLogEntry> entries) {
     return ProviderScope(
-      overrides: [repairHistoryProvider.overrideWith((ref) async => entries)],
+      // The view watches settingsProvider to format its timestamps. The real
+      // notifier reaches for DiverSettingsRepository and a DatabaseService this
+      // harness never starts, and its constructor load is unlistened, so a
+      // failure would escape to the zone and fail a stranger test.
+      overrides: [
+        repairHistoryProvider.overrideWith((ref) async => entries),
+        settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+      ],
       child: const MaterialApp(
         locale: Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/test/features/media/presentation/media_repair_history_test.dart
+++ b/test/features/media/presentation/media_repair_history_test.dart
@@ -97,10 +97,12 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('/nas/Dives/a.jpg'), findsOneWidget);
-    // intl separates the time from the meridiem with U+202F (narrow no-break
-    // space), not an ordinary space.
+    // The stamp goes through UnitFormatter, so it carries the diver's date
+    // and time preferences (defaults here) and the localized "at" connector.
+    // The explicit 'h:mm a' pattern separates the meridiem with an ordinary
+    // space, unlike DateFormat.jm()'s U+202F.
     expect(
-      find.text('Aug 6, 2026 3:04\u202FPM via watched folders'),
+      find.text('Aug 6, 2026 at 3:04 PM via watched folders'),
       findsOneWidget,
     );
   });

--- a/test/features/media/presentation/pages/site_media_viewer_page_test.dart
+++ b/test/features/media/presentation/pages/site_media_viewer_page_test.dart
@@ -690,5 +690,10 @@ DragEndDetails _dragDown(double pixelsPerSecond) => DragEndDetails(
 
 /// Mirrors the overlay's own formatting so the assertion survives locale
 /// data changes (intl has moved the space inside `jm` before now).
+/// The overlay's timestamp line, built from the default unit preferences the
+/// test harness installs: 'MMM d, yyyy' dates and 12-hour times, joined by the
+/// localized "at" connector. The explicit patterns mirror what UnitFormatter
+/// emits, including the ordinary space before the meridiem.
 String _metadataLine(DateTime takenAt) =>
-    '${DateFormat.yMMMd().format(takenAt)} at ${DateFormat.jm().format(takenAt)}';
+    '${DateFormat('MMM d, yyyy').format(takenAt)} at '
+    '${DateFormat('h:mm a').format(takenAt)}';

--- a/test/features/media/presentation/pages/site_media_viewer_page_test.dart
+++ b/test/features/media/presentation/pages/site_media_viewer_page_test.dart
@@ -688,12 +688,16 @@ DragEndDetails _dragDown(double pixelsPerSecond) => DragEndDetails(
   primaryVelocity: pixelsPerSecond,
 );
 
-/// Mirrors the overlay's own formatting so the assertion survives locale
-/// data changes (intl has moved the space inside `jm` before now).
 /// The overlay's timestamp line, built from the default unit preferences the
-/// test harness installs: 'MMM d, yyyy' dates and 12-hour times, joined by the
-/// localized "at" connector. The explicit patterns mirror what UnitFormatter
-/// emits, including the ordinary space before the meridiem.
+/// test harness installs: 'MMM d, yyyy' dates and 12-hour times.
+///
+/// The connector is hard-coded rather than read from l10n because both hosts
+/// above pin `Locale('en')`, whose `formatter_connector_at` is the literal
+/// "at"; a translated connector would mean a different expected string, not a
+/// different assertion. The date and time patterns are spelled out for the
+/// same reason UnitFormatter spells them out: `DateFormat.jm()` puts a narrow
+/// no-break space before the meridiem, and UnitFormatter's pattern-derived
+/// time does not.
 String _metadataLine(DateTime takenAt) =>
     '${DateFormat('MMM d, yyyy').format(takenAt)} at '
     '${DateFormat('h:mm a').format(takenAt)}';

--- a/test/features/media/presentation/widgets/file_review_card_test.dart
+++ b/test/features/media/presentation/widgets/file_review_card_test.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../../../../helpers/mock_providers.dart';
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
 import 'package:submersion/features/media/data/services/local_media_platform.dart';
@@ -16,6 +15,7 @@ import 'package:submersion/features/media/presentation/providers/files_tab_provi
 import 'package:submersion/features/media/presentation/widgets/file_review_card.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
+import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/test_app.dart';
 
 ExtractedFile _ef(String path, {MediaSourceMetadata? metadata}) =>

--- a/test/features/media/presentation/widgets/file_review_card_test.dart
+++ b/test/features/media/presentation/widgets/file_review_card_test.dart
@@ -163,7 +163,9 @@ void main() {
         targetDiveId: 'd1',
       );
 
-      expect(find.textContaining('2025-12-27 11:47'), findsOneWidget);
+      // The line honours the diver's date and time preferences; the
+      // harness leaves them at their defaults.
+      expect(find.textContaining('Dec 27, 2025 11:47 AM'), findsOneWidget);
       expect(find.textContaining('from EXIF'), findsOneWidget);
     });
 
@@ -226,8 +228,8 @@ void main() {
 
       // The corrected time leads; the value actually read from the file
       // follows, so the diver can see what was changed on their behalf.
-      expect(find.textContaining('2025-12-27 11:47'), findsOneWidget);
-      expect(find.textContaining('was 2025-12-27 16:47'), findsOneWidget);
+      expect(find.textContaining('Dec 27, 2025 11:47 AM'), findsOneWidget);
+      expect(find.textContaining('was Dec 27, 2025 4:47 PM'), findsOneWidget);
     });
   });
 

--- a/test/features/media/presentation/widgets/file_review_card_test.dart
+++ b/test/features/media/presentation/widgets/file_review_card_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../helpers/mock_providers.dart';
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
 import 'package:submersion/features/media/data/services/local_media_platform.dart';
@@ -13,6 +14,7 @@ import 'package:submersion/features/media/domain/value_objects/taken_at_source.d
 import 'package:submersion/features/media/domain/value_objects/unmatched_diagnostic.dart';
 import 'package:submersion/features/media/presentation/providers/files_tab_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/file_review_card.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 import '../../../../helpers/test_app.dart';
 
@@ -74,7 +76,12 @@ Future<void> _pumpCard(
   await tester.pumpWidget(
     testApp(
       locale: const Locale('en'),
-      overrides: [filesTabNotifierProvider.overrideWith((ref) => seeded)],
+      // The card watches settingsProvider for the diver's date and time format;
+      // stand in so the real notifier never reaches for the database.
+      overrides: [
+        filesTabNotifierProvider.overrideWith((ref) => seeded),
+        settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+      ],
       child: FileReviewCard(
         file: file,
         targetDiveId: targetDiveId,

--- a/test/features/media/presentation/widgets/media_library_filter_labels_test.dart
+++ b/test/features/media/presentation/widgets/media_library_filter_labels_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/media/presentation/widgets/media_library_filter_labels.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// #1512: the media filter chip and the filter sheet both showed the range
+/// from a locale-derived format, so a diver on DD/MM/YYYY read "Jun 1, 2025".
+/// Both surfaces share this one function, so pinning it here pins both.
+void main() {
+  // Formatted by intl, which resolves against Intl.defaultLocale. This is a
+  // pure unit test with no MaterialApp to pin it, so set it explicitly and
+  // restore it afterwards; intl then wants real symbol data, hence the
+  // initialization.
+  late String? previousLocale;
+
+  setUpAll(() => initializeDateFormatting('en'));
+
+  setUp(() {
+    previousLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en';
+  });
+
+  tearDown(() => Intl.defaultLocale = previousLocale);
+
+  const dayFirst = UnitFormatter(
+    AppSettings(dateFormat: DateFormatPreference.ddmmyyyy),
+  );
+  const monthFirst = UnitFormatter(
+    AppSettings(dateFormat: DateFormatPreference.mmmDYYYY),
+  );
+
+  final from = DateTime(2025, 6, 1);
+  final to = DateTime(2025, 6, 8);
+
+  group('formatFilterDateRange', () {
+    test('renders both bounds in the diver order', () {
+      expect(
+        formatFilterDateRange(dayFirst, from, to),
+        '01/06/2025 - 08/06/2025',
+      );
+      expect(
+        formatFilterDateRange(monthFirst, from, to),
+        'Jun 1, 2025 - Jun 8, 2025',
+      );
+    });
+
+    // A one-sided range renders the bound it has, with no "From"/"Until"
+    // word: the chip has no room for one and the sheet labels it already.
+    test('renders a lower bound alone', () {
+      expect(formatFilterDateRange(dayFirst, from, null), '01/06/2025');
+    });
+
+    test('renders an upper bound alone', () {
+      expect(formatFilterDateRange(dayFirst, null, to), '08/06/2025');
+    });
+  });
+}

--- a/test/features/planner/plan_name_generator_test.dart
+++ b/test/features/planner/plan_name_generator_test.dart
@@ -1,40 +1,20 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl/date_symbol_data_local.dart';
-import 'package:intl/intl.dart';
 import 'package:submersion/features/planner/domain/services/plan_name_generator.dart';
 
 void main() {
-  final date = DateTime(2026, 7, 25);
+  const dateLabel = 'Jul 25';
 
   group('generateDefaultPlanName', () {
-    // The generator dates the name with DateFormat.MMMd(), which resolves
-    // against Intl.defaultLocale - a process global that app.dart sets from
-    // the app locale. Pin it so the "Jul 25" assertions state their real
-    // dependency instead of riding on intl's implicit en_US fallback, and
-    // restore it so the global stays contained.
-    //
-    // Setting the global explicitly means intl stops using its built-in
-    // fallback and demands real symbol data, so the locale must be initialized
-    // first. Widget tests get that for free from GlobalMaterialLocalizations;
-    // this is a pure unit test, so it has to ask.
-    late String? previousLocale;
-
-    // Symbol data does not depend on per-test state, so load it once.
-    setUpAll(() => initializeDateFormatting('en'));
-
-    setUp(() {
-      previousLocale = Intl.defaultLocale;
-      Intl.defaultLocale = 'en';
-    });
-
-    tearDown(() => Intl.defaultLocale = previousLocale);
+    // The caller formats the date, in the diver's own order, and hands the
+    // generator a finished label (#1512). Nothing here depends on
+    // Intl.defaultLocale any more.
 
     test('combines site, depth, and date', () {
       expect(
         generateDefaultPlanName(
           siteName: 'Blue Hole',
           depthLabel: '40m',
-          date: date,
+          dateLabel: dateLabel,
           fallbackLabel: 'Dive Plan',
         ),
         'Blue Hole 40m - Jul 25',
@@ -46,7 +26,7 @@ void main() {
         generateDefaultPlanName(
           siteName: 'Blue Hole',
           depthLabel: null,
-          date: date,
+          dateLabel: dateLabel,
           fallbackLabel: 'Dive Plan',
         ),
         'Blue Hole - Jul 25',
@@ -58,7 +38,7 @@ void main() {
         generateDefaultPlanName(
           siteName: null,
           depthLabel: '40m',
-          date: date,
+          dateLabel: dateLabel,
           fallbackLabel: 'Dive Plan',
         ),
         '40m - Jul 25',
@@ -70,7 +50,7 @@ void main() {
         generateDefaultPlanName(
           siteName: null,
           depthLabel: null,
-          date: date,
+          dateLabel: dateLabel,
           fallbackLabel: 'Dive Plan',
         ),
         'Dive Plan - Jul 25',
@@ -82,7 +62,7 @@ void main() {
         generateDefaultPlanName(
           siteName: '   ',
           depthLabel: null,
-          date: date,
+          dateLabel: dateLabel,
           fallbackLabel: 'Dive Plan',
         ),
         'Dive Plan - Jul 25',
@@ -94,7 +74,7 @@ void main() {
         generateDefaultPlanName(
           siteName: '  Blue Hole  ',
           depthLabel: '40m',
-          date: date,
+          dateLabel: dateLabel,
           fallbackLabel: 'Dive Plan',
         ),
         'Blue Hole 40m - Jul 25',

--- a/test/features/safety/presentation/widgets/flight_window_card_test.dart
+++ b/test/features/safety/presentation/widgets/flight_window_card_test.dart
@@ -1,17 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:submersion/features/safety/presentation/widgets/flight_window_card.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
 
 void main() {
   Future<void> pumpCard(WidgetTester tester, FlightWindowStatus status) {
     return tester.pumpWidget(
-      MaterialApp(
-        locale: const Locale('en'),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: Scaffold(body: FlightWindowCard(status: status)),
+      ProviderScope(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: FlightWindowCard(status: status)),
+        ),
       ),
     );
   }

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -935,6 +935,7 @@ void main() {
       String? channel,
       Map<String, Object> extraPrefs = const {},
       UpdateStatus? status,
+      AppSettings settings = const AppSettings(),
     }) async {
       SharedPreferences.setMockInitialValues({
         'auto_update_enabled': false,
@@ -947,7 +948,7 @@ void main() {
       return [
         sharedPreferencesProvider.overrideWithValue(aboutPrefs),
         logFileServiceProvider.overrideWithValue(logFileService),
-        settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
+        settingsProvider.overrideWith((ref) => _MockSettingsNotifier(settings)),
         currentDiverIdProvider.overrideWith(
           (ref) => _MockCurrentDiverIdNotifier(),
         ),
@@ -1114,13 +1115,20 @@ void main() {
       expect(find.text('Error: offline'), findsOneWidget);
     });
 
-    testWidgets('a recorded last-check time is formatted, not Never', (
+    // #1512: this stamp was hand-rolled as M/D/YYYY on a 24-hour clock, so it
+    // ignored both the date and the time preference. It now goes through
+    // UnitFormatter like every other displayed date.
+    testWidgets('a recorded last-check time follows the diver preferences', (
       tester,
     ) async {
       final lastCheck = DateTime(2026, 7, 4, 9, 5);
       await tester.pumpWidget(
         buildAboutWidget(
           await aboutOverrides(
+            settings: const AppSettings(
+              dateFormat: DateFormatPreference.ddmmyyyy,
+              timeFormat: TimeFormat.twentyFourHour,
+            ),
             extraPrefs: {
               'auto_update_last_check': lastCheck.millisecondsSinceEpoch,
             },
@@ -1130,8 +1138,10 @@ void main() {
       await tester.pumpAndSettle();
       await tester.pump(const Duration(seconds: 6));
       await tester.scrollUntilVisible(find.text('Last checked'), 100);
-      expect(find.text('7/4/2026 09:05'), findsOneWidget);
+      expect(find.text('04/07/2026 at 09:05'), findsOneWidget);
       expect(find.text('Never'), findsNothing);
+      // The old hand-rolled shape, which no preference could ever produce.
+      expect(find.text('7/4/2026 09:05'), findsNothing);
     });
 
     testWidgets('version row shows a beta badge on the beta channel', (

--- a/test/features/statistics/presentation/widgets/date_axis_test.dart
+++ b/test/features/statistics/presentation/widgets/date_axis_test.dart
@@ -1,8 +1,31 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/features/statistics/presentation/widgets/date_axis.dart';
 
 void main() {
+  // The axis formats its labels with intl, which resolves against
+  // Intl.defaultLocale, a process global that app.dart sets from the app
+  // locale. This file is a pure unit test with no MaterialApp to pin it, so
+  // the "8/10 '24" assertions would ride on intl's implicit en_US fallback and
+  // could render non-Latin numerals on a host whose global says otherwise.
+  // Pin it, and restore it so the global stays contained.
+  //
+  // Setting the global explicitly means intl stops using its built-in fallback
+  // and demands real symbol data, so the locale must be initialized first.
+  late String? previousLocale;
+
+  // Symbol data does not depend on per-test state, so load it once.
+  setUpAll(() => initializeDateFormatting('en'));
+
+  setUp(() {
+    previousLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en';
+  });
+
+  tearDown(() => Intl.defaultLocale = previousLocale);
+
   test('bounds are the range endpoints as epoch milliseconds', () {
     final first = DateTime.utc(2024, 1, 1);
     final last = DateTime.utc(2024, 12, 31);

--- a/test/features/statistics/presentation/widgets/date_axis_test.dart
+++ b/test/features/statistics/presentation/widgets/date_axis_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/features/statistics/presentation/widgets/date_axis.dart';
 
 void main() {
@@ -231,6 +232,27 @@ void main() {
 
       final labels = drawn(axis);
       expect(labels.length, labels.toSet().length, reason: '$labels');
+    });
+
+    // #1512: the day label first derived its order from `isDayFirst`, which is
+    // true for the ISO preference as well, so an ISO diver read a day-first
+    // "8/10" and the dotted preference lost its dots.
+    test('day granularity labels follow the diver date preference', () {
+      String firstDayLabel(DateFormatPreference format) {
+        final axis = DateAxis.forRange(
+          DateTime.utc(2024, 8, 10),
+          DateTime.utc(2024, 8, 24),
+          dateFormat: format,
+        );
+        expect(axis.granularity, DateAxisGranularity.day);
+        return drawn(axis).first;
+      }
+
+      expect(firstDayLabel(DateFormatPreference.mmddyyyy), "8/10 '24");
+      expect(firstDayLabel(DateFormatPreference.ddmmyyyy), "10/8 '24");
+      // ISO reads month before day, and with a dash.
+      expect(firstDayLabel(DateFormatPreference.yyyymmdd), "8-10 '24");
+      expect(firstDayLabel(DateFormatPreference.ddmmyyyyDots), "10.8 '24");
     });
 
     test('year granularity stays a plain four-digit year', () {

--- a/test/features/trips/domain/constants/trip_field_test.dart
+++ b/test/features/trips/domain/constants/trip_field_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -8,6 +10,26 @@ import 'package:submersion/features/trips/domain/constants/trip_field.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 
 void main() {
+  // These assertions are formatted by intl, which resolves against
+  // Intl.defaultLocale: a process global that app.dart sets from the app
+  // locale. There is no MaterialApp here to pin it, so without this the
+  // spelled months and the digits would ride on intl's implicit en_US
+  // fallback. Pin it, and restore it so the global stays contained.
+  //
+  // Setting the global explicitly means intl stops using its built-in fallback
+  // and demands real symbol data, so the locale must be initialized first.
+  late String? previousLocale;
+
+  // Symbol data does not depend on per-test state, so load it once.
+  setUpAll(() => initializeDateFormatting('en'));
+
+  setUp(() {
+    previousLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en';
+  });
+
+  tearDown(() => Intl.defaultLocale = previousLocale);
+
   // A UnitFormatter backed by metric default settings.
   const units = UnitFormatter(AppSettings());
 

--- a/test/features/trips/domain/constants/trip_field_test.dart
+++ b/test/features/trips/domain/constants/trip_field_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl/intl.dart' show DateFormat;
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/trips/domain/constants/trip_field.dart';
@@ -10,6 +10,11 @@ import 'package:submersion/features/trips/domain/entities/trip.dart';
 void main() {
   // A UnitFormatter backed by metric default settings.
   const units = UnitFormatter(AppSettings());
+
+  // A diver who picked DD/MM/YYYY in Manage - Units (#1512).
+  const dayFirstUnits = UnitFormatter(
+    AppSettings(dateFormat: DateFormatPreference.ddmmyyyy),
+  );
 
   // A representative TripWithStats entity for adapter tests.
   final testTrip = Trip(
@@ -210,7 +215,6 @@ void main() {
 
   group('TripFieldAdapter.formatValue', () {
     final adapter = TripFieldAdapter.instance;
-    final dateFormat = DateFormat.yMMMd();
 
     test('returns -- for null value', () {
       expect(
@@ -226,19 +230,30 @@ void main() {
       );
     });
 
-    test('formats startDate with DateFormat.yMMMd()', () {
+    // #1512: the trip list read 'Jun 1, 2024' whatever the diver picked,
+    // because the adapter formatted dates from a fixed pattern instead of
+    // the UnitFormatter it is already handed.
+    test('formats startDate with the diver date format', () {
       final date = DateTime(2024, 6, 1);
       expect(
         adapter.formatValue(TripField.startDate, date, units),
-        equals(dateFormat.format(date)),
+        equals(units.formatDate(date)),
+      );
+      expect(
+        adapter.formatValue(TripField.startDate, date, dayFirstUnits),
+        equals('01/06/2024'),
       );
     });
 
-    test('formats endDate with DateFormat.yMMMd()', () {
+    test('formats endDate with the diver date format', () {
       final date = DateTime(2024, 6, 8);
       expect(
         adapter.formatValue(TripField.endDate, date, units),
-        equals(dateFormat.format(date)),
+        equals(units.formatDate(date)),
+      );
+      expect(
+        adapter.formatValue(TripField.endDate, date, dayFirstUnits),
+        equals('08/06/2024'),
       );
     });
 

--- a/test/features/trips/presentation/widgets/compact_trip_list_tile_test.dart
+++ b/test/features/trips/presentation/widgets/compact_trip_list_tile_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import '../../../../helpers/mock_providers.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 import 'package:submersion/features/trips/presentation/widgets/compact_trip_list_tile.dart';
 
+import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/test_app.dart';
 
 TripWithStats _makeTrip({

--- a/test/features/trips/presentation/widgets/compact_trip_list_tile_test.dart
+++ b/test/features/trips/presentation/widgets/compact_trip_list_tile_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import '../../../../helpers/mock_providers.dart';
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 import 'package:submersion/features/trips/presentation/widgets/compact_trip_list_tile.dart';
 
@@ -27,11 +29,20 @@ TripWithStats _makeTrip({
   );
 }
 
+// The tile watches settingsProvider for the diver's date format. The real
+// notifier reaches for DiverSettingsRepository and a DatabaseService this
+// harness never starts, and its constructor load is unlistened, so a failure
+// would escape to the zone and fail whichever test is running at the time.
+List<dynamic> _settingsOverrides() => [
+  settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+];
+
 void main() {
   group('CompactTripListTile', () {
     testWidgets('renders trip name and date range', (tester) async {
       await tester.pumpWidget(
         testApp(
+          overrides: _settingsOverrides(),
           child: CompactTripListTile(
             tripWithStats: _makeTrip(name: 'Palau Adventure'),
             onTap: () {},
@@ -47,6 +58,7 @@ void main() {
     testWidgets('renders dive count', (tester) async {
       await tester.pumpWidget(
         testApp(
+          overrides: _settingsOverrides(),
           child: CompactTripListTile(
             tripWithStats: _makeTrip(diveCount: 12),
             onTap: () {},
@@ -60,6 +72,7 @@ void main() {
     testWidgets('renders bottom time when non-zero', (tester) async {
       await tester.pumpWidget(
         testApp(
+          overrides: _settingsOverrides(),
           child: CompactTripListTile(
             // 3600 seconds = 1h 0m
             tripWithStats: _makeTrip(totalRuntime: 3600),
@@ -75,6 +88,7 @@ void main() {
     testWidgets('hides bottom time when zero', (tester) async {
       await tester.pumpWidget(
         testApp(
+          overrides: _settingsOverrides(),
           child: CompactTripListTile(
             tripWithStats: _makeTrip(totalRuntime: 0),
             onTap: () {},
@@ -88,6 +102,7 @@ void main() {
     testWidgets('shows selected color when isSelected is true', (tester) async {
       await tester.pumpWidget(
         testApp(
+          overrides: _settingsOverrides(),
           child: CompactTripListTile(
             tripWithStats: _makeTrip(),
             isSelected: true,
@@ -104,6 +119,7 @@ void main() {
       var tapped = false;
       await tester.pumpWidget(
         testApp(
+          overrides: _settingsOverrides(),
           child: CompactTripListTile(
             tripWithStats: _makeTrip(),
             onTap: () => tapped = true,

--- a/test/features/trips/presentation/widgets/dive_assignment_dialog_test.dart
+++ b/test/features/trips/presentation/widgets/dive_assignment_dialog_test.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/trips/domain/entities/dive_candidate.dart';
 import 'package:submersion/features/trips/presentation/widgets/dive_assignment_dialog.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
 
 Dive _makeDive({
   required String id,
@@ -56,6 +60,14 @@ List<DiveCandidate> _testCandidates() {
   ];
 }
 
+/// The dialog watches settingsProvider for the diver's date and depth units.
+/// The real notifier reaches for DiverSettingsRepository and a DatabaseService
+/// this harness never starts, so stand in with the shared mock.
+Widget _scoped(Widget child) => ProviderScope(
+  overrides: [settingsProvider.overrideWith((ref) => MockSettingsNotifier())],
+  child: child,
+);
+
 Future<void> _openDialog(
   WidgetTester tester,
   List<DiveCandidate> candidates,
@@ -63,15 +75,17 @@ Future<void> _openDialog(
   late BuildContext savedContext;
 
   await tester.pumpWidget(
-    MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: Scaffold(
-        body: Builder(
-          builder: (context) {
-            savedContext = context;
-            return const SizedBox.shrink();
-          },
+    _scoped(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              savedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
         ),
       ),
     ),
@@ -124,15 +138,17 @@ void main() {
 
       late BuildContext savedContext;
       await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: Builder(
-              builder: (context) {
-                savedContext = context;
-                return const SizedBox.shrink();
-              },
+        _scoped(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  savedContext = context;
+                  return const SizedBox.shrink();
+                },
+              ),
             ),
           ),
         ),
@@ -163,15 +179,17 @@ void main() {
     testWidgets('returns null on cancel', (tester) async {
       late BuildContext savedContext;
       await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: Builder(
-              builder: (context) {
-                savedContext = context;
-                return const SizedBox.shrink();
-              },
+        _scoped(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  savedContext = context;
+                  return const SizedBox.shrink();
+                },
+              ),
             ),
           ),
         ),
@@ -195,15 +213,17 @@ void main() {
     testWidgets('returns null when close (X) button is tapped', (tester) async {
       late BuildContext savedContext;
       await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: Builder(
-              builder: (context) {
-                savedContext = context;
-                return const SizedBox.shrink();
-              },
+        _scoped(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  savedContext = context;
+                  return const SizedBox.shrink();
+                },
+              ),
             ),
           ),
         ),

--- a/test/features/trips/presentation/widgets/trip_summary_widget_test.dart
+++ b/test/features/trips/presentation/widgets/trip_summary_widget_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/trips/domain/entities/trip.dart';
+import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
+import 'package:submersion/features/trips/presentation/widgets/trip_summary_widget.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// #1512: the trips landing panel dated both the recent-trips list and the
+/// next-trip card with `DateFormat.yMMMd()`, so a diver on DD/MM/YYYY read
+/// "Jun 1, 2025" on the first screen the Trips tab shows them.
+///
+/// The host pins `Locale('en')`: UnitFormatter spells the month with `MMM`,
+/// which intl resolves against the app locale.
+
+/// The widget only reads the trip list; every mutation is out of scope here.
+class _StubTripListNotifier
+    extends StateNotifier<AsyncValue<List<TripWithStats>>>
+    implements TripListNotifier {
+  _StubTripListNotifier(List<TripWithStats> trips)
+    : super(AsyncValue.data(trips));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+TripWithStats _trip({
+  required String id,
+  required String name,
+  required DateTime start,
+}) => TripWithStats(
+  trip: Trip(
+    id: id,
+    name: name,
+    startDate: start,
+    endDate: start.add(const Duration(days: 7)),
+    tripType: TripType.shore,
+    createdAt: start,
+    updatedAt: start,
+  ),
+  diveCount: 4,
+);
+
+Future<void> _pump(
+  WidgetTester tester,
+  DateFormatPreference format,
+  List<TripWithStats> trips,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripListNotifierProvider.overrideWith(
+          (ref) => _StubTripListNotifier(trips),
+        ),
+        settingsProvider.overrideWith(
+          (ref) => MockSettingsNotifier(AppSettings(dateFormat: format)),
+        ),
+      ],
+      child: const MaterialApp(
+        locale: Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: TripSummaryWidget(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  // Anchored off "now" so the widget's own past/upcoming split holds whenever
+  // the suite runs; only the month and day are asserted, never the year.
+  final past = DateTime(DateTime.now().year - 1, 6, 1);
+  final upcoming = DateTime.now().add(const Duration(days: 30));
+
+  group('TripSummaryWidget honours the diver date format', () {
+    testWidgets('the recent-trips list is day-first', (tester) async {
+      await _pump(tester, DateFormatPreference.ddmmyyyy, [
+        _trip(id: 't1', name: 'Red Sea Explorer', start: past),
+      ]);
+
+      expect(find.textContaining('01/06/${past.year}'), findsOneWidget);
+      expect(find.textContaining('Jun 1,'), findsNothing);
+    });
+
+    testWidgets('the recent-trips list spells the month when asked', (
+      tester,
+    ) async {
+      await _pump(tester, DateFormatPreference.mmmDYYYY, [
+        _trip(id: 't1', name: 'Red Sea Explorer', start: past),
+      ]);
+
+      expect(find.textContaining('Jun 1, ${past.year}'), findsOneWidget);
+    });
+
+    testWidgets('the next-trip card follows the same preference', (
+      tester,
+    ) async {
+      await _pump(tester, DateFormatPreference.yyyymmdd, [
+        _trip(id: 't1', name: 'Red Sea Explorer', start: past),
+        _trip(id: 't2', name: 'Palau Liveaboard', start: upcoming),
+      ]);
+
+      final iso =
+          '${upcoming.year}-'
+          '${upcoming.month.toString().padLeft(2, '0')}-'
+          '${upcoming.day.toString().padLeft(2, '0')}';
+      expect(find.textContaining(iso), findsWidgets);
+    });
+  });
+}

--- a/test/features/trips/presentation/widgets/trip_tile_date_format_test.dart
+++ b/test/features/trips/presentation/widgets/trip_tile_date_format_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/units.dart';
@@ -11,6 +12,11 @@ import '../../../../helpers/test_app.dart';
 
 /// #1512: the trip tiles dated every row with `DateFormat.yMMMd()`, so a diver
 /// on D MMM YYYY still read "Jun 1, 2025".
+///
+/// Every host pins `Locale('en')`. UnitFormatter's patterns spell the month
+/// with `MMM`, which intl resolves against `Intl.defaultLocale` (set from the
+/// app locale), so an unpinned host would translate "Jun" on a non-English
+/// machine.
 
 /// The tiles watch [settingsProvider]; the real notifier reaches for the
 /// database, so stand in with a fixed [AppSettings].
@@ -53,6 +59,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         testApp(
+          locale: const Locale('en'),
           overrides: _overridesFor(DateFormatPreference.ddmmyyyy),
           child: CompactTripListTile(tripWithStats: _trip()),
         ),
@@ -66,6 +73,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         testApp(
+          locale: const Locale('en'),
           overrides: _overridesFor(DateFormatPreference.mmmDYYYY),
           child: CompactTripListTile(tripWithStats: _trip()),
         ),
@@ -80,6 +88,7 @@ void main() {
       final handle = tester.ensureSemantics();
       await tester.pumpWidget(
         testApp(
+          locale: const Locale('en'),
           overrides: _overridesFor(DateFormatPreference.dMMMYYYY),
           child: TripListTile(tripWithStats: _trip()),
         ),

--- a/test/features/trips/presentation/widgets/trip_tile_date_format_test.dart
+++ b/test/features/trips/presentation/widgets/trip_tile_date_format_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/trips/domain/entities/trip.dart';
+import 'package:submersion/features/trips/presentation/widgets/compact_trip_list_tile.dart';
+import 'package:submersion/features/trips/presentation/widgets/trip_list_content.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// #1512: the trip tiles dated every row with `DateFormat.yMMMd()`, so a diver
+/// on D MMM YYYY still read "Jun 1, 2025".
+
+/// The tiles watch [settingsProvider]; the real notifier reaches for the
+/// database, so stand in with a fixed [AppSettings].
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier(super.initial);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+// `Override` is sealed and not re-exported, so the helper stays dynamic,
+// matching `testApp`'s `overrides` parameter.
+List<dynamic> _overridesFor(DateFormatPreference format) => [
+  settingsProvider.overrideWith(
+    (ref) => _TestSettingsNotifier(AppSettings(dateFormat: format)),
+  ),
+];
+
+TripWithStats _trip() {
+  final start = DateTime(2025, 6, 1);
+  return TripWithStats(
+    trip: Trip(
+      id: 'trip-1',
+      name: 'Red Sea Explorer',
+      startDate: start,
+      endDate: DateTime(2025, 6, 8),
+      tripType: TripType.shore,
+      createdAt: start,
+      updatedAt: start,
+    ),
+    diveCount: 3,
+  );
+}
+
+void main() {
+  group('trip tiles honour the diver date format', () {
+    testWidgets('CompactTripListTile prints the day-first range', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: _overridesFor(DateFormatPreference.ddmmyyyy),
+          child: CompactTripListTile(tripWithStats: _trip()),
+        ),
+      );
+
+      expect(find.text('01/06/2025 - 08/06/2025'), findsOneWidget);
+    });
+
+    testWidgets('CompactTripListTile prints the spelled month-first range', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: _overridesFor(DateFormatPreference.mmmDYYYY),
+          child: CompactTripListTile(tripWithStats: _trip()),
+        ),
+      );
+
+      expect(find.text('Jun 1, 2025 - Jun 8, 2025'), findsOneWidget);
+    });
+
+    testWidgets('TripListTile speaks the range in the diver order', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        testApp(
+          overrides: _overridesFor(DateFormatPreference.dMMMYYYY),
+          child: TripListTile(tripWithStats: _trip()),
+        ),
+      );
+
+      final label = tester.getSemantics(find.byType(TripListTile)).label;
+      expect(label, contains('1 Jun 2025 - 8 Jun 2025'));
+      handle.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #1512. The date format picked in Manage > Units was ignored across a
large part of the app: Trips, Certifications, the update check's "Last checked"
stamp and the equipment editor's purchase date all rendered "Jan 6, 1983" no
matter what the diver chose.

There were two separate causes, both widespread:

1. **`DateFormat.yMMMd()` and friends resolve against `Intl.defaultLocale`, not
   against `DateFormatPreference`.** On an English UI that always produces
   month-first spelled dates. The trip and certification list adapters are
   *handed* a `UnitFormatter` on every `formatValue` call and ignored it in
   favour of a `static final DateFormat _dateFormat = DateFormat.yMMMd()`;
   their sibling adapters (equipment, buddy, course, site) already did it
   correctly, so this was drift rather than a missing capability.
2. **Hand-rolled `'${d.month}/${d.day}/${d.year}'` interpolation**, which cannot
   honour any preference at all. This is what the update check and the
   equipment editor used, and no search for `DateFormat` surfaces it.

Every user-visible date and time in presentation code now goes through
`UnitFormatter`, which reads the preference. Machine-readable strings are
deliberately left alone: export payloads, backup and screenshot filenames,
cache keys, and vendor-file / cloud-API parse formats.

## Changes

- **List adapters**: `TripFieldAdapter` and `CertificationFieldAdapter` now use
  the `UnitFormatter` they already receive, instead of a static `DateFormat`.
- **Trips**: list tiles, compact tiles, picker, summary, itinerary, story hero
  and day header, gallery, detail and edit pages, dive-assignment dialog.
- **Certifications**: detail, edit, list tile, picker and the e-card face.
- **Settings**: update check "Last checked" (was hand-rolled M/D/YYYY *and* a
  fixed 24-hour clock), body weight, insurance, medical, cloud sync, sync
  devices, profile hub, adopt-replaced-library dialog, fix-dive-times range.
- **Equipment**: the editor's purchase date, which the detail page for the same
  field already honoured.
- **Also swept**: media, safety, checklists, courses, buddies, signatures,
  dashboard, reef, backup, GPS log, dive computer, dive import, import wizard,
  offline maps.
- **New in `UnitFormatter`**: `formatMonthYear` / `monthYearPattern`, derived by
  dropping the day token from the diver's own pattern so every preference keeps
  its shape (`dd/MM/yyyy` -> `MM/yyyy`, `yyyy-MM-dd` -> `yyyy-MM`,
  `d MMM yyyy` -> `MMM yyyy`).
- **`DateAxis` / `DiveTrendChart`** take the preference as a parameter, so the
  per-dive axis stops labelling `10/8` to a day-first diver while the axis
  module stays free of Flutter and Riverpod.
- **`generateDefaultPlanName`** now takes a formatted `dateLabel`, mirroring the
  formatted `depthLabel` it already took, keeping that module provider-free.
- **`formatLastDownload`** takes the `UnitFormatter` it cannot reach itself.
- **Regression guard**: `test/architecture/preference_aware_date_format_test.dart`
  scans presentation code for locale-derived date constructors and hand-rolled
  M/D/YYYY, with a small allowlist for the three cases that genuinely need a
  fixed format (export filename stamp, the date picker's own manual-entry hint,
  the CR80 card art). This scanner is what caught the hand-rolled dates.

## Notes for reviewers

- **Widget type changes.** Widgets that needed the preference became
  `ConsumerWidget` / `ConsumerStatefulWidget`. Where a caller already had a
  `UnitFormatter` in scope, private helper methods take it as a parameter
  instead, which is the lighter change. Four existing widget tests pumped the
  converted widgets without a `ProviderScope` and were updated.
- **Intentional string changes.** `DateFormat.yMMMd().add_jm()` becomes
  `formatDateTime`, which renders `<date> at <time>` using the existing
  `formatter_connector_at` ARB key rather than intl's bare space. Affected
  tests were updated. No new ARB keys.
- **What was left alone, on purpose.** Weekday-only (`DateFormat.E()`) and
  month-name-only (`DateFormat.MMMM()`) constructors have no ordering to get
  wrong. In the flight-window and no-fly cards the weekday stays locale-derived
  while the clock half now honours the 12h/24h preference.
- **CRLF.** Two touched files (`offline_maps_page.dart`,
  `scan_results_dialog.dart`) are CRLF in this repo; line endings were verified
  preserved.
- Spotted in passing, not fixed here: `ImportedDiveCard` has no references in
  `lib/` or `test/` and looks like dead code, and it hardcodes metres rather
  than using `units.formatDepth`.

## Test Plan

- [x] `flutter analyze` passes (whole project, no issues)
- [x] `dart format .` clean
- [x] New tests: adapter unit tests for both list adapters, widget tests pinning
      day-first and ISO output for the trip and certification tiles,
      `formatMonthYear` coverage, and the architecture ratchet
- [x] `flutter test` (full suite running locally; feature-area runs for media,
      trips, certifications, safety, checklists, courses, buddies, signatures,
      dashboard, reef, backup, GPS log, dive computer, import wizard and planner
      all pass)
- [x] Manual testing on: macOS

## Screenshots

Not captured. The change is a formatting swap with no layout change; the
behaviour is pinned by the widget tests above, which assert `15/06/2023` and
`2023-06-15` for a certification issued on 15 June 2023.
