### PR TITLE
fix(sync): follow Drive's nextPageToken so listings are not truncated

### DIFF
--- a/lib/core/services/cloud_storage/google_drive_storage_provider.dart
+++ b/lib/core/services/cloud_storage/google_drive_storage_provider.dart
@@ -423,13 +423,12 @@ class GoogleDriveStorageProvider
           query += " and name contains '$namePattern'";
         }
 
-        final fileList = await _requireApi.files.list(
-          spaces: 'appDataFolder',
-          q: query,
-          $fields: 'files(id,name,modifiedTime,size)',
+        final files = await _listAllFiles(
+          query: query,
+          fileFields: 'files(id,name,modifiedTime,size)',
         );
 
-        return (fileList.files ?? [])
+        return files
             .where((f) => f.id != null && f.name != null)
             .map(
               (f) => CloudFileInfo(
@@ -520,14 +519,13 @@ class GoogleDriveStorageProvider
             "and 'appDataFolder' in parents "
             "and trashed = false";
 
-        final fileList = await _requireApi.files.list(
-          spaces: 'appDataFolder',
-          q: query,
-          $fields: 'files(id,name)',
+        final folders = await _listAllFiles(
+          query: query,
+          fileFields: 'files(id,name)',
         );
 
-        if (fileList.files != null && fileList.files!.isNotEmpty) {
-          _syncFolderId = fileList.files!.first.id!;
+        if (folders.isNotEmpty) {
+          _syncFolderId = folders.first.id!;
           _log.info('Found existing sync folder: $_syncFolderId');
           return _syncFolderId!;
         }
@@ -551,6 +549,55 @@ class GoogleDriveStorageProvider
     }
   }
 
+  /// Drive's per-page cap, requested explicitly. `files.list` defaults to
+  /// 100 results per page; 1000 is the documented maximum, so a typical
+  /// sync folder is covered by a single round trip.
+  static const _listPageSize = 1000;
+
+  /// Every appDataFolder file matching [query], following `nextPageToken`
+  /// to exhaustion.
+  ///
+  /// A single `files.list` call returns at most one page and reports the
+  /// rest only through `nextPageToken`, so it silently truncated any sync
+  /// folder holding more than 100 artifacts. A base publish splits into
+  /// many `.pNNNN` parts and every device adds its own changeset log, so
+  /// real backends cross that line: peer discovery, manifest reads,
+  /// compaction pruning and wipe deletion all ran against a partial view,
+  /// with no error to say so.
+  ///
+  /// [fileFields] is the `files(...)` projection. `nextPageToken` is added
+  /// alongside it because Drive's `fields` filter applies to the whole
+  /// response, not just the file records: a projection that names only
+  /// `files(...)` strips the token, and the loop would stop after one page
+  /// exactly as before.
+  ///
+  /// Callers wrap this in [_run], so a 401 mid-listing restarts from the
+  /// first page rather than resuming with a token minted under the old
+  /// credentials -- which is what Drive asks for anyway ("if the token is
+  /// rejected, pagination should be restarted from the first page").
+  Future<List<drive.File>> _listAllFiles({
+    required String query,
+    required String fileFields,
+  }) async {
+    final files = <drive.File>[];
+    String? pageToken;
+    do {
+      final page = await _requireApi.files.list(
+        spaces: 'appDataFolder',
+        q: query,
+        pageSize: _listPageSize,
+        pageToken: pageToken,
+        $fields: 'nextPageToken,$fileFields',
+      );
+      files.addAll(page.files ?? const []);
+      // An empty token means the same thing as an absent one; treating it
+      // as a real token would re-issue the first page forever.
+      final next = page.nextPageToken;
+      pageToken = (next == null || next.isEmpty) ? null : next;
+    } while (pageToken != null);
+    return files;
+  }
+
   /// Find a file by name in a specific folder
   Future<drive.File?> _findFile(String filename, String folderId) async {
     try {
@@ -559,16 +606,12 @@ class GoogleDriveStorageProvider
           "and '$folderId' in parents "
           "and trashed = false";
 
-      final fileList = await _requireApi.files.list(
-        spaces: 'appDataFolder',
-        q: query,
-        $fields: 'files(id,name)',
+      final matches = await _listAllFiles(
+        query: query,
+        fileFields: 'files(id,name)',
       );
 
-      if (fileList.files != null && fileList.files!.isNotEmpty) {
-        return fileList.files!.first;
-      }
-      return null;
+      return matches.isNotEmpty ? matches.first : null;
     } on drive.DetailedApiRequestError {
       // Let auth errors reach _run's 401 handling instead of masking them
       // as "file not found" (which would create a duplicate).

--- a/lib/core/services/media_store/google_drive_media_object_store.dart
+++ b/lib/core/services/media_store/google_drive_media_object_store.dart
@@ -307,29 +307,57 @@ class GoogleDriveMediaObjectStore implements MediaObjectStore {
     return files.isEmpty ? null : files.first;
   }
 
+  /// Drive's documented per-page maximum, requested explicitly so a large
+  /// media folder needs as few round trips as possible.
+  static const _queryPageSize = 1000;
+
+  /// Every file matching [q], following Drive's `nextPageToken` to
+  /// exhaustion.
+  ///
+  /// files.list serves one page at a time (100 results by default, 1000
+  /// max) and reports the rest only through `nextPageToken`. A single call
+  /// hid every media object past the cap from [list], and could return a
+  /// short or empty first page for a name lookup -- which [_findByKey]
+  /// would read as "absent" and re-upload.
+  ///
+  /// `nextPageToken` has to be named in `fields` alongside `files(...)`:
+  /// the projection applies to the whole response, so asking only for
+  /// `files(...)` strips the token and the loop would stop after one page.
   Future<List<_DriveFile>> _query(String q) async {
-    final uri = Uri.parse('$_apiBase/drive/v3/files').replace(
-      queryParameters: {
-        'spaces': 'appDataFolder',
-        'q': q,
-        'fields': 'files(id,name,modifiedTime,size)',
-      },
-    );
-    final response = await _send(http.Request('GET', uri));
-    if (response.statusCode != 200) {
-      throw _forStatus('query', q, response);
-    }
-    final decoded = jsonDecode(response.body) as Map<String, Object?>;
-    final files = decoded['files'] as List<Object?>? ?? const [];
-    return [
-      for (final raw in files.cast<Map<String, Object?>>())
-        _DriveFile(
-          id: raw['id'] as String,
-          name: raw['name'] as String,
-          size: int.tryParse(raw['size'] as String? ?? ''),
-          modified: DateTime.tryParse(raw['modifiedTime'] as String? ?? ''),
-        ),
-    ];
+    final results = <_DriveFile>[];
+    String? pageToken;
+    do {
+      final uri = Uri.parse('$_apiBase/drive/v3/files').replace(
+        queryParameters: {
+          'spaces': 'appDataFolder',
+          'q': q,
+          'pageSize': '$_queryPageSize',
+          'pageToken': ?pageToken,
+          'fields': 'nextPageToken,files(id,name,modifiedTime,size)',
+        },
+      );
+      final response = await _send(http.Request('GET', uri));
+      if (response.statusCode != 200) {
+        throw _forStatus('query', q, response);
+      }
+      final decoded = jsonDecode(response.body) as Map<String, Object?>;
+      final files = decoded['files'] as List<Object?>? ?? const [];
+      for (final raw in files.cast<Map<String, Object?>>()) {
+        results.add(
+          _DriveFile(
+            id: raw['id'] as String,
+            name: raw['name'] as String,
+            size: int.tryParse(raw['size'] as String? ?? ''),
+            modified: DateTime.tryParse(raw['modifiedTime'] as String? ?? ''),
+          ),
+        );
+      }
+      // An empty token means the same thing as an absent one; treating it
+      // as a real token would re-issue the first page forever.
+      final next = decoded['nextPageToken'] as String?;
+      pageToken = (next == null || next.isEmpty) ? null : next;
+    } while (pageToken != null);
+    return results;
   }
 
   Future<http.Response> _send(http.Request request) async {

--- a/test/core/services/cloud_storage/google_drive_storage_provider_test.dart
+++ b/test/core/services/cloud_storage/google_drive_storage_provider_test.dart
@@ -141,6 +141,145 @@ void main() {
     });
   });
 
+  group('listFiles pagination', () {
+    /// Serves [pages] one files.list call at a time, handing out a
+    /// nextPageToken for every page but the last -- Drive's own protocol.
+    /// Records each request so the test can assert what was asked for.
+    MockClient pagedDriveMock(
+      List<List<Map<String, Object?>>> pages, {
+      List<Uri>? listRequests,
+    }) {
+      return MockClient((request) async {
+        if (request.url.path != '/drive/v3/files' || request.method != 'GET') {
+          return http.Response(
+            'unexpected: ${request.method} ${request.url}',
+            500,
+          );
+        }
+        listRequests?.add(request.url);
+        final token = request.url.queryParameters['pageToken'];
+        final index = token == null ? 0 : int.parse(token);
+        return jsonResponse({
+          'files': pages[index],
+          if (index < pages.length - 1) 'nextPageToken': '${index + 1}',
+        });
+      });
+    }
+
+    Map<String, Object?> file(String name) => {
+      'id': 'id-$name',
+      'name': name,
+      'modifiedTime': '2026-01-01T00:00:00.000Z',
+      'size': '10',
+    };
+
+    test('follows nextPageToken and returns every page', () async {
+      final provider = providerWith(
+        pagedDriveMock([
+          [file('a'), file('b')],
+          [file('c')],
+        ]),
+      );
+
+      final files = await provider.listFiles(folderId: 'folder-1');
+
+      expect(files.map((f) => f.name), [
+        'a',
+        'b',
+        'c',
+      ], reason: 'a single files.list call truncates at Drive\'s page size');
+    });
+
+    test('asks for nextPageToken and an explicit page size', () async {
+      final requests = <Uri>[];
+      final provider = providerWith(
+        pagedDriveMock([
+          [file('a')],
+        ], listRequests: requests),
+      );
+
+      await provider.listFiles(folderId: 'folder-1');
+
+      expect(requests, hasLength(1));
+      expect(
+        requests.single.queryParameters['fields'],
+        contains('nextPageToken'),
+        reason:
+            'a \$fields listing only files(...) suppresses the token, so the '
+            'page loop would stop after one page with no error',
+      );
+      expect(requests.single.queryParameters['pageSize'], '1000');
+    });
+
+    test(
+      'paginates a name lookup, so an existing file is never duplicated',
+      () async {
+        final src = File('${tempDir.path}/backup.db')
+          ..writeAsBytesSync([1, 2, 3]);
+        final methods = <String>[];
+        final provider = GoogleDriveStorageProvider()
+          ..debugSetDriveApi(
+            drive.DriveApi(
+              MockClient((request) async {
+                methods.add(request.method);
+                if (request.url.path == '/drive/v3/files' &&
+                    request.method == 'GET') {
+                  final token = request.url.queryParameters['pageToken'];
+                  // Drive may hand back a short (even empty) page while more
+                  // results remain; the match only appears on page two.
+                  return jsonResponse(
+                    token == null
+                        ? {'files': <Object?>[], 'nextPageToken': '1'}
+                        : {
+                            'files': [
+                              {'id': 'uploaded-id', 'name': 'b.db'},
+                            ],
+                          },
+                  );
+                }
+                return jsonResponse({'id': 'uploaded-id', 'name': 'b.db'});
+              }),
+            ),
+          );
+
+        final result = await provider.uploadFileFromPath(
+          src.path,
+          'b.db',
+          folderId: 'folder-1',
+        );
+
+        expect(result.fileId, 'uploaded-id');
+        expect(
+          methods,
+          contains('PATCH'),
+          reason: 'the match on page two must update, not create a duplicate',
+        );
+      },
+    );
+
+    test('treats an empty token as the end of the listing', () async {
+      final provider = providerWith(
+        MockClient((request) async {
+          if (request.url.path != '/drive/v3/files') {
+            return http.Response('unexpected', 500);
+          }
+          // A token of '' would re-issue the same request forever if it were
+          // only null-checked.
+          return jsonResponse({
+            'files': [
+              {'id': 'id-a', 'name': 'a'},
+            ],
+            'nextPageToken': '',
+          });
+        }),
+      );
+
+      final files = await provider.listFiles(folderId: 'folder-1');
+
+      expect(files.map((f) => f.name), ['a']);
+    });
+  });
+
   group('downloadToFile', () {
     test('pipes the media stream straight to disk', () async {
       final data = List<int>.generate(64 * 1024, (i) => i % 249);

--- a/test/core/services/media_store/google_drive_media_object_store_test.dart
+++ b/test/core/services/media_store/google_drive_media_object_store_test.dart
@@ -171,6 +171,27 @@ void main() {
     expect(info!.sizeBytes, 2);
   });
 
+  test('list follows nextPageToken instead of stopping at the first '
+      'page', () async {
+    // Drive caps files.list at one page (100 by default) and reports the
+    // rest only through nextPageToken, so an unpaginated query silently
+    // hides every media object past the cap.
+    server.queryPageSize = 2;
+    for (var i = 0; i < 5; i++) {
+      server.filesById['id-$i'] = (
+        name: 'smv1/objects/aa/$i.jpg',
+        bytes: Uint8List.fromList([i]),
+      );
+    }
+    final store = build();
+
+    final keys = [
+      await for (final info in store.list('smv1/objects/')) info.key,
+    ];
+
+    expect(keys, hasLength(5));
+  });
+
   test('a 5xx from Drive surfaces as MediaStoreException on every '
       'verb', () async {
     final store = GoogleDriveMediaObjectStore(

--- a/test/helpers/fake_drive_server.dart
+++ b/test/helpers/fake_drive_server.dart
@@ -23,6 +23,11 @@ class FakeDriveServer {
   /// value (the adapter has no retry layer, so one shot works).
   int? failAfterChunkPuts;
 
+  /// Files returned per files.list page, forcing pagination regardless of
+  /// the pageSize the caller asked for -- which is what real Drive does
+  /// once a folder outgrows a page. Null serves everything in one page.
+  int? queryPageSize;
+
   MockClient get client => MockClient(_handle);
 
   Future<http.Response> _handle(http.Request request) async {
@@ -95,13 +100,21 @@ class FakeDriveServer {
       );
     }
 
-    final entries = filesById.entries.where(
-      (e) => nameMatch == null || e.value.name == nameMatch.group(1),
-    );
+    final entries = filesById.entries
+        .where((e) => nameMatch == null || e.value.name == nameMatch.group(1))
+        .toList();
+
+    // Page tokens are just the offset of the next entry, which is enough
+    // to make a caller that ignores nextPageToken visibly truncate.
+    final offset = int.parse(request.url.queryParameters['pageToken'] ?? '0');
+    final pageSize = queryPageSize ?? entries.length;
+    final end = (offset + pageSize).clamp(0, entries.length);
+    final page = entries.sublist(offset, end);
+
     return http.Response(
       jsonEncode({
         'files': [
-          for (final e in entries)
+          for (final e in page)
             {
               'id': e.key,
               'name': e.value.name,
@@ -109,6 +122,7 @@ class FakeDriveServer {
               'size': '${e.value.bytes.length}',
             },
         ],
+        if (end < entries.length) 'nextPageToken': '$end',
       }),
       200,
     );


### PR DESCRIPTION
## The bug

Google Drive's `files.list` serves **one page at a time** (100 results by default, 1000 max) and reports the rest only through `nextPageToken`. Both of the app's Drive callers issued a single call and dropped the token, so every listing silently stopped at 100 entries. No error, no warning: the caller just saw a smaller folder than exists.

This is not a theoretical limit for a sync folder. A base publish splits into many `.pNNNN` parts, and every device adds its own changeset log; `sync_service.dart`'s own comments already reference "a wipe of a 400-file backend".

### What the truncated view fed

`GoogleDriveStorageProvider.listFiles` is the single listing surface for the sync layer, so a short list propagated into:

- `SyncInitializer.peerLogFiles` / `peerSyncFiles`, which decide whether a peer library exists at all
- `_epochHasReadableLibrary` and `_readManifest`
- the changeset reader
- compaction pruning
- `_deleteListedFiles`, where a truncated list leaves a wipe quietly incomplete

### The same defect in the media store

`GoogleDriveMediaObjectStore` has its own raw Drive client, and `_query` had the identical bug. `list(keyPrefix)` enumerates the entire media folder and filters by prefix client-side, so past 100 objects it simply stopped seeing them. That file was outside the original report's scope; it is the same defect in the same subsystem, so it is fixed here rather than left behind.

## The fix

Both call sites now loop on `nextPageToken` to exhaustion and request `pageSize=1000`, so a normal folder still costs a single round trip. This matches the pattern the sibling providers already use: Dropbox follows `has_more`/`cursor`, S3 follows `NextContinuationToken`.

Two details worth calling out, because both are silent failure modes:

**`nextPageToken` must be named in `$fields` alongside `files(...)`.** Drive's field projection applies to the whole response, not just the file records, so a projection listing only `files(...)` strips the token. A `pageToken` loop added without touching `$fields` would still stop after one page, with nothing to indicate why. There is a test asserting the request carries it.

**An empty token is treated as absent.** Accepting `''` as a real token would re-issue the first page forever.

### Why the single-name lookups paginate too

`_findFile`, `getOrCreateSyncFolder`, and `_findByKey` all match one name and take the first result, so they look lower risk. They go through the same loop anyway, because Drive may return a **short or even empty page while more results remain**. "Nothing on page one" is therefore not evidence that a file is absent, and `_findFile` reading it that way uploads a duplicate instead of updating in place. Bounding those calls with `pageSize: 1` would have made that worse, not better.

## Tests

Five new tests, each written failing first:

| Test | Guards |
| --- | --- |
| `follows nextPageToken and returns every page` | the core truncation (was `['a','b']`, expected `['a','b','c']`) |
| `asks for nextPageToken and an explicit page size` | the `$fields` trap that would silently re-break the loop |
| `paginates a name lookup, so an existing file is never duplicated` | a match arriving on page two after an empty page one |
| `treats an empty token as the end of the listing` | infinite re-request of page one |
| `list follows nextPageToken instead of stopping at the first page` | the media store (was 2 of 5 objects) |

`FakeDriveServer` now paginates as well, via a `queryPageSize` knob. That is worth more than the one test it unblocks: every media-store test now runs against a fake that speaks Drive's real protocol, so a future unpaginated listing gets caught.

## Verification

- `flutter analyze`: no issues (whole project)
- `dart format .`: clean
- Full suite: **24,077 passed, 0 failures**, exit code 0
