### PR TITLE
docs(scripts): stop claiming the simplification matches the tolerance

### DIFF
--- a/scripts/sea_area_harvester.py
+++ b/scripts/sea_area_harvester.py
@@ -19,7 +19,7 @@ Marine Institute under CC-BY 4.0:
 The full layer is ~250 MB of coordinates. This script simplifies it to
 roughly a megabyte, which is the resolution the runtime lookup actually
 needs: the resolver already tolerates a few kilometres of coastline error
-(see NEAR_SHORE_KM in sea_area_index.dart), because IHO limits stop at the
+(see nearShoreKm in sea_area_index.dart), because IHO limits stop at the
 legal boundary of a sea and dive-site coordinates are routinely recorded
 from a beach or a moored boat.
 
@@ -62,9 +62,14 @@ SOURCE_CITATION = (
 )
 SOURCE_LICENSE = "CC-BY 4.0"
 
-# Coastline simplification, in degrees. 0.05 deg is ~5.5 km, which matches
-# the resolver's near-shore tolerance; finer detail doubles the asset for no
-# measurable gain in which sea a dive site lands in.
+# Coastline simplification, in degrees. 0.05 deg is ~5.5 km of latitude,
+# and less longitude the further from the equator (~2.8 km at 60 degrees).
+# So the error it introduces is not equal to the resolver's 4 km near-shore
+# tolerance (nearShoreKm in sea_area_index.dart), but it sits in the same
+# few-kilometre band -- which is the point: detail finer than that band is
+# swallowed by the tolerance rather than changing which sea a dive site
+# lands in, and it doubles the asset. Measured: halving this to 0.02 deg
+# left all 30 curated sites and the 3,256-site corpus unchanged.
 SIMPLIFY_TOLERANCE = 0.05
 
 # Coordinates are stored to this many decimals: ~110 m, far below the


### PR DESCRIPTION
Follow-up to #1538, which was merged before this landed. Comment-only change to `scripts/sea_area_harvester.py`; no behaviour, no regenerated asset.

## Summary

Two documentation inaccuracies in the sea-area generator, both caught in review on #1538 after the merge.

**The `SIMPLIFY_TOLERANCE` comment claimed 0.05° "matches the resolver's near-shore tolerance".** It does not. 0.05° is ~5.5 km of latitude and less longitude the further from the equator (~2.8 km at 60°), while `nearShoreKm` is a true 4 km regardless of latitude. They sit in the same few-kilometre band, which is the actual argument for the value — detail finer than that band is swallowed by the tolerance rather than changing which sea a dive site lands in — so the comment now says that instead, and records the measurement behind it (halving the tolerance to 0.02° left all 30 curated sites and the 3,256-site corpus unchanged).

**A dangling cross-reference.** The module docstring pointed at `NEAR_SHORE_KM in sea_area_index.dart`. That name does not exist; the Dart constant is `nearShoreKm`, so anyone grepping for it found nothing.

Both are the same class of problem as the `MIN_HOLE_AREA` figure corrected in #1538: a wrong number or name in a comment next to a tuning constant is exactly what misleads the next person who adjusts it.

## Test Plan

- [x] `python3 scripts/sea_area_harvester_test.py` — 12 passed
- [x] `flutter analyze` — no issues
- [x] Manual testing: not applicable, comments only