### PR TITLE
docs(linux): point package downloads at where the files actually are

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,8 @@ sudo apt install ./Submersion-*-Linux-amd64.deb
 
 **Fedora and RHEL**
 
-Download `Submersion-<version>-Linux-x86_64.rpm`, then:
+Download `Submersion-<version>-Linux-x86_64.rpm` from the
+[beta releases](https://github.com/submersion-app/beta-builds/releases), then:
 
 ```bash
 sudo dnf install ./Submersion-*-Linux-x86_64.rpm

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ The built app will be at `build\windows\x64\runner\Release\`.
 
 **Debian, Ubuntu, Mint, and derivatives**
 
-Download `Submersion-<version>-Linux-amd64.deb` from
+Download `Submersion-v<version>-Linux-amd64.deb` from
 [beta releases](https://github.com/submersion-app/beta-builds/releases), then:
 
 ```bash
@@ -359,7 +359,7 @@ sudo apt install ./Submersion-*-Linux-amd64.deb
 
 **Fedora and RHEL**
 
-Download `Submersion-<version>-Linux-x86_64.rpm` from the
+Download `Submersion-v<version>-Linux-x86_64.rpm` from the
 [beta releases](https://github.com/submersion-app/beta-builds/releases), then:
 
 ```bash
@@ -381,7 +381,7 @@ packages recommend but do not require.
 
 **Everything else (Arch, NixOS, and anyone who prefers not to install packages)**
 
-Download `Submersion-<version>-Linux.tar.gz`, unpack it, and run the included
+Download `Submersion-v<version>-Linux.tar.gz`, unpack it, and run the included
 installer:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -341,10 +341,17 @@ The built app will be at `build\windows\x64\runner\Release\`.
 > tarball fails the same way, because three bundled libraries require
 > GLIBC_2.38. Upgrading the distribution is the only path.
 
+> **Where the packages are today:** the `.deb` and `.rpm` ship with every beta
+> build at
+> [submersion-app/beta-builds](https://github.com/submersion-app/beta-builds/releases).
+> They reach the stable
+> [Releases page](https://github.com/submersion-app/submersion/releases) with
+> the next stable release; that page currently carries the tarball only.
+
 **Debian, Ubuntu, Mint, and derivatives**
 
 Download `Submersion-<version>-Linux-amd64.deb` from
-[Releases](https://github.com/submersion-app/submersion/releases), then:
+[beta releases](https://github.com/submersion-app/beta-builds/releases), then:
 
 ```bash
 sudo apt install ./Submersion-*-Linux-amd64.deb

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -24,10 +24,10 @@ To build from source, you'll need:
 
 ## Install on Linux
 
-Linux releases ship as native packages as well as a tarball. The packages
-resolve their own dependencies, register a desktop entry and icon, and install
-udev rules so dive computers connected by USB are reachable without any group
-membership or `usermod` step.
+Submersion ships for Linux as native packages as well as a tarball. The
+packages resolve their own dependencies, register a desktop entry and icon,
+and install udev rules so dive computers connected by USB are reachable
+without any group membership or `usermod` step.
 
 > **Distro requirement:** Submersion needs glibc 2.38 or newer, which means
 > Ubuntu 24.04+, Debian 13+, Fedora 39+, Linux Mint 22+, Arch, or openSUSE
@@ -36,12 +36,19 @@ membership or `usermod` step.
 > tarball fails the same way, because three bundled libraries require
 > GLIBC_2.38. Upgrading the distribution is the only path.
 
+> **Where the packages are today:** the `.deb` and `.rpm` ship with every beta
+> build at
+> [submersion-app/beta-builds](https://github.com/submersion-app/beta-builds/releases).
+> They reach the stable
+> [Releases page](https://github.com/submersion-app/submersion/releases) with
+> the next stable release; that page currently carries the tarball only.
+
 <!-- tabs:start -->
 
 #### **Debian / Ubuntu / Mint**
 
 Download `Submersion-<version>-Linux-amd64.deb` from the
-[Releases page](https://github.com/submersion-app/submersion/releases):
+[beta releases](https://github.com/submersion-app/beta-builds/releases):
 
 ```bash
 sudo apt install ./Submersion-*-Linux-amd64.deb

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -47,7 +47,7 @@ without any group membership or `usermod` step.
 
 #### **Debian / Ubuntu / Mint**
 
-Download `Submersion-<version>-Linux-amd64.deb` from the
+Download `Submersion-v<version>-Linux-amd64.deb` from the
 [beta releases](https://github.com/submersion-app/beta-builds/releases):
 
 ```bash
@@ -56,7 +56,7 @@ sudo apt install ./Submersion-*-Linux-amd64.deb
 
 #### **Fedora / RHEL**
 
-Download `Submersion-<version>-Linux-x86_64.rpm` from the
+Download `Submersion-v<version>-Linux-x86_64.rpm` from the
 [beta releases](https://github.com/submersion-app/beta-builds/releases):
 
 ```bash

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -56,7 +56,8 @@ sudo apt install ./Submersion-*-Linux-amd64.deb
 
 #### **Fedora / RHEL**
 
-Download `Submersion-<version>-Linux-x86_64.rpm`:
+Download `Submersion-<version>-Linux-x86_64.rpm` from the
+[beta releases](https://github.com/submersion-app/beta-builds/releases):
 
 ```bash
 sudo dnf install ./Submersion-*-Linux-x86_64.rpm


### PR DESCRIPTION
## The problem

README and the installation guide both tell users:

> Download `Submersion-<version>-Linux-amd64.deb` from the [Releases page](https://github.com/submersion-app/submersion/releases)

That file is not on that page. The latest stable, `v1.7.6.7161`, carries exactly one Linux asset:

```
Submersion-v1.7.6.7161-Linux.tar.gz
```

No `.deb`, no `.rpm`. Anyone following either document today hits a dead end.

## Why

Not a wiring bug. `release.yml` lists all three assets at lines 437-439. The dates are the whole story:

| Event | Date |
| --- | --- |
| `v1.7.6.7161` cut from | 2026-08-27 |
| `.deb`/`.rpm` added to `release.yml` | 2026-09-03 |

The packaging landed a week after the last stable release, and none has been cut since, so no stable release has ever carried the packages.

## What this changes

The packages do exist, as assets on every beta in [submersion-app/beta-builds](https://github.com/submersion-app/beta-builds/releases), verified in clean Ubuntu and Fedora containers on each run.

- Both `.deb` download links now point at the beta releases, where the file is
- A note in each document records that the stable page gets the packages with the next stable release, and carries the tarball only until then
- The install guide's opening sentence no longer implies every release ships packages

Docs only. No code, no workflow changes.

## Follow-up, not in this PR

Cutting a stable release would put the packages where the docs originally pointed and make this note removable. Separately, APT/DNF repositories (`packages.submersion.app`) are planned in `docs/superpowers/plans/2026-09-03-linux-packaging-phase2-repos.md` but unimplemented: no publisher scripts, no `submersion-app/linux-packages` repo, and the hostname does not resolve.