### PR TITLE
fix(media): let MediaFetchGate release its budget timers on disposal

### DIFF
--- a/lib/features/media/data/resolvers/local_file_resolver.dart
+++ b/lib/features/media/data/resolvers/local_file_resolver.dart
@@ -476,4 +476,13 @@ class LocalFileResolver implements MediaSourceResolver {
     }
     return VerifyResult.notFound;
   }
+
+  /// Releases the fetch gate's budget timers.
+  ///
+  /// Called from `localFileResolverProvider`'s `onDispose`. The resolver is a
+  /// singleton per container, so without this a container that goes away with
+  /// a tile still resolving leaves the gate's slot and caller budgets ticking
+  /// against nobody. That is harmless in the app but fatal to a widget test,
+  /// which fails teardown on any timer the tree left behind.
+  void dispose() => _gate.dispose();
 }

--- a/lib/features/media/data/resolvers/media_fetch_gate.dart
+++ b/lib/features/media/data/resolvers/media_fetch_gate.dart
@@ -181,6 +181,12 @@ class MediaFetchGate {
       if (!caller.isCompleted) complete();
     }
 
+    // Deliberately not .ignore()d, unlike the whenComplete in run(). That one
+    // has to be: whenComplete forwards the source's error, so an unlistened
+    // failure there would be an unhandled async error. This chain cannot carry
+    // the source's error at all, because the onError below consumes it, so the
+    // only way it completes with one is a callback throwing. Ignoring it would
+    // silence exactly that bug.
     future.then(
       (value) => settle(() => caller.complete(value)),
       // Registered rather than left to propagate: without a handler here a

--- a/lib/features/media/data/resolvers/media_fetch_gate.dart
+++ b/lib/features/media/data/resolvers/media_fetch_gate.dart
@@ -96,8 +96,20 @@ class MediaFetchGate {
   /// Callers parked waiting for a slot.
   final Queue<Completer<void>> _waiting = Queue<Completer<void>>();
 
+  /// Slot timers currently armed, so [dispose] can reach them.
+  final Set<Timer> _slotTimers = <Timer>{};
+
+  /// Caller deadlines currently armed, each with the caller it answers.
+  ///
+  /// A map rather than a set because [dispose] has to do more than cancel
+  /// these: the caller behind each one is still waiting, and dropping the
+  /// timer without answering would leave it waiting forever.
+  final Map<Timer, Completer<MediaSourceData?>> _deadlines =
+      <Timer, Completer<MediaSourceData?>>{};
+
   int _running = 0;
   int _detached = 0;
+  bool _disposed = false;
 
   /// Fetches holding a slot, for tests.
   int get runningCount => _running;
@@ -118,6 +130,10 @@ class MediaFetchGate {
     String key,
     Future<MediaSourceData?> Function() fetch,
   ) {
+    // A disposed gate arms no timers, so it cannot start work either: the
+    // budgets ARE the contract, and a fetch running without them is the
+    // unbounded wait this class exists to prevent.
+    if (_disposed) return Future<MediaSourceData?>.value(_givenUp);
     final pending = _inFlight[key];
     if (pending != null) return _bounded(pending);
 
@@ -134,13 +150,76 @@ class MediaFetchGate {
     return _bounded(future);
   }
 
+  /// The answer a caller gets when the gate stops waiting on its behalf.
+  static const MediaSourceData _givenUp = UnavailableData(
+    kind: UnavailableKind.stillFetching,
+  );
+
   /// One caller's bounded view of [future]. The fetch itself is untouched.
+  ///
+  /// Hand-rolled rather than `Future.timeout`, because the timer that call
+  /// arms belongs to the returned future and can never be reached again.
+  /// [dispose] has to be able to cancel it: a 30-second timer still armed
+  /// against a caller that no longer exists is dead weight in the app, and in
+  /// a widget test it trips the binding's pending-timer invariant, which is
+  /// how a media tile still resolving at teardown failed an unrelated test.
   Future<MediaSourceData?> _bounded(Future<MediaSourceData?> future) {
-    return future.timeout(
-      totalBudget,
-      onTimeout: () =>
-          const UnavailableData(kind: UnavailableKind.stillFetching),
+    final caller = Completer<MediaSourceData?>();
+    late final Timer deadline;
+    deadline = Timer(totalBudget, () {
+      _deadlines.remove(deadline);
+      if (!caller.isCompleted) caller.complete(_givenUp);
+    });
+    _deadlines[deadline] = caller;
+
+    void settle(void Function() complete) {
+      deadline.cancel();
+      _deadlines.remove(deadline);
+      // Already answered: the deadline fired first and the fetch has only
+      // now caught up. Its result belongs to whoever joins next, not to a
+      // caller that was told to stop waiting.
+      if (!caller.isCompleted) complete();
+    }
+
+    future.then(
+      (value) => settle(() => caller.complete(value)),
+      // Registered rather than left to propagate: without a handler here a
+      // fetch that fails after its caller gave up is an unhandled async
+      // error, which `Future.timeout` used to absorb for us.
+      onError: (Object error, StackTrace stack) =>
+          settle(() => caller.completeError(error, stack)),
     );
+    return caller.future;
+  }
+
+  /// Releases every timer this gate has armed and answers whoever is waiting.
+  ///
+  /// Cannot cancel the fetches themselves, since Dart has no way to, so it does
+  /// the next honest thing: outstanding callers get the same [_givenUp] answer
+  /// the total budget would have given them, just earlier, and any fetch that
+  /// settles afterwards is allowed to finish quietly with its bookkeeping
+  /// skipped. Parked waiters are dropped rather than admitted, because
+  /// admitting one would start a fresh fetch, and arm a fresh timer, on a gate
+  /// that is being torn down.
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    for (final timer in _slotTimers) {
+      timer.cancel();
+    }
+    _slotTimers.clear();
+    final pending = List<MapEntry<Timer, Completer<MediaSourceData?>>>.of(
+      _deadlines.entries,
+    );
+    _deadlines.clear();
+    for (final entry in pending) {
+      entry.key.cancel();
+      if (!entry.value.isCompleted) entry.value.complete(_givenUp);
+    }
+    _waiting.clear();
+    _inFlight.clear();
+    _running = 0;
+    _detached = 0;
   }
 
   Future<MediaSourceData?> _withSlot(
@@ -150,8 +229,10 @@ class MediaFetchGate {
     var holdsSlot = true;
     var detached = false;
 
+    late final Timer timer;
     void detach() {
-      if (!holdsSlot || _detached >= maxDetached) return;
+      _slotTimers.remove(timer);
+      if (_disposed || !holdsSlot || _detached >= maxDetached) return;
       holdsSlot = false;
       detached = true;
       _detached++;
@@ -161,16 +242,23 @@ class MediaFetchGate {
     // Cancelled in the finally block rather than left to fire harmlessly: a
     // stale firing would release a slot this fetch no longer holds, letting
     // the effective cap drift upward for the life of the process.
-    final timer = Timer(slotBudget, detach);
+    timer = Timer(slotBudget, detach);
+    _slotTimers.add(timer);
     try {
       return await fetch();
     } finally {
       timer.cancel();
-      if (detached) {
-        _detached--;
-      } else if (holdsSlot) {
-        holdsSlot = false;
-        _release();
+      _slotTimers.remove(timer);
+      // A gate torn down mid-fetch has already zeroed these counters, and
+      // decrementing them again would drive the cap negative for a gate that
+      // is only still here because Dart cannot cancel the fetch.
+      if (!_disposed) {
+        if (detached) {
+          _detached--;
+        } else if (holdsSlot) {
+          holdsSlot = false;
+          _release();
+        }
       }
     }
   }

--- a/lib/features/media/data/resolvers/media_fetch_gate.dart
+++ b/lib/features/media/data/resolvers/media_fetch_gate.dart
@@ -216,7 +216,19 @@ class MediaFetchGate {
       entry.key.cancel();
       if (!entry.value.isCompleted) entry.value.complete(_givenUp);
     }
+    // Completed, not dropped. A waiter parked inside _acquire owns the only
+    // path back into its _withSlot body, so abandoning its completer leaves
+    // that future permanently incomplete. Nothing hangs on it today (the
+    // caller was already answered above, and the orphan is unreachable enough
+    // to collect), but a future that can never complete is a trap for the next
+    // caller who holds one. They resume into the _disposed guard in _withSlot,
+    // which returns without starting a fetch or arming a timer, so releasing
+    // them here does not put work back on a gate being torn down.
+    final parked = List<Completer<void>>.of(_waiting);
     _waiting.clear();
+    for (final waiter in parked) {
+      if (!waiter.isCompleted) waiter.complete();
+    }
     _inFlight.clear();
     _running = 0;
     _detached = 0;
@@ -226,6 +238,10 @@ class MediaFetchGate {
     Future<MediaSourceData?> Function() fetch,
   ) async {
     await _acquire();
+    // Torn down while this call was parked, or between the slot and here.
+    // Answer the way the total budget would have rather than starting a fetch
+    // the gate can no longer bound.
+    if (_disposed) return _givenUp;
     var holdsSlot = true;
     var detached = false;
 

--- a/lib/features/media/data/resolvers/media_store_resolver.dart
+++ b/lib/features/media/data/resolvers/media_store_resolver.dart
@@ -261,4 +261,9 @@ class MediaStoreResolver {
       // Best-effort: an undeletable staging file is not worth surfacing.
     }
   }
+
+  /// Releases the fetch gate's budget timers. Called when the store runtime
+  /// that owns this resolver is torn down or replaced; see
+  /// [LocalFileResolver.dispose] for why a stray budget timer matters.
+  void dispose() => _gate.dispose();
 }

--- a/lib/features/media/presentation/providers/media_resolver_providers.dart
+++ b/lib/features/media/presentation/providers/media_resolver_providers.dart
@@ -98,8 +98,8 @@ final pdfThumbnailServiceProvider = Provider<PdfThumbnailService>(
 );
 
 /// Singleton [LocalFileResolver] (Phase 2 — multi-platform).
-final localFileResolverProvider = Provider<LocalFileResolver>(
-  (ref) => LocalFileResolver(
+final localFileResolverProvider = Provider<LocalFileResolver>((ref) {
+  final resolver = LocalFileResolver(
     bookmarkStorage: ref.watch(localBookmarkStorageProvider),
     platform: ref.watch(localMediaPlatformProvider),
     exifExtractor: ref.watch(exifExtractorProvider),
@@ -108,8 +108,13 @@ final localFileResolverProvider = Provider<LocalFileResolver>(
     // and memoized by the resolver; the provider itself never touches the
     // database.
     localDeviceId: () => SyncRepository().getDeviceId(),
-  ),
-);
+  );
+  // The resolver's fetch gate holds timers that outlive the fetch they bound,
+  // so a rebuild or a container teardown with a tile still resolving would
+  // leave them armed against a resolver nothing can reach.
+  ref.onDispose(resolver.dispose);
+  return resolver;
+});
 
 /// Singleton [HttpUrlMediaResolver] for [MediaSourceType.manifestEntry]
 /// items (Phase 3b).

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -442,6 +442,10 @@ final FutureProvider<MediaStoreRuntime?> mediaStoreRuntimeProvider =
         root: await mediaCacheRoot(),
       );
       final resolver = MediaStoreResolver(store: store, cache: cache);
+      // Same reason as worker.dispose below: a superseded runtime must not
+      // leave its resolver's budget timers armed behind the one that
+      // replaced it.
+      ref.onDispose(resolver.dispose);
 
       final mediaRepository = ref.watch(mediaRepositoryProvider);
       final policies = ref.watch(mediaStorePoliciesProvider);

--- a/test/features/media/data/resolvers/media_fetch_gate_test.dart
+++ b/test/features/media/data/resolvers/media_fetch_gate_test.dart
@@ -379,6 +379,54 @@ void main() {
       });
     });
 
+    /// A caller parked behind the concurrency cap is suspended inside
+    /// _acquire, which only its completer can resume. Dropping that completer
+    /// would leave the inner _withSlot future permanently incomplete: nothing
+    /// observes it today, but it is the kind of orphan that hangs whoever
+    /// holds one next.
+    test('a caller parked behind the cap unwinds instead of hanging', () async {
+      final gate = MediaFetchGate(maxConcurrent: 1);
+      var parkedFetchRan = false;
+
+      // Occupies the only slot and never settles, so the second call parks.
+      final running = gate.run('a', () => Completer<MediaSourceData?>().future);
+      final parked = gate.run('b', () {
+        parkedFetchRan = true;
+        return Completer<MediaSourceData?>().future;
+      });
+      await Future<void>.delayed(Duration.zero);
+      expect(gate.waitingCount, 1, reason: 'the second call must be parked');
+
+      gate.dispose();
+
+      // Drain well past the microtask that resumes the parked waiter. Without
+      // this the assertion below passes vacuously: the fetch starts a turn
+      // later than a single await settles.
+      for (var i = 0; i < 10; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      // Both answer rather than hanging, and the parked fetch never started.
+      expect(
+        await running,
+        isA<UnavailableData>().having(
+          (d) => d.kind,
+          'kind',
+          UnavailableKind.stillFetching,
+        ),
+      );
+      expect(
+        await parked,
+        isA<UnavailableData>().having(
+          (d) => d.kind,
+          'kind',
+          UnavailableKind.stillFetching,
+        ),
+      );
+      expect(parkedFetchRan, isFalse);
+      expect(gate.waitingCount, 0);
+    });
+
     test('is idempotent', () {
       final gate = MediaFetchGate(maxConcurrent: 1);
       gate.dispose();

--- a/test/features/media/data/resolvers/media_fetch_gate_test.dart
+++ b/test/features/media/data/resolvers/media_fetch_gate_test.dart
@@ -281,4 +281,108 @@ void main() {
       });
     });
   });
+
+  /// Teardown. The budgets above are what keep a stalled fetch from freezing
+  /// the gallery, and they are implemented with timers that outlive the fetch
+  /// they bound. Once the container that owns the gate is gone those timers
+  /// are pure dead weight: nothing will read their answer, and in a widget
+  /// test they trip the binding's "a Timer is still pending even after the
+  /// widget tree was disposed" invariant, which is how this surfaced: as a
+  /// load-dependent failure in an unrelated media widget test whenever a tile
+  /// resolution was still in flight at teardown.
+  group('dispose', () {
+    testWidgets('leaves no pending timer behind', (tester) async {
+      final gate = MediaFetchGate(maxConcurrent: 1);
+      // Never completes: both budget timers stay armed for their full
+      // duration, exactly as an unreachable share behaves.
+      gate.run('never', () => Completer<MediaSourceData?>().future).ignore();
+      await tester.pump();
+      expect(gate.runningCount, 1, reason: 'the fetch holds a slot');
+
+      gate.dispose();
+
+      // The assertion is the binding's own: reaching the end of this test
+      // with either budget timer still armed fails it during teardown.
+    });
+
+    test('answers an outstanding caller with stillFetching', () {
+      fakeAsync((async) {
+        final gate = MediaFetchGate(maxConcurrent: 1);
+        MediaSourceData? seen;
+        gate
+            .run('never', () => Completer<MediaSourceData?>().future)
+            .then((v) => seen = v);
+        async.flushMicrotasks();
+        expect(seen, isNull);
+
+        gate.dispose();
+        async.flushMicrotasks();
+
+        // The same answer the total budget would have given, just earlier:
+        // a caller is never left waiting on a gate that no longer exists.
+        expect(
+          seen,
+          isA<UnavailableData>().having(
+            (d) => d.kind,
+            'kind',
+            UnavailableKind.stillFetching,
+          ),
+        );
+      });
+    });
+
+    test('answers a later caller without starting the fetch', () {
+      fakeAsync((async) {
+        final gate = MediaFetchGate(maxConcurrent: 1);
+        gate.dispose();
+
+        var started = false;
+        MediaSourceData? seen;
+        gate
+            .run('late', () async {
+              started = true;
+              return result('late');
+            })
+            .then((v) => seen = v);
+        async.flushMicrotasks();
+
+        expect(started, isFalse);
+        expect(
+          seen,
+          isA<UnavailableData>().having(
+            (d) => d.kind,
+            'kind',
+            UnavailableKind.stillFetching,
+          ),
+        );
+        // And no timer to elapse into: a disposed gate arms nothing.
+        async.elapse(const Duration(minutes: 1));
+      });
+    });
+
+    test('a fetch settling after dispose disturbs nothing', () {
+      fakeAsync((async) {
+        final gate = MediaFetchGate(maxConcurrent: 1);
+        final late_ = Completer<MediaSourceData?>();
+        gate.run('k', () => late_.future).ignore();
+        async.flushMicrotasks();
+
+        gate.dispose();
+        late_.complete(result('arrived late'));
+        async.flushMicrotasks();
+        async.elapse(const Duration(minutes: 1));
+
+        // Counters stay put rather than drifting negative: the fetch's
+        // bookkeeping is skipped wholesale once the gate is torn down.
+        expect(gate.runningCount, 0);
+        expect(gate.detachedCount, 0);
+      });
+    });
+
+    test('is idempotent', () {
+      final gate = MediaFetchGate(maxConcurrent: 1);
+      gate.dispose();
+      expect(gate.dispose, returnsNormally);
+    });
+  });
 }

--- a/test/features/media/presentation/providers/media_resolver_providers_test.dart
+++ b/test/features/media/presentation/providers/media_resolver_providers_test.dart
@@ -145,10 +145,16 @@ void main() {
   ///     iOS and macOS, since `_usesSecurityScopedBookmarks` defaults to those
   ///     two, and would pass vacuously on the Linux shards that actually run
   ///     this suite.
-  ///   * `run` arms the caller budget synchronously and `_resolveInner`
-  ///     suspends at its first await, so disposing in the same turn catches
-  ///     the timers armed. Pumping first lets the resolution settle and
-  ///     disarm them, which is the same vacuous pass by a different route.
+  ///   * `run` arms the caller budget synchronously, before `_withSlot` has
+  ///     reached its first await, so disposing in the same turn is guaranteed
+  ///     to catch that one live. It is the only one: the slot budget is armed
+  ///     a microtask later, once `_acquire` resumes, which a same-turn dispose
+  ///     beats. That is enough, since one stray timer fails teardown, and
+  ///     without the disposal guard the slot timer is then armed on an
+  ///     already-disposed gate, which is the second timer the original CI
+  ///     failure reported. Pumping first would let the resolution settle and
+  ///     disarm the caller budget, which is the same vacuous pass by a
+  ///     different route.
   testWidgets('a resolution still in flight at teardown leaves no timer', (
     tester,
   ) async {

--- a/test/features/media/presentation/providers/media_resolver_providers_test.dart
+++ b/test/features/media/presentation/providers/media_resolver_providers_test.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
 import 'package:submersion/features/media/data/services/local_files_diagnostics_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
@@ -32,16 +30,6 @@ class _StubDiagnosticsService implements LocalFilesDiagnosticsService {
   @override
   dynamic noSuchMethod(Invocation invocation) =>
       throw UnimplementedError('${invocation.memberName} should not be called');
-}
-
-/// Stalls resolution inside the fetch gate. The bookmark read is the first
-/// await [LocalFileResolver] makes for an item with no local path, and it sits
-/// inside the gate, so a resolution parked here is one holding a slot with
-/// both budget timers armed, the state a media tile is in whenever its
-/// source is slow.
-class _StalledBookmarkStorage extends LocalBookmarkStorage {
-  @override
-  Future<Uint8List?> read(String bookmarkRef) => Completer<Uint8List?>().future;
 }
 
 void main() {
@@ -121,22 +109,31 @@ void main() {
   );
 
   /// The one that bit us. A tile whose resolution has not landed by the time
-  /// the tree comes down is normal, since the fetch cannot be cancelled, but the
-  /// gate's budget timers were surviving the container that owned them, and
-  /// the test binding fails teardown on any timer left pending. On a fast
+  /// the tree comes down is normal, since the fetch cannot be cancelled, but
+  /// the gate's budget timers were surviving the container that owned them,
+  /// and the test binding fails teardown on any timer left pending. On a fast
   /// machine the resolution finished first and nothing showed; under CI load
   /// it did not, and an unrelated media widget test failed with two pending
   /// timers it had no way to see.
+  ///
+  /// Deliberately uses a localPath item and never pumps before disposing.
+  /// Both details keep the test honest across platforms:
+  ///
+  ///   * localPath takes the desktop branch of `_resolveInner`, which every
+  ///     platform runs. Keying off a bookmarkRef instead would stall only on
+  ///     iOS and macOS, since `_usesSecurityScopedBookmarks` defaults to those
+  ///     two, and would pass vacuously on the Linux shards that actually run
+  ///     this suite.
+  ///   * `run` arms the caller budget synchronously and `_resolveInner`
+  ///     suspends at its first await, so disposing in the same turn catches
+  ///     the timers armed. Pumping first lets the resolution settle and
+  ///     disarm them, which is the same vacuous pass by a different route.
   testWidgets('a resolution still in flight at teardown leaves no timer', (
     tester,
   ) async {
-    final container = ProviderContainer(
-      overrides: [
-        localBookmarkStorageProvider.overrideWith(
-          (ref) => _StalledBookmarkStorage(),
-        ),
-      ],
-    );
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
     unawaited(
       container
           .read(localFileResolverProvider)
@@ -145,14 +142,13 @@ void main() {
               id: 'm1',
               mediaType: MediaType.photo,
               sourceType: MediaSourceType.localFile,
-              bookmarkRef: 'ref-1',
+              localPath: '/nonexistent/m1.jpg',
               takenAt: DateTime(2026),
               createdAt: DateTime(2026),
               updatedAt: DateTime(2026),
             ),
           ),
     );
-    await tester.pump();
 
     // What unmounting a ProviderScope does, and what the binding does for
     // every widget test before it checks for stray timers.

--- a/test/features/media/presentation/providers/media_resolver_providers_test.dart
+++ b/test/features/media/presentation/providers/media_resolver_providers_test.dart
@@ -32,6 +32,26 @@ class _StubDiagnosticsService implements LocalFilesDiagnosticsService {
       throw UnimplementedError('${invocation.memberName} should not be called');
 }
 
+/// Registers teardown disposal and hands back a dispose that runs at most once.
+///
+/// Both regression tests below have to dispose inside the body, because the
+/// disposal IS the event under test. They still want the teardown safety net,
+/// since a throw before that line would leak the container into whatever runs
+/// next. Disposing twice is harmless in Riverpod today, which is why these
+/// tests pass, but a regression test for a teardown bug should not be resting
+/// on that.
+void Function() _disposeOnce(ProviderContainer container) {
+  var disposed = false;
+  void dispose() {
+    if (disposed) return;
+    disposed = true;
+    container.dispose();
+  }
+
+  addTearDown(dispose);
+  return dispose;
+}
+
 void main() {
   test(
     'androidUriUsageProvider delegates to service.androidUriUsage',
@@ -79,9 +99,10 @@ void main() {
     'disposing the container stops the local file resolver fetching',
     () async {
       final container = ProviderContainer();
+      final disposeContainer = _disposeOnce(container);
       final resolver = container.read(localFileResolverProvider);
 
-      container.dispose();
+      disposeContainer();
 
       final data = await resolver.resolve(
         MediaItem(
@@ -132,7 +153,7 @@ void main() {
     tester,
   ) async {
     final container = ProviderContainer();
-    addTearDown(container.dispose);
+    final disposeContainer = _disposeOnce(container);
 
     unawaited(
       container
@@ -152,6 +173,6 @@ void main() {
 
     // What unmounting a ProviderScope does, and what the binding does for
     // every widget test before it checks for stray timers.
-    container.dispose();
+    disposeContainer();
   });
 }

--- a/test/features/media/presentation/providers/media_resolver_providers_test.dart
+++ b/test/features/media/presentation/providers/media_resolver_providers_test.dart
@@ -1,6 +1,13 @@
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
 import 'package:submersion/features/media/data/services/local_files_diagnostics_service.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
 
 /// Stub diagnostics service used to drive the FutureProvider tests in this
@@ -25,6 +32,16 @@ class _StubDiagnosticsService implements LocalFilesDiagnosticsService {
   @override
   dynamic noSuchMethod(Invocation invocation) =>
       throw UnimplementedError('${invocation.memberName} should not be called');
+}
+
+/// Stalls resolution inside the fetch gate. The bookmark read is the first
+/// await [LocalFileResolver] makes for an item with no local path, and it sits
+/// inside the gate, so a resolution parked here is one holding a slot with
+/// both budget timers armed, the state a media tile is in whenever its
+/// source is slow.
+class _StalledBookmarkStorage extends LocalBookmarkStorage {
+  @override
+  Future<Uint8List?> read(String bookmarkRef) => Completer<Uint8List?>().future;
 }
 
 void main() {
@@ -62,5 +79,83 @@ void main() {
 
     final result = await container.read(localFilesDiagnosticsProvider.future);
     expect(result, expected);
+  });
+
+  /// The resolver's fetch gate arms a slot budget and a caller budget per
+  /// resolution, and both outlive the fetch they bound. A container that goes
+  /// away mid-resolution, which is every widget test that mounts a media
+  /// tile, must not leave them armed: the binding fails teardown on any
+  /// timer the tree left behind, and that is a flake nothing in the test can
+  /// see or prevent.
+  test(
+    'disposing the container stops the local file resolver fetching',
+    () async {
+      final container = ProviderContainer();
+      final resolver = container.read(localFileResolverProvider);
+
+      container.dispose();
+
+      final data = await resolver.resolve(
+        MediaItem(
+          id: 'm1',
+          mediaType: MediaType.photo,
+          sourceType: MediaSourceType.localFile,
+          localPath: '/nonexistent/m1.jpg',
+          takenAt: DateTime(2026),
+          createdAt: DateTime(2026),
+          updatedAt: DateTime(2026),
+        ),
+      );
+
+      // Answered from the disposed gate without touching the filesystem: no
+      // fetch was started, so no budget timer was armed to bound it.
+      expect(
+        data,
+        isA<UnavailableData>().having(
+          (d) => d.kind,
+          'kind',
+          UnavailableKind.stillFetching,
+        ),
+      );
+    },
+  );
+
+  /// The one that bit us. A tile whose resolution has not landed by the time
+  /// the tree comes down is normal, since the fetch cannot be cancelled, but the
+  /// gate's budget timers were surviving the container that owned them, and
+  /// the test binding fails teardown on any timer left pending. On a fast
+  /// machine the resolution finished first and nothing showed; under CI load
+  /// it did not, and an unrelated media widget test failed with two pending
+  /// timers it had no way to see.
+  testWidgets('a resolution still in flight at teardown leaves no timer', (
+    tester,
+  ) async {
+    final container = ProviderContainer(
+      overrides: [
+        localBookmarkStorageProvider.overrideWith(
+          (ref) => _StalledBookmarkStorage(),
+        ),
+      ],
+    );
+    unawaited(
+      container
+          .read(localFileResolverProvider)
+          .resolve(
+            MediaItem(
+              id: 'm1',
+              mediaType: MediaType.photo,
+              sourceType: MediaSourceType.localFile,
+              bookmarkRef: 'ref-1',
+              takenAt: DateTime(2026),
+              createdAt: DateTime(2026),
+              updatedAt: DateTime(2026),
+            ),
+          ),
+    );
+    await tester.pump();
+
+    // What unmounting a ProviderScope does, and what the binding does for
+    // every widget test before it checks for stray timers.
+    container.dispose();
   });
 }


### PR DESCRIPTION
## Problem

`MediaFetchGate` bounds every fetch with two timers: a 5s **slot budget** that
detaches a slow fetch so it stops holding a concurrency slot, and a 30s
**caller budget** that answers a caller who has waited long enough. Both
outlive the fetch they bound, and nothing could reach them. The 30s one was
created by `Future.timeout`, whose timer belongs to the returned future and is
unreachable by definition.

That is harmless in the app and fatal in a widget test. The test binding fails
teardown on any timer the tree left behind, so a media tile still resolving
when its container went away failed the entire test file.

The result was a **load-dependent flake in PRs that touch no media code at
all**:

| PR | Subject | Shard | Result |
| --- | --- | --- | --- |
| #1530 | Dive insurance | 1 | 2964 passed, 1 failed |
| #1542 | Date pickers | 4 | 2581 passed, 1 failed |

Both failed on `dive_media_section_unlink_test.dart` with `A Timer is still
pending even after the widget tree was disposed` and the same two pending
`FakeTimer`s, 30s and 5s, under `LocalFileResolver.resolveThumbnail`.

## Why it hid so well

`tester.runAsync` runs its callback in the real async zone, so a `Timer` armed
inside a `runAsync` block is a real `_Timer` that the binding never inspects.
Only `FakeTimer`s are counted. A tile's resolution normally starts inside the
test's `runAsync` block; under load it starts during a later plain `pump`, and
the very same timers become `FakeTimer`s the binding does audit.

So the fast path was leaking identically all along. Load only moved the leak
into the zone that checks, which is why this reads as a flake rather than as
the deterministic bug it is.

## Fix

`MediaFetchGate.dispose()` cancels every armed timer, answers outstanding
callers with the same `stillFetching` the total budget would have given them,
drops parked waiters (admitting one would arm a fresh timer on a dying gate)
and zeroes the counters.

`_bounded` is hand-rolled on a `Completer` instead of `Future.timeout`, so the
gate owns that timer and can cancel it. It also registers an `onError` handler,
which `Future.timeout` used to supply implicitly: without one, a fetch that
fails after its caller gave up becomes an unhandled async error.

`LocalFileResolver.dispose` and `MediaStoreResolver.dispose` forward to the
gate, wired through `ref.onDispose` in `localFileResolverProvider` and
`mediaStoreRuntimeProvider`.

## Testing

- `media_resolver_providers_test.dart` gains the direct regression: park a
  resolution inside the gate so both budgets are armed, dispose the container,
  and let the binding's own teardown check assert. **Confirmed red without the
  lib-side change**, failing with the exact CI message (`A Timer is still
  pending even after the widget tree was disposed`), and green with it.
- `media_fetch_gate_test.dart` covers `dispose` directly: outstanding callers
  get `stillFetching`, a later caller is answered without starting a fetch, a
  fetch settling after dispose disturbs nothing, and dispose is idempotent.
- The originally flaky `dive_media_section_unlink_test.dart` passes 3/3.
- 2417 tests across `test/features/media/` and `test/features/media_store/`
  pass; `flutter analyze` clean project-wide.

## Note on provenance

This change was authored on 2026-09-04 but never committed, so its branch
carried nothing and no PR ever existed. It was recovered from the uncommitted
working tree it was left in and re-landed here unchanged apart from comment
punctuation.