### PR TITLE
fix(sync): stop a fresh install inheriting the old install's device id

### DIFF
--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -231,6 +231,42 @@ class SyncRepository {
     return metadata.deviceId;
   }
 
+  /// Whether this database has ever taken part in a sync.
+  ///
+  /// True as soon as anything sync-related has been recorded: a baseline
+  /// timestamp, an accepted library epoch, a remote file reference, a sync
+  /// record, a tombstone, a peer cursor or a publish state.
+  ///
+  /// False only for a database that has never synced. On a launch whose
+  /// out-of-database anchors name some other install, that is the signature of
+  /// a fresh install rather than a restore; see
+  /// [SyncInitializer.reconcileDeviceIdentity].
+  ///
+  /// Deliberately does NOT count [SyncMetadataData.syncProvider], which merely
+  /// names a chosen backend and is set before any sync has run.
+  Future<bool> hasSyncHistory() async {
+    final metadata = await getOrCreateMetadata();
+    if (metadata.lastSyncTimestamp != null) return true;
+    // Accepting a library epoch, or holding a remote file reference, both mean
+    // this database has taken part in a sync even when no baseline survives.
+    if (metadata.lastAcceptedEpochId != null) return true;
+    if (metadata.remoteFileId != null) return true;
+    if (await _hasAnyRow(_db.syncRecords)) return true;
+    if (await _hasAnyRow(_db.deletionLog)) return true;
+    if (await _hasAnyRow(_db.syncPeerCursors)) return true;
+    if (await _hasAnyRow(_db.localPublishStates)) return true;
+    return false;
+  }
+
+  /// True if [table] holds at least one row. Uses a LIMIT 1 select rather than
+  /// a COUNT so the check stops at the first row on a large table.
+  Future<bool> _hasAnyRow<T extends HasResultSet, R>(
+    ResultSetImplementation<T, R> table,
+  ) async {
+    final row = await (_db.select(table)..limit(1)).getSingleOrNull();
+    return row != null;
+  }
+
   /// Get this database's instance token, or null if none has been set yet
   /// (rows predating the column, or a freshly created/restored database).
   Future<String?> getInstanceToken() async {

--- a/lib/core/services/sync/sync_initializer.dart
+++ b/lib/core/services/sync/sync_initializer.dart
@@ -145,6 +145,22 @@ class SyncInitializer {
           sentinelDeviceId != deviceId;
 
       if (restoreDetected) {
+        // A database with no sync history has no baseline to rewind and no
+        // stale tombstones to clear, so there is nothing for a rebaseline to
+        // repair: this is a fresh install, not a restore. Preserving the
+        // anchored id here would be actively harmful: this install would then
+        // own every file the previous install published, so its own cloud
+        // library would list as "ours" rather than a peer's and the account
+        // would read as empty. Keep the identity we minted and re-point the
+        // anchors at it instead.
+        if (!await _syncRepository.hasSyncHistory()) {
+          _log.info(
+            'Anchors name a previous install but this database has never '
+            'synced; keeping the freshly minted identity',
+          );
+          await _establishAnchors(deviceId);
+          return DeviceIdentityStatus.freshInstall;
+        }
         _log.warning(
           'On-disk database is not the one we last wrote (restore/overwrite '
           'detected); re-baselining sync and restoring the live identity',
@@ -402,6 +418,45 @@ class SyncInitializer {
     CloudStorageProvider provider,
   ) async => classifyPeerFiles(await peerLogFiles(provider));
 
+  /// What the account holds, from the point of view of an install that has no
+  /// library of its own yet, i.e. the setup wizard's Connect step.
+  ///
+  /// Differs from [peerLibraryState] in one case: the listing is empty of
+  /// PEER files but the account does hold a changeset log under OUR OWN device
+  /// id. That happens whenever an install inherits an earlier install's
+  /// identity, which is routine on macOS, where replacing the .app leaves
+  /// ~/Library/Preferences, and with it the device-id anchor, in place. Every
+  /// file the earlier install published then reads as "ours", the account
+  /// lists as empty, and the wizard offers Start Fresh over a live library.
+  ///
+  /// The files can only be pulled as a peer's, so the fix is to stop claiming
+  /// the retired identity: mint a fresh one and re-classify. Guarded on
+  /// [localLibraryIsEmpty] because a device that still holds the library it
+  /// published must keep the identity that published it, or it orphans its own
+  /// log. Nothing is deleted either way.
+  Future<PeerLibraryState> firstContactLibraryState(
+    CloudStorageProvider provider, {
+    required bool localLibraryIsEmpty,
+  }) async {
+    final state = await peerLibraryState(provider);
+    if (state != PeerLibraryState.none || !localLibraryIsEmpty) return state;
+
+    final deviceId = await _syncRepository.getDeviceId();
+    final ours = (await provider.listFiles(
+      namePattern: ChangesetLogLayout.prefix,
+    )).where((f) => ChangesetLogLayout.deviceIdOf(f.name) == deviceId).toList();
+    if (ours.isEmpty) return state;
+    if (classifyPeerFiles(ours) == PeerLibraryState.none) return state;
+
+    _log.warning(
+      'The account holds a library under this install\'s own device id while '
+      'it has no library locally; adopting a fresh identity so those files '
+      'can be pulled as a peer\'s',
+    );
+    await adoptFreshIdentity();
+    return peerLibraryState(provider);
+  }
+
   /// Classifies a peer listing. Static and visible for testing for the same
   /// reason as SyncNotifier.skippedPeerLabels: it is pure, and the rule
   /// deserves tests that do not need a provider or a database.
@@ -461,6 +516,14 @@ enum DeviceIdentityStatus {
   /// or a changed device id: a restore replaced the database. Sync was
   /// re-baselined and the live identity restored.
   rebaselined,
+
+  /// The anchors named a previous install, but the on-disk database has no
+  /// sync history at all: a fresh install on a machine whose preferences
+  /// outlived the old one (routine on macOS, where replacing the .app leaves
+  /// ~/Library/Preferences untouched). This install keeps the identity it
+  /// minted and the anchors are re-pointed at it, so the previous install's
+  /// cloud files stay visible as a peer's.
+  freshInstall,
 
   /// The reconcile could not run (e.g. the metadata lookup failed). Launch
   /// continues regardless.

--- a/lib/core/services/sync/sync_initializer.dart
+++ b/lib/core/services/sync/sync_initializer.dart
@@ -404,13 +404,21 @@ class SyncInitializer {
     CloudStorageProvider provider,
   ) async {
     final deviceId = await _syncRepository.getDeviceId();
+    return (await _changesetLogFiles(
+      provider,
+    )).where((f) => ChangesetLogLayout.deviceIdOf(f.name) != deviceId).toList();
+  }
+
+  /// Every changeset-log artifact on the account, this device's own included.
+  /// One listing, so callers that need both halves of the split can take the
+  /// snapshot once instead of paying a second network round trip.
+  Future<List<CloudFileInfo>> _changesetLogFiles(
+    CloudStorageProvider provider,
+  ) async {
     final files = await provider.listFiles(
       namePattern: ChangesetLogLayout.prefix,
     );
-    return files
-        .where((f) => ChangesetLogLayout.isOurs(f.name))
-        .where((f) => ChangesetLogLayout.deviceIdOf(f.name) != deviceId)
-        .toList();
+    return files.where((f) => ChangesetLogLayout.isOurs(f.name)).toList();
   }
 
   /// What a peer listing says about this account, in one round trip.
@@ -438,14 +446,18 @@ class SyncInitializer {
     CloudStorageProvider provider, {
     required bool localLibraryIsEmpty,
   }) async {
-    final state = await peerLibraryState(provider);
+    // One listing serves every branch below, including the re-classification
+    // after an identity swap: the Connect step waits on this, and listFiles is
+    // a network round trip on every real provider.
+    final files = await _changesetLogFiles(provider);
+    final deviceId = await _syncRepository.getDeviceId();
+    bool isOurOwn(CloudFileInfo f) =>
+        ChangesetLogLayout.deviceIdOf(f.name) == deviceId;
+
+    final state = classifyPeerFiles(files.where((f) => !isOurOwn(f)).toList());
     if (state != PeerLibraryState.none || !localLibraryIsEmpty) return state;
 
-    final deviceId = await _syncRepository.getDeviceId();
-    final ours = (await provider.listFiles(
-      namePattern: ChangesetLogLayout.prefix,
-    )).where((f) => ChangesetLogLayout.deviceIdOf(f.name) == deviceId).toList();
-    if (ours.isEmpty) return state;
+    final ours = files.where(isOurOwn).toList();
     if (classifyPeerFiles(ours) == PeerLibraryState.none) return state;
 
     _log.warning(
@@ -454,7 +466,10 @@ class SyncInitializer {
       'can be pulled as a peer\'s',
     );
     await adoptFreshIdentity();
-    return peerLibraryState(provider);
+    // The id just minted is brand new, so no file in the snapshot can carry
+    // it: every one of them belongs to a peer now, and re-classifying is
+    // local work.
+    return classifyPeerFiles(files);
   }
 
   /// Classifies a peer listing. Static and visible for testing for the same

--- a/lib/features/setup_wizard/presentation/widgets/steps/sync_connect_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/sync_connect_step.dart
@@ -46,9 +46,18 @@ class _SyncConnectStepState extends ConsumerState<SyncConnectStep> {
     }
     try {
       final instance = cloudProviderInstanceFor(connected);
+      // First contact, so the local library being empty is the normal case,
+      // and it is what licenses the initializer to shed an inherited device
+      // identity when the account's only library turns out to be filed under
+      // our own id (a reinstall that outlived its predecessor's anchors).
+      final localLibraryIsEmpty =
+          (await ref.read(diverRepositoryProvider).getDiverCount()) == 0;
       final library = await ref
           .read(syncInitializerProvider)
-          .peerLibraryState(instance);
+          .firstContactLibraryState(
+            instance,
+            localLibraryIsEmpty: localLibraryIsEmpty,
+          );
       if (library != PeerLibraryState.pullable) {
         // "Nothing here" and "a publish died partway" both leave no manifest
         // to pull, but only the first one means Start Fresh is the right

--- a/test/core/services/sync/sync_initializer_reconcile_test.dart
+++ b/test/core/services/sync/sync_initializer_reconcile_test.dart
@@ -321,6 +321,55 @@ void main() {
     });
   });
 
+  group('a fresh install whose preferences survived', () {
+    // macOS leaves ~/Library/Preferences in place when the .app is replaced,
+    // so a reinstall can present anchors from the previous install against a
+    // brand-new database. Treating that as a restore made the new install
+    // adopt the old device id, which then classified every file the previous
+    // install had published as "ours" rather than a peer's: the account read
+    // as empty and the setup wizard offered Start Fresh over a live library.
+    test('keeps its own identity instead of adopting the sentinel', () async {
+      const previousInstallId = 'device-of-the-install-that-was-replaced';
+      await prefs.setString('sync_device_id_sentinel', previousInstallId);
+      await prefs.setString('sync_db_instance_token', 'token-of-a-gone-db');
+
+      final freshId = await repository.getDeviceId();
+
+      final status = await initializer.reconcileDeviceIdentity();
+
+      expect(status, DeviceIdentityStatus.freshInstall);
+      expect(
+        await repository.getDeviceId(),
+        freshId,
+        reason:
+            'a database with no sync history has nothing to restore; taking '
+            "the previous install's id hides that install's cloud library",
+      );
+      expect(
+        prefs.getString('sync_device_id_sentinel'),
+        freshId,
+        reason: 'the anchors must be re-pointed at the identity we kept',
+      );
+    });
+
+    test('still rebaselines when the database carries sync history', () async {
+      // The discriminator is history, not the token: a backup predating
+      // instance tokens also arrives with a null token, and that IS a restore.
+      const liveId = 'live-device';
+      await prefs.setString('sync_device_id_sentinel', liveId);
+      await prefs.setString('sync_db_instance_token', 'token-of-a-gone-db');
+      await repository.getOrCreateMetadata();
+      await repository.updateLastSyncTime(
+        DateTime.fromMillisecondsSinceEpoch(1000),
+      );
+
+      final status = await initializer.reconcileDeviceIdentity();
+
+      expect(status, DeviceIdentityStatus.rebaselined);
+      expect(await repository.getDeviceId(), liveId);
+    });
+  });
+
   group('SyncNotifier.resetSyncState', () {
     test('adopts a fresh device identity', () async {
       // The twin-device trap: two installs syncing as the same device write

--- a/test/core/services/sync/sync_initializer_test.dart
+++ b/test/core/services/sync/sync_initializer_test.dart
@@ -249,6 +249,101 @@ void main() {
     });
   });
 
+  group('firstContactLibraryState', () {
+    // An install can end up owning the cloud files some earlier install on the
+    // same machine published, most routinely on macOS, where replacing the
+    // .app leaves ~/Library/Preferences (and with it the device-id anchor)
+    // in place. Every one of those files then classifies as "ours" rather than
+    // a peer's, so the account lists as empty and the setup wizard offers
+    // Start Fresh over a live library.
+    test(
+      'adopts a fresh identity so a self-owned library is pullable',
+      () async {
+        final inheritedId = await repository.getDeviceId();
+        await provider.uploadFile(_payload, peerFileName(inheritedId));
+        await provider.uploadFile(
+          _payload,
+          ChangesetLogLayout.basePartName(inheritedId, 1, 0),
+        );
+
+        // The plain classification cannot see it: it is all "ours".
+        expect(
+          await initializer.peerLibraryState(provider),
+          PeerLibraryState.none,
+        );
+
+        final state = await initializer.firstContactLibraryState(
+          provider,
+          localLibraryIsEmpty: true,
+        );
+
+        expect(state, PeerLibraryState.pullable);
+        expect(
+          await repository.getDeviceId(),
+          isNot(inheritedId),
+          reason:
+              'the files can only be pulled as a peer\'s, so this install has '
+              'to stop claiming the retired identity',
+        );
+      },
+    );
+
+    test(
+      'leaves the identity alone when this device holds a library',
+      () async {
+        final ownId = await repository.getDeviceId();
+        await provider.uploadFile(_payload, peerFileName(ownId));
+
+        final state = await initializer.firstContactLibraryState(
+          provider,
+          localLibraryIsEmpty: false,
+        );
+
+        expect(
+          state,
+          PeerLibraryState.none,
+          reason: 'our own manifest beside our own library is the normal case',
+        );
+        expect(
+          await repository.getDeviceId(),
+          ownId,
+          reason:
+              'a device that still holds its library must keep the identity '
+              'that published it, or its own log is orphaned',
+        );
+      },
+    );
+
+    test('leaves a real peer library untouched', () async {
+      final ownId = await repository.getDeviceId();
+      await provider.uploadFile(_payload, peerFileName('deviceB'));
+
+      final state = await initializer.firstContactLibraryState(
+        provider,
+        localLibraryIsEmpty: true,
+      );
+
+      expect(state, PeerLibraryState.pullable);
+      expect(
+        await repository.getDeviceId(),
+        ownId,
+        reason: 'a pullable peer needs no identity surgery',
+      );
+    });
+
+    test('leaves a genuinely empty account empty', () async {
+      final ownId = await repository.getDeviceId();
+
+      final state = await initializer.firstContactLibraryState(
+        provider,
+        localLibraryIsEmpty: true,
+      );
+
+      expect(state, PeerLibraryState.none);
+      expect(await repository.getDeviceId(), ownId);
+    });
+  });
+
   group('checkSyncOnLaunch provider persistence', () {
     test('saveProvider then getLastProvider round-trips', () async {
       expect(initializer.getLastProvider(), isNull);

--- a/test/core/services/sync/sync_initializer_test.dart
+++ b/test/core/services/sync/sync_initializer_test.dart
@@ -314,6 +314,32 @@ void main() {
       },
     );
 
+    test('lists the account exactly once, recovery included', () async {
+      // The Connect step waits on this, and listFiles is a network round trip
+      // on every real provider, so the recovery must not cost extra listings.
+      final inheritedId = await repository.getDeviceId();
+      await provider.uploadFile(_payload, peerFileName(inheritedId));
+      provider.operationLog.clear();
+
+      await initializer.firstContactLibraryState(
+        provider,
+        localLibraryIsEmpty: true,
+      );
+
+      expect(provider.operationLog.where((op) => op == 'list').length, 1);
+    });
+
+    test('lists the account exactly once for an empty account', () async {
+      provider.operationLog.clear();
+
+      await initializer.firstContactLibraryState(
+        provider,
+        localLibraryIsEmpty: true,
+      );
+
+      expect(provider.operationLog.where((op) => op == 'list').length, 1);
+    });
+
     test('leaves a real peer library untouched', () async {
       final ownId = await repository.getDeviceId();
       await provider.uploadFile(_payload, peerFileName('deviceB'));

--- a/test/features/setup_wizard/presentation/pages/setup_wizard_page_test.dart
+++ b/test/features/setup_wizard/presentation/pages/setup_wizard_page_test.dart
@@ -16,6 +16,7 @@ import 'package:submersion/features/setup_wizard/presentation/pages/setup_wizard
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/test_app.dart';
+import '../../../../helpers/test_database.dart';
 
 /// Idle fakes so the existing-data source steps render without real pickers,
 /// timers, or sync services when driven through the shell.
@@ -40,6 +41,14 @@ class _FakeSyncInit implements SyncInitializer {
     CloudStorageProvider provider,
   ) async => PeerLibraryState.none;
 
+  /// A genuinely empty account: nothing under a peer's id and nothing under
+  /// ours either, so there is no inherited identity to shed.
+  @override
+  Future<PeerLibraryState> firstContactLibraryState(
+    CloudStorageProvider provider, {
+    required bool localLibraryIsEmpty,
+  }) async => PeerLibraryState.none;
+
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
@@ -61,6 +70,12 @@ Future<void> pumpWizard(WidgetTester tester) async {
 }
 
 void main() {
+  // The sync-connect step reads the live diver count to decide whether this
+  // install has a library of its own, so these tests need a database even
+  // though they assert on navigation.
+  setUp(() async => setUpTestDatabase());
+  tearDown(() async => tearDownTestDatabase());
+
   testWidgets('wizard ocean background follows resolved brightness', (
     tester,
   ) async {

--- a/test/features/setup_wizard/presentation/widgets/steps/sync_connect_step_test.dart
+++ b/test/features/setup_wizard/presentation/widgets/steps/sync_connect_step_test.dart
@@ -30,12 +30,31 @@ class _FakeSyncInit implements SyncInitializer {
   List<CloudFileInfo> peers = [];
   bool throwOnPeers = false;
 
+  /// Artifacts on the account that carry THIS install's own device id: the
+  /// inherited-identity case. Invisible to [peerLibraryState] by definition;
+  /// [firstContactLibraryState] recovers them by adopting a fresh identity,
+  /// after which they classify as any other peer's would.
+  List<CloudFileInfo> selfOwned = [];
+
   @override
   Future<PeerLibraryState> peerLibraryState(
     CloudStorageProvider provider,
   ) async {
     if (throwOnPeers) throw Exception('network down');
     return SyncInitializer.classifyPeerFiles(peers);
+  }
+
+  @override
+  Future<PeerLibraryState> firstContactLibraryState(
+    CloudStorageProvider provider, {
+    required bool localLibraryIsEmpty,
+  }) async {
+    final state = await peerLibraryState(provider);
+    if (state != PeerLibraryState.none || !localLibraryIsEmpty) return state;
+    if (SyncInitializer.classifyPeerFiles(selfOwned) == PeerLibraryState.none) {
+      return state;
+    }
+    return SyncInitializer.classifyPeerFiles([...peers, ...selfOwned]);
   }
 
   @override
@@ -230,6 +249,61 @@ void main() {
     expect(find.text('No library found'), findsOneWidget);
     await tester.tap(find.widgetWithText(FilledButton, 'Start fresh'));
     expect(pivoted, 1);
+  });
+
+  testWidgets('a library under our own device id is not "no library"', (
+    tester,
+  ) async {
+    // The inherited-identity case: a reinstall on the same machine picked up
+    // the previous install's device-id anchor, so the library that install
+    // published lists as ours rather than a peer's. Offering Start Fresh here
+    // invites the user to walk away from live data.
+    syncInit.peers = [];
+    syncInit.selfOwned = [
+      CloudFileInfo(
+        id: 'a',
+        name: ChangesetLogLayout.manifestName('the-previous-install'),
+        modifiedTime: DateTime(2026),
+      ),
+    ];
+    var pivoted = 0;
+    late ProviderContainer container;
+    await tester.pumpWidget(
+      testApp(
+        locale: const Locale('en'),
+        overrides: await overrides(onSync: _writeSyncedDiver),
+        child: Builder(
+          builder: (context) {
+            container = ProviderScope.containerOf(context);
+            return SyncConnectStep(
+              mode: SetupWizardMode.firstRun,
+              onNoLibrary: () => pivoted++,
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    container
+        .read(setupWizardProvider(SetupWizardMode.firstRun).notifier)
+        .setConnectedProvider(CloudProviderType.s3);
+    await tester.pumpAndSettle();
+
+    await tester.runAsync(() async {
+      await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+
+    expect(find.text('No library found'), findsNothing);
+    expect(pivoted, 0);
+    expect(
+      find.text('Library adopted'),
+      findsOneWidget,
+      reason:
+          'the self-owned library must actually be pulled, not just '
+          'stop rendering the pivot',
+    );
   });
 
   testWidgets('a failing pull returns to the connect UI with an error', (


### PR DESCRIPTION
## Problem

Connecting Google Drive on a **new install on macOS** showed "No library found" for an account that holds a full library, and offered Start Fresh over live data.

This is not Drive-specific. The install had **adopted the previous install's sync device id**, so every changeset file that install had published classified as *ours* rather than a peer's, and the peer listing came back empty.

The chain:

1. macOS leaves `~/Library/Preferences/app.submersion.plist` in place when the `.app` is replaced, so the device-id anchor and instance-token mirror survive while the database is new.
2. `reconcileDeviceIdentity` treats "the on-disk database is not the one we last wrote" as a restore. A brand-new database trips that test too, because it has no instance token yet, so it takes the `rebaselineAfterRestore(preserveDeviceId: sentinelDeviceId)` path.
3. `peerLogFiles` excludes every file whose name encodes our own device id. That is now the entire library.
4. `classifyPeerFiles` returns `PeerLibraryState.none`, and the wizard renders "No library found".

`adoptFreshIdentity`'s own doc comment already described the shape of this: *"Each twin lists the shared per-device sync file as 'its own', sees no peers."*

Worse, the obvious recovery was destructive. `resetSyncState()` mints a fresh identity and then calls `deleteDeviceSyncFile(oldDeviceId)`, which deletes every changeset-log file owned by that id. In this state that id owns the whole library.

## Fix

**Layer 1, `reconcileDeviceIdentity`.** A database with no sync history has no baseline to rewind and no stale tombstones to clear, so there is nothing for a rebaseline to repair: it is a fresh install, not a restore. It now keeps the identity it minted and the anchors are re-pointed at it, reported as the new `DeviceIdentityStatus.freshInstall`.

The discriminator is history, not the null token: a backup predating instance tokens also arrives with a null token, and that genuinely is a restore. `SyncRepository.hasSyncHistory()` counts a baseline timestamp, an accepted library epoch, a remote file reference, a sync record, a tombstone, a peer cursor or a publish state. It deliberately does not count `syncProvider`, which merely names a chosen backend and is set before any sync has run.

**Layer 2, the setup wizard's Connect step.** Layer 1 protects future installs; it cannot help one that has *already* inherited an identity. The step now calls `SyncInitializer.firstContactLibraryState`, which on an empty peer listing checks whether the account holds a library under our own device id and, if this install has no library locally, adopts a fresh identity so those files can be pulled as a peer's. Nothing is deleted.

The guard matters in both directions: a device that still holds the library it published keeps the identity that published it, or it orphans its own log.

## Tests

Written first, each watched failing for the right reason.

- `sync_initializer_reconcile_test.dart`: a fresh install whose preferences survived keeps its own identity; one whose database carries sync history still rebaselines.
- `sync_initializer_test.dart`: `firstContactLibraryState` adopts a fresh identity so a self-owned library is pullable, and leaves the identity alone for a device that holds a library, a real peer library, and a genuinely empty account.
- `sync_connect_step_test.dart`: a library under our own device id is pulled through to "Library adopted" instead of "No library found". Verified to fail when the call site is reverted.

`setup_wizard_page_test.dart` gained a test database, since the step now reads the live diver count.

Full suite: 24,079 passed, 21 skipped, 0 failures. `flutter analyze` clean.

## Not in scope

`GoogleDriveStorageProvider.listFiles` never follows `nextPageToken`, so it only ever sees the first 100 files in the sync folder. Real, but independent of this bug and tracked separately.
