### PR TITLE
fix(export): route exports to a save dialog on Linux (#1573)

### DIFF
--- a/lib/core/services/export/shared/file_export_utils.dart
+++ b/lib/core/services/export/shared/file_export_utils.dart
@@ -1,19 +1,43 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 import 'dart:ui' show Rect;
 
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:gal/gal.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 
-/// Save string content to a file and open the system share sheet.
+/// Whether the running platform's share sheet can carry files.
+///
+/// share_plus has no file sharing on Linux: its backend there is a `mailto:`
+/// launcher whose `share` throws `UnimplementedError` as soon as
+/// [ShareParams.files] is non-empty. Every helper in this file shares files,
+/// so on Linux each export wrote its file into the documents directory and
+/// then appeared to do nothing at all -- the throw only ever reached the log.
+///
+/// Where the sheet cannot take files the share helpers fall back to the same
+/// save dialog the `save*ToFile` helpers use, which is the destination a
+/// desktop user expects anyway.
+bool get canShareFiles => _canShareFilesOverride ?? !Platform.isLinux;
+
+bool? _canShareFilesOverride;
+
+/// Pin [canShareFiles] for a test; null restores the platform default.
+///
+/// The gate reads the host platform, so without this the share-sheet tests
+/// take the save-dialog branch whenever the suite runs on Linux, and the
+/// save-dialog tests pass for the wrong reason everywhere else.
+@visibleForTesting
+set debugCanShareFiles(bool? value) => _canShareFilesOverride = value;
+
+/// Save string content and hand it to the system share sheet, or to the save
+/// dialog where [canShareFiles] is false.
 ///
 /// This is the "share" half of the export idiom. Callers that want the user to
-/// pick a destination on disk should use the matching `save*ToFile` helper
-/// instead -- those return `null` when the save dialog is cancelled, which this
-/// function has no way to express.
+/// pick a destination on every platform should use the matching `save*ToFile`
+/// helper instead -- those return `null` when the save dialog is cancelled,
+/// which this function has no way to express.
 ///
 /// [sharePositionOrigin] is the screen rect the iPad share popover points at,
 /// normally from `shareAnchorFrom` on the button's context. It is optional
@@ -26,44 +50,79 @@ Future<String> saveAndShareFile(
   String fileName,
   String mimeType, {
   Rect? sharePositionOrigin,
-}) async {
-  final directory = await getApplicationDocumentsDirectory();
-  final file = File('${directory.path}/$fileName');
-  await file.writeAsString(content);
+}) => _shareOrSave(
+  Uint8List.fromList(utf8.encode(content)),
+  fileName,
+  mimeType,
+  sharePositionOrigin: sharePositionOrigin,
+);
 
-  await SharePlus.instance.share(
-    ShareParams(
-      files: [XFile(file.path, mimeType: mimeType)],
-      subject: fileName,
-      sharePositionOrigin: sharePositionOrigin,
-    ),
-  );
-
-  return file.path;
-}
-
-/// Save raw bytes to a file and open the system share sheet.
+/// Save raw bytes and hand them to the system share sheet, or to the save
+/// dialog where [canShareFiles] is false.
 ///
-/// See [saveAndShareFile] for why this never opens a save dialog, and for what
-/// [sharePositionOrigin] is and when it is null.
+/// See [saveAndShareFile] for why this never reports a cancelled dialog, and
+/// for what [sharePositionOrigin] is and when it is null.
 Future<String> saveAndShareFileBytes(
   List<int> bytes,
   String fileName,
   String mimeType, {
   Rect? sharePositionOrigin,
+}) => _shareOrSave(
+  Uint8List.fromList(bytes),
+  fileName,
+  mimeType,
+  sharePositionOrigin: sharePositionOrigin,
+);
+
+Future<String> _shareOrSave(
+  Uint8List bytes,
+  String fileName,
+  String mimeType, {
+  Rect? sharePositionOrigin,
 }) async {
-  final directory = await getApplicationDocumentsDirectory();
-  final file = File('${directory.path}/$fileName');
-  await file.writeAsBytes(bytes);
+  if (!canShareFiles) return _saveViaDialog(bytes, fileName, mimeType);
+
+  // The sheet takes a file, not bytes, so the export has to exist on disk
+  // before it opens.
+  final path = await _writeToDocuments(bytes, fileName);
 
   await SharePlus.instance.share(
     ShareParams(
-      files: [XFile(file.path, mimeType: mimeType)],
+      files: [XFile(path, mimeType: mimeType)],
       subject: fileName,
       sharePositionOrigin: sharePositionOrigin,
     ),
   );
 
+  return path;
+}
+
+/// The share sheet's stand-in: let the user choose where the export lands.
+///
+/// [FilePicker.saveFile] writes the bytes itself, so nothing is written to the
+/// documents directory first -- doing both would leave a stray copy of every
+/// export behind. Cancelling picks no destination but does not throw the
+/// export away: the bytes are already built and callers are promised a path,
+/// so the file lands where the share path would have left it.
+Future<String> _saveViaDialog(
+  Uint8List bytes,
+  String fileName,
+  String mimeType,
+) async {
+  final saved = await FilePicker.saveFile(
+    fileName: fileName,
+    bytes: bytes,
+    mimeType: mimeType,
+  );
+
+  if (saved != null) return savedFileLocation(saved);
+  return _writeToDocuments(bytes, fileName);
+}
+
+Future<String> _writeToDocuments(Uint8List bytes, String fileName) async {
+  final directory = await getApplicationDocumentsDirectory();
+  final file = File('${directory.path}/$fileName');
+  await file.writeAsBytes(bytes);
   return file.path;
 }
 

--- a/test/core/services/export/shared/share_file_fallback_test.dart
+++ b/test/core/services/export/shared/share_file_fallback_test.dart
@@ -1,0 +1,163 @@
+import 'dart:io';
+import 'dart:ui' show Rect;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
+import 'package:submersion/core/services/export/shared/file_export_utils.dart';
+
+import '../../../../helpers/mock_file_picker_platform.dart';
+
+/// share_plus has no file sharing on Linux: `share` throws UnimplementedError
+/// the moment ShareParams.files is non-empty. Every helper in
+/// file_export_utils shares files, so before the fallback each export menu
+/// item wrote its file into the documents directory and then appeared to do
+/// nothing -- the throw only ever reached the log.
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.documentsPath);
+  final String documentsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+}
+
+class _FakeSharePlatform extends SharePlatform {
+  final List<ShareParams> calls = [];
+
+  @override
+  Future<ShareResult> share(ShareParams params) async {
+    calls.add(params);
+    return const ShareResult('ok', ShareResultStatus.success);
+  }
+}
+
+void main() {
+  late Directory documents;
+  late Directory chosen;
+  late MockFilePickerPlatform picker;
+  late FilePickerPlatform originalPicker;
+  final sharePlatform = _FakeSharePlatform();
+
+  setUpAll(() => SharePlatform.instance = sharePlatform);
+
+  setUp(() {
+    documents = Directory.systemTemp.createTempSync('share_fallback_docs');
+    chosen = Directory.systemTemp.createTempSync('share_fallback_chosen');
+    PathProviderPlatform.instance = _FakePathProvider(documents.path);
+    originalPicker = FilePickerPlatform.instance;
+    picker = MockFilePickerPlatform();
+    FilePickerPlatform.instance = picker;
+    sharePlatform.calls.clear();
+    debugCanShareFiles = false;
+  });
+
+  tearDown(() {
+    debugCanShareFiles = true;
+    FilePickerPlatform.instance = originalPicker;
+    documents.deleteSync(recursive: true);
+    chosen.deleteSync(recursive: true);
+  });
+
+  group('without a file-capable share sheet', () {
+    test('saveAndShareFile saves through the dialog, not the sheet', () async {
+      final target = '${chosen.path}/dives.uddf';
+      picker.saveFileResult = Uri.file(target);
+
+      final path = await saveAndShareFile(
+        '<uddf/>',
+        'dives.uddf',
+        'application/xml',
+      );
+
+      expect(path, target);
+      expect(File(target).readAsStringSync(), '<uddf/>');
+      expect(sharePlatform.calls, isEmpty);
+      expect(picker.lastSavedFileName, 'dives.uddf');
+    });
+
+    test('saveAndShareFileBytes saves through the dialog', () async {
+      final target = '${chosen.path}/dives.xlsx';
+      picker.saveFileResult = Uri.file(target);
+
+      final path = await saveAndShareFileBytes(
+        [1, 2, 3],
+        'dives.xlsx',
+        'application/vnd.ms-excel',
+        sharePositionOrigin: const Rect.fromLTWH(1, 2, 3, 4),
+      );
+
+      expect(path, target);
+      expect(File(target).readAsBytesSync(), [1, 2, 3]);
+      expect(sharePlatform.calls, isEmpty);
+    });
+
+    test('sharePdfBytes reaches the dialog as a PDF', () async {
+      picker.saveFileResult = Uri.file('${chosen.path}/logbook.pdf');
+
+      await sharePdfBytes([4, 5, 6], 'logbook.pdf');
+
+      expect(picker.lastSavedFileName, 'logbook.pdf');
+      expect(picker.lastSavedBytes, [4, 5, 6]);
+    });
+
+    test('a chosen destination leaves no copy in the documents dir', () async {
+      // The share path writes into the documents directory because the sheet
+      // needs a file to hand over. The dialog writes the bytes itself, so
+      // doing both would litter the user's Documents with every export.
+      picker.saveFileResult = Uri.file('${chosen.path}/dives.uddf');
+
+      await saveAndShareFile('<uddf/>', 'dives.uddf', 'application/xml');
+
+      expect(documents.listSync(), isEmpty);
+    });
+
+    test('cancelling keeps the export in the documents dir', () async {
+      // Callers promise a path and the bytes are already built, so a cancelled
+      // destination dialog must not throw the work away.
+      picker.saveFileResult = null;
+
+      final path = await saveAndShareFile(
+        '<uddf>kept</uddf>',
+        'dives.uddf',
+        'application/xml',
+      );
+
+      expect(path, '${documents.path}/dives.uddf');
+      expect(File(path).readAsStringSync(), '<uddf>kept</uddf>');
+    });
+
+    test('non-ASCII content survives the dialog as UTF-8', () async {
+      final target = '${chosen.path}/sites.kml';
+      picker.saveFileResult = Uri.file(target);
+
+      await saveAndShareFile(
+        '<name>Cozumel – Palancar</name>',
+        'sites.kml',
+        'application/vnd.google-earth.kml+xml',
+      );
+
+      expect(
+        File(target).readAsStringSync(),
+        '<name>Cozumel – Palancar</name>',
+      );
+    });
+  });
+
+  group('with a file-capable share sheet', () {
+    setUp(() => debugCanShareFiles = true);
+
+    test('the sheet is used and the dialog is left alone', () async {
+      final path = await saveAndShareFile(
+        '<uddf/>',
+        'dives.uddf',
+        'application/xml',
+      );
+
+      expect(path, '${documents.path}/dives.uddf');
+      expect(sharePlatform.calls.single.subject, 'dives.uddf');
+      expect(picker.lastSavedFileName, isNull);
+    });
+  });
+}

--- a/test/flutter_test_config.dart
+++ b/test/flutter_test_config.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:submersion/core/services/export/shared/file_export_utils.dart';
 import 'package:submersion/features/data_quality/data/services/quality_scan_service.dart';
 
 /// Global test harness config (run once per test file by `flutter test`).
@@ -11,7 +12,15 @@ import 'package:submersion/features/data_quality/data/services/quality_scan_serv
 /// it by default here; tests that specifically exercise the scheduler
 /// (e.g. quality_scan_service_test) opt back in with
 /// `QualityScanScheduler.enabled = true`.
+///
+/// `canShareFiles` reads the host platform, and it is false on Linux because
+/// share_plus cannot put files on the sheet there. Left alone, every test that
+/// runs an export would take the save-dialog fallback on a Linux machine and
+/// the share sheet everywhere else -- the same suite passing or failing on the
+/// developer's OS. Pin it to the share sheet, which is what those tests assert
+/// against, and let share_file_fallback_test opt out for the other branch.
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   QualityScanScheduler.enabled = false;
+  debugCanShareFiles = true;
   await testMain();
 }


### PR DESCRIPTION
## Summary

On Linux every export silently did nothing. `share_plus` has no file sharing
there -- its Linux backend is a `mailto:` launcher whose `share` throws
`UnimplementedError` the moment `ShareParams.files` is non-empty. Every helper
in `file_export_utils.dart` shares files, and ~20 call sites across every
export format go through them, so each export wrote its file into the
application documents directory and then threw. The exception only reached the
log, so the UI looked completely inert.

This adds a `canShareFiles` gate. Where the platform's sheet cannot carry
files, the share helpers fall back to the same `FilePicker.saveFile` dialog the
`save*ToFile` helpers already use -- which is the destination a desktop user
expects anyway. Behaviour on the platforms that do have a working share sheet
is unchanged.

## Changes

- Add `canShareFiles`, false on Linux, and route `saveAndShareFile`,
  `saveAndShareFileBytes` and everything built on them through a shared
  `_shareOrSave`.
- Fall back to `FilePicker.saveFile` when the sheet cannot take files.
  `saveFile` writes the bytes itself, so nothing is written to the documents
  directory first -- doing both would leave a stray copy of every export
  behind.
- Keep the caller contract intact: these helpers promise a path and cannot
  express cancellation, so a cancelled dialog still lands the file where the
  share path would have left it rather than discarding work already done.
- Pin the gate in the test harness via `debugCanShareFiles`. It reads the host
  platform, so without pinning, export tests would take the fallback branch on
  a Linux machine and the share sheet everywhere else -- the same suite passing
  or failing depending on the developer's OS.
- Add `share_file_fallback_test.dart` covering both branches: dialog vs sheet,
  no stray documents-dir copy, cancellation, and UTF-8 content.

## Test Plan

- [x] `flutter test` passes -- **not run in full.** Ran the import-graph
      affected-test subset instead: 219 files, 2424 passed, 6 skipped, 0
      failures.
- [x] `flutter analyze` passes (clean; `dart format .` reports no changes)
- [x] Manual testing on: **none.** This was not exercised against a running
      Linux desktop build; the Linux branch is covered by unit tests only.

Two gaps worth calling out explicitly:

- `test/flutter_test_config.dart` is loaded by every test file in the repo, so
  the affected-test subset above cannot cover that change. Only a full
  `flutter test` would.
- The Linux fallback path itself has not been run on a real Linux desktop
  build, only under the test harness with the gate pinned off.

Fixes #1573
