### PR TITLE
fix(planner): derive the seeded GF-low anchor after off-gassing

### DIFF
--- a/lib/core/deco/buhlmann_algorithm.dart
+++ b/lib/core/deco/buhlmann_algorithm.dart
@@ -98,12 +98,28 @@ class BuhlmannAlgorithm {
   }
 
   /// Set compartments to a specific state (for loading from saved data).
+  ///
+  /// Treats [compartments] as the start of a new dive: the GF-low anchor is
+  /// re-derived from that loading via [deriveGfAnchorFromLoading].
   void setCompartments(List<TissueCompartment> compartments) {
     if (compartments.length == zhl16CompartmentCount) {
       _compartments = List.from(compartments);
-      _gfLowCeilingAnchor = 0.0;
-      _updateGfAnchor();
+      deriveGfAnchorFromLoading();
     }
+  }
+
+  /// Re-derive the GF-low anchor from the current loading, discarding any
+  /// previously recorded maximum.
+  ///
+  /// Only for starting a new dive from a seeded state, once that state is
+  /// final -- notably after off-gassing a surface interval, so the anchor
+  /// reflects the loading the dive actually begins with rather than the prior
+  /// dive's. Never call this mid-dive: within a dive the anchor is deliberately
+  /// a running maximum (see [_gfLowCeilingAnchor]), and resetting it would
+  /// collapse shallow stops toward GF-low.
+  void deriveGfAnchorFromLoading() {
+    _gfLowCeilingAnchor = 0.0;
+    _updateGfAnchor();
   }
 
   /// Deepest GF-low ceiling reached so far this dive (meters).

--- a/lib/features/planner/domain/services/tissue_seed.dart
+++ b/lib/features/planner/domain/services/tissue_seed.dart
@@ -11,7 +11,7 @@ import 'package:submersion/core/deco/entities/tissue_compartment.dart';
 /// Mirrors the residual-tissue lookback the dive details page performs in
 /// profile_analysis_provider so a plan seeded from a dive agrees with the
 /// log's own repetitive-dive math. The GF-low ceiling anchor is re-derived
-/// from the seeded loading, as a fresh dive would.
+/// from the off-gassed loading, as a fresh dive would.
 ///
 /// Returns null when [compartments] is null (nothing to seed).
 TissueState? seededTissueState({
@@ -28,7 +28,12 @@ TissueState? seededTissueState({
     gfHigh: gfHigh,
     environment: environment,
   );
-  algorithm.setCompartments(List.from(compartments));
+  // restoreState, not setCompartments: loading the prior dive's compartments
+  // must not derive the anchor yet, or the anchor would record that dive's
+  // deepest ceiling and -- being a running maximum -- survive the surface
+  // interval untouched, leaving every repetitive plan less conservative than
+  // an identical fresh one.
+  algorithm.restoreState(List.from(compartments));
 
   final intervalSeconds = surfaceInterval?.inSeconds ?? 0;
   if (intervalSeconds > 0) {
@@ -39,6 +44,9 @@ TissueState? seededTissueState({
       fHe: 0.0,
     );
   }
+
+  // Anchor the plan to the loading it actually starts from, post-interval.
+  algorithm.deriveGfAnchorFromLoading();
 
   return BuhlmannState(
     compartments: algorithm.compartments,

--- a/lib/features/planner/domain/services/tissue_seed.dart
+++ b/lib/features/planner/domain/services/tissue_seed.dart
@@ -33,7 +33,7 @@ TissueState? seededTissueState({
   // deepest ceiling and -- being a running maximum -- survive the surface
   // interval untouched, leaving every repetitive plan less conservative than
   // an identical fresh one.
-  algorithm.restoreState(List.from(compartments));
+  algorithm.restoreState(compartments);
 
   final intervalSeconds = surfaceInterval?.inSeconds ?? 0;
   if (intervalSeconds > 0) {

--- a/test/features/planner/plan_engine_seeding_test.dart
+++ b/test/features/planner/plan_engine_seeding_test.dart
@@ -5,6 +5,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_planner/domain/entities/plan_segment.dart';
 import 'package:submersion/features/planner/domain/entities/dive_plan.dart'
     as domain;
+import 'package:submersion/features/planner/domain/entities/plan_outcome.dart';
 import 'package:submersion/features/planner/domain/services/plan_engine.dart';
 import 'package:submersion/features/planner/domain/services/tissue_seed.dart';
 
@@ -52,6 +53,11 @@ List<TissueCompartment> _priorDiveCompartments() {
   return algorithm.compartments;
 }
 
+/// The stop schedule as (depth, duration) pairs, for readable comparisons.
+List<List<num>> _schedule(PlanOutcome outcome) => outcome.stops
+    .map((s) => <num>[s.depthMeters, s.durationSeconds])
+    .toList(growable: false);
+
 void main() {
   group('tissue seeding', () {
     test('null compartments produce no seed', () {
@@ -79,6 +85,26 @@ void main() {
       final repetitive = engine.compute(_plan(), startState: seeded);
 
       expect(repetitive.totalDecoSeconds, greaterThan(fresh.totalDecoSeconds));
+    });
+
+    test('a plan seeded from a long-ago dive matches the fresh plan', () {
+      const engine = PlanEngine();
+      final fresh = engine.compute(_plan());
+
+      // Four days at the surface is roughly nine half-times of the slowest
+      // ZH-L16C compartment: the tissues, and so the GF-low ceiling anchor the
+      // plan starts from, are indistinguishable from a fresh diver's.
+      final seeded = engine.compute(
+        _plan(),
+        startState: seededTissueState(
+          compartments: _priorDiveCompartments(),
+          surfaceInterval: const Duration(hours: 96),
+          gfLow: 0.40,
+          gfHigh: 0.80,
+        ),
+      );
+
+      expect(_schedule(seeded), equals(_schedule(fresh)));
     });
 
     test('a long surface interval trends back toward the fresh plan', () {
@@ -109,11 +135,9 @@ void main() {
         longInterval.totalDecoSeconds,
         lessThan(shortInterval.totalDecoSeconds),
       );
-      // After a day at the surface the tissues are essentially clean again.
-      expect(
-        (longInterval.totalDecoSeconds - fresh.totalDecoSeconds).abs(),
-        lessThanOrEqualTo(60),
-      );
+      // After a day at the surface the tissues are clean enough that the plan
+      // is indistinguishable from a fresh one, stop for stop.
+      expect(_schedule(longInterval), equals(_schedule(fresh)));
     });
   });
 }


### PR DESCRIPTION
## Summary

A dive plan seeded from a logged dive came out permanently **less conservative** than an identical fresh plan, no matter how long the surface interval was.

`seededTissueState` loaded the prior dive's end-of-dive compartments with `setCompartments`, which resets the GF-low ceiling anchor and immediately re-derives it from that heavy loading. Only afterwards did it off-gas the surface interval, and `_updateGfAnchor` only ever *increases* the anchor, so the returned `BuhlmannState` kept the previous dive's deepest GF-low ceiling forever.

`_interpolateGf` then used that deep anchor for the whole planned dive, putting the gradient factor closer to GF-high at every depth than a fresh diver would get. The function's doc comment already claimed the anchor was "re-derived from the seeded loading, as a fresh dive would" — it was just derived from the pre-interval snapshot.

Measured on 40 m for 20 min, GF 40/80, seeded from a prior 40 m for 35 min:

| Surface interval | Before | After | Fresh |
| --- | --- | --- | --- |
| 1 h | 12m:60s 9m:240s 6m:960s 3m:2760s (4020 s) | 12m:**120s** 9m:240s 6m:960s 3m:2760s (4080 s) | n/a |
| 6 h through 96 h | 12m:60s 9m:180s 6m:**300s** 3m:**840s** | 12m:60s 9m:180s 6m:360s 3m:780s | 12m:60s 9m:180s 6m:360s 3m:780s |

The stale anchor shortened the deep stop by a minute and pushed that time shallow at every interval, and at 1 h it cost a full minute of total obligation.

## Changes

- `BuhlmannAlgorithm`: split the anchor derivation out of `setCompartments` into a public `deriveGfAnchorFromLoading()`. `setCompartments` delegates to it, so its behavior is unchanged; the seam is now callable at the right moment. Its doc states the invariant that the anchor is deliberately a running maximum during a dive and must never be reset mid-dive.
- `seededTissueState`: load the compartments with `restoreState` (which does not touch the anchor), off-gas the surface interval, then derive the anchor from the loading the dive actually starts from.
- Tests: a plan seeded from a 96 h surface interval now must match the fresh plan stop for stop. The pre-existing 24 h test's `<= 60 s` tolerance is replaced by the same exact schedule comparison.

Both assertions fail against the old ordering. Worth noting for review: `totalDecoSeconds` alone does **not** catch this bug — the stale anchor redistributes stop time (6 m to 3 m) while leaving the total identical at 1380 s. The tests compare the full stop schedule for that reason.

### Sibling paths checked, and clean

`seededTissueState` is described as mirroring the residual-tissue lookback in `profile_analysis_provider`, so that path and the other seeding seams were audited. None share the bug, and the reason is structural: `profile_analysis_provider._computeResidualTissueState`, `plan_calculator_service.calculateSurfaceInterval` and the surface-interval tool's NDL providers all pass **compartments only** across the interval and let the consumer call `setCompartments` on the already off-gassed loading, deriving the anchor at the correct moment by construction. `seededTissueState` is the one path that must carry the anchor across the boundary, because `BuhlmannState` bundles it for the plan engine — which is exactly what exposed the ordering hazard.

## Test Plan

- [x] `flutter test` passes (24478 passed, 21 skipped, 0 failures)
- [x] `flutter analyze` passes (no issues)
- [ ] Manual testing on: not applicable, pure deco-math change covered by unit tests

## Screenshots

Not applicable.
