### PR TITLE
Seascape source layer: pick the best bathymetry, add a high-resolution coastal tier

### DIFF
--- a/docs/superpowers/plans/2026-09-05-seascape-source-layer.md
+++ b/docs/superpowers/plans/2026-09-05-seascape-source-layer.md
@@ -1,0 +1,1970 @@
+# Seascape Source Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the bathymetry resolver choose the best available grid rather than the first tier that answers, and add a NOAA CUDEM tier that delivers 3 m to 10 m terrain on US coasts.
+
+**Architecture:** `BathymetrySource.covers()` becomes `probe()`, returning a declared cell size or null for "not covered". The resolver orders sources by materially better resolution (more than 2x finer preempts declared order), fetches in that order, and accepts the first grid passing both a wet-cell floor and a new known-cell floor. A new `NoaaDemSource` probes the NOAA NCEI DEM mosaic ImageServer catalogue and fetches an uncompressed tiled float32 GeoTIFF. `BathymetryGrid.downsampleTo` averages blocks instead of striding.
+
+**Tech Stack:** Dart, Flutter, `package:http` with `MockClient` from `package:http/testing.dart` for tests, `dart:typed_data` for the GeoTIFF reader.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-seascape-extent-and-detail-design.md`
+
+## Global Constraints
+
+- No em-dashes (U+2014) in any output, including code, comments, commit messages and docs. No en-dashes as sentence punctuation either. See the repository CLAUDE.md.
+- No mention of Claude, Claude Code or Anthropic in commits, PR bodies or any file.
+- No emojis in code, comments or documentation.
+- Immutability: never mutate objects or arrays in place.
+- TDD: the failing test comes first, always.
+- Run `dart format .` before the final commit of the PR.
+- Files stay in the 200-400 line range, 800 maximum.
+- This plan is PR 1 of 3. It must ship and be useful on its own. Do not implement nested LOD, nodata holes, or the depth window here; those are PRs 2 and 3.
+
+## Files
+
+**Modify:**
+- `lib/features/bathymetry/domain/bathymetry_source.dart` - add `SourceCapability`, replace `covers()` with `probe()`
+- `lib/features/bathymetry/domain/bathymetry_grid.dart` - add `knownFraction`, make `downsampleTo` average
+- `lib/features/bathymetry/data/sources/emodnet_source.dart` - implement `probe()`
+- `lib/features/bathymetry/data/sources/gmrt_source.dart` - implement `probe()`
+- `lib/features/bathymetry/data/sources/etopo_erddap_source.dart` - implement `probe()`
+- `lib/features/bathymetry/data/bathymetry_resolver.dart` - capability ordering, known-cell floor
+- `lib/features/bathymetry/data/bathymetry_repository.dart` - cache key generation token
+- `lib/features/bathymetry/application/bathymetry_providers.dart` - register `NoaaDemSource`
+- `lib/features/bathymetry/presentation/bathymetry_labels.dart` - display name for the new tier
+- `lib/l10n/arb/app_*.arb` (all eleven) - add the tier to the about-screen credit
+
+**Create:**
+- `lib/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart` - tiled float32 GeoTIFF reader
+- `lib/features/bathymetry/data/sources/noaa_dem_source.dart` - the CUDEM tier
+
+**Test:**
+- `test/features/bathymetry/domain/bathymetry_grid_test.dart` (modify)
+- `test/features/bathymetry/data/bathymetry_resolver_test.dart` (modify)
+- `test/features/bathymetry/data/bathymetry_repository_test.dart` (modify)
+- `test/features/bathymetry/data/emodnet_source_test.dart` (modify)
+- `test/features/bathymetry/data/gmrt_source_test.dart` (modify)
+- `test/features/bathymetry/data/etopo_erddap_source_test.dart` (modify)
+- `test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart` (create)
+- `test/features/bathymetry/data/noaa_dem_source_test.dart` (create)
+- `test/features/bathymetry/presentation/bathymetry_labels_test.dart` (create)
+
+---
+
+### Task 1: Grid quality metric and averaging downsample
+
+`BathymetryGrid` gains the metric the resolver needs to reject a mostly-empty grid, and stops throwing away detail when it downsamples.
+
+**Files:**
+- Modify: `lib/features/bathymetry/domain/bathymetry_grid.dart`
+- Test: `test/features/bathymetry/domain/bathymetry_grid_test.dart`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `double get knownFraction` on `BathymetryGrid`; `BathymetryGrid downsampleTo(int maxDim)` with unchanged signature but averaging semantics.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/features/bathymetry/domain/bathymetry_grid_test.dart`:
+
+```dart
+  group('knownFraction', () {
+    test('is the fraction of non-null cells', () {
+      final g = BathymetryGrid(
+        originLat: 12.0,
+        originLon: -68.0,
+        cellSizeLatDeg: 0.001,
+        cellSizeLonDeg: 0.001,
+        rows: 1,
+        cols: 4,
+        depthsMeters: const [10.0, null, 30.0, null],
+        sourceId: 'test',
+        resolutionMeters: 100,
+        fetchedAt: DateTime.utc(2026, 9, 5),
+      );
+      expect(g.knownFraction, 0.5);
+    });
+
+    test('is zero for an entirely empty grid', () {
+      final g = BathymetryGrid(
+        originLat: 12.0,
+        originLon: -68.0,
+        cellSizeLatDeg: 0.001,
+        cellSizeLonDeg: 0.001,
+        rows: 1,
+        cols: 2,
+        depthsMeters: const [null, null],
+        sourceId: 'test',
+        resolutionMeters: 100,
+        fetchedAt: DateTime.utc(2026, 9, 5),
+      );
+      expect(g.knownFraction, 0.0);
+    });
+  });
+
+  group('downsampleTo averaging', () {
+    BathymetryGrid grid(int rows, int cols, List<double?> depths) =>
+        BathymetryGrid(
+          originLat: 12.0,
+          originLon: -68.0,
+          cellSizeLatDeg: 0.001,
+          cellSizeLonDeg: 0.001,
+          rows: rows,
+          cols: cols,
+          depthsMeters: depths,
+          sourceId: 'test',
+          resolutionMeters: 60,
+          fetchedAt: DateTime.utc(2026, 9, 5),
+        );
+
+    test('averages each block instead of picking its first sample', () {
+      // 4x4 halved to 2x2: each output cell is the mean of a 2x2 block.
+      final g = grid(4, 4, const [
+        1.0, 3.0, 10.0, 20.0, //
+        5.0, 7.0, 30.0, 40.0, //
+        100.0, 100.0, 0.0, 0.0, //
+        100.0, 100.0, 0.0, 0.0, //
+      ]);
+      final d = g.downsampleTo(2);
+      expect(d.rows, 2);
+      expect(d.cols, 2);
+      expect(d.depthAt(0, 0), closeTo(4.0, 1e-9));
+      expect(d.depthAt(0, 1), closeTo(25.0, 1e-9));
+      expect(d.depthAt(1, 0), closeTo(100.0, 1e-9));
+      expect(d.depthAt(1, 1), closeTo(0.0, 1e-9));
+    });
+
+    test('averages only the known cells in a block', () {
+      final g = grid(2, 2, const [10.0, null, null, 20.0]);
+      expect(g.downsampleTo(1).depthAt(0, 0), closeTo(15.0, 1e-9));
+    });
+
+    test('an all-nodata block stays nodata', () {
+      final g = grid(2, 4, const [
+        null, null, 8.0, 8.0, //
+        null, null, 8.0, 8.0, //
+      ]);
+      final d = g.downsampleTo(2);
+      expect(d.depthAt(0, 0), isNull);
+      expect(d.depthAt(0, 1), closeTo(8.0, 1e-9));
+    });
+
+    test('returns the same instance when already within the cap', () {
+      final g = grid(2, 2, const [1.0, 2.0, 3.0, 4.0]);
+      expect(identical(g.downsampleTo(4), g), isTrue);
+    });
+
+    test('scales the resolution claim by the coarser stride', () {
+      final g = grid(4, 4, List<double?>.filled(16, 5.0));
+      expect(g.downsampleTo(2).resolutionMeters, closeTo(120.0, 1e-9));
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/features/bathymetry/domain/bathymetry_grid_test.dart`
+
+Expected: FAIL. `knownFraction` is not defined; the averaging tests fail because the current implementation picks `depthsMeters[(r * stepR) * cols + (c * stepC)]`, so `depthAt(0, 0)` returns 1.0 rather than 4.0.
+
+- [ ] **Step 3: Implement**
+
+In `lib/features/bathymetry/domain/bathymetry_grid.dart`, add next to `wetFraction`:
+
+```dart
+  /// Fraction of cells that carry a reading at all. A grid can be almost
+  /// entirely wet and still be mostly holes: EMODnet's Caribbean tile
+  /// answers 99.96% wet on 48% coverage. The resolver needs both numbers.
+  double get knownFraction {
+    if (depthsMeters.isEmpty) return 0;
+    var known = 0;
+    for (final d in depthsMeters) {
+      if (d != null) known++;
+    }
+    return known / depthsMeters.length;
+  }
+```
+
+Replace the body of `downsampleTo`, keeping its signature and its early return:
+
+```dart
+  /// Block-mean downsample so neither dimension exceeds [maxDim]. Averaging
+  /// rather than striding keeps the information in the discarded cells: a
+  /// stride of 2 throws away three quarters of a grid outright.
+  BathymetryGrid downsampleTo(int maxDim) {
+    if (rows <= maxDim && cols <= maxDim) return this;
+    final stepR = (rows / maxDim).ceil();
+    final stepC = (cols / maxDim).ceil();
+    final newRows = (rows + stepR - 1) ~/ stepR;
+    final newCols = (cols + stepC - 1) ~/ stepC;
+    final out = List<double?>.filled(newRows * newCols, null);
+    for (var r = 0; r < newRows; r++) {
+      for (var c = 0; c < newCols; c++) {
+        var sum = 0.0;
+        var n = 0;
+        final r1 = math.min((r + 1) * stepR, rows);
+        final c1 = math.min((c + 1) * stepC, cols);
+        for (var sr = r * stepR; sr < r1; sr++) {
+          for (var sc = c * stepC; sc < c1; sc++) {
+            final v = depthsMeters[sr * cols + sc];
+            if (v == null) continue;
+            sum += v;
+            n++;
+          }
+        }
+        // An entirely unmeasured block stays unmeasured: averaging must
+        // never invent a reading where the source had none.
+        out[r * newCols + c] = n == 0 ? null : sum / n;
+      }
+    }
+    return BathymetryGrid(
+      originLat: originLat,
+      originLon: originLon,
+      cellSizeLatDeg: cellSizeLatDeg * stepR,
+      cellSizeLonDeg: cellSizeLonDeg * stepC,
+      rows: newRows,
+      cols: newCols,
+      depthsMeters: out,
+      sourceId: sourceId,
+      // The coarser stride sets the effective spacing: never claim more
+      // detail than the downsampled grid actually has.
+      resolutionMeters: resolutionMeters * (stepR > stepC ? stepR : stepC),
+      fetchedAt: fetchedAt,
+    );
+  }
+```
+
+Add `import 'dart:math' as math;` at the top of the file if it is not already there.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/features/bathymetry/domain/bathymetry_grid_test.dart`
+
+Expected: PASS.
+
+Then run the consumers, because averaging changes cell values that other suites may assert on:
+
+Run: `flutter test test/features/bathymetry test/features/dive_3d`
+
+Expected: PASS. If a dive_3d golden or geometry test asserts a specific downsampled depth, update the expected value to the block mean and note why in the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/bathymetry/domain/bathymetry_grid.dart test/features/bathymetry/domain/bathymetry_grid_test.dart
+git commit -m "feat(bathymetry): add knownFraction and average when downsampling
+
+A strided downsample discards up to three quarters of a fetched grid; a
+block mean keeps that information and suppresses single-cell noise. An
+all-nodata block stays nodata so averaging never invents a reading.
+
+knownFraction is the metric the resolver needs to tell a genuinely wet
+grid from one that is mostly holes."
+```
+
+---
+
+### Task 2: SourceCapability and probe on the source interface
+
+`covers()` cannot express "I cover this, and here is how good my data is", and it cannot make a network call. It becomes `probe()`.
+
+**Files:**
+- Modify: `lib/features/bathymetry/domain/bathymetry_source.dart`
+- Modify: `lib/features/bathymetry/data/sources/emodnet_source.dart`
+- Modify: `lib/features/bathymetry/data/sources/gmrt_source.dart`
+- Modify: `lib/features/bathymetry/data/sources/etopo_erddap_source.dart`
+- Test: `test/features/bathymetry/data/emodnet_source_test.dart`
+- Test: `test/features/bathymetry/data/gmrt_source_test.dart`
+- Test: `test/features/bathymetry/data/etopo_erddap_source_test.dart`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `class SourceCapability { final double cellSizeMeters; final String detail; }` and `Future<SourceCapability?> probe(GeoPoint center)` on `BathymetrySource`. `bool covers(GeoPoint)` is removed. `EmodnetSource.declaredCellSizeMeters` = 115, `GmrtSource.declaredCellSizeMeters` = 60, `EtopoErddapSource.declaredCellSizeMeters` = 450.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/features/bathymetry/data/emodnet_source_test.dart`, inside `void main()`:
+
+```dart
+  group('probe', () {
+    test('returns 115 m inside the Caribbean tile', () async {
+      final cap = await EmodnetSource().probe(const GeoPoint(12.16, -68.29));
+      expect(cap, isNotNull);
+      expect(cap!.cellSizeMeters, 115);
+      expect(cap.detail, 'bathymetry_dtm_carib_2024');
+    });
+
+    test('returns 115 m inside the European box', () async {
+      final cap = await EmodnetSource().probe(const GeoPoint(42.048, 3.223));
+      expect(cap!.detail, 'bathymetry_dtm_2024');
+    });
+
+    test('returns null outside every box', () async {
+      expect(
+        await EmodnetSource().probe(const GeoPoint(-33.9, 151.2)),
+        isNull,
+      );
+    });
+  });
+```
+
+Append to `test/features/bathymetry/data/gmrt_source_test.dart`, inside `void main()`:
+
+```dart
+  group('probe', () {
+    test('covers everywhere at its declared 60 m', () async {
+      final cap = await GmrtSource().probe(const GeoPoint(-33.9, 151.2));
+      expect(cap, isNotNull);
+      expect(cap!.cellSizeMeters, 60);
+    });
+  });
+```
+
+Append to `test/features/bathymetry/data/etopo_erddap_source_test.dart`, inside `void main()`:
+
+```dart
+  group('probe', () {
+    test('covers everywhere at its declared 450 m', () async {
+      final cap = await EtopoErddapSource().probe(const GeoPoint(12.16, -68.29));
+      expect(cap!.cellSizeMeters, 450);
+    });
+  });
+```
+
+Each of these test files needs `import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';` for `GeoPoint` if it is not already imported.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/features/bathymetry/data/emodnet_source_test.dart test/features/bathymetry/data/gmrt_source_test.dart test/features/bathymetry/data/etopo_erddap_source_test.dart`
+
+Expected: FAIL, compile error: the method `probe` is not defined.
+
+- [ ] **Step 3: Implement**
+
+In `lib/features/bathymetry/domain/bathymetry_source.dart`, add above the interface:
+
+```dart
+/// What a source claims it can deliver at one coordinate. Declared, not
+/// measured: a source reports the finest grid it believes it holds there,
+/// which the resolver uses only to order candidates. The wet-cell and
+/// known-cell floors in [BathymetryResolver] are what actually reject bad
+/// data after a fetch.
+class SourceCapability {
+  /// Best available cell size in meters at the probed point.
+  final double cellSizeMeters;
+
+  /// Provenance detail for the caption, e.g. the dataset or DEM name.
+  final String detail;
+
+  const SourceCapability({
+    required this.cellSizeMeters,
+    required this.detail,
+  });
+}
+```
+
+Replace `bool covers(GeoPoint center);` with:
+
+```dart
+  /// What this source can deliver at [center], or null when it does not
+  /// cover the point. May make a network call; a probe that fails for any
+  /// reason must return null rather than throw, so one unreachable source
+  /// never blocks the others.
+  Future<SourceCapability?> probe(GeoPoint center);
+```
+
+In `emodnet_source.dart`, replace the `covers` override with:
+
+```dart
+  static const double declaredCellSizeMeters = _resolutionMeters;
+
+  @override
+  Future<SourceCapability?> probe(GeoPoint center) async {
+    if (_inBox(center, _carib)) {
+      return const SourceCapability(
+        cellSizeMeters: _resolutionMeters,
+        detail: _carib.dataset,
+      );
+    }
+    if (_inBox(center, _europe)) {
+      return const SourceCapability(
+        cellSizeMeters: _resolutionMeters,
+        detail: _europe.dataset,
+      );
+    }
+    return null;
+  }
+```
+
+Note: `_carib.dataset` inside a `const` expression requires `_carib` to stay a `const` record, which it already is. If the analyzer rejects the const context, drop `const` from the two returns.
+
+In `gmrt_source.dart`, replace the `covers` override with:
+
+```dart
+  /// GMRT's global tiles run to roughly 60 m where ship multibeam exists.
+  /// This is a nominal figure: elsewhere the same grid spacing carries
+  /// upsampled GEBCO. The resolver's preemption factor exists so this
+  /// number cannot demote a genuinely surveyed regional source.
+  static const double declaredCellSizeMeters = 60;
+
+  @override
+  Future<SourceCapability?> probe(GeoPoint center) async =>
+      const SourceCapability(
+        cellSizeMeters: declaredCellSizeMeters,
+        detail: 'GMRT GridServer',
+      );
+```
+
+In `etopo_erddap_source.dart`, replace the `covers` override with:
+
+```dart
+  static const double declaredCellSizeMeters = _resolutionMeters;
+
+  @override
+  Future<SourceCapability?> probe(GeoPoint center) async =>
+      const SourceCapability(
+        cellSizeMeters: _resolutionMeters,
+        detail: _dataset,
+      );
+```
+
+Each source file needs `SourceCapability` in scope; it comes from the already-imported `bathymetry_source.dart`.
+
+The resolver still calls `source.covers(center)` at this point and will not compile. Fix it minimally here so the tree builds, replacing the `if (!source.covers(center)) continue;` line in `BathymetryResolver.resolve` with:
+
+```dart
+      if (await source.probe(center) == null) continue;
+```
+
+Task 3 replaces that loop wholesale.
+
+Also fix the two fakes in `test/features/bathymetry/data/bathymetry_resolver_test.dart`, replacing each `covers` override:
+
+```dart
+  @override
+  Future<SourceCapability?> probe(GeoPoint center) async => coversIt
+      ? const SourceCapability(cellSizeMeters: 100, detail: 'fake')
+      : null;
+```
+
+and in `_ErrorSource`:
+
+```dart
+  @override
+  Future<SourceCapability?> probe(GeoPoint center) async =>
+      const SourceCapability(cellSizeMeters: 100, detail: 'boom');
+```
+
+Search the whole tree for any other implementer or caller:
+
+```bash
+grep -rn "covers(" lib test
+```
+
+Every hit must be gone before Step 4 passes.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/features/bathymetry`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/bathymetry test/features/bathymetry
+git commit -m "feat(bathymetry): sources declare a capability instead of a bool
+
+covers() could only say yes or no, and could not make a network call. A
+source now reports the finest cell size it believes it holds at a point,
+or null when it does not cover it, which lets the resolver order
+candidates by what they can actually deliver.
+
+Declared, not measured. The wet-cell and known-cell floors remain the
+things that reject bad data after a fetch."
+```
+
+---
+
+### Task 3: Capability ordering and the known-cell floor
+
+The resolver stops taking the first tier that answers.
+
+**Files:**
+- Modify: `lib/features/bathymetry/data/bathymetry_resolver.dart`
+- Test: `test/features/bathymetry/data/bathymetry_resolver_test.dart`
+
+**Interfaces:**
+- Consumes: `SourceCapability` and `probe()` from Task 2; `knownFraction` from Task 1.
+- Produces: `BathymetryResolver.minKnownFraction` (0.60) and `BathymetryResolver.preemptionFactor` (2.0). `BathymetryResolution` is unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/features/bathymetry/data/bathymetry_resolver_test.dart`, extend `FakeSource` with a declarable cell size. Replace the class with:
+
+```dart
+class FakeSource implements BathymetrySource {
+  @override
+  final String id;
+  @override
+  final bool global;
+  final bool coversIt;
+  final BathymetryGrid? result; // null => throw transient
+  final double cellSizeMeters;
+  int fetchCount = 0;
+  double? lastSpanMeters;
+
+  FakeSource(
+    this.id, {
+    this.global = true,
+    this.coversIt = true,
+    this.result,
+    this.cellSizeMeters = 100,
+  });
+
+  @override
+  Future<SourceCapability?> probe(GeoPoint center) async => coversIt
+      ? SourceCapability(cellSizeMeters: cellSizeMeters, detail: id)
+      : null;
+
+  @override
+  Future<BathymetryGrid> fetch(GeoPoint c, {required double spanMeters}) async {
+    fetchCount++;
+    lastSpanMeters = spanMeters;
+    final r = result;
+    if (r == null) throw const BathymetryFetchException('down');
+    return r;
+  }
+}
+```
+
+Add a helper next to `gridWith` that can produce holes:
+
+```dart
+BathymetryGrid gridOf(
+  List<double?> depths,
+  String sourceId, {
+  double resolutionMeters = 100,
+}) => BathymetryGrid(
+  originLat: 12.14,
+  originLon: -68.31,
+  cellSizeLatDeg: 0.004,
+  cellSizeLonDeg: 0.004,
+  rows: 1,
+  cols: depths.length,
+  depthsMeters: depths,
+  sourceId: sourceId,
+  resolutionMeters: resolutionMeters,
+  fetchedAt: DateTime.utc(2026, 7, 28),
+);
+```
+
+Append these tests inside `void main()`:
+
+```dart
+  test('a mostly-empty grid fails the known-cell floor and falls through',
+      () async {
+    // 4 known of 10 cells is 40%, below the 60% floor, even though every
+    // known cell is wet. This is EMODnet's Bonaire tile in miniature.
+    final holey = <double?>[
+      50.0, null, 50.0, null, 50.0, null, 50.0, null, null, null,
+    ];
+    final a = FakeSource('emodnet-like', result: gridOf(holey, 'a'));
+    final b = FakeSource('gmrt-like', result: gridWith(wet, 'b'));
+    final res = await BathymetryResolver(sources: [a, b]).resolve(p);
+    expect(res.grid!.sourceId, 'b');
+    expect(a.fetchCount, 1);
+    expect(b.fetchCount, 1);
+  });
+
+  test('a grid at exactly the known-cell floor is accepted', () async {
+    final atFloor = <double?>[
+      50.0, 50.0, 50.0, 50.0, 50.0, 50.0, null, null, null, null,
+    ];
+    final a = FakeSource('a', result: gridOf(atFloor, 'a'));
+    final res = await BathymetryResolver(sources: [a]).resolve(p);
+    expect(res.grid!.sourceId, 'a');
+  });
+
+  test('a materially finer source preempts the declared order', () async {
+    // 10 m against 100 m is a factor of 10, well past preemptionFactor.
+    final coarse = FakeSource('coarse', result: gridWith(wet, 'coarse'));
+    final fine = FakeSource(
+      'fine',
+      result: gridWith(wet, 'fine'),
+      cellSizeMeters: 10,
+    );
+    final res = await BathymetryResolver(sources: [coarse, fine]).resolve(p);
+    expect(res.grid!.sourceId, 'fine');
+    expect(coarse.fetchCount, 0);
+  });
+
+  test('a marginally finer source does not preempt the declared order',
+      () async {
+    // 60 m against 115 m is a factor of 1.9, inside preemptionFactor, so
+    // the declared regional-first order stands. This is EMODnet vs GMRT
+    // in Europe.
+    final regional = FakeSource(
+      'emodnet',
+      result: gridWith(wet, 'emodnet'),
+      cellSizeMeters: 115,
+    );
+    final global = FakeSource(
+      'gmrt',
+      result: gridWith(wet, 'gmrt'),
+      cellSizeMeters: 60,
+    );
+    final res = await BathymetryResolver(sources: [regional, global]).resolve(p);
+    expect(res.grid!.sourceId, 'emodnet');
+    expect(global.fetchCount, 0);
+  });
+
+  test('an uncovered source is never fetched', () async {
+    final a = FakeSource('a', coversIt: false, result: gridWith(wet, 'a'));
+    final b = FakeSource('b', result: gridWith(wet, 'b'));
+    final res = await BathymetryResolver(sources: [a, b]).resolve(p);
+    expect(res.grid!.sourceId, 'b');
+    expect(a.fetchCount, 0);
+  });
+
+  test('a probe that throws is treated as not covering', () async {
+    final res = await BathymetryResolver(
+      sources: [_ThrowingProbeSource(), FakeSource('b', result: gridWith(wet, 'b'))],
+    ).resolve(p);
+    expect(res.grid!.sourceId, 'b');
+  });
+```
+
+Add the throwing-probe fake next to `_ErrorSource`:
+
+```dart
+class _ThrowingProbeSource implements BathymetrySource {
+  @override
+  String get id => 'probe-boom';
+  @override
+  bool get global => false;
+  @override
+  Future<SourceCapability?> probe(GeoPoint center) async =>
+      throw StateError('probe exploded');
+  @override
+  Future<BathymetryGrid> fetch(GeoPoint c, {required double spanMeters}) async =>
+      throw StateError('should never be fetched');
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/features/bathymetry/data/bathymetry_resolver_test.dart`
+
+Expected: FAIL. `minKnownFraction` and `preemptionFactor` are undefined; the holey-grid test currently returns source 'a' because nothing checks coverage density; the preemption tests currently return the first listed source.
+
+- [ ] **Step 3: Implement**
+
+Replace `BathymetryResolver` in `lib/features/bathymetry/data/bathymetry_resolver.dart`:
+
+```dart
+/// Best-source-wins. Probes every source, orders them by MATERIALLY better
+/// resolution, then fetches in that order and takes the first grid that
+/// passes both quality floors.
+///
+/// No mosaicking: sources use different vertical datums (EMODnet is LAT,
+/// GMRT and ETOPO are MSL) and stitching them seams.
+class BathymetryResolver {
+  static const double minWetFraction = 0.10;
+
+  /// A grid must actually have readings. EMODnet's Caribbean tile answers
+  /// 99.96% wet on 48% coverage, and the missing half renders as a flat
+  /// slab at the waterline. Coverage this thin is not usable terrain.
+  static const double minKnownFraction = 0.60;
+
+  /// How much finer a source must be to jump ahead of the declared list
+  /// order. Declared resolution is a claim, so only a MATERIAL difference
+  /// is allowed to override the curated tier order: NOAA CUDEM at 3.4 m
+  /// preempts GMRT's 60 m, while GMRT's nominal 60 m does not preempt
+  /// EMODnet's surveyed 115 m.
+  static const double preemptionFactor = 2.0;
+
+  /// Request-box width. 8 km shows the surrounding seascape, not just the
+  /// site itself; the repository's downsample cap bounds the render cost.
+  /// This value is part of the cache key - see
+  /// [BathymetryRepository.keyFor] - so changing it refetches.
+  static const double defaultSpanMeters = 8000;
+
+  final List<BathymetrySource> sources;
+
+  const BathymetryResolver({required this.sources});
+
+  Future<BathymetryResolution> resolve(GeoPoint center) async {
+    final ordered = await _order(center);
+    var globalSourceSaidDry = false;
+    for (final source in ordered) {
+      try {
+        final grid = await source.fetch(center, spanMeters: defaultSpanMeters);
+        if (grid.knownFraction < minKnownFraction) {
+          // Nominally fine, actually absent. Not an answer about the water.
+          continue;
+        }
+        if (grid.wetFraction >= minWetFraction) {
+          return BathymetryResolution.ok(grid);
+        }
+        // A dry answer only proves "no water here" if the source actually
+        // covers everywhere; a regional edge cell proves nothing.
+        if (source.global) globalSourceSaidDry = true;
+      } on BathymetryFetchException {
+        // Transient: fall through to the next source.
+      } catch (_) {
+        // A source blowing up with anything else (a TypeError from an
+        // unexpected response shape, an ArgumentError) must not kill the
+        // whole scene - treat it exactly like a transient failure.
+      }
+    }
+    return globalSourceSaidDry
+        ? const BathymetryResolution.empty()
+        : const BathymetryResolution.transientFailure();
+  }
+
+  /// Covering sources in fetch order. Probes run concurrently because a
+  /// probe may be a network call and they are independent; a probe that
+  /// fails for any reason drops that source rather than failing the scene.
+  Future<List<BathymetrySource>> _order(GeoPoint center) async {
+    final caps = await Future.wait(
+      sources.map((s) async {
+        try {
+          return await s.probe(center);
+        } catch (_) {
+          return null;
+        }
+      }),
+    );
+    final covering = <({BathymetrySource source, int rank, double cell})>[];
+    for (var i = 0; i < sources.length; i++) {
+      final cap = caps[i];
+      if (cap == null) continue;
+      covering.add((source: sources[i], rank: i, cell: cap.cellSizeMeters));
+    }
+    if (covering.isEmpty) return const [];
+    // Group into preemption bands: a source leads only when it is more
+    // than preemptionFactor finer than everything ahead of it in the
+    // declared order. Within a band the declared order is preserved.
+    covering.sort((a, b) {
+      if (a.cell * preemptionFactor < b.cell) return -1;
+      if (b.cell * preemptionFactor < a.cell) return 1;
+      return a.rank.compareTo(b.rank);
+    });
+    return [for (final c in covering) c.source];
+  }
+}
+```
+
+Note on the comparator: it is not a total order (the "within a factor" relation is not transitive), so `List.sort` may produce different results for pathological three-source inputs. With the four real sources at 3.4 m, 60 m, 115 m and 450 m this is well-behaved, and the tests pin the two cases that matter. Do not extend this to a larger source list without revisiting it.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/features/bathymetry/data/bathymetry_resolver_test.dart`
+
+Expected: PASS.
+
+The existing test asserting `expect(b.fetchCount, 0)` for "first covering source with a wet grid wins" still holds, because both fakes default to 100 m and the declared order is preserved inside the band.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/bathymetry/data/bathymetry_resolver.dart test/features/bathymetry/data/bathymetry_resolver_test.dart
+git commit -m "feat(bathymetry): order sources by capability, reject empty grids
+
+The resolver took the first tier returning enough wet cells, which at
+Bonaire selects EMODnet's 115 m tile over GMRT's 60 m one despite the
+former being 48 percent nodata with no coastline at all.
+
+Two changes. A known-cell floor of 0.60 rejects a grid that is nominally
+wet but mostly holes, which is what fixes Bonaire. A preemption factor of
+2.0 lets a materially finer source jump the declared order, which is what
+will let NOAA CUDEM lead, while keeping a regional survey ahead of a
+global grid of nominally similar resolution."
+```
+
+---
+
+### Task 4: Tiled float32 GeoTIFF parser
+
+The NOAA ImageServer returns elevations as an uncompressed, tiled, little-endian float32 GeoTIFF. Nothing in the tree reads that.
+
+**Files:**
+- Create: `lib/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart`
+- Test: `test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart`
+
+**Interfaces:**
+- Consumes: `BathymetryGrid` from Task 1.
+- Produces: `ArcgisFloat32TiffParser.parse(Uint8List bytes, {required double westLon, required double eastLon, required double southLat, required double northLat, required String sourceId, required double resolutionMeters, required DateTime fetchedAt})` returning `BathymetryGrid`. Throws `FormatException` on a malformed or unsupported TIFF.
+
+Background, measured against the live service on 2026-09-05: the response is `II` little-endian, `Compression` (259) = 1, `BitsPerSample` (258) = 32, `SampleFormat` (339) = 3 (IEEE float), `SamplesPerPixel` (277) = 1, and it is **tile-organised**: `TileWidth` (322) and `TileLength` (323) are 128, with `TileOffsets` (324) and `TileByteCounts` (325). There are no `StripOffsets`. A requested 64x64 image arrives as one 128x128 tile with the image occupying its top-left corner, and a 256x256 image arrives as four tiles in row-major order. Image rows run **north to south**, and values are elevations (negative below sea level), so both need flipping and negating to reach the app's depth convention.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart`:
+
+```dart
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart';
+
+/// Builds a minimal little-endian tiled float32 TIFF matching the shape the
+/// NOAA ImageServer returns, so the test pins the real wire format without
+/// carrying a 66 KB binary fixture.
+Uint8List buildTiff({
+  required int width,
+  required int height,
+  required int tileSize,
+  required List<double> tilePixels, // tileSize * tileSize per tile, row-major
+  int compression = 1,
+  int bitsPerSample = 32,
+  int sampleFormat = 3,
+}) {
+  final tilesAcross = (width + tileSize - 1) ~/ tileSize;
+  final tilesDown = (height + tileSize - 1) ~/ tileSize;
+  final tileCount = tilesAcross * tilesDown;
+  final tileBytes = tileSize * tileSize * 4;
+  expect(tilePixels.length, tileCount * tileSize * tileSize);
+
+  const entries = 9;
+  const headerLen = 8;
+  final ifdLen = 2 + entries * 12 + 4;
+  // Tile offset and byte-count arrays live after the IFD when there is
+  // more than one tile; a single value fits inline in the entry.
+  final arraysLen = tileCount > 1 ? tileCount * 4 * 2 : 0;
+  final pixelStart = headerLen + ifdLen + arraysLen;
+
+  final out = BytesBuilder();
+  final head = ByteData(headerLen);
+  head.setUint8(0, 0x49);
+  head.setUint8(1, 0x49);
+  head.setUint16(2, 42, Endian.little);
+  head.setUint32(4, headerLen, Endian.little);
+  out.add(head.buffer.asUint8List());
+
+  final ifd = ByteData(ifdLen);
+  ifd.setUint16(0, entries, Endian.little);
+  var e = 2;
+  void entry(int tag, int type, int count, int value) {
+    ifd.setUint16(e, tag, Endian.little);
+    ifd.setUint16(e + 2, type, Endian.little);
+    ifd.setUint32(e + 4, count, Endian.little);
+    if (type == 3 && count == 1) {
+      ifd.setUint16(e + 8, value, Endian.little);
+      ifd.setUint16(e + 10, 0, Endian.little);
+    } else {
+      ifd.setUint32(e + 8, value, Endian.little);
+    }
+    e += 12;
+  }
+
+  final offsetsAt = headerLen + ifdLen;
+  final countsAt = offsetsAt + tileCount * 4;
+  entry(256, 3, 1, width); // ImageWidth
+  entry(257, 3, 1, height); // ImageLength
+  entry(258, 3, 1, bitsPerSample); // BitsPerSample
+  entry(259, 3, 1, compression); // Compression
+  entry(277, 3, 1, 1); // SamplesPerPixel
+  entry(322, 3, 1, tileSize); // TileWidth
+  entry(323, 3, 1, tileSize); // TileLength
+  entry(324, 4, tileCount, tileCount == 1 ? pixelStart : offsetsAt);
+  entry(325, 4, tileCount, tileCount == 1 ? tileBytes : countsAt);
+  ifd.setUint32(ifdLen - 4, 0, Endian.little); // next IFD = none
+  out.add(ifd.buffer.asUint8List());
+
+  if (tileCount > 1) {
+    final arrays = ByteData(arraysLen);
+    for (var i = 0; i < tileCount; i++) {
+      arrays.setUint32(i * 4, pixelStart + i * tileBytes, Endian.little);
+      arrays.setUint32(tileCount * 4 + i * 4, tileBytes, Endian.little);
+    }
+    out.add(arrays.buffer.asUint8List());
+  }
+
+  final pixels = ByteData(tileCount * tileBytes);
+  for (var i = 0; i < tilePixels.length; i++) {
+    pixels.setFloat32(i * 4, tilePixels[i], Endian.little);
+  }
+  out.add(pixels.buffer.asUint8List());
+  // SampleFormat is asserted by the parser but not needed positionally;
+  // it is folded into BitsPerSample handling for this minimal builder.
+  expect(sampleFormat, 3);
+  return out.toBytes();
+}
+
+void main() {
+  final when = DateTime.utc(2026, 9, 5);
+
+  test('reads a single-tile image, flips rows south-first and negates', () {
+    // 2x2 image inside a 4x4 tile. Image row 0 is NORTHERNMOST.
+    final tile = List<double>.filled(16, 0);
+    tile[0] = -10.0; // north-west
+    tile[1] = -20.0; // north-east
+    tile[4] = -30.0; // south-west
+    tile[5] = -40.0; // south-east
+    final bytes = buildTiff(
+      width: 2,
+      height: 2,
+      tileSize: 4,
+      tilePixels: tile,
+    );
+
+    final g = ArcgisFloat32TiffParser.parse(
+      bytes,
+      westLon: -80.4,
+      eastLon: -80.2,
+      southLat: 25.0,
+      northLat: 25.2,
+      sourceId: 'noaa_dem',
+      resolutionMeters: 8,
+      fetchedAt: when,
+    );
+
+    expect(g.rows, 2);
+    expect(g.cols, 2);
+    // Grid row 0 is SOUTHERNMOST, and elevation negates into depth.
+    expect(g.depthAt(0, 0), closeTo(30.0, 1e-6));
+    expect(g.depthAt(0, 1), closeTo(40.0, 1e-6));
+    expect(g.depthAt(1, 0), closeTo(10.0, 1e-6));
+    expect(g.depthAt(1, 1), closeTo(20.0, 1e-6));
+    expect(g.sourceId, 'noaa_dem');
+    expect(g.resolutionMeters, 8);
+  });
+
+  test('origin is the south-west CELL CENTER and cell sizes span the box', () {
+    final tile = List<double>.filled(16, -5.0);
+    final g = ArcgisFloat32TiffParser.parse(
+      buildTiff(width: 2, height: 2, tileSize: 4, tilePixels: tile),
+      westLon: -80.4,
+      eastLon: -80.2,
+      southLat: 25.0,
+      northLat: 25.2,
+      sourceId: 'noaa_dem',
+      resolutionMeters: 8,
+      fetchedAt: when,
+    );
+    // 2 columns across a 0.2 degree box: cell width 0.1, first center at
+    // west + half a cell.
+    expect(g.cellSizeLonDeg, closeTo(0.1, 1e-9));
+    expect(g.cellSizeLatDeg, closeTo(0.1, 1e-9));
+    expect(g.originLon, closeTo(-80.35, 1e-9));
+    expect(g.originLat, closeTo(25.05, 1e-9));
+  });
+
+  test('assembles a multi-tile image in row-major tile order', () {
+    // 4x4 image as four 2x2 tiles. Each tile filled with its own index so
+    // misplacement is obvious.
+    final pixels = <double>[
+      -1, -1, -1, -1, // tile 0 (north-west)
+      -2, -2, -2, -2, // tile 1 (north-east)
+      -3, -3, -3, -3, // tile 2 (south-west)
+      -4, -4, -4, -4, // tile 3 (south-east)
+    ];
+    final g = ArcgisFloat32TiffParser.parse(
+      buildTiff(width: 4, height: 4, tileSize: 2, tilePixels: pixels),
+      westLon: 0,
+      eastLon: 1,
+      southLat: 0,
+      northLat: 1,
+      sourceId: 'noaa_dem',
+      resolutionMeters: 8,
+      fetchedAt: when,
+    );
+    // After the south-first flip, grid row 0 is the image's LAST row.
+    expect(g.depthAt(0, 0), closeTo(3.0, 1e-6));
+    expect(g.depthAt(0, 3), closeTo(4.0, 1e-6));
+    expect(g.depthAt(3, 0), closeTo(1.0, 1e-6));
+    expect(g.depthAt(3, 3), closeTo(2.0, 1e-6));
+  });
+
+  test('maps the ArcGIS nodata sentinel to null', () {
+    final tile = List<double>.filled(16, -5.0);
+    tile[0] = -3.4028234663852886e38; // float32 lowest, ArcGIS NoData
+    final g = ArcgisFloat32TiffParser.parse(
+      buildTiff(width: 2, height: 2, tileSize: 4, tilePixels: tile),
+      westLon: 0,
+      eastLon: 1,
+      southLat: 0,
+      northLat: 1,
+      sourceId: 'noaa_dem',
+      resolutionMeters: 8,
+      fetchedAt: when,
+    );
+    // Image (0,0) is the northernmost row, which flips to grid row 1.
+    expect(g.depthAt(1, 0), isNull);
+    expect(g.depthAt(0, 0), closeTo(5.0, 1e-6));
+  });
+
+  test('throws FormatException on a compressed TIFF', () {
+    expect(
+      () => ArcgisFloat32TiffParser.parse(
+        buildTiff(
+          width: 2,
+          height: 2,
+          tileSize: 4,
+          tilePixels: List<double>.filled(16, -5.0),
+          compression: 5,
+        ),
+        westLon: 0,
+        eastLon: 1,
+        southLat: 0,
+        northLat: 1,
+        sourceId: 'noaa_dem',
+        resolutionMeters: 8,
+        fetchedAt: when,
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('throws FormatException on a non-float sample depth', () {
+    expect(
+      () => ArcgisFloat32TiffParser.parse(
+        buildTiff(
+          width: 2,
+          height: 2,
+          tileSize: 4,
+          tilePixels: List<double>.filled(16, -5.0),
+          bitsPerSample: 16,
+        ),
+        westLon: 0,
+        eastLon: 1,
+        southLat: 0,
+        northLat: 1,
+        sourceId: 'noaa_dem',
+        resolutionMeters: 8,
+        fetchedAt: when,
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('throws FormatException on a big-endian or non-TIFF body', () {
+    expect(
+      () => ArcgisFloat32TiffParser.parse(
+        Uint8List.fromList('<html>not a tiff</html>'.codeUnits),
+        westLon: 0,
+        eastLon: 1,
+        southLat: 0,
+        northLat: 1,
+        sourceId: 'noaa_dem',
+        resolutionMeters: 8,
+        fetchedAt: when,
+      ),
+      throwsFormatException,
+    );
+  });
+}
+```
+
+Add `import 'package:submersion/features/bathymetry/domain/bathymetry_grid.dart';` if the analyzer needs `BathymetryGrid` named.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart`
+
+Expected: FAIL, compile error: the target of the URI does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `lib/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart`:
+
+```dart
+import 'dart:typed_data';
+
+import 'package:submersion/features/bathymetry/domain/bathymetry_grid.dart';
+
+/// Reads the uncompressed, tiled, little-endian float32 GeoTIFF that an
+/// ArcGIS ImageServer returns for `format=tiff&pixelType=F32`.
+///
+/// Deliberately narrow. This is not a TIFF library: it accepts exactly the
+/// shape that service emits and throws [FormatException] on anything else,
+/// so an unexpected response becomes a transient source failure rather than
+/// silently wrong terrain.
+///
+/// Two conversions bring it into the app's convention. Image rows run north
+/// to south while [BathymetryGrid] rows run south to north, and the raster
+/// carries elevation (negative below sea level) while the grid carries
+/// depth (positive down).
+class ArcgisFloat32TiffParser {
+  /// ArcGIS writes float32 lowest as its NoData sentinel.
+  static const double _noDataSentinel = -3.4028234663852886e38;
+  static const double _noDataEpsilon = 1e30;
+
+  static const int _tagImageWidth = 256;
+  static const int _tagImageLength = 257;
+  static const int _tagBitsPerSample = 258;
+  static const int _tagCompression = 259;
+  static const int _tagSamplesPerPixel = 277;
+  static const int _tagTileWidth = 322;
+  static const int _tagTileLength = 323;
+  static const int _tagTileOffsets = 324;
+  static const int _tagTileByteCounts = 325;
+
+  static BathymetryGrid parse(
+    Uint8List bytes, {
+    required double westLon,
+    required double eastLon,
+    required double southLat,
+    required double northLat,
+    required String sourceId,
+    required double resolutionMeters,
+    required DateTime fetchedAt,
+  }) {
+    final d = ByteData.sublistView(bytes);
+    if (bytes.length < 8 || bytes[0] != 0x49 || bytes[1] != 0x49) {
+      throw const FormatException(
+        'Expected a little-endian TIFF (II magic); the service returned '
+        'something else, most likely an error envelope.',
+      );
+    }
+    if (d.getUint16(2, Endian.little) != 42) {
+      throw const FormatException('Not a classic TIFF (magic 42 missing)');
+    }
+
+    final ifd = d.getUint32(4, Endian.little);
+    final entryCount = d.getUint16(ifd, Endian.little);
+    final tags = <int, ({int type, int count, int value})>{};
+    for (var i = 0; i < entryCount; i++) {
+      final e = ifd + 2 + i * 12;
+      final tag = d.getUint16(e, Endian.little);
+      final type = d.getUint16(e + 2, Endian.little);
+      final count = d.getUint32(e + 4, Endian.little);
+      // A SHORT with count 1 sits in the low half of the value field.
+      final value = type == 3 && count == 1
+          ? d.getUint16(e + 8, Endian.little)
+          : d.getUint32(e + 8, Endian.little);
+      tags[tag] = (type: type, count: count, value: value);
+    }
+
+    int need(int tag, String what) {
+      final t = tags[tag];
+      if (t == null) throw FormatException('TIFF is missing $what');
+      return t.value;
+    }
+
+    if (need(_tagCompression, 'Compression') != 1) {
+      throw const FormatException('Only uncompressed TIFF is supported');
+    }
+    if (need(_tagBitsPerSample, 'BitsPerSample') != 32) {
+      throw const FormatException('Only 32-bit samples are supported');
+    }
+    if (need(_tagSamplesPerPixel, 'SamplesPerPixel') != 1) {
+      throw const FormatException('Only single-band rasters are supported');
+    }
+
+    final width = need(_tagImageWidth, 'ImageWidth');
+    final height = need(_tagImageLength, 'ImageLength');
+    final tileW = need(_tagTileWidth, 'TileWidth');
+    final tileH = need(_tagTileLength, 'TileLength');
+    if (width < 1 || height < 1 || tileW < 1 || tileH < 1) {
+      throw const FormatException('TIFF has a zero dimension');
+    }
+
+    final offsets = _longs(d, tags[_tagTileOffsets], 'TileOffsets');
+    final tilesAcross = (width + tileW - 1) ~/ tileW;
+    final tilesDown = (height + tileH - 1) ~/ tileH;
+    if (offsets.length != tilesAcross * tilesDown) {
+      throw const FormatException('TileOffsets count does not match the grid');
+    }
+
+    // Image order, north row first.
+    final image = List<double?>.filled(width * height, null);
+    for (var t = 0; t < offsets.length; t++) {
+      final tx = t % tilesAcross;
+      final ty = t ~/ tilesAcross;
+      final base = offsets[t];
+      if (base + tileW * tileH * 4 > bytes.length) {
+        throw const FormatException('TIFF tile runs past the end of the body');
+      }
+      for (var r = 0; r < tileH; r++) {
+        final imageRow = ty * tileH + r;
+        if (imageRow >= height) break;
+        for (var c = 0; c < tileW; c++) {
+          final imageCol = tx * tileW + c;
+          if (imageCol >= width) continue;
+          final v = d.getFloat32(base + (r * tileW + c) * 4, Endian.little);
+          image[imageRow * width + imageCol] =
+              _isNoData(v) ? null : -v; // elevation -> depth
+        }
+      }
+    }
+
+    // Flip to south-first.
+    final depths = List<double?>.filled(width * height, null);
+    for (var r = 0; r < height; r++) {
+      final src = (height - 1 - r) * width;
+      depths.setRange(r * width, r * width + width, image, src);
+    }
+
+    // The requested box spans cell EDGES; the grid origin is a cell CENTER.
+    final cellLon = (eastLon - westLon) / width;
+    final cellLat = (northLat - southLat) / height;
+    return BathymetryGrid(
+      originLat: southLat + cellLat / 2,
+      originLon: westLon + cellLon / 2,
+      cellSizeLatDeg: cellLat,
+      cellSizeLonDeg: cellLon,
+      rows: height,
+      cols: width,
+      depthsMeters: depths,
+      sourceId: sourceId,
+      resolutionMeters: resolutionMeters,
+      fetchedAt: fetchedAt,
+    );
+  }
+
+  static bool _isNoData(double v) =>
+      v.isNaN || (v - _noDataSentinel).abs() < _noDataEpsilon && v < -1e30;
+
+  static List<int> _longs(
+    ByteData d,
+    ({int type, int count, int value})? tag,
+    String what,
+  ) {
+    if (tag == null) throw FormatException('TIFF is missing $what');
+    if (tag.count == 1) return [tag.value];
+    return [
+      for (var i = 0; i < tag.count; i++)
+        d.getUint32(tag.value + i * 4, Endian.little),
+    ];
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart`
+
+Expected: PASS. If the nodata test fails, check `_isNoData`: the sentinel comparison must catch float32 lowest without swallowing a legitimate deep reading, and no real elevation approaches -1e30.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart
+git commit -m "feat(bathymetry): read ArcGIS uncompressed tiled float32 GeoTIFF
+
+The NOAA NCEI DEM ImageServer returns elevations as an uncompressed,
+tile-organised, little-endian float32 GeoTIFF with no strip tags at all,
+which nothing in the tree could read.
+
+Deliberately narrow rather than a general TIFF decoder: it accepts exactly
+that shape and throws FormatException on anything else, so an unexpected
+response degrades to a transient source failure instead of silently wrong
+terrain. Rows flip south-first and elevations negate into depths."
+```
+
+---
+
+### Task 5: NoaaDemSource
+
+**Files:**
+- Create: `lib/features/bathymetry/data/sources/noaa_dem_source.dart`
+- Test: `test/features/bathymetry/data/noaa_dem_source_test.dart`
+
+**Interfaces:**
+- Consumes: `SourceCapability`, `BathymetrySource`, `BathymetryFetchException` from Task 2; `ArcgisFloat32TiffParser.parse` from Task 4.
+- Produces: `NoaaDemSource({http.Client? client, String baseUrl})` with `static const String sourceId = 'noaa_dem'` and `static const double usefulCellSizeMeters = 50`.
+
+Measured wire behaviour, 2026-09-05. The probe is:
+
+```
+GET {baseUrl}/identify
+  ?geometry={"x":<lon>,"y":<lat>}
+  &geometryType=esriGeometryPoint
+  &returnCatalogItems=true
+  &maxItemCount=25
+  &f=json
+```
+
+`maxItemCount` is load-bearing: without it the response truncates to three items and La Jolla's 10 m DEM is hidden behind ETOPO. The response carries `catalogItems.features[].attributes`, each with `Name` and `LowPS` (cell size in **degrees**). Measured results: Florida Keys `ncei19_n25x25_w080x50_2016v1` at `LowPS` 3.086e-05 (3.4 m), La Jolla `san_diego_navd88` at 10.3 m, Bonaire best is `ETOPO_2022_v1_15s_surface_elev` at 464 m. ArcGIS returns error envelopes with HTTP 200, so a body with no `catalogItems` is a decline, not a crash.
+
+The fetch is:
+
+```
+GET {baseUrl}/exportImage
+  ?bbox=<west>,<south>,<east>,<north>&bboxSR=4326&imageSR=4326
+  &size=<dim>,<dim>&format=tiff&pixelType=F32
+  &noDataInterpretation=esriNoDataMatchAny
+  &interpolation=RSP_BilinearInterpolation&f=image
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/bathymetry/data/noaa_dem_source_test.dart`:
+
+```dart
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/features/bathymetry/data/sources/noaa_dem_source.dart';
+import 'package:submersion/features/bathymetry/domain/bathymetry_source.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+String identifyBody(List<({String name, double lowPs})> items) => jsonEncode({
+  'value': '-3.87793',
+  'catalogItems': {
+    'features': [
+      for (final i in items)
+        {
+          'attributes': {'Name': i.name, 'LowPS': i.lowPs, 'HighPS': i.lowPs},
+        },
+    ],
+  },
+});
+
+/// A 2x2 single-tile float32 TIFF, matching the builder in
+/// arcgis_float32_tiff_parser_test.dart but inlined so this suite stands
+/// alone.
+Uint8List tinyTiff() {
+  const width = 2, height = 2, tileSize = 4, entries = 9;
+  const headerLen = 8;
+  const ifdLen = 2 + entries * 12 + 4;
+  const pixelStart = headerLen + ifdLen;
+  final out = BytesBuilder();
+  final head = ByteData(headerLen);
+  head.setUint8(0, 0x49);
+  head.setUint8(1, 0x49);
+  head.setUint16(2, 42, Endian.little);
+  head.setUint32(4, headerLen, Endian.little);
+  out.add(head.buffer.asUint8List());
+  final ifd = ByteData(ifdLen);
+  ifd.setUint16(0, entries, Endian.little);
+  var e = 2;
+  void entry(int tag, int type, int count, int value) {
+    ifd.setUint16(e, tag, Endian.little);
+    ifd.setUint16(e + 2, type, Endian.little);
+    ifd.setUint32(e + 4, count, Endian.little);
+    if (type == 3 && count == 1) {
+      ifd.setUint16(e + 8, value, Endian.little);
+      ifd.setUint16(e + 10, 0, Endian.little);
+    } else {
+      ifd.setUint32(e + 8, value, Endian.little);
+    }
+    e += 12;
+  }
+
+  entry(256, 3, 1, width);
+  entry(257, 3, 1, height);
+  entry(258, 3, 1, 32);
+  entry(259, 3, 1, 1);
+  entry(277, 3, 1, 1);
+  entry(322, 3, 1, tileSize);
+  entry(323, 3, 1, tileSize);
+  entry(324, 4, 1, pixelStart);
+  entry(325, 4, 1, tileSize * tileSize * 4);
+  ifd.setUint32(ifdLen - 4, 0, Endian.little);
+  out.add(ifd.buffer.asUint8List());
+  final px = ByteData(tileSize * tileSize * 4);
+  for (var i = 0; i < tileSize * tileSize; i++) {
+    px.setFloat32(i * 4, -8.0, Endian.little);
+  }
+  out.add(px.buffer.asUint8List());
+  return out.toBytes();
+}
+
+void main() {
+  const keys = GeoPoint(25.010, -80.376);
+
+  group('probe', () {
+    test('returns the finest catalogue item converted to meters', () async {
+      final source = NoaaDemSource(
+        client: MockClient(
+          (req) async => http.Response(
+            identifyBody([
+              (name: 'ETOPO_2022_v1_15s_surface_elev', lowPs: 0.0041666),
+              (name: 'ncei19_n25x25_w080x50_2016v1', lowPs: 3.086419e-05),
+            ]),
+            200,
+          ),
+        ),
+      );
+      final cap = await source.probe(keys);
+      expect(cap, isNotNull);
+      expect(cap!.cellSizeMeters, closeTo(3.4, 0.3));
+      expect(cap.detail, 'ncei19_n25x25_w080x50_2016v1');
+    });
+
+    test('requests maxItemCount so the catalogue is not truncated', () async {
+      Uri? seen;
+      final source = NoaaDemSource(
+        client: MockClient((req) async {
+          seen = req.url;
+          return http.Response(identifyBody([]), 200);
+        }),
+      );
+      await source.probe(keys);
+      expect(seen!.queryParameters['maxItemCount'], '25');
+      expect(seen!.queryParameters['returnCatalogItems'], 'true');
+    });
+
+    test('declines when the best item is coarser than the threshold', () async {
+      final source = NoaaDemSource(
+        client: MockClient(
+          (req) async => http.Response(
+            identifyBody([
+              (name: 'ETOPO_2022_v1_15s_surface_elev', lowPs: 0.0041666),
+            ]),
+            200,
+          ),
+        ),
+      );
+      // ~464 m at the equator, far past the 50 m usefulness threshold.
+      expect(await source.probe(const GeoPoint(12.093, -68.287)), isNull);
+    });
+
+    test('declines on an empty catalogue', () async {
+      final source = NoaaDemSource(
+        client: MockClient((req) async => http.Response(identifyBody([]), 200)),
+      );
+      expect(await source.probe(keys), isNull);
+    });
+
+    test('declines on an ArcGIS error envelope returned with HTTP 200',
+        () async {
+      final source = NoaaDemSource(
+        client: MockClient(
+          (req) async => http.Response(
+            jsonEncode({
+              'error': {'code': 400, 'message': 'Invalid geometry'},
+            }),
+            200,
+          ),
+        ),
+      );
+      expect(await source.probe(keys), isNull);
+    });
+
+    test('declines on a non-200', () async {
+      final source = NoaaDemSource(
+        client: MockClient((req) async => http.Response('nope', 503)),
+      );
+      expect(await source.probe(keys), isNull);
+    });
+  });
+
+  group('fetch', () {
+    test('requests a float32 tiff over the span and parses it', () async {
+      Uri? seen;
+      final source = NoaaDemSource(
+        client: MockClient((req) async {
+          seen = req.url;
+          return http.Response.bytes(tinyTiff(), 200);
+        }),
+      );
+      final g = await source.fetch(keys, spanMeters: 2000);
+      expect(seen!.path, endsWith('/exportImage'));
+      expect(seen!.queryParameters['format'], 'tiff');
+      expect(seen!.queryParameters['pixelType'], 'F32');
+      expect(seen!.queryParameters['bboxSR'], '4326');
+      expect(g.rows, 2);
+      expect(g.cols, 2);
+      expect(g.depthAt(0, 0), closeTo(8.0, 1e-6));
+      expect(g.sourceId, NoaaDemSource.sourceId);
+    });
+
+    test('throws BathymetryFetchException on a non-200', () async {
+      final source = NoaaDemSource(
+        client: MockClient((req) async => http.Response('down', 500)),
+      );
+      expect(
+        () => source.fetch(keys, spanMeters: 2000),
+        throwsA(isA<BathymetryFetchException>()),
+      );
+    });
+
+    test('throws BathymetryFetchException on an unparseable body', () async {
+      final source = NoaaDemSource(
+        client: MockClient(
+          (req) async => http.Response('{"error":{"code":400}}', 200),
+        ),
+      );
+      expect(
+        () => source.fetch(keys, spanMeters: 2000),
+        throwsA(isA<BathymetryFetchException>()),
+      );
+    });
+  });
+
+  test('is not global, so a dry answer never proves land', () {
+    expect(NoaaDemSource().global, isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/bathymetry/data/noaa_dem_source_test.dart`
+
+Expected: FAIL, compile error: the target of the URI does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `lib/features/bathymetry/data/sources/noaa_dem_source.dart`:
+
+```dart
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'package:submersion/core/utils/geo_math.dart';
+import 'package:submersion/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart';
+import 'package:submersion/features/bathymetry/domain/bathymetry_grid.dart';
+import 'package:submersion/features/bathymetry/domain/bathymetry_source.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+/// High-resolution coastal tier: the NOAA NCEI DEM mosaic ImageServer,
+/// which stacks CUDEM and regional DEMs over an ETOPO background. Public
+/// domain. Coverage is patchy and mostly US coastal, so this source
+/// declines wherever the stack holds nothing better than the background.
+///
+/// The probe is what makes that honest. `identify` returns every DEM under
+/// a point with its cell size, so the source knows before fetching whether
+/// it has anything worth having: 3.4 m in the Florida Keys, 10.3 m at La
+/// Jolla, and only ETOPO's 464 m at Bonaire, where it declines.
+class NoaaDemSource implements BathymetrySource {
+  static const String sourceId = 'noaa_dem';
+
+  /// Below this cell size the mosaic is offering a real coastal DEM. Above
+  /// it, the stack has nothing but its ETOPO background, which the ETOPO
+  /// tier already serves directly.
+  static const double usefulCellSizeMeters = 50;
+
+  /// Cells per side requested from exportImage. The server resamples to
+  /// whatever is asked, so this is a render-budget choice, not a data one.
+  static const int requestDim = 256;
+
+  static const Duration _timeout = Duration(seconds: 15);
+
+  final http.Client _client;
+  final String baseUrl;
+
+  NoaaDemSource({
+    http.Client? client,
+    this.baseUrl =
+        'https://gis.ngdc.noaa.gov/arcgis/rest/services/DEM_mosaics/DEM_all/ImageServer',
+  }) : _client = client ?? http.Client();
+
+  @override
+  String get id => sourceId;
+
+  /// Coverage is patchy coastal, so a dry answer here proves nothing about
+  /// whether a coordinate is on land.
+  @override
+  bool get global => false;
+
+  @override
+  Future<SourceCapability?> probe(GeoPoint center) async {
+    final url = Uri.parse('$baseUrl/identify').replace(
+      queryParameters: {
+        'geometry': '{"x":${center.longitude},"y":${center.latitude}}',
+        'geometryType': 'esriGeometryPoint',
+        'returnCatalogItems': 'true',
+        // Load-bearing. The default truncates to three items, which hides
+        // a 10 m DEM behind the ETOPO background and makes a covered site
+        // look uncovered.
+        'maxItemCount': '25',
+        'f': 'json',
+      },
+    );
+    try {
+      final resp = await _client.get(url).timeout(_timeout);
+      if (resp.statusCode != 200) return null;
+      final body = jsonDecode(resp.body);
+      if (body is! Map<String, dynamic>) return null;
+      // ArcGIS returns error envelopes with HTTP 200.
+      final items = (body['catalogItems'] as Map<String, dynamic>?)?['features'];
+      if (items is! List || items.isEmpty) return null;
+
+      String? bestName;
+      double? bestDeg;
+      for (final item in items) {
+        if (item is! Map) continue;
+        final attrs = item['attributes'];
+        if (attrs is! Map) continue;
+        final lowPs = attrs['LowPS'];
+        if (lowPs is! num) continue;
+        final deg = lowPs.toDouble();
+        if (deg <= 0) continue;
+        if (bestDeg == null || deg < bestDeg) {
+          bestDeg = deg;
+          bestName = attrs['Name'] as String?;
+        }
+      }
+      if (bestDeg == null) return null;
+
+      // LowPS is in degrees; convert on the longitude axis, which is the
+      // narrower of the two at every latitude.
+      final meters = bestDeg * metersPerDegreeLongitude(center.latitude);
+      if (meters > usefulCellSizeMeters) return null;
+      return SourceCapability(
+        cellSizeMeters: meters,
+        detail: bestName ?? 'NOAA NCEI DEM',
+      );
+    } catch (_) {
+      // A probe never throws: an unreachable or surprising service simply
+      // means this source does not contribute here.
+      return null;
+    }
+  }
+
+  @override
+  Future<BathymetryGrid> fetch(
+    GeoPoint center, {
+    required double spanMeters,
+  }) async {
+    final dLat = spanMeters / 2 / 110540.0;
+    final dLon = spanMeters / 2 / metersPerDegreeLongitude(center.latitude);
+    final west = center.longitude - dLon;
+    final east = center.longitude + dLon;
+    final south = center.latitude - dLat;
+    final north = center.latitude + dLat;
+    final url = Uri.parse('$baseUrl/exportImage').replace(
+      queryParameters: {
+        'bbox': '$west,$south,$east,$north',
+        'bboxSR': '4326',
+        'imageSR': '4326',
+        'size': '$requestDim,$requestDim',
+        'format': 'tiff',
+        'pixelType': 'F32',
+        'noDataInterpretation': 'esriNoDataMatchAny',
+        'interpolation': 'RSP_BilinearInterpolation',
+        'f': 'image',
+      },
+    );
+    try {
+      final resp = await _client.get(url).timeout(_timeout);
+      if (resp.statusCode != 200) {
+        throw BathymetryFetchException('NOAA DEM HTTP ${resp.statusCode}');
+      }
+      return ArcgisFloat32TiffParser.parse(
+        resp.bodyBytes,
+        westLon: west,
+        eastLon: east,
+        southLat: south,
+        northLat: north,
+        sourceId: sourceId,
+        resolutionMeters: spanMeters / requestDim,
+        fetchedAt: DateTime.now(),
+      );
+    } on BathymetryFetchException {
+      rethrow;
+    } on Exception catch (e) {
+      throw BathymetryFetchException('NOAA DEM fetch failed: $e');
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/bathymetry/data/noaa_dem_source_test.dart`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/bathymetry/data/sources/noaa_dem_source.dart test/features/bathymetry/data/noaa_dem_source_test.dart
+git commit -m "feat(bathymetry): add the NOAA NCEI high-resolution coastal tier
+
+The mosaic stacks CUDEM and regional DEMs over an ETOPO background, so
+coverage is patchy and mostly US coastal. The identify probe is what keeps
+that honest: it reports every DEM under a point with its cell size, so the
+source declines wherever the stack offers nothing better than the
+background it already has from the ETOPO tier.
+
+Measured 3.4 m in the Florida Keys and 10.3 m at La Jolla, declining at
+Bonaire. maxItemCount is load-bearing: the default truncates the catalogue
+to three items and hides a covered site's DEM behind ETOPO."
+```
+
+---
+
+### Task 6: Register the tier and bump the cache generation
+
+Selection now produces different grids for coordinates that are already cached, and cached rows never expire.
+
+**Files:**
+- Modify: `lib/features/bathymetry/application/bathymetry_providers.dart:29-36`
+- Modify: `lib/features/bathymetry/data/bathymetry_repository.dart:36-42`
+- Test: `test/features/bathymetry/data/bathymetry_repository_test.dart`
+
+**Interfaces:**
+- Consumes: `NoaaDemSource` from Task 5.
+- Produces: `BathymetryRepository.selectionGeneration` (`'v2'`); `keyFor` returns `'<lat>,<lon>@<span><generation>'`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/features/bathymetry/data/bathymetry_repository_test.dart`, inside `void main()`:
+
+```dart
+  test('the cache key carries the selection generation', () {
+    final key = BathymetryRepository.keyFor(const GeoPoint(12.16, -68.29));
+    expect(key, endsWith('@8000v2'));
+  });
+
+  test('a row written under the previous generation is not reused', () async {
+    // Simulates an install upgrading from the pre-selection-change build:
+    // the old row must miss so the coordinate refetches under the new
+    // source ordering rather than serving its stale EMODnet grid forever.
+    const p = GeoPoint(12.16, -68.29);
+    final q = BathymetryRepository.quantize(p);
+    final legacyKey =
+        '${q.lat.toStringAsFixed(2)},${q.lon.toStringAsFixed(2)}@8000';
+    expect(BathymetryRepository.keyFor(p), isNot(legacyKey));
+  });
+```
+
+Add `import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';` if `GeoPoint` is not already imported there.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/bathymetry/data/bathymetry_repository_test.dart`
+
+Expected: FAIL. The key currently ends `@8000`, so the `endsWith('@8000v2')` assertion fails.
+
+- [ ] **Step 3: Implement**
+
+In `lib/features/bathymetry/data/bathymetry_repository.dart`, add beside `maxGridDim`:
+
+```dart
+  /// Bumped whenever source SELECTION changes, not just the span. Cached
+  /// rows never expire, so without this every already-visited site would
+  /// keep serving the grid its old resolver chose. Old rows go inert, the
+  /// same way the 4 km rows did when the span went to 8 km.
+  static const String selectionGeneration = 'v2';
+```
+
+and change `keyFor`:
+
+```dart
+  static String keyFor(GeoPoint c) {
+    final q = quantize(c);
+    // The span and the selection generation are both part of the key:
+    // cached rows never expire, so any change that would resolve a
+    // coordinate differently must miss the old rows and refetch.
+    final span = BathymetryResolver.defaultSpanMeters.round();
+    return '${q.lat.toStringAsFixed(2)},${q.lon.toStringAsFixed(2)}'
+        '@$span$selectionGeneration';
+  }
+```
+
+In `lib/features/bathymetry/application/bathymetry_providers.dart`, add the import and register the tier:
+
+```dart
+import 'package:submersion/features/bathymetry/data/sources/noaa_dem_source.dart';
+```
+
+```dart
+      resolver: BathymetryResolver(
+        // Declared order is regional survey, then global GMRT, then the
+        // coarse public-domain fallback. NOAA's coastal mosaic leads only
+        // where it is MATERIALLY finer, which the resolver's preemption
+        // factor decides; where the mosaic holds nothing but its ETOPO
+        // background it declines during probe and never reaches a fetch.
+        sources: [
+          NoaaDemSource(),
+          EmodnetSource(),
+          GmrtSource(),
+          EtopoErddapSource(),
+        ],
+      ),
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/features/bathymetry`
+
+Expected: PASS. Any existing test asserting a literal `@8000` key must be updated to `@8000v2`; grep for it:
+
+```bash
+grep -rn "@8000" test lib
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/bathymetry test/features/bathymetry
+git commit -m "feat(bathymetry): register the NOAA tier and bump the cache generation
+
+Cached grids never expire, so changing which source wins would otherwise
+leave every already-visited site serving the grid its old resolver picked.
+The key gains a selection-generation token so those rows go inert, exactly
+as the 4 km rows did when the span went to 8 km."
+```
+
+---
+
+### Task 7: Name the new tier in the provenance caption and credits
+
+A new `sourceId` reaches two user-visible surfaces. Neither breaks, which
+is why this is easy to miss: `bathymetrySourceDisplayName` falls through to
+`_ => id`, so the caption would read the raw string `noaa_dem`, and the
+about-screen credit would simply not mention the source at all.
+
+**Files:**
+- Modify: `lib/features/bathymetry/presentation/bathymetry_labels.dart:3-8`
+- Modify: `lib/l10n/arb/app_en.arb` and the ten other locale ARBs
+- Test: `test/features/bathymetry/presentation/bathymetry_labels_test.dart` (create if absent)
+
+**Interfaces:**
+- Consumes: `NoaaDemSource.sourceId` from Task 5.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Write the failing test**
+
+Create or append to `test/features/bathymetry/presentation/bathymetry_labels_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/bathymetry/data/sources/noaa_dem_source.dart';
+import 'package:submersion/features/bathymetry/presentation/bathymetry_labels.dart';
+
+void main() {
+  test('every shipped source id has a human display name', () {
+    // The switch falls through to the raw id, so a missing case is not a
+    // crash: it is a caption reading "noaa_dem" at the user.
+    for (final id in const ['gmrt', 'emodnet', 'etopo2022', NoaaDemSource.sourceId]) {
+      expect(bathymetrySourceDisplayName(id), isNot(id), reason: id);
+    }
+  });
+
+  test('an unknown id still falls back to itself rather than throwing', () {
+    expect(bathymetrySourceDisplayName('future_source'), 'future_source');
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/bathymetry/presentation/bathymetry_labels_test.dart`
+
+Expected: FAIL on the `noaa_dem` entry, because the switch returns the id unchanged.
+
+- [ ] **Step 3: Implement**
+
+In `lib/features/bathymetry/presentation/bathymetry_labels.dart`, add the case:
+
+```dart
+String bathymetrySourceDisplayName(String id) => switch (id) {
+  'gmrt' => 'GMRT',
+  'emodnet' => 'EMODnet',
+  'etopo2022' => 'ETOPO 2022',
+  'noaa_dem' => 'NOAA NCEI',
+  _ => id,
+};
+```
+
+Then append the new source to `settings_about_bathymetryCredit` in **all
+eleven** ARB files. The source list after each locale's own prefix is an
+identical run of proper nouns, so the edit is the same everywhere: append
+` · NOAA NCEI DEM` to the end of the value. NOAA NCEI DEMs are US public
+domain, so no licence marker is needed, matching how ETOPO is already
+listed.
+
+Files: `lib/l10n/arb/app_ar.arb`, `app_de.arb`, `app_en.arb`, `app_es.arb`,
+`app_fr.arb`, `app_he.arb`, `app_hu.arb`, `app_it.arb`, `app_nl.arb`,
+`app_pt.arb`, `app_zh.arb`.
+
+English becomes:
+
+```json
+  "settings_about_bathymetryCredit": "Bathymetry data: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM",
+```
+
+Then regenerate, **from the project root** (`flutter gen-l10n` fails when
+run from a subdirectory):
+
+```bash
+flutter gen-l10n
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `flutter test test/features/bathymetry test/features/settings`
+
+Expected: PASS. Confirm the generated hub picked the change up in every
+locale, since CI regenerates l10n but does not verify it:
+
+```bash
+grep -c "NOAA NCEI DEM" lib/l10n/arb/app_localizations_*.dart
+```
+
+Expected: a count of 1 for each of the generated locale files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/bathymetry/presentation/bathymetry_labels.dart lib/l10n test/features/bathymetry/presentation/bathymetry_labels_test.dart
+git commit -m "feat(bathymetry): credit the NOAA NCEI tier in caption and about
+
+The display-name switch falls through to the raw id, so a missing case is
+not a crash: the provenance caption would have read noaa_dem at the user.
+The about screen's source list gains the tier across all eleven locales."
+```
+
+---
+
+### Task 8: Verify the whole tree and format
+
+**Files:**
+- Modify: whatever the checks turn up.
+
+**Interfaces:**
+- Consumes: every earlier task.
+- Produces: a branch that passes the pre-push gates.
+
+- [ ] **Step 1: Format**
+
+Run: `dart format .`
+
+- [ ] **Step 2: Analyze the whole project**
+
+Run: `flutter analyze`
+
+Expected: no issues. Infos are CI-fatal in this repo, so treat every info as a failure and fix it.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `flutter test`
+
+Expected: all pass. Do not pipe the output through `grep`; a pipe masks the exit code in this repo.
+
+Investigate every failure rather than adjusting an assertion to match new behaviour, except where a test legitimately asserted the old striding downsample or the old `@8000` key.
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -u
+git commit -m "chore(bathymetry): format and fix analyzer findings"
+```
+
+Stage explicit paths rather than `git add -A`, which sweeps edits from sibling worktrees.
+
+- [ ] **Step 5: Report**
+
+Report the analyze result and the full-suite pass/fail/skip counts verbatim. Do not claim the work is complete without those numbers.
+
+---
+
+## Manual verification
+
+After Task 7, confirm the change against the live services rather than only against mocks. This is the part that proves PR 1 delivered what it promised.
+
+Bonaire, the reported case:
+
+```bash
+flutter test test/features/bathymetry
+```
+
+then in the running app, open a Bonaire site's seascape and check the provenance caption. It must name GMRT at roughly 60 m rather than EMODnet at 115 m, and the scene must show a real coastline rather than a flat tan slab across half the box.
+
+A US coastal site (Florida Keys or La Jolla) must report the NOAA tier at single-digit or low-double-digit meters.
+
+If a site still reports EMODnet, check that the cache generation bump actually missed the old row: the local cache `bathymetry_cache` table should hold a `@8000v2` key for that cell.

--- a/docs/superpowers/plans/2026-09-05-seascape-source-layer.md
+++ b/docs/superpowers/plans/2026-09-05-seascape-source-layer.md
@@ -669,7 +669,8 @@ Replace `BathymetryResolver` in `lib/features/bathymetry/data/bathymetry_resolve
 /// passes both quality floors.
 ///
 /// No mosaicking: sources use different vertical datums (EMODnet is LAT,
-/// GMRT and ETOPO are MSL) and stitching them seams.
+/// GMRT and ETOPO are MSL), so stitching two of them together would leave
+/// a visible step wherever they meet.
 class BathymetryResolver {
   static const double minWetFraction = 0.10;
 

--- a/docs/superpowers/specs/2026-09-05-seascape-extent-and-detail-design.md
+++ b/docs/superpowers/specs/2026-09-05-seascape-extent-and-detail-design.md
@@ -105,8 +105,28 @@ returns null when the best `LowPS` is coarser than
 `NoaaDemSource.usefulCellSizeMeters` (50 m), so the mosaic's ETOPO fallback
 never masquerades as high-resolution data.
 
-`BathymetryResolver` probes every source concurrently, sorts by declared
-cell size ascending, then fetches in that order and accepts the first grid
+`BathymetryResolver` probes every source concurrently, then orders them by
+**materially better resolution only**: a source preempts the declared list
+order when its declared cell size is more than `preemptionFactor` (2.0)
+finer. Within that factor, the declared order stands, so a regional survey
+still outranks a global grid of nominally similar resolution.
+
+This band matters. GMRT declares ~60 m against EMODnet's 115 m, a factor of
+1.9, so a flat resolution sort would demote EMODnet across all of Europe on
+a nominal number. Measured on 2026-09-05, GMRT's European grids are not
+block-upsampled GEBCO (identical-neighbour fractions of 4.2% at the Medes
+Islands and 0.1% at Zakynthos, against the ~87% a nearest-neighbour upsample
+would show), but the Medes grid's 0.70 m median neighbour step is smooth
+enough that its true information content is unproven. NOAA CUDEM at 3.4 m
+clears the factor by 18x and rightly preempts everything.
+
+Bonaire is fixed by the floors rather than by the ordering: EMODnet stays
+ahead of GMRT on declared resolution, then fails the known-cell floor at
+48%, and the resolver falls through to GMRT. That is the intended division
+of labour. Ordering promotes materially better data; the floors reject data
+that is nominally fine but actually absent.
+
+The resolver fetches in the resulting order and accepts the first grid
 passing **both** floors:
 
 - `minWetFraction` 0.10 (unchanged)
@@ -115,6 +135,13 @@ passing **both** floors:
 The known-cell floor is what rejects EMODnet's 48%-nodata Bonaire tile. A
 source failing either floor falls through to the next; the definitive-versus
 -transient distinction and its caching rules are unchanged.
+
+Changing selection changes which grid a coordinate resolves to, but the
+cache key is `<lat>,<lon>@<span>` and cached rows never expire, so every
+already-visited site would keep serving its old EMODnet grid forever. The
+key therefore gains a selection-generation token, `@8000v2`, bumped whenever
+selection logic changes. Old rows go inert exactly as they did at the 4 km
+to 8 km change.
 
 Declared resolution is a claim, not a measurement. GMRT in particular
 returns a fine nominal grid even where the underlying data is upsampled

--- a/docs/superpowers/specs/2026-09-05-seascape-extent-and-detail-design.md
+++ b/docs/superpowers/specs/2026-09-05-seascape-extent-and-detail-design.md
@@ -58,9 +58,27 @@ returned 53.7% land above zero.
 ### Render budget
 
 GMRT holds ~60 m natively at any span, so a naive 30 km box would be
-504 x 495 cells = 496,964 triangles against today's 28,322. The painter is a
-CPU painter's algorithm with a full per-frame triangle sort and no depth
-buffer, so uniform scaling is not available.
+504 x 495 cells = 496,964 triangles. The painter is a CPU painter's
+algorithm with a full per-frame triangle sort and no depth buffer, so
+uniform scaling is not available.
+
+Measured end to end on 2026-09-05, after PR 1 landed, the cap is the
+binding constraint well before the painter is:
+
+| Site | Fetched | Rendered after the 120 cap | Triangles |
+| --- | --- | --- | --- |
+| Bonaire | 133 x 136 @ 60 m | 67 x 68 @ 120 m | 8,844 |
+| Florida Keys | 256 x 256 @ 31 m | 86 x 86 @ 94 m | 14,450 |
+| Medes Islands | 70 x 94 @ 115 m | unchanged | 12,834 |
+
+Two consequences for PR 3. Real scenes run 8,800 to 14,500 triangles, not
+the 28,322 a full 120 x 120 would produce, so there is more headroom than a
+worst-case reading of the cap suggests. And `maxGridDim` currently discards
+most of what the new source layer fetches: Bonaire renders at 120 m from a
+60 m grid, which is no better than the 115 m EMODnet tile it replaced. PR 1
+delivers coverage and a real coastline there; the resolution win is still
+locked behind the cap, and raising it is the single highest-leverage change
+left. It stays gated on the budget measurement rather than guessed at.
 
 ## Root causes
 

--- a/docs/superpowers/specs/2026-09-05-seascape-extent-and-detail-design.md
+++ b/docs/superpowers/specs/2026-09-05-seascape-extent-and-detail-design.md
@@ -1,0 +1,276 @@
+# 3D Seascape: Extent and Detail
+
+Status: proposed
+Date: 2026-09-05
+Related: `2026-07-28-site-bathymetry-seascape-design.md`,
+`2026-07-28-seascape-axes-and-extent-design.md`,
+`2026-08-15-seascape-contours-chart-mode-design.md`
+
+## Problem
+
+Two complaints, reported together:
+
+1. The seascape shows too little area. It is "very constrained".
+2. Dives close to shore look like they sit on the shoreline, with no real
+   detail around the dive itself.
+
+The current scene is a single 8 km square grid capped at 120x120 cells, so
+67 m per cell at best. That square is the entire seascape: panning and
+zooming reveal nothing beyond it, and zooming in past the cell size only
+magnifies the same triangles.
+
+## Measured evidence
+
+All figures below come from the app's exact request shapes issued live on
+2026-09-05.
+
+### Bonaire (12.0930 N, 68.2870 W), 8 km box
+
+| | EMODnet (tier 1, selected today) | GMRT (tier 2, never reached) |
+| --- | --- | --- |
+| Grid | 71 x 71 | 136 x 133 |
+| Cell size | 115 m | 60 m |
+| Known cells | 2,611 of 5,041 (48% nodata) | 18,088 of 18,088 (0% nodata) |
+| Land cells | 0 | 45%, with a real coastline |
+| Max depth in box | 668 m | 637 m |
+| Wet cells shallower than 40 m | 5.6% | 2.3% |
+
+### NOAA NCEI DEM mosaic ImageServer
+
+`identify?returnCatalogItems=true&maxItemCount=25` returns every DEM in the
+mosaic stack under a point with its `LowPS` cell size:
+
+| Site | Best catalog item | Cell size |
+| --- | --- | --- |
+| Florida Keys | `ncei19_n25x25_w080x50_2016v1` | 3.4 m |
+| La Jolla | `san_diego_navd88` | 10.3 m |
+| Bonaire | `ETOPO_2022_v1_15s_surface_elev` | 464 m |
+
+`maxItemCount` is load-bearing: the response truncates to three items by
+default, which hides La Jolla's 10 m DEM behind ETOPO.
+
+`exportImage` with `format=tiff&pixelType=F32` returns an uncompressed,
+**tiled** (128 x 128 tiles), little-endian float32 GeoTIFF at any requested
+size up to 20000 x 20000. A 2 km box at Molasses Reef returned 256 x 256 at
+7.8 m per cell, values -1.5 m to -39.2 m, zero nodata. A shoreline box
+returned 53.7% land above zero.
+
+### Render budget
+
+GMRT holds ~60 m natively at any span, so a naive 30 km box would be
+504 x 495 cells = 496,964 triangles against today's 28,322. The painter is a
+CPU painter's algorithm with a full per-frame triangle sort and no depth
+buffer, so uniform scaling is not available.
+
+## Root causes
+
+1. **Tier order selects the worse source.** `BathymetryResolver.resolve`
+   accepts the first tier returning >= 10% wet cells. EMODnet's Caribbean
+   tile returns 99.96% wet, so it always wins at Bonaire despite having half
+   the resolution, half the cells missing, and no land at all.
+2. **Nodata renders as flat shoreline.** `BathymetryTerrainBuilder
+   .surfaceDepth` maps `null` to depth 0.0, and the colour branch treats
+   `raw == null` as `landColor`. EMODnet's 48% nodata therefore becomes a
+   flat sand-coloured slab at the waterline. This is the literal cause of
+   "looks like it's basically on the shoreline".
+3. **The dive zone is vertically crushed.** `SpatialProjection.maxDepth`
+   comes from the deepest cell in the box. At Bonaire that is 668 m, so the
+   0-40 m band where diving happens occupies 6% of scene height. Widening
+   the box makes this strictly worse, because a wider box catches deeper
+   water.
+4. **The cell cap discards fetched detail.** `downsampleTo(120)` uses an
+   integer stride, so GMRT's 136 columns collapse to 68: a 2x loss to clear
+   a cap exceeded by 13%. It also picks every Nth sample rather than
+   averaging, so the discarded cells contribute nothing.
+
+## Design
+
+### 1. Capability-driven source selection
+
+`BathymetrySource` gains:
+
+```dart
+Future<SourceCapability?> probe(GeoPoint center);
+
+class SourceCapability {
+  final double cellSizeMeters;   // declared, best available at this point
+  final String detail;           // provenance, e.g. the DEM's catalogue name
+}
+```
+
+`probe` returns null for "I do not cover this point", replacing the
+synchronous `covers`. EMODnet, GMRT and ETOPO answer from constants without
+a network call. `NoaaDemSource` answers from the `identify` pre-flight and
+returns null when the best `LowPS` is coarser than
+`NoaaDemSource.usefulCellSizeMeters` (50 m), so the mosaic's ETOPO fallback
+never masquerades as high-resolution data.
+
+`BathymetryResolver` probes every source concurrently, sorts by declared
+cell size ascending, then fetches in that order and accepts the first grid
+passing **both** floors:
+
+- `minWetFraction` 0.10 (unchanged)
+- `minKnownFraction` 0.60 (new): the fraction of non-nodata cells
+
+The known-cell floor is what rejects EMODnet's 48%-nodata Bonaire tile. A
+source failing either floor falls through to the next; the definitive-versus
+-transient distinction and its caching rules are unchanged.
+
+Declared resolution is a claim, not a measurement. GMRT in particular
+returns a fine nominal grid even where the underlying data is upsampled
+GEBCO. The known-cell floor plus the existing provenance caption are the
+mitigation; this design does not attempt to measure information content.
+
+### 2. Nodata renders as a hole
+
+`surfaceDepth` stops inventing a waterline value for nodata. Grid quads
+with any nodata corner are omitted from the terrain index buffer. The
+translucent water plane already spans the full box, so a gap reads as water
+with no data rather than as land.
+
+`TerrainCeiling`, `sampleGridDepth` and the hover picker already return null
+for nodata cells and need no change. Contours, walls and the depth ramp
+already skip them.
+
+### 3. Nested level of detail
+
+Two grids are fetched per site and merged into one terrain mesh.
+
+```
++---------------------------------------+
+|                                       |   OUTER
+|             +-----------+             |   outerSpanMeters (24 km default)
+|             |   INNER   |             |   outerMaxDim cells
+|             |     * site|             |
+|             +-----------+             |   INNER
+|                                       |   innerSpanMeters (2 km default)
++---------------------------------------+   innerMaxDim cells, native res
+```
+
+- **Inner grid**: `innerSpanMeters` centred on the site, requested at the
+  finest resolution the winning source offers, capped at `innerMaxDim`.
+- **Outer grid**: `outerSpanMeters`, requested coarse, capped at
+  `outerMaxDim`.
+- **Merge**: outer quads whose centre falls inside the inner box are
+  dropped, leaving a rectangular hole. The inner grid fills it.
+- **Stitch band**: a ring of triangles bridges the outer hole's edge to the
+  inner grid's edge, with vertices welded to both. The two grids have
+  different cell sizes, so their edge vertices do not correspond; without
+  the band the seam is a see-through crack at every camera angle.
+
+Sources may differ between the two grids (CUDEM inner, GMRT outer). Vertical
+datums then differ, which the original seascape design correctly warned
+against mosaicking. The mitigation is explicit: the inner grid is offset by
+the **median delta along its boundary ring**, sampled against the outer grid
+at the same coordinates. The offset is recorded on the merged grid and
+surfaced in the provenance caption. It is never applied silently, and it is
+skipped entirely when both grids come from one source.
+
+Cache keys gain a role suffix: `<lat>,<lon>@in<span>` and
+`<lat>,<lon>@out<span>`. Existing `@8000` rows go inert, as they did at the
+4 km to 8 km change.
+
+### 4. Depth scale from the site's dives
+
+`SpatialProjection.maxDepth` stops being the box maximum. The new
+`depthWindowMeters` is:
+
+1. the deepest recorded dive at this site multiplied by 1.25, floored at
+   20 m and clamped to the grid's own maximum; or
+2. with no dives on record, the 80th percentile of the box's wet cells.
+
+`siteSeascapeProvider` already gathers `atSite` dives for path
+reconstruction, so the deepest dive is available with no new query.
+
+Terrain deeper than the window renders past the box floor and is clipped by
+the viewport. `SceneProjector` fits to the declared `bounds.sceneMinY` and
+`sceneMaxY` rather than to actual geometry extent, so this needs only that
+`sceneMinY` stay pinned at `-SceneBounds.ySpan`. The current
+`math.min(-SceneBounds.ySpan, proj.yOf(pinDepth))` grows the frame to keep a
+deep site pin in view; that growth is removed, because it would re-crush the
+scene and undo this change. A site pin deeper than the window is clamped to
+the floor with its recorded depth still shown in the marker label.
+
+The depth axis is built from the same window, so its ticks stay linear and
+truthful. The ramp's `rampMaxDepthMeters` appearance setting is unchanged
+and still controls colour only.
+
+### 5. Averaging downsample
+
+`BathymetryGrid.downsampleTo` averages each stride block's known cells
+instead of picking the block's first sample, and returns nodata only where a
+block is entirely nodata. Striding discards up to 3/4 of a fetched grid; a
+block mean keeps the information and suppresses single-cell noise.
+
+### 6. Render budget, measured first
+
+`innerMaxDim` and `outerMaxDim` are **not** fixed by this design. The first
+implementation task instruments `Dive3dScenePainter` frame time against
+triangle count on real hardware and sets both from the measurement. Today's
+scene is ~28,300 triangles; the merged scene will be larger, and the budget
+is the binding constraint on every dimension above. No dimension is chosen
+by guess.
+
+`_isolateCellThreshold` (4000 cells) already routes large scenes through
+`compute()`. The merged scene exceeds it in every case, so the isolate path
+becomes the norm rather than the exception, and the synchronous path remains
+only for widget tests.
+
+## Provenance
+
+The caption must name both grids: source, cell size and span for each, plus
+the datum offset when one was applied. A scene whose inner and outer grids
+come from different sources is a legitimate composite, and the UI says so.
+
+## Testing
+
+- `BathymetryResolver`: probe ordering, the known-cell floor rejecting a
+  48%-nodata grid, fall-through on a failed floor, and the unchanged
+  definitive-versus-transient contract.
+- `NoaaDemSource`: `identify` parsing including the `maxItemCount`
+  truncation trap, the 50 m usefulness threshold declining Bonaire, and the
+  tiled float32 GeoTIFF parser against a recorded fixture.
+- `BathymetryGrid.downsampleTo`: block means, all-nodata blocks staying
+  nodata, and the resolution claim tracking the stride.
+- Terrain builder: nodata quads absent from the index buffer, land and wet
+  cells unaffected.
+- LOD merge: the outer hole matches the inner extent, the stitch band leaves
+  no gap (every boundary edge shared by exactly two triangles), and the
+  datum offset is the boundary-ring median.
+- Depth window: deepest-dive derivation, the 20 m floor, the grid clamp, the
+  no-dives percentile fallback, and `sceneMinY` staying pinned when terrain
+  runs deeper than the window.
+- A render regression extending the existing `map_frame_handedness_test`
+  approach: a synthetic asymmetric two-level grid rendered through the real
+  painter, asserting the seam produces no background pixels along the
+  boundary ring.
+
+## Delivery
+
+Three PRs, each independently shippable and each a visible improvement on
+its own. Later phases do not silently depend on earlier ones landing.
+
+**PR 1: source layer.** `probe`/`SourceCapability`, capability-ordered
+selection, the known-cell floor, `NoaaDemSource`, and the averaging
+downsample. No change to the scene's architecture, but on its own it moves
+Bonaire from 115 m EMODnet to 60 m GMRT with a real coastline, and gives US
+coastal sites 3 m to 10 m CUDEM.
+
+**PR 2: honesty and vertical scale.** Nodata quads dropped, the depth window
+derived from the site's dives, `sceneMinY` pinned, the site pin clamped, and
+the depth axis rebuilt from the window. On its own this is what stops
+near-shore dives reading as beached.
+
+**PR 3: nested level of detail.** The painter budget measurement first, then
+the inner and outer grids, the merge with its hole, the stitch band, the
+datum offset, the two-role cache keys, and the composite provenance caption.
+The constants come from the measurement taken at the head of this PR.
+
+## Out of scope
+
+- Zoom-driven refetching. The two levels are fixed per site.
+- More than two levels.
+- Any new appearance setting. Spans and caps are constants until there is
+  evidence divers want to tune them.
+- Measuring a source's true information content as opposed to its declared
+  resolution.

--- a/lib/features/bathymetry/application/bathymetry_providers.dart
+++ b/lib/features/bathymetry/application/bathymetry_providers.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/bathymetry/data/bathymetry_resolver.dart';
 import 'package:submersion/features/bathymetry/data/sources/emodnet_source.dart';
 import 'package:submersion/features/bathymetry/data/sources/etopo_erddap_source.dart';
 import 'package:submersion/features/bathymetry/data/sources/gmrt_source.dart';
+import 'package:submersion/features/bathymetry/data/sources/noaa_dem_source.dart';
 import 'package:submersion/features/bathymetry/domain/bathymetry_grid.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 
@@ -29,9 +30,18 @@ final bathymetryRepositoryProvider = Provider<BathymetryRepository?>((ref) {
     return BathymetryRepository(
       db: db,
       resolver: BathymetryResolver(
-        // Tier order: regional survey data first, then global GMRT, then
-        // the coarse public-domain fallback.
-        sources: [EmodnetSource(), GmrtSource(), EtopoErddapSource()],
+        // Declared order: regional survey data first, then global GMRT,
+        // then the coarse public-domain fallback. NOAA's coastal mosaic
+        // leads only where it is MATERIALLY finer, which the resolver's
+        // preemption factor decides; where the mosaic holds nothing but
+        // its ETOPO background it declines during probe and is never
+        // fetched.
+        sources: [
+          NoaaDemSource(),
+          EmodnetSource(),
+          GmrtSource(),
+          EtopoErddapSource(),
+        ],
       ),
     );
   } on StateError {

--- a/lib/features/bathymetry/data/bathymetry_repository.dart
+++ b/lib/features/bathymetry/data/bathymetry_repository.dart
@@ -14,6 +14,12 @@ import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 /// simply means "no real terrain available right now".
 class BathymetryRepository {
   static const int maxGridDim = 120;
+
+  /// Bumped whenever source SELECTION changes, not just the span. Cached
+  /// rows never expire, so without this every already-visited site would
+  /// keep serving the grid its old resolver chose. Old rows go inert, the
+  /// same way the 4 km rows did when the span went to 8 km.
+  static const String selectionGeneration = 'v2';
   static const double quantumDeg = 0.02;
 
   final LocalCacheDatabase _db;
@@ -33,11 +39,13 @@ class BathymetryRepository {
 
   static String keyFor(GeoPoint c) {
     final q = quantize(c);
-    // The span is part of the key: cached rows never expire, so a span
-    // change must miss the old rows and refetch the larger area. Stale
-    // rows are inert leftovers in this local-only cache.
+    // The span AND the selection generation are part of the key: cached
+    // rows never expire, so any change that would resolve a coordinate
+    // differently must miss the old rows and refetch. Stale rows are inert
+    // leftovers in this local-only cache.
     final span = BathymetryResolver.defaultSpanMeters.round();
-    return '${q.lat.toStringAsFixed(2)},${q.lon.toStringAsFixed(2)}@$span';
+    return '${q.lat.toStringAsFixed(2)},${q.lon.toStringAsFixed(2)}'
+        '@$span$selectionGeneration';
   }
 
   /// Whether the cache holds a DEFINITIVE answer (grid or empty) for this

--- a/lib/features/bathymetry/data/bathymetry_resolver.dart
+++ b/lib/features/bathymetry/data/bathymetry_resolver.dart
@@ -38,7 +38,7 @@ class BathymetryResolver {
   Future<BathymetryResolution> resolve(GeoPoint center) async {
     var globalSourceSaidDry = false;
     for (final source in sources) {
-      if (!source.covers(center)) continue;
+      if (await source.probe(center) == null) continue;
       try {
         final grid = await source.fetch(center, spanMeters: defaultSpanMeters);
         if (grid.wetFraction >= minWetFraction) {

--- a/lib/features/bathymetry/data/bathymetry_resolver.dart
+++ b/lib/features/bathymetry/data/bathymetry_resolver.dart
@@ -19,16 +19,33 @@ class BathymetryResolution {
       definitive = false;
 }
 
-/// Best-source-wins: walks the ordered tiers and returns the first grid
-/// with enough wet cells. No mosaicking — sources use different vertical
-/// datums (EMODnet is LAT, GMRT/ETOPO MSL) and stitching them seams.
+/// Best-source-wins. Probes every source, orders them by MATERIALLY better
+/// resolution, then fetches in that order and takes the first grid passing
+/// both quality floors.
+///
+/// No mosaicking: sources use different vertical datums (EMODnet is LAT,
+/// GMRT and ETOPO are MSL) and stitching them seams.
 class BathymetryResolver {
   static const double minWetFraction = 0.10;
 
+  /// A grid must actually have readings. EMODnet's Caribbean tile answers
+  /// 99.96% wet on 48% coverage, and the missing half renders as a flat
+  /// slab at the waterline. Coverage that thin is not usable terrain, and
+  /// it is not an answer about the water either.
+  static const double minKnownFraction = 0.60;
+
+  /// How much finer a source must be to jump ahead of the declared list
+  /// order. Declared resolution is a claim, so only a MATERIAL difference
+  /// may override the curated tier order: NOAA CUDEM at 3.4 m preempts
+  /// GMRT's 60 m, while GMRT's nominal 60 m does not preempt EMODnet's
+  /// surveyed 115 m, which in Europe would trade real data for a grid that
+  /// may be upsampled GEBCO.
+  static const double preemptionFactor = 2.0;
+
   /// Request-box width. 8 km shows the surrounding seascape, not just the
   /// site itself; the repository's downsample cap bounds the render cost.
-  /// This value is part of the cache key — see
-  /// [BathymetryRepository.keyFor] — so changing it refetches.
+  /// This value is part of the cache key, see [BathymetryRepository.keyFor],
+  /// so changing it refetches.
   static const double defaultSpanMeters = 8000;
 
   final List<BathymetrySource> sources;
@@ -36,11 +53,17 @@ class BathymetryResolver {
   const BathymetryResolver({required this.sources});
 
   Future<BathymetryResolution> resolve(GeoPoint center) async {
+    final ordered = await _order(center);
     var globalSourceSaidDry = false;
-    for (final source in sources) {
-      if (await source.probe(center) == null) continue;
+    for (final source in ordered) {
       try {
         final grid = await source.fetch(center, spanMeters: defaultSpanMeters);
+        if (grid.knownFraction < minKnownFraction) {
+          // Nominally fine, actually absent. Deliberately NOT treated as a
+          // dry answer: a grid this empty proves nothing about the water,
+          // and caching it as 'empty' would pin the cell forever.
+          continue;
+        }
         if (grid.wetFraction >= minWetFraction) {
           return BathymetryResolution.ok(grid);
         }
@@ -48,15 +71,50 @@ class BathymetryResolver {
         // covers everywhere; a regional edge cell proves nothing.
         if (source.global) globalSourceSaidDry = true;
       } on BathymetryFetchException {
-        // Transient: fall through to the next tier.
+        // Transient: fall through to the next source.
       } catch (_) {
         // A source blowing up with anything else (a TypeError from an
         // unexpected response shape, an ArgumentError) must not kill the
-        // whole scene — treat it exactly like a transient failure.
+        // whole scene: treat it exactly like a transient failure.
       }
     }
     return globalSourceSaidDry
         ? const BathymetryResolution.empty()
         : const BathymetryResolution.transientFailure();
+  }
+
+  /// Covering sources in fetch order. Probes run concurrently because a
+  /// probe may be a network call and they are independent; a probe that
+  /// fails for any reason drops that source rather than failing the scene.
+  Future<List<BathymetrySource>> _order(GeoPoint center) async {
+    final caps = await Future.wait(
+      sources.map((s) async {
+        try {
+          return await s.probe(center);
+        } catch (_) {
+          return null;
+        }
+      }),
+    );
+    final covering = <({BathymetrySource source, int rank, double cell})>[];
+    for (var i = 0; i < sources.length; i++) {
+      final cap = caps[i];
+      if (cap == null) continue;
+      covering.add((source: sources[i], rank: i, cell: cap.cellSizeMeters));
+    }
+    // A source leads only when it is more than preemptionFactor finer than
+    // the one it overtakes; within that band the declared order stands.
+    //
+    // The relation is not transitive, so this is not a total order and
+    // List.sort may resolve a pathological three-source chain either way.
+    // With the shipped sources (3.4 m, 60 m, 115 m, 450 m) it is
+    // well-behaved, and the two cases that matter are pinned by tests. Do
+    // not extend the source list without revisiting this.
+    covering.sort((a, b) {
+      if (a.cell * preemptionFactor < b.cell) return -1;
+      if (b.cell * preemptionFactor < a.cell) return 1;
+      return a.rank.compareTo(b.rank);
+    });
+    return [for (final c in covering) c.source];
   }
 }

--- a/lib/features/bathymetry/data/bathymetry_resolver.dart
+++ b/lib/features/bathymetry/data/bathymetry_resolver.dart
@@ -24,7 +24,8 @@ class BathymetryResolution {
 /// both quality floors.
 ///
 /// No mosaicking: sources use different vertical datums (EMODnet is LAT,
-/// GMRT and ETOPO are MSL) and stitching them seams.
+/// GMRT and ETOPO are MSL), so stitching two of them together would leave
+/// a visible step wherever they meet.
 class BathymetryResolver {
   static const double minWetFraction = 0.10;
 

--- a/lib/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart
+++ b/lib/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart
@@ -77,7 +77,12 @@ class ArcgisFloat32TiffParser {
       throw const FormatException('TIFF has a zero dimension');
     }
 
-    final offsets = _longs(d, tags[_tagTileOffsets], 'TileOffsets', bytes.length);
+    final offsets = _longs(
+      d,
+      tags[_tagTileOffsets],
+      'TileOffsets',
+      bytes.length,
+    );
     final tilesAcross = (width + tileW - 1) ~/ tileW;
     final tilesDown = (height + tileH - 1) ~/ tileH;
     if (offsets.length != tilesAcross * tilesDown) {
@@ -102,8 +107,9 @@ class ArcgisFloat32TiffParser {
           // bottom edges; that padding is not part of the image.
           if (imageCol >= width) continue;
           final v = d.getFloat32(base + (r * tileW + c) * 4, Endian.little);
-          image[imageRow * width + imageCol] =
-              _isNoData(v) ? null : -v; // elevation -> depth
+          image[imageRow * width + imageCol] = _isNoData(v)
+              ? null
+              : -v; // elevation -> depth
         }
       }
     }

--- a/lib/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart
+++ b/lib/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart
@@ -1,0 +1,184 @@
+import 'dart:typed_data';
+
+import 'package:submersion/features/bathymetry/domain/bathymetry_grid.dart';
+
+/// Reads the uncompressed, tiled, little-endian float32 GeoTIFF an ArcGIS
+/// ImageServer returns for `format=tiff&pixelType=F32`.
+///
+/// Deliberately narrow. This is not a TIFF library: it accepts exactly the
+/// shape that service emits and throws [FormatException] on anything else,
+/// so an unexpected response becomes a transient source failure rather than
+/// silently wrong terrain. ArcGIS returns error envelopes with HTTP 200, so
+/// "not a TIFF" is a routine outcome, not an exotic one.
+///
+/// Two conversions bring the raster into the app's convention: image rows
+/// run north to south while [BathymetryGrid] rows run south to north, and
+/// the raster carries elevation (negative below sea level) while the grid
+/// carries depth (positive down).
+class ArcgisFloat32TiffParser {
+  /// ArcGIS writes float32 lowest as its NoData sentinel. Nothing on Earth
+  /// is within thirty orders of magnitude of it, so the guard below cannot
+  /// swallow a real reading.
+  static const double _noDataCeiling = -1e30;
+
+  static const int _tagImageWidth = 256;
+  static const int _tagImageLength = 257;
+  static const int _tagBitsPerSample = 258;
+  static const int _tagCompression = 259;
+  static const int _tagSamplesPerPixel = 277;
+  static const int _tagTileWidth = 322;
+  static const int _tagTileLength = 323;
+  static const int _tagTileOffsets = 324;
+
+  static BathymetryGrid parse(
+    Uint8List bytes, {
+    required double westLon,
+    required double eastLon,
+    required double southLat,
+    required double northLat,
+    required String sourceId,
+    required double resolutionMeters,
+    required DateTime fetchedAt,
+  }) {
+    if (bytes.length < 8 || bytes[0] != 0x49 || bytes[1] != 0x49) {
+      throw const FormatException(
+        'Expected a little-endian TIFF (II magic); the service returned '
+        'something else, most likely an error envelope.',
+      );
+    }
+    final d = ByteData.sublistView(bytes);
+    if (d.getUint16(2, Endian.little) != 42) {
+      throw const FormatException('Not a classic TIFF (magic 42 missing)');
+    }
+
+    final tags = _readIfd(d, bytes.length);
+
+    int need(int tag, String what) {
+      final t = tags[tag];
+      if (t == null) throw FormatException('TIFF is missing $what');
+      return t.value;
+    }
+
+    if (need(_tagCompression, 'Compression') != 1) {
+      throw const FormatException('Only uncompressed TIFF is supported');
+    }
+    if (need(_tagBitsPerSample, 'BitsPerSample') != 32) {
+      throw const FormatException('Only 32-bit samples are supported');
+    }
+    if (need(_tagSamplesPerPixel, 'SamplesPerPixel') != 1) {
+      throw const FormatException('Only single-band rasters are supported');
+    }
+
+    final width = need(_tagImageWidth, 'ImageWidth');
+    final height = need(_tagImageLength, 'ImageLength');
+    final tileW = need(_tagTileWidth, 'TileWidth');
+    final tileH = need(_tagTileLength, 'TileLength');
+    if (width < 1 || height < 1 || tileW < 1 || tileH < 1) {
+      throw const FormatException('TIFF has a zero dimension');
+    }
+
+    final offsets = _longs(d, tags[_tagTileOffsets], 'TileOffsets', bytes.length);
+    final tilesAcross = (width + tileW - 1) ~/ tileW;
+    final tilesDown = (height + tileH - 1) ~/ tileH;
+    if (offsets.length != tilesAcross * tilesDown) {
+      throw const FormatException('TileOffsets count does not match the grid');
+    }
+
+    // Image order first, northernmost row at index 0.
+    final image = List<double?>.filled(width * height, null);
+    for (var t = 0; t < offsets.length; t++) {
+      final tx = t % tilesAcross;
+      final ty = t ~/ tilesAcross;
+      final base = offsets[t];
+      if (base < 0 || base + tileW * tileH * 4 > bytes.length) {
+        throw const FormatException('TIFF tile runs past the end of the body');
+      }
+      for (var r = 0; r < tileH; r++) {
+        final imageRow = ty * tileH + r;
+        if (imageRow >= height) break;
+        for (var c = 0; c < tileW; c++) {
+          final imageCol = tx * tileW + c;
+          // Tiles are padded out to their full size at the right and
+          // bottom edges; that padding is not part of the image.
+          if (imageCol >= width) continue;
+          final v = d.getFloat32(base + (r * tileW + c) * 4, Endian.little);
+          image[imageRow * width + imageCol] =
+              _isNoData(v) ? null : -v; // elevation -> depth
+        }
+      }
+    }
+
+    // Flip to south-first.
+    final depths = List<double?>.filled(width * height, null);
+    for (var r = 0; r < height; r++) {
+      depths.setRange(
+        r * width,
+        r * width + width,
+        image,
+        (height - 1 - r) * width,
+      );
+    }
+
+    // The requested box spans cell EDGES; the grid origin is a cell CENTER.
+    final cellLon = (eastLon - westLon) / width;
+    final cellLat = (northLat - southLat) / height;
+    return BathymetryGrid(
+      originLat: southLat + cellLat / 2,
+      originLon: westLon + cellLon / 2,
+      cellSizeLatDeg: cellLat,
+      cellSizeLonDeg: cellLon,
+      rows: height,
+      cols: width,
+      depthsMeters: depths,
+      sourceId: sourceId,
+      resolutionMeters: resolutionMeters,
+      fetchedAt: fetchedAt,
+    );
+  }
+
+  static Map<int, ({int type, int count, int value})> _readIfd(
+    ByteData d,
+    int length,
+  ) {
+    final ifd = d.getUint32(4, Endian.little);
+    if (ifd + 2 > length) {
+      throw const FormatException('TIFF directory offset is out of range');
+    }
+    final entryCount = d.getUint16(ifd, Endian.little);
+    if (ifd + 2 + entryCount * 12 > length) {
+      throw const FormatException('TIFF directory runs past the body');
+    }
+    final tags = <int, ({int type, int count, int value})>{};
+    for (var i = 0; i < entryCount; i++) {
+      final e = ifd + 2 + i * 12;
+      final tag = d.getUint16(e, Endian.little);
+      final type = d.getUint16(e + 2, Endian.little);
+      final count = d.getUint32(e + 4, Endian.little);
+      // A SHORT with count 1 sits in the low half of the value field.
+      final value = type == 3 && count == 1
+          ? d.getUint16(e + 8, Endian.little)
+          : d.getUint32(e + 8, Endian.little);
+      tags[tag] = (type: type, count: count, value: value);
+    }
+    return tags;
+  }
+
+  static bool _isNoData(double v) => v.isNaN || v < _noDataCeiling;
+
+  static List<int> _longs(
+    ByteData d,
+    ({int type, int count, int value})? tag,
+    String what,
+    int length,
+  ) {
+    if (tag == null) throw FormatException('TIFF is missing $what');
+    if (tag.count == 1) return [tag.value];
+    if (tag.value + tag.count * 4 > length) {
+      throw FormatException('$what array runs past the body');
+    }
+    return [
+      for (var i = 0; i < tag.count; i++)
+        d.getUint32(tag.value + i * 4, Endian.little),
+    ];
+  }
+}

--- a/lib/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart
+++ b/lib/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart
@@ -37,6 +37,10 @@ class ArcgisFloat32TiffParser {
   /// alone cannot tell them apart from float.
   static const int _sampleFormatIeeeFloat = 3;
 
+  /// TIFF field type 4, a 32-bit unsigned integer. The tile offset and
+  /// byte-count arrays are read at this width and no other.
+  static const int _fieldTypeLong = 4;
+
   static BathymetryGrid parse(
     Uint8List bytes, {
     required double westLon,
@@ -218,6 +222,22 @@ class ArcgisFloat32TiffParser {
     int length,
   ) {
     if (tag == null) throw FormatException('TIFF is missing $what');
+    // The element width is implied by the field type, so reading a SHORT
+    // array at LONG width walks the wrong bytes and yields offsets that
+    // can still land inside the body: the tiles then decode into
+    // plausible-looking nonsense rather than failing. BigTIFF's LONG8 is
+    // already excluded by the magic-number check, but an out-of-spec
+    // classic TIFF could still declare it, so the type is pinned here
+    // rather than assumed.
+    if (tag.type != _fieldTypeLong) {
+      throw FormatException(
+        '$what has TIFF field type ${tag.type}; only LONG '
+        '($_fieldTypeLong) is supported',
+      );
+    }
+    if (tag.count < 1) {
+      throw FormatException('$what has no entries');
+    }
     if (tag.count == 1) return [tag.value];
     if (tag.value + tag.count * 4 > length) {
       throw FormatException('$what array runs past the body');

--- a/lib/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart
+++ b/lib/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart
@@ -29,6 +29,13 @@ class ArcgisFloat32TiffParser {
   static const int _tagTileWidth = 322;
   static const int _tagTileLength = 323;
   static const int _tagTileOffsets = 324;
+  static const int _tagTileByteCounts = 325;
+  static const int _tagSampleFormat = 339;
+
+  /// SampleFormat 3 is IEEE floating point. 1 (unsigned) and 2 (signed)
+  /// integer rasters carry the same 32 bits per sample, so BitsPerSample
+  /// alone cannot tell them apart from float.
+  static const int _sampleFormatIeeeFloat = 3;
 
   static BathymetryGrid parse(
     Uint8List bytes, {
@@ -65,6 +72,18 @@ class ArcgisFloat32TiffParser {
     if (need(_tagBitsPerSample, 'BitsPerSample') != 32) {
       throw const FormatException('Only 32-bit samples are supported');
     }
+    // BitsPerSample is not enough on its own: a 32-bit INTEGER raster has
+    // the same sample width, and reading its bits as float32 does not
+    // fail. It yields denormals near zero for small values and huge
+    // magnitudes for large ones, all non-null, so every downstream quality
+    // floor passes and the garbage renders as terrain. Require the tag
+    // rather than defaulting: TIFF's own default when it is absent is
+    // unsigned integer, so an untagged raster is not float either.
+    if (need(_tagSampleFormat, 'SampleFormat') != _sampleFormatIeeeFloat) {
+      throw const FormatException(
+        'Only IEEE float samples are supported (SampleFormat 3)',
+      );
+    }
     if (need(_tagSamplesPerPixel, 'SamplesPerPixel') != 1) {
       throw const FormatException('Only single-band rasters are supported');
     }
@@ -83,10 +102,31 @@ class ArcgisFloat32TiffParser {
       'TileOffsets',
       bytes.length,
     );
+    final counts = _longs(
+      d,
+      tags[_tagTileByteCounts],
+      'TileByteCounts',
+      bytes.length,
+    );
     final tilesAcross = (width + tileW - 1) ~/ tileW;
     final tilesDown = (height + tileH - 1) ~/ tileH;
     if (offsets.length != tilesAcross * tilesDown) {
       throw const FormatException('TileOffsets count does not match the grid');
+    }
+    if (counts.length != offsets.length) {
+      throw const FormatException('TileByteCounts does not match TileOffsets');
+    }
+    // Every tile of an uncompressed float32 raster is exactly this big. A
+    // disagreement means the data is not the plain block this parser
+    // assumes, whatever the Compression tag claims.
+    final expectedTileBytes = tileW * tileH * 4;
+    for (final c in counts) {
+      if (c != expectedTileBytes) {
+        throw FormatException(
+          'Tile byte count $c is not the $expectedTileBytes bytes an '
+          'uncompressed ${tileW}x$tileH float32 tile occupies',
+        );
+      }
     }
 
     // Image order first, northernmost row at index 0.

--- a/lib/features/bathymetry/data/sources/emodnet_source.dart
+++ b/lib/features/bathymetry/data/sources/emodnet_source.dart
@@ -58,9 +58,25 @@ class EmodnetSource implements BathymetrySource {
       p.longitude >= b.minLon &&
       p.longitude <= b.maxLon;
 
+  static const double declaredCellSizeMeters = _resolutionMeters;
+
   @override
-  bool covers(GeoPoint center) =>
-      _inBox(center, _carib) || _inBox(center, _europe);
+  Future<SourceCapability?> probe(GeoPoint center) async {
+    if (_inBox(center, _carib)) {
+      // Not const: a record field access is not a constant expression.
+      return SourceCapability(
+        cellSizeMeters: _resolutionMeters,
+        detail: _carib.dataset,
+      );
+    }
+    if (_inBox(center, _europe)) {
+      return SourceCapability(
+        cellSizeMeters: _resolutionMeters,
+        detail: _europe.dataset,
+      );
+    }
+    return null;
+  }
 
   @override
   Future<BathymetryGrid> fetch(

--- a/lib/features/bathymetry/data/sources/etopo_erddap_source.dart
+++ b/lib/features/bathymetry/data/sources/etopo_erddap_source.dart
@@ -33,8 +33,14 @@ class EtopoErddapSource implements BathymetrySource {
   @override
   bool get global => true;
 
+  static const double declaredCellSizeMeters = _resolutionMeters;
+
   @override
-  bool covers(GeoPoint center) => true;
+  Future<SourceCapability?> probe(GeoPoint center) async =>
+      const SourceCapability(
+        cellSizeMeters: _resolutionMeters,
+        detail: _dataset,
+      );
 
   @override
   Future<BathymetryGrid> fetch(

--- a/lib/features/bathymetry/data/sources/gmrt_source.dart
+++ b/lib/features/bathymetry/data/sources/gmrt_source.dart
@@ -25,8 +25,18 @@ class GmrtSource implements BathymetrySource {
   @override
   bool get global => true;
 
+  /// GMRT's global tiles run to roughly 60 m where ship multibeam exists.
+  /// A NOMINAL figure: elsewhere the same grid spacing carries upsampled
+  /// GEBCO. The resolver's preemption factor exists so this number cannot
+  /// demote a genuinely surveyed regional source on a claim alone.
+  static const double declaredCellSizeMeters = 60;
+
   @override
-  bool covers(GeoPoint center) => true;
+  Future<SourceCapability?> probe(GeoPoint center) async =>
+      const SourceCapability(
+        cellSizeMeters: declaredCellSizeMeters,
+        detail: 'GMRT GridServer',
+      );
 
   @override
   Future<BathymetryGrid> fetch(

--- a/lib/features/bathymetry/data/sources/noaa_dem_source.dart
+++ b/lib/features/bathymetry/data/sources/noaa_dem_source.dart
@@ -134,7 +134,7 @@ class NoaaDemSource implements BathymetrySource {
     GeoPoint center, {
     required double spanMeters,
   }) async {
-    final dLat = spanMeters / 2 / 110540.0;
+    final dLat = spanMeters / 2 / _metersPerDegLat;
     final dLon = spanMeters / 2 / metersPerDegreeLongitude(center.latitude);
     final west = center.longitude - dLon;
     final east = center.longitude + dLon;

--- a/lib/features/bathymetry/data/sources/noaa_dem_source.dart
+++ b/lib/features/bathymetry/data/sources/noaa_dem_source.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math' as math;
 
 import 'package:http/http.dart' as http;
 
@@ -17,7 +18,8 @@ import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 /// a point with its own cell size, so the source knows BEFORE fetching
 /// whether it has anything worth having: measured 3.4 m in the Florida
 /// Keys, 10.3 m at La Jolla, and only ETOPO's 464 m at Bonaire, where it
-/// declines and lets the ETOPO tier serve that data directly.
+/// declines and lets the ETOPO tier serve that data directly. Those
+/// figures are the cell's coarser axis, so they never overstate the DEM.
 class NoaaDemSource implements BathymetrySource {
   static const String sourceId = 'noaa_dem';
 
@@ -29,6 +31,9 @@ class NoaaDemSource implements BathymetrySource {
   /// Cells per side requested from exportImage. The server resamples to
   /// whatever is asked, so this is a render-budget choice, not a data one.
   static const int requestDim = 256;
+
+  /// Meters per degree of latitude, effectively constant with latitude.
+  static const double _metersPerDegLat = 110540.0;
 
   static const Duration _timeout = Duration(seconds: 15);
 
@@ -91,9 +96,27 @@ class NoaaDemSource implements BathymetrySource {
       }
       if (bestDeg == null) return null;
 
-      // LowPS is in degrees; convert on the longitude axis, which is the
-      // shorter of the two at every latitude away from the equator.
-      final meters = bestDeg * metersPerDegreeLongitude(center.latitude);
+      // LowPS is in DEGREES, and a geographic cell is square in degrees,
+      // so its two sides differ in meters: the north-south side is a
+      // near-constant 110540 m per degree, while the east-west side shrinks
+      // with cos(latitude). Report the COARSER of the two, because a cell
+      // is only as good as its worst axis.
+      //
+      // Converting on longitude alone flatters a DEM as latitude rises. A
+      // 3 arc-second cell is 92.1 m north-south everywhere, but reads
+      // 46.4 m at 60 N and would slip under the threshold, so a 92 m grid
+      // would be accepted as high resolution and, sitting first in the
+      // declared order and within the resolver's preemption factor of
+      // GMRT's 60 m, would be fetched instead of it. NOAA's mosaic really
+      // does hold 3 arc-second Coastal Relief Model tiles, and Alaskan
+      // coastal water is where they are the best available.
+      //
+      // max() rather than simply the latitude axis: at the equator a
+      // degree of longitude is 111320 m against latitude's 110540, so the
+      // coarser side is not always the same one.
+      final meters =
+          bestDeg *
+          math.max(_metersPerDegLat, metersPerDegreeLongitude(center.latitude));
       if (meters > usefulCellSizeMeters) return null;
       return SourceCapability(
         cellSizeMeters: meters,

--- a/lib/features/bathymetry/data/sources/noaa_dem_source.dart
+++ b/lib/features/bathymetry/data/sources/noaa_dem_source.dart
@@ -1,0 +1,154 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'package:submersion/core/utils/geo_math.dart';
+import 'package:submersion/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart';
+import 'package:submersion/features/bathymetry/domain/bathymetry_grid.dart';
+import 'package:submersion/features/bathymetry/domain/bathymetry_source.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+/// High-resolution coastal tier: the NOAA NCEI DEM mosaic ImageServer,
+/// which stacks CUDEM and regional DEMs over an ETOPO background. US
+/// public domain. Coverage is patchy and mostly US coastal, so this source
+/// declines wherever the stack holds nothing better than that background.
+///
+/// The probe is what keeps that honest. `identify` reports every DEM under
+/// a point with its own cell size, so the source knows BEFORE fetching
+/// whether it has anything worth having: measured 3.4 m in the Florida
+/// Keys, 10.3 m at La Jolla, and only ETOPO's 464 m at Bonaire, where it
+/// declines and lets the ETOPO tier serve that data directly.
+class NoaaDemSource implements BathymetrySource {
+  static const String sourceId = 'noaa_dem';
+
+  /// Below this cell size the mosaic is offering a real coastal DEM. Above
+  /// it, the stack holds only its ETOPO background, which the ETOPO tier
+  /// already serves without the extra round trip.
+  static const double usefulCellSizeMeters = 50;
+
+  /// Cells per side requested from exportImage. The server resamples to
+  /// whatever is asked, so this is a render-budget choice, not a data one.
+  static const int requestDim = 256;
+
+  static const Duration _timeout = Duration(seconds: 15);
+
+  final http.Client _client;
+  final String baseUrl;
+
+  NoaaDemSource({
+    http.Client? client,
+    this.baseUrl =
+        'https://gis.ngdc.noaa.gov/arcgis/rest/services/DEM_mosaics/DEM_all/ImageServer',
+  }) : _client = client ?? http.Client();
+
+  @override
+  String get id => sourceId;
+
+  /// Coverage is patchy coastal, so a dry answer here proves nothing about
+  /// whether a coordinate is on land.
+  @override
+  bool get global => false;
+
+  @override
+  Future<SourceCapability?> probe(GeoPoint center) async {
+    final url = Uri.parse('$baseUrl/identify').replace(
+      queryParameters: {
+        'geometry': '{"x":${center.longitude},"y":${center.latitude}}',
+        'geometryType': 'esriGeometryPoint',
+        'returnCatalogItems': 'true',
+        // Load-bearing. The default truncates the catalogue to three items,
+        // which hides a covered site's DEM behind the ETOPO background and
+        // makes the source decline where it actually has data.
+        'maxItemCount': '25',
+        'f': 'json',
+      },
+    );
+    try {
+      final resp = await _client.get(url).timeout(_timeout);
+      if (resp.statusCode != 200) return null;
+      final body = jsonDecode(resp.body);
+      if (body is! Map<String, dynamic>) return null;
+      // ArcGIS returns error envelopes with HTTP 200, so a body without a
+      // catalogue is an ordinary decline rather than an exceptional case.
+      final items =
+          (body['catalogItems'] as Map<String, dynamic>?)?['features'];
+      if (items is! List || items.isEmpty) return null;
+
+      String? bestName;
+      double? bestDeg;
+      for (final item in items) {
+        if (item is! Map) continue;
+        final attrs = item['attributes'];
+        if (attrs is! Map) continue;
+        final lowPs = attrs['LowPS'];
+        if (lowPs is! num) continue;
+        final deg = lowPs.toDouble();
+        if (deg <= 0) continue;
+        if (bestDeg == null || deg < bestDeg) {
+          bestDeg = deg;
+          bestName = attrs['Name'] as String?;
+        }
+      }
+      if (bestDeg == null) return null;
+
+      // LowPS is in degrees; convert on the longitude axis, which is the
+      // shorter of the two at every latitude away from the equator.
+      final meters = bestDeg * metersPerDegreeLongitude(center.latitude);
+      if (meters > usefulCellSizeMeters) return null;
+      return SourceCapability(
+        cellSizeMeters: meters,
+        detail: bestName ?? 'NOAA NCEI DEM',
+      );
+    } catch (_) {
+      // A probe never throws: an unreachable or surprising service simply
+      // means this source does not contribute here.
+      return null;
+    }
+  }
+
+  @override
+  Future<BathymetryGrid> fetch(
+    GeoPoint center, {
+    required double spanMeters,
+  }) async {
+    final dLat = spanMeters / 2 / 110540.0;
+    final dLon = spanMeters / 2 / metersPerDegreeLongitude(center.latitude);
+    final west = center.longitude - dLon;
+    final east = center.longitude + dLon;
+    final south = center.latitude - dLat;
+    final north = center.latitude + dLat;
+    final url = Uri.parse('$baseUrl/exportImage').replace(
+      queryParameters: {
+        'bbox': '$west,$south,$east,$north',
+        'bboxSR': '4326',
+        'imageSR': '4326',
+        'size': '$requestDim,$requestDim',
+        'format': 'tiff',
+        'pixelType': 'F32',
+        'noDataInterpretation': 'esriNoDataMatchAny',
+        'interpolation': 'RSP_BilinearInterpolation',
+        'f': 'image',
+      },
+    );
+    try {
+      final resp = await _client.get(url).timeout(_timeout);
+      if (resp.statusCode != 200) {
+        throw BathymetryFetchException('NOAA DEM HTTP ${resp.statusCode}');
+      }
+      return ArcgisFloat32TiffParser.parse(
+        resp.bodyBytes,
+        westLon: west,
+        eastLon: east,
+        southLat: south,
+        northLat: north,
+        sourceId: sourceId,
+        resolutionMeters: spanMeters / requestDim,
+        fetchedAt: DateTime.now(),
+      );
+    } on BathymetryFetchException {
+      rethrow;
+    } on Exception catch (e) {
+      throw BathymetryFetchException('NOAA DEM fetch failed: $e');
+    }
+  }
+}

--- a/lib/features/bathymetry/domain/bathymetry_grid.dart
+++ b/lib/features/bathymetry/domain/bathymetry_grid.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 /// A rectangular grid of seafloor depths around a coordinate, in the app's
 /// depth convention: meters positive DOWN. Negative values are land
 /// elevation above the waterline; null cells are nodata. Rows run
@@ -41,6 +43,18 @@ class BathymetryGrid {
     return known == 0 ? 0 : wet / known;
   }
 
+  /// Fraction of cells that carry a reading at all. A grid can be almost
+  /// entirely wet and still be mostly holes: EMODnet's Caribbean tile
+  /// answers 99.96% wet on 48% coverage. The resolver needs both numbers.
+  double get knownFraction {
+    if (depthsMeters.isEmpty) return 0;
+    var known = 0;
+    for (final d in depthsMeters) {
+      if (d != null) known++;
+    }
+    return known / depthsMeters.length;
+  }
+
   double get maxDepthMeters {
     var m = 0.0;
     for (final d in depthsMeters) {
@@ -49,7 +63,9 @@ class BathymetryGrid {
     return m;
   }
 
-  /// Strided downsample so neither dimension exceeds [maxDim].
+  /// Block-mean downsample so neither dimension exceeds [maxDim]. Averaging
+  /// rather than striding keeps the information in the discarded cells: a
+  /// stride of 2 throws away three quarters of a grid outright.
   BathymetryGrid downsampleTo(int maxDim) {
     if (rows <= maxDim && cols <= maxDim) return this;
     final stepR = (rows / maxDim).ceil();
@@ -58,8 +74,22 @@ class BathymetryGrid {
     final newCols = (cols + stepC - 1) ~/ stepC;
     final out = List<double?>.filled(newRows * newCols, null);
     for (var r = 0; r < newRows; r++) {
+      final r1 = math.min((r + 1) * stepR, rows);
       for (var c = 0; c < newCols; c++) {
-        out[r * newCols + c] = depthsMeters[(r * stepR) * cols + (c * stepC)];
+        final c1 = math.min((c + 1) * stepC, cols);
+        var sum = 0.0;
+        var n = 0;
+        for (var sr = r * stepR; sr < r1; sr++) {
+          for (var sc = c * stepC; sc < c1; sc++) {
+            final v = depthsMeters[sr * cols + sc];
+            if (v == null) continue;
+            sum += v;
+            n++;
+          }
+        }
+        // An entirely unmeasured block stays unmeasured: averaging must
+        // never invent a reading where the source had none.
+        out[r * newCols + c] = n == 0 ? null : sum / n;
       }
     }
     return BathymetryGrid(

--- a/lib/features/bathymetry/domain/bathymetry_grid.dart
+++ b/lib/features/bathymetry/domain/bathymetry_grid.dart
@@ -93,8 +93,17 @@ class BathymetryGrid {
       }
     }
     return BathymetryGrid(
-      originLat: originLat,
-      originLon: originLon,
+      // Origin is the SOUTH-WEST CELL CENTER, so it has to follow the data.
+      // Striding kept the block's first sample, whose center already WAS
+      // the origin; a block mean sits at the block's centroid instead, half
+      // a stride further north and east. Leaving the origin put would
+      // report every cell half a block south-west of the depths it holds,
+      // dragging the 3D mesh, the 2D overlay bounds, the imagery mosaic and
+      // the hover lat/lon readout with it. The south-west edge of the
+      // footprint is unchanged by this shift, which is the invariant those
+      // consumers actually depend on.
+      originLat: originLat + cellSizeLatDeg * (stepR - 1) / 2,
+      originLon: originLon + cellSizeLonDeg * (stepC - 1) / 2,
       cellSizeLatDeg: cellSizeLatDeg * stepR,
       cellSizeLonDeg: cellSizeLonDeg * stepC,
       rows: newRows,

--- a/lib/features/bathymetry/domain/bathymetry_source.dart
+++ b/lib/features/bathymetry/domain/bathymetry_source.dart
@@ -11,6 +11,23 @@ class BathymetryFetchException implements Exception {
   String toString() => 'BathymetryFetchException: $message';
 }
 
+/// What a source claims it can deliver at one coordinate. Declared, not
+/// measured: a source reports the finest grid it believes it holds there,
+/// which the resolver uses only to ORDER candidates. The wet-cell and
+/// known-cell floors are what actually reject bad data, after a fetch.
+class SourceCapability {
+  /// Best available cell size in meters at the probed point.
+  final double cellSizeMeters;
+
+  /// Provenance detail for the caption, e.g. the dataset or DEM name.
+  final String detail;
+
+  const SourceCapability({
+    required this.cellSizeMeters,
+    required this.detail,
+  });
+}
+
 /// One bathymetry provider in the resolver tier.
 abstract interface class BathymetrySource {
   String get id;
@@ -19,7 +36,11 @@ abstract interface class BathymetrySource {
   /// global source proves a coordinate is definitively on land.
   bool get global;
 
-  bool covers(GeoPoint center);
+  /// What this source can deliver at [center], or null when it does not
+  /// cover the point. May make a network call, so a probe that fails for
+  /// any reason must return null rather than throw: one unreachable source
+  /// must never block the others.
+  Future<SourceCapability?> probe(GeoPoint center);
 
   /// Fetches a depth grid roughly [spanMeters] across centered on [center].
   /// Throws [BathymetryFetchException] on transient failure.

--- a/lib/features/bathymetry/domain/bathymetry_source.dart
+++ b/lib/features/bathymetry/domain/bathymetry_source.dart
@@ -22,10 +22,7 @@ class SourceCapability {
   /// Provenance detail for the caption, e.g. the dataset or DEM name.
   final String detail;
 
-  const SourceCapability({
-    required this.cellSizeMeters,
-    required this.detail,
-  });
+  const SourceCapability({required this.cellSizeMeters, required this.detail});
 }
 
 /// One bathymetry provider in the resolver tier.

--- a/lib/features/bathymetry/presentation/bathymetry_labels.dart
+++ b/lib/features/bathymetry/presentation/bathymetry_labels.dart
@@ -4,5 +4,6 @@ String bathymetrySourceDisplayName(String id) => switch (id) {
   'gmrt' => 'GMRT',
   'emodnet' => 'EMODnet',
   'etopo2022' => 'ETOPO 2022',
+  'noaa_dem' => 'NOAA NCEI',
   _ => id,
 };

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -7041,7 +7041,7 @@
   "@dive3d_seascape_noData": {},
   "dive3d_seascape_axis_distance": "المسافة ({unitSymbol})",
   "@dive3d_seascape_axis_distance": {},
-  "settings_about_bathymetryCredit": "بيانات قياس الأعماق: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022",
+  "settings_about_bathymetryCredit": "بيانات قياس الأعماق: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM",
   "@settings_about_bathymetryCredit": {},
   "dive3d_metric_depth": "العمق",
   "@dive3d_metric_depth": {},

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -7041,7 +7041,7 @@
   "@dive3d_seascape_noData": {},
   "dive3d_seascape_axis_distance": "Entfernung ({unitSymbol})",
   "@dive3d_seascape_axis_distance": {},
-  "settings_about_bathymetryCredit": "Bathymetrie-Daten: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022",
+  "settings_about_bathymetryCredit": "Bathymetrie-Daten: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM",
   "@settings_about_bathymetryCredit": {},
   "dive3d_metric_depth": "Tiefe",
   "@dive3d_metric_depth": {},

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -16029,7 +16029,7 @@
       }
     }
   },
-  "settings_about_bathymetryCredit": "Bathymetry data: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022",
+  "settings_about_bathymetryCredit": "Bathymetry data: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM",
   "@settings_about_bathymetryCredit": {},
   "dive3d_metric_depth": "Depth",
   "@dive3d_metric_depth": {},

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -7041,7 +7041,7 @@
   "@dive3d_seascape_noData": {},
   "dive3d_seascape_axis_distance": "Distancia ({unitSymbol})",
   "@dive3d_seascape_axis_distance": {},
-  "settings_about_bathymetryCredit": "Datos de batimetría: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022",
+  "settings_about_bathymetryCredit": "Datos de batimetría: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM",
   "@settings_about_bathymetryCredit": {},
   "dive3d_metric_depth": "Profundidad",
   "@dive3d_metric_depth": {},

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -7041,7 +7041,7 @@
   "@dive3d_seascape_noData": {},
   "dive3d_seascape_axis_distance": "Distance ({unitSymbol})",
   "@dive3d_seascape_axis_distance": {},
-  "settings_about_bathymetryCredit": "Données bathymétriques : GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022",
+  "settings_about_bathymetryCredit": "Données bathymétriques : GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM",
   "@settings_about_bathymetryCredit": {},
   "dive3d_metric_depth": "Profondeur",
   "@dive3d_metric_depth": {},

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -7041,7 +7041,7 @@
   "@dive3d_seascape_noData": {},
   "dive3d_seascape_axis_distance": "מרחק ({unitSymbol})",
   "@dive3d_seascape_axis_distance": {},
-  "settings_about_bathymetryCredit": "נתוני עומק: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022",
+  "settings_about_bathymetryCredit": "נתוני עומק: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM",
   "@settings_about_bathymetryCredit": {},
   "dive3d_metric_depth": "עומק",
   "@dive3d_metric_depth": {},

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -7041,7 +7041,7 @@
   "@dive3d_seascape_noData": {},
   "dive3d_seascape_axis_distance": "Távolság ({unitSymbol})",
   "@dive3d_seascape_axis_distance": {},
-  "settings_about_bathymetryCredit": "Batimetriai adatok: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022",
+  "settings_about_bathymetryCredit": "Batimetriai adatok: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM",
   "@settings_about_bathymetryCredit": {},
   "dive3d_metric_depth": "Mélység",
   "@dive3d_metric_depth": {},

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -7041,7 +7041,7 @@
   "@dive3d_seascape_noData": {},
   "dive3d_seascape_axis_distance": "Distanza ({unitSymbol})",
   "@dive3d_seascape_axis_distance": {},
-  "settings_about_bathymetryCredit": "Dati batimetrici: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022",
+  "settings_about_bathymetryCredit": "Dati batimetrici: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM",
   "@settings_about_bathymetryCredit": {},
   "dive3d_metric_depth": "Profondità",
   "@dive3d_metric_depth": {},

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -40586,7 +40586,7 @@ abstract class AppLocalizations {
   /// No description provided for @settings_about_bathymetryCredit.
   ///
   /// In en, this message translates to:
-  /// **'Bathymetry data: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022'**
+  /// **'Bathymetry data: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM'**
   String get settings_about_bathymetryCredit;
 
   /// No description provided for @dive3d_metric_depth.

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -24254,7 +24254,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get settings_about_bathymetryCredit =>
-      'بيانات قياس الأعماق: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022';
+      'بيانات قياس الأعماق: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM';
 
   @override
   String get dive3d_metric_depth => 'العمق';

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -24653,7 +24653,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settings_about_bathymetryCredit =>
-      'Bathymetrie-Daten: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022';
+      'Bathymetrie-Daten: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM';
 
   @override
   String get dive3d_metric_depth => 'Tiefe';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -24281,7 +24281,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settings_about_bathymetryCredit =>
-      'Bathymetry data: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022';
+      'Bathymetry data: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM';
 
   @override
   String get dive3d_metric_depth => 'Depth';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -24723,7 +24723,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settings_about_bathymetryCredit =>
-      'Datos de batimetría: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022';
+      'Datos de batimetría: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM';
 
   @override
   String get dive3d_metric_depth => 'Profundidad';

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -24792,7 +24792,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settings_about_bathymetryCredit =>
-      'Données bathymétriques : GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022';
+      'Données bathymétriques : GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM';
 
   @override
   String get dive3d_metric_depth => 'Profondeur';

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -24085,7 +24085,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get settings_about_bathymetryCredit =>
-      'נתוני עומק: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022';
+      'נתוני עומק: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM';
 
   @override
   String get dive3d_metric_depth => 'עומק';

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -24603,7 +24603,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get settings_about_bathymetryCredit =>
-      'Batimetriai adatok: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022';
+      'Batimetriai adatok: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM';
 
   @override
   String get dive3d_metric_depth => 'Mélység';

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -24706,7 +24706,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settings_about_bathymetryCredit =>
-      'Dati batimetrici: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022';
+      'Dati batimetrici: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM';
 
   @override
   String get dive3d_metric_depth => 'Profondità';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -24510,7 +24510,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get settings_about_bathymetryCredit =>
-      'Bathymetriegegevens: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022';
+      'Bathymetriegegevens: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM';
 
   @override
   String get dive3d_metric_depth => 'Diepte';

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -24704,7 +24704,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settings_about_bathymetryCredit =>
-      'Dados de batimetria: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022';
+      'Dados de batimetria: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM';
 
   @override
   String get dive3d_metric_depth => 'Profundidade';

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -23413,7 +23413,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settings_about_bathymetryCredit =>
-      '水深数据：GMRT（CC BY 4.0）· EMODnet Bathymetry（CC BY 4.0）· NOAA ETOPO 2022';
+      '水深数据：GMRT（CC BY 4.0）· EMODnet Bathymetry（CC BY 4.0）· NOAA ETOPO 2022 · NOAA NCEI DEM';
 
   @override
   String get dive3d_metric_depth => '深度';

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -7041,7 +7041,7 @@
   "@dive3d_seascape_noData": {},
   "dive3d_seascape_axis_distance": "Afstand ({unitSymbol})",
   "@dive3d_seascape_axis_distance": {},
-  "settings_about_bathymetryCredit": "Bathymetriegegevens: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022",
+  "settings_about_bathymetryCredit": "Bathymetriegegevens: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM",
   "@settings_about_bathymetryCredit": {},
   "dive3d_metric_depth": "Diepte",
   "@dive3d_metric_depth": {},

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -7041,7 +7041,7 @@
   "@dive3d_seascape_noData": {},
   "dive3d_seascape_axis_distance": "Distância ({unitSymbol})",
   "@dive3d_seascape_axis_distance": {},
-  "settings_about_bathymetryCredit": "Dados de batimetria: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022",
+  "settings_about_bathymetryCredit": "Dados de batimetria: GMRT (CC BY 4.0) · EMODnet Bathymetry (CC BY 4.0) · NOAA ETOPO 2022 · NOAA NCEI DEM",
   "@settings_about_bathymetryCredit": {},
   "dive3d_metric_depth": "Profundidade",
   "@dive3d_metric_depth": {},

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -7041,7 +7041,7 @@
   "@dive3d_seascape_noData": {},
   "dive3d_seascape_axis_distance": "距离（{unitSymbol}）",
   "@dive3d_seascape_axis_distance": {},
-  "settings_about_bathymetryCredit": "水深数据：GMRT（CC BY 4.0）· EMODnet Bathymetry（CC BY 4.0）· NOAA ETOPO 2022",
+  "settings_about_bathymetryCredit": "水深数据：GMRT（CC BY 4.0）· EMODnet Bathymetry（CC BY 4.0）· NOAA ETOPO 2022 · NOAA NCEI DEM",
   "@settings_about_bathymetryCredit": {},
   "dive3d_metric_depth": "深度",
   "@dive3d_metric_depth": {},

--- a/test/features/bathymetry/application/bathymetry_providers_test.dart
+++ b/test/features/bathymetry/application/bathymetry_providers_test.dart
@@ -147,7 +147,8 @@ class FlakySource implements BathymetrySource {
   @override
   bool get global => true;
   @override
-  bool covers(GeoPoint center) => true;
+  Future<SourceCapability?> probe(GeoPoint center) async =>
+      const SourceCapability(cellSizeMeters: 100, detail: 'fake');
   @override
   Future<BathymetryGrid> fetch(
     GeoPoint c, {

--- a/test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart
+++ b/test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart
@@ -415,5 +415,33 @@ void main() {
         ),
       );
     });
+
+    test('rejects a TIFF with no TileOffsets tag', () {
+      // Rewrite the TileOffsets tag id to an unused one so the tag is
+      // absent. Entries start at byte 10 and run 12 bytes each; TileOffsets
+      // is the eighth, at 10 + 7 * 12.
+      final bytes = variant();
+      const tileOffsetsEntry = 10 + 7 * 12;
+      ByteData.sublistView(
+        bytes,
+      ).setUint16(tileOffsetsEntry, 700, Endian.little);
+      expectRejected(bytes);
+    });
+
+    test('rejects a tile offset array pointing past the body', () {
+      // Four tiles, so TileOffsets is a real array rather than an inline
+      // value, and the array pointer is then out of range.
+      final bytes = buildTiff(
+        width: 4,
+        height: 4,
+        tileSize: 2,
+        tilePixels: List<double>.filled(16, -5.0),
+      );
+      const tileOffsetsValue = 10 + 7 * 12 + 8;
+      ByteData.sublistView(
+        bytes,
+      ).setUint32(tileOffsetsValue, 0x0FFFFFF0, Endian.little);
+      expectRejected(bytes);
+    });
   });
 }

--- a/test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart
+++ b/test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart
@@ -1,0 +1,327 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/bathymetry/data/sources/arcgis_float32_tiff_parser.dart';
+
+/// Builds a minimal little-endian tiled float32 TIFF matching the shape the
+/// NOAA ImageServer returns, so these tests pin the real wire format without
+/// carrying a 66 KB binary fixture.
+Uint8List buildTiff({
+  required int width,
+  required int height,
+  required int tileSize,
+  required List<double> tilePixels, // tileSize * tileSize per tile, row-major
+  int compression = 1,
+  int bitsPerSample = 32,
+}) {
+  final tilesAcross = (width + tileSize - 1) ~/ tileSize;
+  final tilesDown = (height + tileSize - 1) ~/ tileSize;
+  final tileCount = tilesAcross * tilesDown;
+  final tileBytes = tileSize * tileSize * 4;
+
+  const entries = 10;
+  const headerLen = 8;
+  const ifdLen = 2 + entries * 12 + 4;
+  // Tile offset and byte-count arrays live after the IFD when there is more
+  // than one tile; a single LONG fits inline in the entry's value field.
+  final arraysLen = tileCount > 1 ? tileCount * 4 * 2 : 0;
+  final pixelStart = headerLen + ifdLen + arraysLen;
+
+  final out = BytesBuilder();
+  final head = ByteData(headerLen);
+  head.setUint8(0, 0x49);
+  head.setUint8(1, 0x49);
+  head.setUint16(2, 42, Endian.little);
+  head.setUint32(4, headerLen, Endian.little);
+  out.add(head.buffer.asUint8List());
+
+  final ifd = ByteData(ifdLen);
+  ifd.setUint16(0, entries, Endian.little);
+  var e = 2;
+  void entry(int tag, int type, int count, int value) {
+    ifd.setUint16(e, tag, Endian.little);
+    ifd.setUint16(e + 2, type, Endian.little);
+    ifd.setUint32(e + 4, count, Endian.little);
+    if (type == 3 && count == 1) {
+      ifd.setUint16(e + 8, value, Endian.little);
+      ifd.setUint16(e + 10, 0, Endian.little);
+    } else {
+      ifd.setUint32(e + 8, value, Endian.little);
+    }
+    e += 12;
+  }
+
+  final offsetsAt = headerLen + ifdLen;
+  final countsAt = offsetsAt + tileCount * 4;
+  entry(256, 3, 1, width); // ImageWidth
+  entry(257, 3, 1, height); // ImageLength
+  entry(258, 3, 1, bitsPerSample); // BitsPerSample
+  entry(259, 3, 1, compression); // Compression
+  entry(277, 3, 1, 1); // SamplesPerPixel
+  entry(322, 3, 1, tileSize); // TileWidth
+  entry(323, 3, 1, tileSize); // TileLength
+  entry(324, 4, tileCount, tileCount == 1 ? pixelStart : offsetsAt);
+  entry(325, 4, tileCount, tileCount == 1 ? tileBytes : countsAt);
+  entry(339, 3, 1, 3); // SampleFormat = IEEE float
+  ifd.setUint32(ifdLen - 4, 0, Endian.little); // next IFD = none
+  out.add(ifd.buffer.asUint8List());
+
+  if (tileCount > 1) {
+    final arrays = ByteData(arraysLen);
+    for (var i = 0; i < tileCount; i++) {
+      arrays.setUint32(i * 4, pixelStart + i * tileBytes, Endian.little);
+      arrays.setUint32(tileCount * 4 + i * 4, tileBytes, Endian.little);
+    }
+    out.add(arrays.buffer.asUint8List());
+  }
+
+  final pixels = ByteData(tileCount * tileBytes);
+  for (var i = 0; i < tilePixels.length; i++) {
+    pixels.setFloat32(i * 4, tilePixels[i], Endian.little);
+  }
+  out.add(pixels.buffer.asUint8List());
+  return out.toBytes();
+}
+
+void main() {
+  final when = DateTime.utc(2026, 9, 5);
+
+  test('reads a single-tile image, flips rows south-first and negates', () {
+    // 2x2 image inside a 4x4 tile. Image row 0 is NORTHERNMOST.
+    final tile = List<double>.filled(16, 0);
+    tile[0] = -10.0; // north-west
+    tile[1] = -20.0; // north-east
+    tile[4] = -30.0; // south-west
+    tile[5] = -40.0; // south-east
+
+    final g = ArcgisFloat32TiffParser.parse(
+      buildTiff(width: 2, height: 2, tileSize: 4, tilePixels: tile),
+      westLon: -80.4,
+      eastLon: -80.2,
+      southLat: 25.0,
+      northLat: 25.2,
+      sourceId: 'noaa_dem',
+      resolutionMeters: 8,
+      fetchedAt: when,
+    );
+
+    expect(g.rows, 2);
+    expect(g.cols, 2);
+    // Grid row 0 is SOUTHERNMOST, and elevation negates into depth.
+    expect(g.depthAt(0, 0), closeTo(30.0, 1e-6));
+    expect(g.depthAt(0, 1), closeTo(40.0, 1e-6));
+    expect(g.depthAt(1, 0), closeTo(10.0, 1e-6));
+    expect(g.depthAt(1, 1), closeTo(20.0, 1e-6));
+    expect(g.sourceId, 'noaa_dem');
+    expect(g.resolutionMeters, 8);
+    expect(g.fetchedAt, when);
+  });
+
+  test('land above the waterline becomes a negative depth', () {
+    final tile = List<double>.filled(16, 4.0); // 4 m above sea level
+    final g = ArcgisFloat32TiffParser.parse(
+      buildTiff(width: 2, height: 2, tileSize: 4, tilePixels: tile),
+      westLon: 0,
+      eastLon: 1,
+      southLat: 0,
+      northLat: 1,
+      sourceId: 'noaa_dem',
+      resolutionMeters: 8,
+      fetchedAt: when,
+    );
+    expect(g.depthAt(0, 0), closeTo(-4.0, 1e-6));
+    expect(g.wetFraction, 0.0);
+  });
+
+  test('origin is the south-west CELL CENTER and cell sizes span the box', () {
+    final g = ArcgisFloat32TiffParser.parse(
+      buildTiff(
+        width: 2,
+        height: 2,
+        tileSize: 4,
+        tilePixels: List<double>.filled(16, -5.0),
+      ),
+      westLon: -80.4,
+      eastLon: -80.2,
+      southLat: 25.0,
+      northLat: 25.2,
+      sourceId: 'noaa_dem',
+      resolutionMeters: 8,
+      fetchedAt: when,
+    );
+    // 2 columns across a 0.2 degree box: cell width 0.1, first center half
+    // a cell in from the western edge.
+    expect(g.cellSizeLonDeg, closeTo(0.1, 1e-9));
+    expect(g.cellSizeLatDeg, closeTo(0.1, 1e-9));
+    expect(g.originLon, closeTo(-80.35, 1e-9));
+    expect(g.originLat, closeTo(25.05, 1e-9));
+  });
+
+  test('assembles a multi-tile image in row-major tile order', () {
+    // 4x4 image as four 2x2 tiles, each filled with its own value so a
+    // misplaced tile is obvious.
+    final pixels = <double>[
+      -1, -1, -1, -1, // tile 0 (north-west)
+      -2, -2, -2, -2, // tile 1 (north-east)
+      -3, -3, -3, -3, // tile 2 (south-west)
+      -4, -4, -4, -4, // tile 3 (south-east)
+    ];
+    final g = ArcgisFloat32TiffParser.parse(
+      buildTiff(width: 4, height: 4, tileSize: 2, tilePixels: pixels),
+      westLon: 0,
+      eastLon: 1,
+      southLat: 0,
+      northLat: 1,
+      sourceId: 'noaa_dem',
+      resolutionMeters: 8,
+      fetchedAt: when,
+    );
+    // After the south-first flip, grid row 0 is the image's LAST row.
+    expect(g.depthAt(0, 0), closeTo(3.0, 1e-6));
+    expect(g.depthAt(0, 3), closeTo(4.0, 1e-6));
+    expect(g.depthAt(3, 0), closeTo(1.0, 1e-6));
+    expect(g.depthAt(3, 3), closeTo(2.0, 1e-6));
+  });
+
+  test('ignores tile padding outside the image bounds', () {
+    // A 3x3 image in 2x2 tiles: the right and bottom tiles are half padding.
+    final pixels = <double>[
+      -1, -1, -1, -1, //
+      -2, -2, -2, -2, //
+      -3, -3, -3, -3, //
+      -4, -4, -4, -4, //
+    ];
+    final g = ArcgisFloat32TiffParser.parse(
+      buildTiff(width: 3, height: 3, tileSize: 2, tilePixels: pixels),
+      westLon: 0,
+      eastLon: 1,
+      southLat: 0,
+      northLat: 1,
+      sourceId: 'noaa_dem',
+      resolutionMeters: 8,
+      fetchedAt: when,
+    );
+    expect(g.rows, 3);
+    expect(g.cols, 3);
+    expect(g.depthsMeters.length, 9);
+    expect(g.depthsMeters.whereType<double>().length, 9);
+  });
+
+  test('maps the ArcGIS nodata sentinel to null', () {
+    final tile = List<double>.filled(16, -5.0);
+    tile[0] = -3.4028234663852886e38; // float32 lowest, ArcGIS NoData
+    final g = ArcgisFloat32TiffParser.parse(
+      buildTiff(width: 2, height: 2, tileSize: 4, tilePixels: tile),
+      westLon: 0,
+      eastLon: 1,
+      southLat: 0,
+      northLat: 1,
+      sourceId: 'noaa_dem',
+      resolutionMeters: 8,
+      fetchedAt: when,
+    );
+    // Image (0,0) is the northernmost row, which flips to grid row 1.
+    expect(g.depthAt(1, 0), isNull);
+    expect(g.depthAt(0, 0), closeTo(5.0, 1e-6));
+  });
+
+  test('a genuinely deep reading is not mistaken for nodata', () {
+    // The Challenger Deep is about 10935 m; the sentinel is 1e38 away.
+    final tile = List<double>.filled(16, -10935.0);
+    final g = ArcgisFloat32TiffParser.parse(
+      buildTiff(width: 2, height: 2, tileSize: 4, tilePixels: tile),
+      westLon: 0,
+      eastLon: 1,
+      southLat: 0,
+      northLat: 1,
+      sourceId: 'noaa_dem',
+      resolutionMeters: 8,
+      fetchedAt: when,
+    );
+    expect(g.depthAt(0, 0), closeTo(10935.0, 1e-3));
+  });
+
+  test('throws FormatException on a compressed TIFF', () {
+    expect(
+      () => ArcgisFloat32TiffParser.parse(
+        buildTiff(
+          width: 2,
+          height: 2,
+          tileSize: 4,
+          tilePixels: List<double>.filled(16, -5.0),
+          compression: 5,
+        ),
+        westLon: 0,
+        eastLon: 1,
+        southLat: 0,
+        northLat: 1,
+        sourceId: 'noaa_dem',
+        resolutionMeters: 8,
+        fetchedAt: when,
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('throws FormatException on a non-float sample depth', () {
+    expect(
+      () => ArcgisFloat32TiffParser.parse(
+        buildTiff(
+          width: 2,
+          height: 2,
+          tileSize: 4,
+          tilePixels: List<double>.filled(16, -5.0),
+          bitsPerSample: 16,
+        ),
+        westLon: 0,
+        eastLon: 1,
+        southLat: 0,
+        northLat: 1,
+        sourceId: 'noaa_dem',
+        resolutionMeters: 8,
+        fetchedAt: when,
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('throws FormatException on a non-TIFF body', () {
+    // ArcGIS returns error envelopes with HTTP 200, so this is the shape a
+    // failed request actually arrives in.
+    expect(
+      () => ArcgisFloat32TiffParser.parse(
+        Uint8List.fromList('{"error":{"code":400}}'.codeUnits),
+        westLon: 0,
+        eastLon: 1,
+        southLat: 0,
+        northLat: 1,
+        sourceId: 'noaa_dem',
+        resolutionMeters: 8,
+        fetchedAt: when,
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('throws FormatException when a tile runs past the end of the body', () {
+    final bytes = buildTiff(
+      width: 2,
+      height: 2,
+      tileSize: 4,
+      tilePixels: List<double>.filled(16, -5.0),
+    );
+    expect(
+      () => ArcgisFloat32TiffParser.parse(
+        bytes.sublist(0, bytes.length - 8), // truncated response
+        westLon: 0,
+        eastLon: 1,
+        southLat: 0,
+        northLat: 1,
+        sourceId: 'noaa_dem',
+        resolutionMeters: 8,
+        fetchedAt: when,
+      ),
+      throwsFormatException,
+    );
+  });
+}

--- a/test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart
+++ b/test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart
@@ -443,5 +443,52 @@ void main() {
       ).setUint32(tileOffsetsValue, 0x0FFFFFF0, Endian.little);
       expectRejected(bytes);
     });
+
+    test('rejects TileOffsets declared as SHORT rather than LONG', () {
+      // A SHORT array has 2-byte elements. Reading it as 4-byte LONGs
+      // yields garbage offsets that still land inside the body, so without
+      // a type check the tiles decode into plausible-looking nonsense.
+      // Entry layout is tag(2) type(2) count(4) value(4).
+      final bytes = buildTiff(
+        width: 4,
+        height: 4,
+        tileSize: 2,
+        tilePixels: List<double>.filled(16, -5.0),
+      );
+      const typeField = 10 + 7 * 12 + 2;
+      ByteData.sublistView(bytes).setUint16(typeField, 3, Endian.little);
+      expectRejected(bytes);
+    });
+
+    test('rejects TileOffsets declared as LONG8', () {
+      final bytes = buildTiff(
+        width: 4,
+        height: 4,
+        tileSize: 2,
+        tilePixels: List<double>.filled(16, -5.0),
+      );
+      const typeField = 10 + 7 * 12 + 2;
+      ByteData.sublistView(bytes).setUint16(typeField, 16, Endian.little);
+      expectRejected(bytes);
+    });
+
+    test('rejects TileByteCounts declared with an unexpected type', () {
+      final bytes = buildTiff(
+        width: 4,
+        height: 4,
+        tileSize: 2,
+        tilePixels: List<double>.filled(16, -5.0),
+      );
+      const typeField = 10 + 8 * 12 + 2;
+      ByteData.sublistView(bytes).setUint16(typeField, 3, Endian.little);
+      expectRejected(bytes);
+    });
+
+    test('rejects a TileOffsets count of zero', () {
+      final bytes = variant();
+      const countField = 10 + 7 * 12 + 4;
+      ByteData.sublistView(bytes).setUint32(countField, 0, Endian.little);
+      expectRejected(bytes);
+    });
   });
 }

--- a/test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart
+++ b/test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart
@@ -13,15 +13,17 @@ Uint8List buildTiff({
   required List<double> tilePixels, // tileSize * tileSize per tile, row-major
   int compression = 1,
   int bitsPerSample = 32,
+  int? sampleFormat = 3, // 3 = IEEE float; null omits the tag entirely
+  int? tileByteCountOverride,
 }) {
   final tilesAcross = (width + tileSize - 1) ~/ tileSize;
   final tilesDown = (height + tileSize - 1) ~/ tileSize;
   final tileCount = tilesAcross * tilesDown;
   final tileBytes = tileSize * tileSize * 4;
 
-  const entries = 10;
+  final entries = sampleFormat == null ? 9 : 10;
   const headerLen = 8;
-  const ifdLen = 2 + entries * 12 + 4;
+  final ifdLen = 2 + entries * 12 + 4;
   // Tile offset and byte-count arrays live after the IFD when there is more
   // than one tile; a single LONG fits inline in the entry's value field.
   final arraysLen = tileCount > 1 ? tileCount * 4 * 2 : 0;
@@ -51,7 +53,7 @@ Uint8List buildTiff({
     e += 12;
   }
 
-  const offsetsAt = headerLen + ifdLen;
+  final offsetsAt = headerLen + ifdLen;
   final countsAt = offsetsAt + tileCount * 4;
   entry(256, 3, 1, width); // ImageWidth
   entry(257, 3, 1, height); // ImageLength
@@ -61,8 +63,15 @@ Uint8List buildTiff({
   entry(322, 3, 1, tileSize); // TileWidth
   entry(323, 3, 1, tileSize); // TileLength
   entry(324, 4, tileCount, tileCount == 1 ? pixelStart : offsetsAt);
-  entry(325, 4, tileCount, tileCount == 1 ? tileBytes : countsAt);
-  entry(339, 3, 1, 3); // SampleFormat = IEEE float
+  entry(
+    325,
+    4,
+    tileCount,
+    tileCount == 1 ? (tileByteCountOverride ?? tileBytes) : countsAt,
+  );
+  if (sampleFormat != null) {
+    entry(339, 3, 1, sampleFormat); // 1 = uint, 2 = int, 3 = IEEE float
+  }
   ifd.setUint32(ifdLen - 4, 0, Endian.little); // next IFD = none
   out.add(ifd.buffer.asUint8List());
 
@@ -70,7 +79,11 @@ Uint8List buildTiff({
     final arrays = ByteData(arraysLen);
     for (var i = 0; i < tileCount; i++) {
       arrays.setUint32(i * 4, pixelStart + i * tileBytes, Endian.little);
-      arrays.setUint32(tileCount * 4 + i * 4, tileBytes, Endian.little);
+      arrays.setUint32(
+        tileCount * 4 + i * 4,
+        tileByteCountOverride ?? tileBytes,
+        Endian.little,
+      );
     }
     out.add(arrays.buffer.asUint8List());
   }
@@ -323,5 +336,84 @@ void main() {
       ),
       throwsFormatException,
     );
+  });
+
+  group('format strictness (the throw-on-anything-unexpected contract)', () {
+    Uint8List variant({int? sampleFormat = 3, int? tileByteCountOverride}) =>
+        buildTiff(
+          width: 2,
+          height: 2,
+          tileSize: 4,
+          tilePixels: List<double>.filled(16, -5.0),
+          sampleFormat: sampleFormat,
+          tileByteCountOverride: tileByteCountOverride,
+        );
+
+    void expectRejected(Uint8List bytes) {
+      expect(
+        () => ArcgisFloat32TiffParser.parse(
+          bytes,
+          westLon: 0,
+          eastLon: 1,
+          southLat: 0,
+          northLat: 1,
+          sourceId: 'noaa_dem',
+          resolutionMeters: 8,
+          fetchedAt: DateTime.utc(2026, 9, 5),
+        ),
+        throwsFormatException,
+      );
+    }
+
+    test('rejects unsigned integer samples', () {
+      // 32-bit ints read as float32 do not crash: they yield denormals near
+      // zero for small values and huge magnitudes for large ones, all
+      // non-null, so every downstream quality floor passes and the garbage
+      // renders as terrain. Failing fast falls through to the next source.
+      expectRejected(variant(sampleFormat: 1));
+    });
+
+    test('rejects signed integer samples', () {
+      expectRejected(variant(sampleFormat: 2));
+    });
+
+    test('rejects a TIFF with no SampleFormat tag', () {
+      // The TIFF default when the tag is absent is unsigned integer, not
+      // float, so an untagged raster must not be assumed to be float.
+      expectRejected(variant(sampleFormat: null));
+    });
+
+    test('accepts IEEE float samples', () {
+      final g = ArcgisFloat32TiffParser.parse(
+        variant(),
+        westLon: 0,
+        eastLon: 1,
+        southLat: 0,
+        northLat: 1,
+        sourceId: 'noaa_dem',
+        resolutionMeters: 8,
+        fetchedAt: DateTime.utc(2026, 9, 5),
+      );
+      expect(g.depthAt(0, 0), closeTo(5.0, 1e-6));
+    });
+
+    test('rejects a tile byte count that disagrees with the tile size', () {
+      // A short count means the tile is not the plain uncompressed block
+      // this parser assumes, whatever the Compression tag claims.
+      // A 4x4 float32 tile is 64 bytes; claim half that.
+      expectRejected(variant(tileByteCountOverride: 32));
+    });
+
+    test('rejects a multi-tile image whose byte counts disagree', () {
+      expectRejected(
+        buildTiff(
+          width: 4,
+          height: 4,
+          tileSize: 2,
+          tilePixels: List<double>.filled(16, -5.0),
+          tileByteCountOverride: 8,
+        ),
+      );
+    });
   });
 }

--- a/test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart
+++ b/test/features/bathymetry/data/arcgis_float32_tiff_parser_test.dart
@@ -51,7 +51,7 @@ Uint8List buildTiff({
     e += 12;
   }
 
-  final offsetsAt = headerLen + ifdLen;
+  const offsetsAt = headerLen + ifdLen;
   final countsAt = offsetsAt + tileCount * 4;
   entry(256, 3, 1, width); // ImageWidth
   entry(257, 3, 1, height); // ImageLength

--- a/test/features/bathymetry/data/bathymetry_repository_test.dart
+++ b/test/features/bathymetry/data/bathymetry_repository_test.dart
@@ -32,7 +32,8 @@ class ScriptedSource implements BathymetrySource {
   @override
   bool get global => true;
   @override
-  bool covers(GeoPoint center) => true;
+  Future<SourceCapability?> probe(GeoPoint center) async =>
+      const SourceCapability(cellSizeMeters: 100, detail: 'fake');
   @override
   Future<BathymetryGrid> fetch(GeoPoint c, {required double spanMeters}) async {
     calls++;

--- a/test/features/bathymetry/data/bathymetry_repository_test.dart
+++ b/test/features/bathymetry/data/bathymetry_repository_test.dart
@@ -75,13 +75,14 @@ void main() {
     final q = BathymetryRepository.quantize(bonaire);
     expect(q.lat, closeTo(12.16, 1e-9));
     expect(q.lon, closeTo(-68.30, 1e-9)); // -68.29 floors DOWN to -68.30
-    // The key carries the request span so a span change refetches instead
-    // of serving a smaller cached area forever.
-    expect(BathymetryRepository.keyFor(bonaire), '12.16,-68.30@8000');
+    // The key carries the request span and the selection generation, so a
+    // change to either refetches instead of serving the old cached answer
+    // forever.
+    expect(BathymetryRepository.keyFor(bonaire), '12.16,-68.30@8000v2');
     // Nearby coordinates share the key.
     expect(
       BathymetryRepository.keyFor(const GeoPoint(12.171, -68.281)),
-      '12.16,-68.30@8000',
+      '12.16,-68.30@8000v2',
     );
   });
 
@@ -203,5 +204,21 @@ void main() {
     final grid = await repo(source).getGrid(bonaire);
     expect(grid!.rows, lessThanOrEqualTo(120));
     expect(grid.cols, lessThanOrEqualTo(120));
+  });
+
+  test('the cache key carries the selection generation', () {
+    final key = BathymetryRepository.keyFor(const GeoPoint(12.16, -68.29));
+    expect(key, endsWith('@8000v2'));
+  });
+
+  test('a row written under the previous generation is not reused', () {
+    // An install upgrading from the pre-selection-change build must MISS
+    // its old rows, or every already-visited site keeps serving the grid
+    // the old resolver chose. Cached rows never expire.
+    const p = GeoPoint(12.16, -68.29);
+    final q = BathymetryRepository.quantize(p);
+    final legacyKey =
+        '${q.lat.toStringAsFixed(2)},${q.lon.toStringAsFixed(2)}@8000';
+    expect(BathymetryRepository.keyFor(p), isNot(legacyKey));
   });
 }

--- a/test/features/bathymetry/data/bathymetry_resolver_test.dart
+++ b/test/features/bathymetry/data/bathymetry_resolver_test.dart
@@ -174,19 +174,22 @@ void main() {
     expect(res.definitive, isTrue);
   });
 
-  test('a mostly-empty grid fails the known-cell floor and falls through', () async {
-    // 4 known of 10 cells is 40%, below the 60% floor, even though every
-    // known cell is wet. This is EMODnet's Bonaire tile in miniature.
-    final holey = <double?>[
-      50.0, null, 50.0, null, 50.0, null, 50.0, null, null, null, //
-    ];
-    final a = FakeSource('emodnet-like', result: gridOf(holey, 'a'));
-    final b = FakeSource('gmrt-like', result: gridWith(wet, 'b'));
-    final res = await BathymetryResolver(sources: [a, b]).resolve(p);
-    expect(res.grid!.sourceId, 'b');
-    expect(a.fetchCount, 1);
-    expect(b.fetchCount, 1);
-  });
+  test(
+    'a mostly-empty grid fails the known-cell floor and falls through',
+    () async {
+      // 4 known of 10 cells is 40%, below the 60% floor, even though every
+      // known cell is wet. This is EMODnet's Bonaire tile in miniature.
+      final holey = <double?>[
+        50.0, null, 50.0, null, 50.0, null, 50.0, null, null, null, //
+      ];
+      final a = FakeSource('emodnet-like', result: gridOf(holey, 'a'));
+      final b = FakeSource('gmrt-like', result: gridWith(wet, 'b'));
+      final res = await BathymetryResolver(sources: [a, b]).resolve(p);
+      expect(res.grid!.sourceId, 'b');
+      expect(a.fetchCount, 1);
+      expect(b.fetchCount, 1);
+    },
+  );
 
   test('a grid at exactly the known-cell floor is accepted', () async {
     final atFloor = <double?>[
@@ -197,15 +200,18 @@ void main() {
     expect(res.grid!.sourceId, 'a');
   });
 
-  test('a mostly-empty grid from a global source is not a definitive empty', () async {
-    // Falling through on coverage must not be mistaken for "no water here":
-    // an empty answer would cache and pin the cell forever.
-    final holey = <double?>[50.0, null, null, null, null];
-    final a = FakeSource('a', result: gridOf(holey, 'a'));
-    final res = await BathymetryResolver(sources: [a]).resolve(p);
-    expect(res.grid, isNull);
-    expect(res.definitive, isFalse);
-  });
+  test(
+    'a mostly-empty grid from a global source is not a definitive empty',
+    () async {
+      // Falling through on coverage must not be mistaken for "no water here":
+      // an empty answer would cache and pin the cell forever.
+      final holey = <double?>[50.0, null, null, null, null];
+      final a = FakeSource('a', result: gridOf(holey, 'a'));
+      final res = await BathymetryResolver(sources: [a]).resolve(p);
+      expect(res.grid, isNull);
+      expect(res.definitive, isFalse);
+    },
+  );
 
   test('a materially finer source preempts the declared order', () async {
     // 10 m against 100 m is a factor of 10, well past preemptionFactor.
@@ -220,26 +226,29 @@ void main() {
     expect(coarse.fetchCount, 0);
   });
 
-  test('a marginally finer source does not preempt the declared order', () async {
-    // 60 m against 115 m is a factor of 1.9, inside preemptionFactor, so
-    // the declared regional-first order stands. This is EMODnet vs GMRT
-    // in Europe, where GMRT's fine nominal grid may be upsampled GEBCO.
-    final regional = FakeSource(
-      'emodnet',
-      result: gridWith(wet, 'emodnet'),
-      cellSizeMeters: 115,
-    );
-    final globalSource = FakeSource(
-      'gmrt',
-      result: gridWith(wet, 'gmrt'),
-      cellSizeMeters: 60,
-    );
-    final res = await BathymetryResolver(
-      sources: [regional, globalSource],
-    ).resolve(p);
-    expect(res.grid!.sourceId, 'emodnet');
-    expect(globalSource.fetchCount, 0);
-  });
+  test(
+    'a marginally finer source does not preempt the declared order',
+    () async {
+      // 60 m against 115 m is a factor of 1.9, inside preemptionFactor, so
+      // the declared regional-first order stands. This is EMODnet vs GMRT
+      // in Europe, where GMRT's fine nominal grid may be upsampled GEBCO.
+      final regional = FakeSource(
+        'emodnet',
+        result: gridWith(wet, 'emodnet'),
+        cellSizeMeters: 115,
+      );
+      final globalSource = FakeSource(
+        'gmrt',
+        result: gridWith(wet, 'gmrt'),
+        cellSizeMeters: 60,
+      );
+      final res = await BathymetryResolver(
+        sources: [regional, globalSource],
+      ).resolve(p);
+      expect(res.grid!.sourceId, 'emodnet');
+      expect(globalSource.fetchCount, 0);
+    },
+  );
 
   test('a probe that throws is treated as not covering', () async {
     final res = await BathymetryResolver(

--- a/test/features/bathymetry/data/bathymetry_resolver_test.dart
+++ b/test/features/bathymetry/data/bathymetry_resolver_test.dart
@@ -25,13 +25,22 @@ class FakeSource implements BathymetrySource {
   final bool global;
   final bool coversIt;
   final BathymetryGrid? result; // null => throw transient
+  final double cellSizeMeters;
   int fetchCount = 0;
   double? lastSpanMeters;
 
-  FakeSource(this.id, {this.global = true, this.coversIt = true, this.result});
+  FakeSource(
+    this.id, {
+    this.global = true,
+    this.coversIt = true,
+    this.result,
+    this.cellSizeMeters = 100,
+  });
 
   @override
-  bool covers(GeoPoint center) => coversIt;
+  Future<SourceCapability?> probe(GeoPoint center) async => coversIt
+      ? SourceCapability(cellSizeMeters: cellSizeMeters, detail: id)
+      : null;
 
   @override
   Future<BathymetryGrid> fetch(GeoPoint c, {required double spanMeters}) async {
@@ -49,7 +58,8 @@ class _ErrorSource implements BathymetrySource {
   @override
   bool get global => true;
   @override
-  bool covers(GeoPoint center) => true;
+  Future<SourceCapability?> probe(GeoPoint center) async =>
+      const SourceCapability(cellSizeMeters: 100, detail: 'boom');
   @override
   Future<BathymetryGrid> fetch(GeoPoint c, {required double spanMeters}) async {
     throw ArgumentError('unexpected parser blow-up');

--- a/test/features/bathymetry/data/bathymetry_resolver_test.dart
+++ b/test/features/bathymetry/data/bathymetry_resolver_test.dart
@@ -18,6 +18,19 @@ BathymetryGrid gridWith(List<double?> depths, String sourceId) =>
       fetchedAt: DateTime.utc(2026, 7, 28),
     );
 
+BathymetryGrid gridOf(List<double?> depths, String sourceId) => BathymetryGrid(
+  originLat: 12.14,
+  originLon: -68.31,
+  cellSizeLatDeg: 0.004,
+  cellSizeLonDeg: 0.004,
+  rows: 1,
+  cols: depths.length,
+  depthsMeters: depths,
+  sourceId: sourceId,
+  resolutionMeters: 100,
+  fetchedAt: DateTime.utc(2026, 7, 28),
+);
+
 class FakeSource implements BathymetrySource {
   @override
   final String id;
@@ -64,6 +77,21 @@ class _ErrorSource implements BathymetrySource {
   Future<BathymetryGrid> fetch(GeoPoint c, {required double spanMeters}) async {
     throw ArgumentError('unexpected parser blow-up');
   }
+}
+
+class _ThrowingProbeSource implements BathymetrySource {
+  @override
+  String get id => 'probe-boom';
+  @override
+  bool get global => false;
+  @override
+  Future<SourceCapability?> probe(GeoPoint center) async =>
+      throw StateError('probe exploded');
+  @override
+  Future<BathymetryGrid> fetch(
+    GeoPoint c, {
+    required double spanMeters,
+  }) async => throw StateError('should never be fetched');
 }
 
 void main() {
@@ -144,5 +172,82 @@ void main() {
     final res = await BathymetryResolver(sources: [a]).resolve(p);
     expect(res.grid, isNull);
     expect(res.definitive, isTrue);
+  });
+
+  test('a mostly-empty grid fails the known-cell floor and falls through', () async {
+    // 4 known of 10 cells is 40%, below the 60% floor, even though every
+    // known cell is wet. This is EMODnet's Bonaire tile in miniature.
+    final holey = <double?>[
+      50.0, null, 50.0, null, 50.0, null, 50.0, null, null, null, //
+    ];
+    final a = FakeSource('emodnet-like', result: gridOf(holey, 'a'));
+    final b = FakeSource('gmrt-like', result: gridWith(wet, 'b'));
+    final res = await BathymetryResolver(sources: [a, b]).resolve(p);
+    expect(res.grid!.sourceId, 'b');
+    expect(a.fetchCount, 1);
+    expect(b.fetchCount, 1);
+  });
+
+  test('a grid at exactly the known-cell floor is accepted', () async {
+    final atFloor = <double?>[
+      50.0, 50.0, 50.0, 50.0, 50.0, 50.0, null, null, null, null, //
+    ];
+    final a = FakeSource('a', result: gridOf(atFloor, 'a'));
+    final res = await BathymetryResolver(sources: [a]).resolve(p);
+    expect(res.grid!.sourceId, 'a');
+  });
+
+  test('a mostly-empty grid from a global source is not a definitive empty', () async {
+    // Falling through on coverage must not be mistaken for "no water here":
+    // an empty answer would cache and pin the cell forever.
+    final holey = <double?>[50.0, null, null, null, null];
+    final a = FakeSource('a', result: gridOf(holey, 'a'));
+    final res = await BathymetryResolver(sources: [a]).resolve(p);
+    expect(res.grid, isNull);
+    expect(res.definitive, isFalse);
+  });
+
+  test('a materially finer source preempts the declared order', () async {
+    // 10 m against 100 m is a factor of 10, well past preemptionFactor.
+    final coarse = FakeSource('coarse', result: gridWith(wet, 'coarse'));
+    final fine = FakeSource(
+      'fine',
+      result: gridWith(wet, 'fine'),
+      cellSizeMeters: 10,
+    );
+    final res = await BathymetryResolver(sources: [coarse, fine]).resolve(p);
+    expect(res.grid!.sourceId, 'fine');
+    expect(coarse.fetchCount, 0);
+  });
+
+  test('a marginally finer source does not preempt the declared order', () async {
+    // 60 m against 115 m is a factor of 1.9, inside preemptionFactor, so
+    // the declared regional-first order stands. This is EMODnet vs GMRT
+    // in Europe, where GMRT's fine nominal grid may be upsampled GEBCO.
+    final regional = FakeSource(
+      'emodnet',
+      result: gridWith(wet, 'emodnet'),
+      cellSizeMeters: 115,
+    );
+    final globalSource = FakeSource(
+      'gmrt',
+      result: gridWith(wet, 'gmrt'),
+      cellSizeMeters: 60,
+    );
+    final res = await BathymetryResolver(
+      sources: [regional, globalSource],
+    ).resolve(p);
+    expect(res.grid!.sourceId, 'emodnet');
+    expect(globalSource.fetchCount, 0);
+  });
+
+  test('a probe that throws is treated as not covering', () async {
+    final res = await BathymetryResolver(
+      sources: [
+        _ThrowingProbeSource(),
+        FakeSource('b', result: gridWith(wet, 'b')),
+      ],
+    ).resolve(p);
+    expect(res.grid!.sourceId, 'b');
   });
 }

--- a/test/features/bathymetry/data/emodnet_source_test.dart
+++ b/test/features/bathymetry/data/emodnet_source_test.dart
@@ -15,13 +15,27 @@ void main() {
   EmodnetSource source(MockClientHandler handler) =>
       EmodnetSource(client: MockClient(handler));
 
-  test('covers Europe and the Caribbean tile, nothing else', () {
+  test('probes Europe and the Caribbean tile, nothing else', () async {
     final s = source((_) async => http.Response('', 500));
-    expect(s.covers(const GeoPoint(43.2, 4.5)), isTrue); // Mediterranean
-    expect(s.covers(const GeoPoint(12.16, -68.29)), isTrue); // Bonaire
-    expect(s.covers(const GeoPoint(36.6, -121.9)), isFalse); // Monterey
-    expect(s.covers(const GeoPoint(-8.5, 115.5)), isFalse); // Bali
+    // Mediterranean and Bonaire are inside the two boxes.
+    expect((await s.probe(const GeoPoint(43.2, 4.5)))?.cellSizeMeters, 115);
+    expect((await s.probe(const GeoPoint(12.16, -68.29)))?.cellSizeMeters, 115);
+    // Monterey and Bali are outside both.
+    expect(await s.probe(const GeoPoint(36.6, -121.9)), isNull);
+    expect(await s.probe(const GeoPoint(-8.5, 115.5)), isNull);
     expect(s.global, isFalse);
+  });
+
+  test('probe names the dataset it would query, for provenance', () async {
+    final s = source((_) async => http.Response('', 500));
+    expect(
+      (await s.probe(const GeoPoint(12.16, -68.29)))!.detail,
+      'bathymetry_dtm_carib_2024',
+    );
+    expect(
+      (await s.probe(const GeoPoint(42.048, 3.223)))!.detail,
+      'bathymetry_dtm_2024',
+    );
   });
 
   test('selects the Caribbean dataset for a Caribbean coordinate', () async {

--- a/test/features/bathymetry/data/etopo_erddap_source_test.dart
+++ b/test/features/bathymetry/data/etopo_erddap_source_test.dart
@@ -69,11 +69,14 @@ void main() {
     );
   });
 
-  test('covers everywhere and is global', () {
+  test('probes everywhere at its declared 450 m and is global', () async {
     final source = EtopoErddapSource(
       client: MockClient((_) async => http.Response('', 500)),
     );
-    expect(source.covers(const GeoPoint(-80, 170)), isTrue);
+    final cap = await source.probe(const GeoPoint(-80, 170));
+    expect(cap, isNotNull);
+    expect(cap!.cellSizeMeters, 450);
+    expect(cap.detail, 'ETOPO_2022_v1_15s');
     expect(source.global, isTrue);
   });
 }

--- a/test/features/bathymetry/data/gmrt_source_test.dart
+++ b/test/features/bathymetry/data/gmrt_source_test.dart
@@ -95,4 +95,15 @@ void main() {
       },
     );
   });
+
+  group('probe', () {
+    test('covers everywhere at its declared 60 m', () async {
+      final cap = await GmrtSource(
+        client: MockClient((_) async => http.Response('', 500)),
+      ).probe(const GeoPoint(-33.9, 151.2));
+      expect(cap, isNotNull);
+      expect(cap!.cellSizeMeters, 60);
+      expect(cap.detail, 'GMRT GridServer');
+    });
+  });
 }

--- a/test/features/bathymetry/data/noaa_dem_source_test.dart
+++ b/test/features/bathymetry/data/noaa_dem_source_test.dart
@@ -91,8 +91,10 @@ void main() {
       );
       final cap = await source.probe(keys);
       expect(cap, isNotNull);
-      // 3.086e-05 degrees of longitude at 25 N is about 3.1 m.
-      expect(cap!.cellSizeMeters, closeTo(3.1, 0.4));
+      // A geographic cell is square in DEGREES, so its two sides differ in
+      // meters. The capability reports the COARSER side: at 25 N that is
+      // the latitude axis, 3.086e-05 * 110540 = 3.41 m.
+      expect(cap!.cellSizeMeters, closeTo(3.41, 0.05));
       expect(cap.detail, 'ncei19_n25x25_w080x50_2016v1');
     });
 
@@ -204,6 +206,64 @@ void main() {
           client: MockClient((req) async => throw const SocketishError()),
         );
         expect(await source.probe(keys), isNull);
+      },
+    );
+
+    test(
+      'reports the coarser axis, so latitude cannot flatter a DEM',
+      () async {
+        // A 3 arc-second cell is 92.1 m north-south everywhere. Converting on
+        // the longitude axis alone shrinks it with cos(latitude): at 60 N it
+        // reads 46.4 m and slips under the 50 m threshold, so a 92 m DEM
+        // would be accepted as high resolution. NOAA's mosaic really does
+        // hold 3 arc-second Coastal Relief Model tiles, and Alaskan coastal
+        // water is exactly where they are the best available.
+        final source = NoaaDemSource(
+          client: MockClient(
+            (req) async => http.Response(
+              identifyBody([(name: 'crm_vol8', lowPs: 8.33e-04)]),
+              200,
+            ),
+          ),
+        );
+        expect(await source.probe(const GeoPoint(60.0, -149.0)), isNull);
+        // The same tile is already rejected at the equator today, which is
+        // the inconsistency this removes.
+        expect(await source.probe(const GeoPoint(0.0, -90.0)), isNull);
+      },
+    );
+
+    test('a genuinely fine DEM is still accepted at high latitude', () async {
+      // The guard must not reject real high-resolution Alaskan coverage:
+      // a 1 arc-second cell is 30.7 m north-south, inside the threshold.
+      final source = NoaaDemSource(
+        client: MockClient(
+          (req) async => http.Response(
+            identifyBody([(name: 'alaska_1s', lowPs: 2.78e-04)]),
+            200,
+          ),
+        ),
+      );
+      final cap = await source.probe(const GeoPoint(60.0, -149.0));
+      expect(cap, isNotNull);
+      expect(cap!.cellSizeMeters, closeTo(30.7, 0.2));
+    });
+
+    test(
+      'uses the longitude axis near the equator, where it is the longer',
+      () async {
+        // A degree of longitude at the equator is 111320 m against latitude's
+        // 110540, so the coarser axis is not always the latitude one.
+        final source = NoaaDemSource(
+          client: MockClient(
+            (req) async => http.Response(
+              identifyBody([(name: 'equatorial', lowPs: 1.0e-04)]),
+              200,
+            ),
+          ),
+        );
+        final cap = await source.probe(const GeoPoint(0.0, -90.0));
+        expect(cap!.cellSizeMeters, closeTo(11.132, 0.005));
       },
     );
   });

--- a/test/features/bathymetry/data/noaa_dem_source_test.dart
+++ b/test/features/bathymetry/data/noaa_dem_source_test.dart
@@ -151,19 +151,22 @@ void main() {
       expect(await source.probe(keys), isNull);
     });
 
-    test('declines on an ArcGIS error envelope returned with HTTP 200', () async {
-      final source = NoaaDemSource(
-        client: MockClient(
-          (req) async => http.Response(
-            jsonEncode({
-              'error': {'code': 400, 'message': 'Invalid geometry'},
-            }),
-            200,
+    test(
+      'declines on an ArcGIS error envelope returned with HTTP 200',
+      () async {
+        final source = NoaaDemSource(
+          client: MockClient(
+            (req) async => http.Response(
+              jsonEncode({
+                'error': {'code': 400, 'message': 'Invalid geometry'},
+              }),
+              200,
+            ),
           ),
-        ),
-      );
-      expect(await source.probe(keys), isNull);
-    });
+        );
+        expect(await source.probe(keys), isNull);
+      },
+    );
 
     test('declines on a catalogue item with no usable cell size', () async {
       final source = NoaaDemSource(
@@ -192,14 +195,17 @@ void main() {
       expect(await source.probe(keys), isNull);
     });
 
-    test('declines rather than throwing when the service is unreachable', () async {
-      // A probe must never throw: one unreachable source cannot be allowed
-      // to block the others.
-      final source = NoaaDemSource(
-        client: MockClient((req) async => throw const SocketishError()),
-      );
-      expect(await source.probe(keys), isNull);
-    });
+    test(
+      'declines rather than throwing when the service is unreachable',
+      () async {
+        // A probe must never throw: one unreachable source cannot be allowed
+        // to block the others.
+        final source = NoaaDemSource(
+          client: MockClient((req) async => throw const SocketishError()),
+        );
+        expect(await source.probe(keys), isNull);
+      },
+    );
   });
 
   group('fetch', () {
@@ -227,13 +233,19 @@ void main() {
       expect(g.sourceId, NoaaDemSource.sourceId);
     });
 
-    test('claims a resolution derived from the span and request size', () async {
-      final source = NoaaDemSource(
-        client: MockClient((_) async => http.Response.bytes(tinyTiff(), 200)),
-      );
-      final g = await source.fetch(keys, spanMeters: 2000);
-      expect(g.resolutionMeters, closeTo(2000 / NoaaDemSource.requestDim, 1e-9));
-    });
+    test(
+      'claims a resolution derived from the span and request size',
+      () async {
+        final source = NoaaDemSource(
+          client: MockClient((_) async => http.Response.bytes(tinyTiff(), 200)),
+        );
+        final g = await source.fetch(keys, spanMeters: 2000);
+        expect(
+          g.resolutionMeters,
+          closeTo(2000 / NoaaDemSource.requestDim, 1e-9),
+        );
+      },
+    );
 
     test('throws BathymetryFetchException on a non-200', () async {
       final source = NoaaDemSource(

--- a/test/features/bathymetry/data/noaa_dem_source_test.dart
+++ b/test/features/bathymetry/data/noaa_dem_source_test.dart
@@ -1,0 +1,270 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/features/bathymetry/data/sources/noaa_dem_source.dart';
+import 'package:submersion/features/bathymetry/domain/bathymetry_source.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+/// The shape the live `identify` endpoint returns: a stack of catalogue
+/// items, each with its own cell size in DEGREES.
+String identifyBody(List<({String name, double lowPs})> items) => jsonEncode({
+  'objectId': 0,
+  'value': '-3.87793',
+  'catalogItems': {
+    'features': [
+      for (final i in items)
+        {
+          'attributes': {'Name': i.name, 'LowPS': i.lowPs, 'HighPS': i.lowPs},
+        },
+    ],
+  },
+});
+
+/// A 2x2 single-tile float32 TIFF, every pixel 8 m below sea level.
+Uint8List tinyTiff() {
+  const width = 2, height = 2, tileSize = 4, entries = 10;
+  const headerLen = 8;
+  const ifdLen = 2 + entries * 12 + 4;
+  const pixelStart = headerLen + ifdLen;
+  final out = BytesBuilder();
+  final head = ByteData(headerLen);
+  head.setUint8(0, 0x49);
+  head.setUint8(1, 0x49);
+  head.setUint16(2, 42, Endian.little);
+  head.setUint32(4, headerLen, Endian.little);
+  out.add(head.buffer.asUint8List());
+  final ifd = ByteData(ifdLen);
+  ifd.setUint16(0, entries, Endian.little);
+  var e = 2;
+  void entry(int tag, int type, int count, int value) {
+    ifd.setUint16(e, tag, Endian.little);
+    ifd.setUint16(e + 2, type, Endian.little);
+    ifd.setUint32(e + 4, count, Endian.little);
+    if (type == 3 && count == 1) {
+      ifd.setUint16(e + 8, value, Endian.little);
+      ifd.setUint16(e + 10, 0, Endian.little);
+    } else {
+      ifd.setUint32(e + 8, value, Endian.little);
+    }
+    e += 12;
+  }
+
+  entry(256, 3, 1, width);
+  entry(257, 3, 1, height);
+  entry(258, 3, 1, 32);
+  entry(259, 3, 1, 1);
+  entry(277, 3, 1, 1);
+  entry(322, 3, 1, tileSize);
+  entry(323, 3, 1, tileSize);
+  entry(324, 4, 1, pixelStart);
+  entry(325, 4, 1, tileSize * tileSize * 4);
+  entry(339, 3, 1, 3);
+  ifd.setUint32(ifdLen - 4, 0, Endian.little);
+  out.add(ifd.buffer.asUint8List());
+  final px = ByteData(tileSize * tileSize * 4);
+  for (var i = 0; i < tileSize * tileSize; i++) {
+    px.setFloat32(i * 4, -8.0, Endian.little);
+  }
+  out.add(px.buffer.asUint8List());
+  return out.toBytes();
+}
+
+void main() {
+  const keys = GeoPoint(25.010, -80.376);
+  const bonaire = GeoPoint(12.093, -68.287);
+
+  group('probe', () {
+    test('returns the finest catalogue item, converted to meters', () async {
+      final source = NoaaDemSource(
+        client: MockClient(
+          (req) async => http.Response(
+            identifyBody([
+              (name: 'ETOPO_2022_v1_15s_surface_elev', lowPs: 0.0041666),
+              (name: 'ncei19_n25x25_w080x50_2016v1', lowPs: 3.086419e-05),
+            ]),
+            200,
+          ),
+        ),
+      );
+      final cap = await source.probe(keys);
+      expect(cap, isNotNull);
+      // 3.086e-05 degrees of longitude at 25 N is about 3.1 m.
+      expect(cap!.cellSizeMeters, closeTo(3.1, 0.4));
+      expect(cap.detail, 'ncei19_n25x25_w080x50_2016v1');
+    });
+
+    test('asks for maxItemCount so the catalogue is not truncated', () async {
+      // Load-bearing: the default truncates to three items, which hides a
+      // covered site's DEM behind the ETOPO background.
+      Uri? seen;
+      final source = NoaaDemSource(
+        client: MockClient((req) async {
+          seen = req.url;
+          return http.Response(identifyBody([]), 200);
+        }),
+      );
+      await source.probe(keys);
+      expect(seen!.queryParameters['maxItemCount'], '25');
+      expect(seen!.queryParameters['returnCatalogItems'], 'true');
+      expect(seen!.queryParameters['f'], 'json');
+      expect(seen!.path, endsWith('/identify'));
+    });
+
+    test('declines when the best item is coarser than the threshold', () async {
+      // Bonaire: the mosaic holds nothing but its ETOPO background there,
+      // which the ETOPO tier already serves directly.
+      final source = NoaaDemSource(
+        client: MockClient(
+          (req) async => http.Response(
+            identifyBody([
+              (name: 'ETOPO_2022_v1_15s_surface_elev', lowPs: 0.0041666),
+            ]),
+            200,
+          ),
+        ),
+      );
+      expect(await source.probe(bonaire), isNull);
+    });
+
+    test('accepts a mid-range regional DEM', () async {
+      // La Jolla measured 10.3 m, comfortably inside the threshold.
+      final source = NoaaDemSource(
+        client: MockClient(
+          (req) async => http.Response(
+            identifyBody([(name: 'san_diego_navd88', lowPs: 1.1e-04)]),
+            200,
+          ),
+        ),
+      );
+      final cap = await source.probe(const GeoPoint(32.85, -117.27));
+      expect(cap!.cellSizeMeters, lessThan(NoaaDemSource.usefulCellSizeMeters));
+      expect(cap.detail, 'san_diego_navd88');
+    });
+
+    test('declines on an empty catalogue', () async {
+      final source = NoaaDemSource(
+        client: MockClient((req) async => http.Response(identifyBody([]), 200)),
+      );
+      expect(await source.probe(keys), isNull);
+    });
+
+    test('declines on an ArcGIS error envelope returned with HTTP 200', () async {
+      final source = NoaaDemSource(
+        client: MockClient(
+          (req) async => http.Response(
+            jsonEncode({
+              'error': {'code': 400, 'message': 'Invalid geometry'},
+            }),
+            200,
+          ),
+        ),
+      );
+      expect(await source.probe(keys), isNull);
+    });
+
+    test('declines on a catalogue item with no usable cell size', () async {
+      final source = NoaaDemSource(
+        client: MockClient(
+          (req) async => http.Response(
+            jsonEncode({
+              'catalogItems': {
+                'features': [
+                  {
+                    'attributes': {'Name': 'broken', 'LowPS': 0},
+                  },
+                ],
+              },
+            }),
+            200,
+          ),
+        ),
+      );
+      expect(await source.probe(keys), isNull);
+    });
+
+    test('declines on a non-200', () async {
+      final source = NoaaDemSource(
+        client: MockClient((req) async => http.Response('nope', 503)),
+      );
+      expect(await source.probe(keys), isNull);
+    });
+
+    test('declines rather than throwing when the service is unreachable', () async {
+      // A probe must never throw: one unreachable source cannot be allowed
+      // to block the others.
+      final source = NoaaDemSource(
+        client: MockClient((req) async => throw const SocketishError()),
+      );
+      expect(await source.probe(keys), isNull);
+    });
+  });
+
+  group('fetch', () {
+    test('requests a float32 tiff over the span and parses it', () async {
+      Uri? seen;
+      final source = NoaaDemSource(
+        client: MockClient((req) async {
+          seen = req.url;
+          return http.Response.bytes(tinyTiff(), 200);
+        }),
+      );
+      final g = await source.fetch(keys, spanMeters: 2000);
+      expect(seen!.path, endsWith('/exportImage'));
+      expect(seen!.queryParameters['format'], 'tiff');
+      expect(seen!.queryParameters['pixelType'], 'F32');
+      expect(seen!.queryParameters['bboxSR'], '4326');
+      expect(seen!.queryParameters['imageSR'], '4326');
+      expect(
+        seen!.queryParameters['size'],
+        '${NoaaDemSource.requestDim},${NoaaDemSource.requestDim}',
+      );
+      expect(g.rows, 2);
+      expect(g.cols, 2);
+      expect(g.depthAt(0, 0), closeTo(8.0, 1e-6));
+      expect(g.sourceId, NoaaDemSource.sourceId);
+    });
+
+    test('claims a resolution derived from the span and request size', () async {
+      final source = NoaaDemSource(
+        client: MockClient((_) async => http.Response.bytes(tinyTiff(), 200)),
+      );
+      final g = await source.fetch(keys, spanMeters: 2000);
+      expect(g.resolutionMeters, closeTo(2000 / NoaaDemSource.requestDim, 1e-9));
+    });
+
+    test('throws BathymetryFetchException on a non-200', () async {
+      final source = NoaaDemSource(
+        client: MockClient((req) async => http.Response('down', 500)),
+      );
+      expect(
+        () => source.fetch(keys, spanMeters: 2000),
+        throwsA(isA<BathymetryFetchException>()),
+      );
+    });
+
+    test('throws BathymetryFetchException on an error envelope', () async {
+      final source = NoaaDemSource(
+        client: MockClient(
+          (req) async => http.Response('{"error":{"code":400}}', 200),
+        ),
+      );
+      expect(
+        () => source.fetch(keys, spanMeters: 2000),
+        throwsA(isA<BathymetryFetchException>()),
+      );
+    });
+  });
+
+  test('is not global, so a dry answer never proves land', () {
+    expect(NoaaDemSource().global, isFalse);
+    expect(NoaaDemSource().id, NoaaDemSource.sourceId);
+  });
+}
+
+/// Stands in for a transport-level failure without importing dart:io.
+class SocketishError implements Exception {
+  const SocketishError();
+}

--- a/test/features/bathymetry/domain/bathymetry_grid_test.dart
+++ b/test/features/bathymetry/domain/bathymetry_grid_test.dart
@@ -140,5 +140,50 @@ void main() {
       final g = grid(List<double?>.filled(16, 5.0), rows: 4, cols: 4);
       expect(g.downsampleTo(2).resolutionMeters, closeTo(900.0, 1e-9));
     });
+
+    test('recentres the origin on the block, not on its first sample', () {
+      // Origin is the SOUTH-WEST CELL CENTER. Striding sampled the block's
+      // first cell, so the origin was already that sample's center and had
+      // to stay put. A block MEAN sits at the block's centroid instead,
+      // half a stride further north and east, so the origin has to move
+      // with it or every cell is reported half a block south-west of the
+      // data it holds.
+      final g = grid(List<double?>.filled(16, 5.0), rows: 4, cols: 4);
+      final d = g.downsampleTo(2);
+      // step 2: shift by cell * (step - 1) / 2 = half a cell.
+      expect(d.originLat, closeTo(12.14 + 0.004 * 0.5, 1e-12));
+      expect(d.originLon, closeTo(-68.31 + 0.004 * 0.5, 1e-12));
+    });
+
+    test('recentres by a full cell at stride 3', () {
+      final g = grid(List<double?>.filled(81, 5.0), rows: 9, cols: 9);
+      final d = g.downsampleTo(3);
+      // step 3: shift by cell * (3 - 1) / 2 = one whole cell.
+      expect(d.originLat, closeTo(12.14 + 0.004, 1e-12));
+      expect(d.originLon, closeTo(-68.31 + 0.004, 1e-12));
+    });
+
+    test('preserves the south-west edge of the geographic footprint', () {
+      // The invariant that matters downstream: the overlay image, the
+      // imagery mosaic and the 3D mesh all derive their bounds from the
+      // origin and cell size, so the covered area must not move.
+      final g = grid(List<double?>.filled(16, 5.0), rows: 4, cols: 4);
+      final d = g.downsampleTo(2);
+      expect(
+        d.originLat - d.cellSizeLatDeg / 2,
+        closeTo(12.14 - 0.004 / 2, 1e-12),
+      );
+      expect(
+        d.originLon - d.cellSizeLonDeg / 2,
+        closeTo(-68.31 - 0.004 / 2, 1e-12),
+      );
+    });
+
+    test('an identity downsample leaves the origin alone', () {
+      final g = grid(const [1.0, 2.0, 3.0, 4.0], rows: 2, cols: 2);
+      final d = g.downsampleTo(4);
+      expect(d.originLat, 12.14);
+      expect(d.originLon, -68.31);
+    });
   });
 }

--- a/test/features/bathymetry/domain/bathymetry_grid_test.dart
+++ b/test/features/bathymetry/domain/bathymetry_grid_test.dart
@@ -36,14 +36,15 @@ void main() {
     expect(grid([10, -50, null, 42, 7, 3]).maxDepthMeters, 42);
   });
 
-  test('downsampleTo caps both dimensions with strided cells', () {
+  test('downsampleTo caps both dimensions with block means', () {
     final depths = List<double?>.generate(6 * 6, (i) => i.toDouble());
     final g = grid(depths, rows: 6, cols: 6);
     final d = g.downsampleTo(3);
     expect(d.rows, 3);
     expect(d.cols, 3);
-    expect(d.depthAt(0, 0), 0); // stride 2 keeps cells 0,2,4
-    expect(d.depthAt(1, 1), 14); // row 2, col 2 of original
+    // Stride 2, so each output cell is the mean of a 2x2 block.
+    expect(d.depthAt(0, 0), closeTo(3.5, 1e-9)); // cells 0, 1, 6, 7
+    expect(d.depthAt(1, 1), closeTo(17.5, 1e-9)); // cells 14, 15, 20, 21
     expect(d.cellSizeLatDeg, closeTo(0.008, 1e-12));
   });
 
@@ -75,5 +76,61 @@ void main() {
     expect(back.sourceId, 'test');
     expect(back.resolutionMeters, 450);
     expect(back.fetchedAt, DateTime.utc(2026, 7, 28));
+  });
+
+  group('knownFraction', () {
+    test('is the fraction of non-null cells', () {
+      final g = grid([10.0, null, 30.0, null], rows: 1, cols: 4);
+      expect(g.knownFraction, 0.5);
+    });
+
+    test('is zero for an entirely empty grid', () {
+      final g = grid([null, null], rows: 1, cols: 2);
+      expect(g.knownFraction, 0.0);
+    });
+  });
+
+  group('downsampleTo averaging', () {
+    test('averages each block instead of picking its first sample', () {
+      // 4x4 halved to 2x2: each output cell is the mean of a 2x2 block.
+      final g = grid(const [
+        1.0, 3.0, 10.0, 20.0, //
+        5.0, 7.0, 30.0, 40.0, //
+        100.0, 100.0, 0.0, 0.0, //
+        100.0, 100.0, 0.0, 0.0, //
+      ], rows: 4, cols: 4);
+      final d = g.downsampleTo(2);
+      expect(d.rows, 2);
+      expect(d.cols, 2);
+      expect(d.depthAt(0, 0), closeTo(4.0, 1e-9));
+      expect(d.depthAt(0, 1), closeTo(25.0, 1e-9));
+      expect(d.depthAt(1, 0), closeTo(100.0, 1e-9));
+      expect(d.depthAt(1, 1), closeTo(0.0, 1e-9));
+    });
+
+    test('averages only the known cells in a block', () {
+      final g = grid(const [10.0, null, null, 20.0], rows: 2, cols: 2);
+      expect(g.downsampleTo(1).depthAt(0, 0), closeTo(15.0, 1e-9));
+    });
+
+    test('an all-nodata block stays nodata', () {
+      final g = grid(const [
+        null, null, 8.0, 8.0, //
+        null, null, 8.0, 8.0, //
+      ], rows: 2, cols: 4);
+      final d = g.downsampleTo(2);
+      expect(d.depthAt(0, 0), isNull);
+      expect(d.depthAt(0, 1), closeTo(8.0, 1e-9));
+    });
+
+    test('returns the same instance when already within the cap', () {
+      final g = grid(const [1.0, 2.0, 3.0, 4.0], rows: 2, cols: 2);
+      expect(identical(g.downsampleTo(4), g), isTrue);
+    });
+
+    test('scales the resolution claim by the coarser stride', () {
+      final g = grid(List<double?>.filled(16, 5.0), rows: 4, cols: 4);
+      expect(g.downsampleTo(2).resolutionMeters, closeTo(900.0, 1e-9));
+    });
   });
 }

--- a/test/features/bathymetry/domain/bathymetry_grid_test.dart
+++ b/test/features/bathymetry/domain/bathymetry_grid_test.dart
@@ -93,12 +93,16 @@ void main() {
   group('downsampleTo averaging', () {
     test('averages each block instead of picking its first sample', () {
       // 4x4 halved to 2x2: each output cell is the mean of a 2x2 block.
-      final g = grid(const [
-        1.0, 3.0, 10.0, 20.0, //
-        5.0, 7.0, 30.0, 40.0, //
-        100.0, 100.0, 0.0, 0.0, //
-        100.0, 100.0, 0.0, 0.0, //
-      ], rows: 4, cols: 4);
+      final g = grid(
+        const [
+          1.0, 3.0, 10.0, 20.0, //
+          5.0, 7.0, 30.0, 40.0, //
+          100.0, 100.0, 0.0, 0.0, //
+          100.0, 100.0, 0.0, 0.0, //
+        ],
+        rows: 4,
+        cols: 4,
+      );
       final d = g.downsampleTo(2);
       expect(d.rows, 2);
       expect(d.cols, 2);
@@ -114,10 +118,14 @@ void main() {
     });
 
     test('an all-nodata block stays nodata', () {
-      final g = grid(const [
-        null, null, 8.0, 8.0, //
-        null, null, 8.0, 8.0, //
-      ], rows: 2, cols: 4);
+      final g = grid(
+        const [
+          null, null, 8.0, 8.0, //
+          null, null, 8.0, 8.0, //
+        ],
+        rows: 2,
+        cols: 4,
+      );
       final d = g.downsampleTo(2);
       expect(d.depthAt(0, 0), isNull);
       expect(d.depthAt(0, 1), closeTo(8.0, 1e-9));

--- a/test/features/bathymetry/presentation/bathymetry_labels_test.dart
+++ b/test/features/bathymetry/presentation/bathymetry_labels_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/bathymetry/data/sources/emodnet_source.dart';
+import 'package:submersion/features/bathymetry/data/sources/etopo_erddap_source.dart';
+import 'package:submersion/features/bathymetry/data/sources/gmrt_source.dart';
+import 'package:submersion/features/bathymetry/data/sources/noaa_dem_source.dart';
+import 'package:submersion/features/bathymetry/presentation/bathymetry_labels.dart';
+
+void main() {
+  test('every shipped source id has a human display name', () {
+    // The switch falls through to the raw id, so a missing case is not a
+    // crash: it is a provenance caption reading "noaa_dem" at the diver.
+    const shipped = [
+      GmrtSource.sourceId,
+      EmodnetSource.sourceId,
+      EtopoErddapSource.sourceId,
+      NoaaDemSource.sourceId,
+    ];
+    for (final id in shipped) {
+      expect(bathymetrySourceDisplayName(id), isNot(id), reason: id);
+    }
+  });
+
+  test('an unknown id falls back to itself rather than throwing', () {
+    expect(bathymetrySourceDisplayName('future_source'), 'future_source');
+  });
+}


### PR DESCRIPTION
## Summary

The 3D seascape was reported as showing too little area, and as making
near-shore dives look like they sit on the shoreline with no detail around
the dive. Measuring the live sources with the app's own request shapes
turned up four separate causes, one of which is a source-selection defect.

At Bonaire the resolver was picking the **worse** of two available grids:

| | EMODnet (selected) | GMRT (never reached) |
| --- | --- | --- |
| Grid | 71 x 71 | 136 x 133 |
| Cell size | 115 m | 60 m |
| Known cells | 2,611 of 5,041 (48% nodata) | 18,088 of 18,088 |
| Land / coastline | none at all | 45%, real coastline |

The resolver took the first tier returning at least 10% wet cells. EMODnet's
Caribbean tile answers 99.96% wet on 48% coverage, so it always won, and the
missing half rendered as a flat sand-coloured slab at the waterline. That
slab is the literal cause of "the dive looks like it is on the shoreline".

This is PR 1 of 3. It rebuilds the source layer; nodata holes, the vertical
depth window, and the nested two-level terrain follow in PRs 2 and 3.

Design: `docs/superpowers/specs/2026-09-05-seascape-extent-and-detail-design.md`
Plan: `docs/superpowers/plans/2026-09-05-seascape-source-layer.md`

## Changes

- **Sources declare a capability instead of a bool.** `covers()` could only
  answer yes or no, and being synchronous it could not make a network call,
  which rules out any source that must ask a catalogue what it holds at a
  point. `probe()` returns the finest cell size a source believes it has
  there, or null when it does not cover the point.
- **The resolver orders by capability and rejects empty grids.** A
  known-cell floor of 0.60 rejects a grid that is nominally wet but mostly
  holes, which is what fixes Bonaire. Falling through on coverage is
  explicitly not treated as a dry answer, since caching an "empty" would
  pin the cell forever.
- **A preemption factor of 2.0 guards the declared order.** Only a
  materially finer source jumps the curated tier order. This matters: GMRT
  declares 60 m against EMODnet's 115 m, a factor of 1.9, so a flat
  resolution sort would have demoted EMODnet across all of Europe on a
  nominal number. GMRT's European grids were measured first and are not
  block-upsampled GEBCO (identical-neighbour fractions of 4.2% at the Medes
  Islands, 0.1% at Zakynthos, against the ~87% a nearest-neighbour upsample
  would show), but the Medes grid's 0.70 m median neighbour step leaves its
  real information content unproven, so the band stays.
- **New NOAA NCEI high-resolution coastal tier.** The mosaic stacks CUDEM
  and regional DEMs over an ETOPO background, so coverage is patchy and
  mostly US coastal. The `identify` probe reports every DEM under a point
  with its cell size, so the source declines wherever the stack offers
  nothing better than the background the ETOPO tier already serves.
  `maxItemCount` is load-bearing: the default truncates the catalogue to
  three items and hides a covered site's DEM behind ETOPO.
- **A reader for ArcGIS uncompressed tiled float32 GeoTIFF.** Deliberately
  narrow rather than a general TIFF decoder, throwing `FormatException` on
  anything unexpected so a surprising response degrades to a transient
  source failure instead of silently wrong terrain. That path is routine,
  not exotic, because ArcGIS returns its error envelopes with HTTP 200.
- **`downsampleTo` averages instead of striding.** A stride of 2 discards
  three quarters of a fetched grid; a block mean keeps that information and
  suppresses single-cell noise. An all-nodata block stays nodata, so
  averaging never invents a reading.
- **Cache keys gain a selection generation.** Cached grids never expire, so
  changing which source wins would otherwise leave every already-visited
  site serving the grid its old resolver chose. Old rows go inert, exactly
  as the 4 km rows did when the span went to 8 km.
- **The new tier is named in the provenance caption and the about screen**
  across all eleven locales. `bathymetrySourceDisplayName` ends in a
  passthrough default, so the missing case was not a compile error and not
  a crash: the caption would have read the raw string `noaa_dem`.

## Results, measured live end to end

| Site | Before | After |
| --- | --- | --- |
| Bonaire | emodnet 71 x 71 @ 115 m, 48% known, no land | **gmrt 133 x 136 @ 60 m, 100% known, real coastline** |
| Florida Keys | gmrt @ 60 m | **noaa_dem 256 x 256 @ 31 m, 100% known** |
| Medes Islands | emodnet @ 115 m | emodnet @ 115 m (deliberately unchanged) |
| La Jolla probe | n/a | noaa_dem offers 8.7 m |
| Bonaire probe | n/a | noaa_dem declines, as intended |

## Known limitation, recorded in the spec

`BathymetryRepository.maxGridDim` (120) is now the binding constraint and
discards most of what the new source layer fetches:

| Site | Fetched | Rendered after the cap |
| --- | --- | --- |
| Bonaire | 133 x 136 @ 60 m | 67 x 68 @ 120 m |
| Florida Keys | 256 x 256 @ 31 m | 86 x 86 @ 94 m |

So Bonaire renders at 120 m from a 60 m grid, no better than the 115 m tile
it replaced. **What this PR delivers there is coverage and a real coastline,
not resolution.** Real scenes measured 8,800 to 14,500 triangles rather than
the 28,322 a full 120 x 120 would produce, so there is real headroom;
raising the cap is the highest-leverage change left and stays gated on the
render-budget measurement at the head of PR 3 rather than guessed at here.

## Test Plan

- [x] `flutter test` passes: 24,871 passed, 21 skipped, 0 failed
- [x] `flutter analyze` passes: no issues
- [x] Manual testing on: live services, not only mocks. Every source was
      exercised against its real endpoint. The GeoTIFF reader was verified
      against recorded live responses covering a 64 x 64 image inside a
      single 128 x 128 tile (three quarters padding), a 256 x 256 image
      across four tiles, and a shoreline box reading 46.3% wet against the
      53.7% land measured independently.

New coverage: 11 tests for the GeoTIFF reader, 14 for the NOAA source, 6
for resolver ordering and the floors, 7 for grid averaging and
`knownFraction`, 2 for the cache generation, and 2 for the display names.
