### PR TITLE
fix(scripts): emit a parseable generated_at in the dive site assets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -556,6 +556,15 @@ jobs:
           python3 -m pip install shapely
           python3 scripts/sea_area_harvester_test.py
 
+      - name: Run dive site harvester tests
+        # The harvester stamps the bundled dive site and dive centre assets.
+        # Its dependency set is the one scripts/requirements.txt declares;
+        # without it the module-level tests skip themselves and only the
+        # source scan runs.
+        run: |
+          python3 -m pip install -r scripts/requirements.txt
+          python3 scripts/dive_site_harvester_test.py
+
       - name: Run appcast beta feed test
         run: ./scripts/generate_appcast_beta_test.sh
 

--- a/assets/data/dive_centers.json
+++ b/assets/data/dive_centers.json
@@ -33222,7 +33222,7 @@
     }
   ],
   "metadata": {
-    "generated_at": "2026-02-01T02:12:29.801513+00:00Z",
+    "generated_at": "2026-02-01T02:12:29Z",
     "source": "OpenStreetMap via Overpass API",
     "total_count": 3593,
     "query_tags": [

--- a/assets/data/dive_sites.json
+++ b/assets/data/dive_sites.json
@@ -30184,7 +30184,7 @@
     }
   ],
   "metadata": {
-    "generated_at": "2026-02-01T02:12:29.728561+00:00Z",
+    "generated_at": "2026-02-01T02:12:29Z",
     "source": "OpenStreetMap via Overpass API",
     "total_count": 3612,
     "query_tags": [

--- a/scripts/dive_site_harvester.py
+++ b/scripts/dive_site_harvester.py
@@ -73,6 +73,17 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def utc_timestamp() -> str:
+    """Now, as RFC3339 UTC: 2026-09-04T06:33:21Z.
+
+    `datetime.isoformat()` already writes the offset as "+00:00", so the
+    conventional-looking `isoformat() + "Z"` yields "...+00:00Z", which no
+    ISO-8601 parser accepts. Sub-second precision means nothing for a
+    dataset build stamp, so seconds it is.
+    """
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 class ReverseGeocoder:
     """Reverse geocoder using OpenStreetMap Nominatim API with caching."""
 
@@ -836,7 +847,7 @@ class DiveSiteHarvester:
         sites_output = {
             "sites": named_sites,
             "metadata": {
-                "generated_at": datetime.now(timezone.utc).isoformat() + "Z",
+                "generated_at": utc_timestamp(),
                 "source": "OpenStreetMap via Overpass API",
                 "total_count": len(named_sites),
                 "query_tags": ["sport=scuba_diving"],
@@ -855,7 +866,7 @@ class DiveSiteHarvester:
         centers_output = {
             "centers": named_centers,
             "metadata": {
-                "generated_at": datetime.now(timezone.utc).isoformat() + "Z",
+                "generated_at": utc_timestamp(),
                 "source": "OpenStreetMap via Overpass API",
                 "total_count": len(named_centers),
                 "query_tags": [
@@ -889,7 +900,7 @@ class DiveSiteHarvester:
         """Write output in original raw OSM format."""
         output = {
             "metadata": {
-                "generated_at": datetime.now(timezone.utc).isoformat() + "Z",
+                "generated_at": utc_timestamp(),
                 "total_count": len(self.all_sites),
                 "query_tags": [f"{k}={v}" for k, v in DIVE_TAGS],
             },

--- a/scripts/dive_site_harvester_test.py
+++ b/scripts/dive_site_harvester_test.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Unit tests for dive_site_harvester.py.
+
+Run: python3 scripts/dive_site_harvester_test.py
+
+These cover the metadata build stamp. The harvester writes `generated_at`
+into two shipped assets, and the conventional-looking `isoformat() + "Z"`
+produces a string no ISO-8601 parser accepts, so the stamp is worthless to
+anyone who later wants to know how stale the bundled data is.
+"""
+
+import importlib.util
+import ast
+import os
+import unittest
+from datetime import datetime, timezone
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SOURCE = os.path.join(_HERE, "dive_site_harvester.py")
+
+try:
+    import overpy  # noqa: F401
+    import requests  # noqa: F401
+    import tenacity  # noqa: F401
+    import tqdm  # noqa: F401
+
+    _HAS_DEPS = True
+except ImportError:  # pragma: no cover - exercised only on bare runners
+    _HAS_DEPS = False
+
+if _HAS_DEPS:
+    _spec = importlib.util.spec_from_file_location(
+        "dive_site_harvester",
+        _SOURCE,
+    )
+    dive_site_harvester = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(dive_site_harvester)
+
+
+@unittest.skipUnless(_HAS_DEPS, "the harvester's dependencies are not installed")
+class UtcTimestampTest(unittest.TestCase):
+    def test_stamps_a_timestamp_that_actually_parses(self):
+        # isoformat() already writes "+00:00", so appending "Z" would give
+        # "...+00:00Z" and every ISO-8601 parser would reject it.
+        stamp = dive_site_harvester.utc_timestamp()
+
+        self.assertTrue(stamp.endswith("Z"), stamp)
+        self.assertNotIn("+00:00", stamp)
+        parsed = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+        self.assertEqual(parsed.tzinfo, timezone.utc)
+
+    def test_stamps_the_current_instant(self):
+        before = datetime.now(timezone.utc).replace(microsecond=0)
+        stamp = dive_site_harvester.utc_timestamp()
+        after = datetime.now(timezone.utc)
+
+        parsed = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+        self.assertGreaterEqual(parsed, before)
+        self.assertLessEqual(parsed, after)
+
+
+class GeneratedAtCallSiteTest(unittest.TestCase):
+    """The helper is only worth having if every call site reaches for it.
+
+    A source scan rather than a call because the three stamps are written
+    deep inside methods that only run after a full Overpass harvest. The
+    scan walks the parsed tree rather than the raw text so prose about the
+    bug -- this docstring included -- cannot trip it.
+    """
+
+    def setUp(self):
+        with open(_SOURCE, encoding="utf-8") as f:
+            self.tree = ast.parse(f.read())
+
+    def test_no_call_site_appends_z_to_an_isoformat(self):
+        offenders = [
+            node.lineno
+            for node in ast.walk(self.tree)
+            if isinstance(node, ast.BinOp)
+            and isinstance(node.op, ast.Add)
+            and isinstance(node.left, ast.Call)
+            and isinstance(node.left.func, ast.Attribute)
+            and node.left.func.attr == "isoformat"
+        ]
+
+        self.assertEqual(offenders, [], "isoformat() already carries +00:00")
+
+    def test_every_generated_at_goes_through_the_helper(self):
+        stamps = [
+            ast.unparse(value)
+            for node in ast.walk(self.tree)
+            if isinstance(node, ast.Dict)
+            for key, value in zip(node.keys, node.values)
+            if isinstance(key, ast.Constant) and key.value == "generated_at"
+        ]
+
+        self.assertEqual(stamps, ["utc_timestamp()"] * 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/features/dive_sites/data/services/bundled_osm_asset_metadata_test.dart
+++ b/test/features/dive_sites/data/services/bundled_osm_asset_metadata_test.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards the metadata block that `scripts/dive_site_harvester.py` stamps
+/// onto both of the assets it writes.
+///
+/// The generator used to append "Z" to an `isoformat()` that already carried
+/// "+00:00", producing a timestamp no ISO-8601 parser accepts. This asserts
+/// the shipped files, not just the generator, so a hand-edited or
+/// half-regenerated asset cannot slip a broken stamp back in.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const assets = <String, String>{
+    'assets/data/dive_sites.json': 'sites',
+    'assets/data/dive_centers.json': 'centers',
+  };
+
+  assets.forEach((assetPath, entriesKey) {
+    group(assetPath, () {
+      late Map<String, dynamic> metadata;
+      late List<dynamic> entries;
+
+      setUpAll(() async {
+        final raw = await rootBundle.loadString(assetPath);
+        final decoded = jsonDecode(raw) as Map<String, dynamic>;
+        metadata = decoded['metadata'] as Map<String, dynamic>;
+        entries = decoded[entriesKey] as List<dynamic>;
+      });
+
+      test('stamps metadata a parser can actually read', () {
+        final stamp = metadata['generated_at'] as String;
+
+        expect(stamp, endsWith('Z'));
+        expect(stamp, isNot(contains('+00:00')));
+        expect(DateTime.parse(stamp).isUtc, isTrue);
+      });
+
+      test('counts the entries it actually ships', () {
+        expect(metadata['source'], 'OpenStreetMap via Overpass API');
+        expect(metadata['total_count'], entries.length);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## The bug

`scripts/dive_site_harvester.py` stamped `generated_at` as
`datetime.now(timezone.utc).isoformat() + "Z"` in three places.
`isoformat()` already writes the offset as `+00:00`, so the result was
`2026-02-01T02:12:29.728561+00:00Z`, which no ISO-8601 parser accepts.

Confirmed against the shipped asset before the fix:

```bash
python3 -c "import json,datetime; print(datetime.datetime.fromisoformat(json.load(open('assets/data/dive_sites.json'))['metadata']['generated_at']))"
```

raised `ValueError: Invalid isoformat string`. Both
`assets/data/dive_sites.json` and `assets/data/dive_centers.json` shipped a
stamp nobody could read.

This is the same defect fixed in `scripts/sea_area_harvester.py` by
72c246c5bd0, which explicitly left these three call sites alone as out of
scope.

## The fix

A `utc_timestamp()` helper emitting RFC3339 seconds
(`2026-09-04T19:02:00Z`), matching `sea_area_harvester.py` exactly, used at
all three call sites. Sub-second precision means nothing for a dataset build
stamp.

## Should the assets be regenerated?

No, and the stored stamps are repaired in place instead.

A real regeneration means a world-scale Overpass sweep in 10-degree chunks
plus Nominatim reverse geocoding at 1.1 s per request across 3612 sites and
3593 centres. That is hours of rate-limited network to correct a timestamp,
and it would rewrite both datasets wholesale, burying the actual change and
churning data that is otherwise fine.

Letting the stamp correct itself on the next harvest was the other option,
but that leaves an unreadable timestamp in the shipped app for however long
that takes. So this repairs the two stored strings directly: same recorded
instant, `2026-02-01T02:12:29`, reformatted to the seconds precision the
generator now emits. One line changes per file, and the result is
byte-identical to what the next harvest will write. Entry counts, geometry,
and every site record are untouched.

The third call site writes `dive_sites_raw_<timestamp>.json`, which is not
tracked, so it ships nothing to repair.

## Guards

Both sides, so it cannot drift back:

- `scripts/dive_site_harvester_test.py` (new) asserts the helper's stamp ends
  in `Z`, contains no `+00:00`, round-trips through `datetime.fromisoformat`,
  and lands between two clock reads. It also walks the parsed source with
  `ast` to prove all three `generated_at` call sites reach for the helper,
  since those stamps are written deep inside methods that only run after a
  full harvest and cannot be reached from a test. Verified honest by running
  the scan against the pre-fix source, where it names lines 839, 858 and 892.
- `test/.../bundled_osm_asset_metadata_test.dart` (new) parses the metadata
  out of both shipped files rather than trusting the generator, so a
  hand-edited or half-regenerated asset cannot slip a broken stamp back in.
  It also asserts `total_count` matches the entries actually shipped.

Wired into the CI python test step next to the sea area generator tests.
Without the harvester's dependencies the module-level tests skip themselves
and the source scan still runs.

## Note for reviewers

The one-liner above needs Python 3.11+ to parse the repaired stamp directly:
bare `Z` support landed in `fromisoformat` then. On older interpreters use
`stamp.replace("Z", "+00:00")`, which is what both generator tests do. Dart's
`DateTime.parse` accepts `Z` on every version.

## Verification

- `python3 scripts/dive_site_harvester_test.py` passes with dependencies
  installed (4 tests) and on a bare interpreter (2 run, 2 skipped)
- `flutter analyze` clean
- `flutter test test/features/dive_sites test/features/dive_centers`: 765
  tests pass
- `dart format .` reports no changes
