### PR TITLE
fix(backup): retain the pre-migration copy an older build can open (#1590)

### DIFF
--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -18,6 +18,9 @@ typedef AsyncPathResolver = Future<String> Function();
 /// existing BackupPreferences registry so it appears alongside manual
 /// backups in the backup list UI.
 class PreMigrationBackupService {
+  /// How many unpinned pre-migration copies survive a prune. Each one is a
+  /// full database, so this stays small; see [_pruneExcess] for which of
+  /// them are kept.
   static const int _retainN = 3;
   final AsyncPathResolver _livePathProvider;
   final AsyncPathResolver _backupsDirProvider;
@@ -244,22 +247,70 @@ class PreMigrationBackupService {
     }
   }
 
+  /// Keeps [_retainN] pre-migration copies: the recovery floor, plus the
+  /// newest of the rest.
+  ///
+  /// Retention here is not "the last few backups". These copies exist for one
+  /// job: to be opened by a build that refuses the live database because the
+  /// schema has moved past what that build understands. Only a copy whose
+  /// [BackupRecord.fromSchemaVersion] is at or below that build's own version
+  /// can do that job, so the single most valuable record is the one with the
+  /// LOWEST `fromSchemaVersion` -- and pruning newest-first is precisely the
+  /// order that deletes it first. A diver crossing several schema rungs would
+  /// otherwise end up holding three copies, none of which the build in front
+  /// of them can open, having deleted the one that it could.
+  ///
+  /// The floor is therefore retained in place of the third-newest rather than
+  /// in addition to it: which copies are kept changes, how many does not.
   Future<void> _pruneExcess() async {
     final all = _preferences.getHistory();
-    final preMigration = all
-        .where((r) => r.type == BackupType.preMigration)
-        .toList();
-    final unpinned = preMigration.where((r) => !r.pinned).toList()
-      ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
-    if (unpinned.length <= _retainN) return;
-    final toDelete = unpinned.sublist(_retainN);
-    for (final record in toDelete) {
+    final candidates =
+        all
+            .where((r) => r.type == BackupType.preMigration && !r.pinned)
+            .toList()
+          ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    if (candidates.length <= _retainN) return;
+
+    final keep = <String>{};
+    final floor = _recoveryFloor(candidates);
+    if (floor != null) keep.add(floor.id);
+    for (final record in candidates) {
+      if (keep.length >= _retainN) break;
+      keep.add(record.id);
+    }
+
+    for (final record in candidates) {
+      if (keep.contains(record.id)) continue;
       final path = record.localPath;
       if (path != null) {
         await _safeDelete(path);
       }
       await _preferences.removeRecord(record.id);
     }
+  }
+
+  /// The copy the oldest build could still open: the lowest
+  /// [BackupRecord.fromSchemaVersion] among [candidates], ties going to the
+  /// newer copy since both open in the same builds and the newer one holds
+  /// more of the diver's data.
+  ///
+  /// A record with no recorded `fromSchemaVersion` was written before the
+  /// schema pair existed, so there is nothing to show it opens anywhere; it
+  /// never claims the floor slot and competes on recency like any other copy.
+  /// Returns null when no candidate records a version, which leaves retention
+  /// purely newest-first.
+  ///
+  /// [candidates] must already be ordered newest-first, which is what makes
+  /// the strict `<` below resolve ties toward the newer copy.
+  BackupRecord? _recoveryFloor(List<BackupRecord> candidates) {
+    BackupRecord? floor;
+    for (final record in candidates) {
+      final version = record.fromSchemaVersion;
+      if (version == null) continue;
+      final lowest = floor?.fromSchemaVersion;
+      if (lowest == null || version < lowest) floor = record;
+    }
+    return floor;
   }
 
   Future<void> _sweepTempFiles(String backupsDir) async {

--- a/test/features/backup/data/services/pre_migration_backup_service_test.dart
+++ b/test/features/backup/data/services/pre_migration_backup_service_test.dart
@@ -250,67 +250,95 @@ void main() {
 
   group('retention prune', () {
     test(
-      'keeps newest 3 unpinned pre-migration backups, deletes older',
+      'keeps the lowest fromSchemaVersion copy in place of the third-newest',
       () async {
+        // Recoverability runs oldest-first: the copy that matters is the one
+        // whose schema is low enough for an older build to open, which is the
+        // lowest fromSchemaVersion, not the third-newest by timestamp.
         final f = await _makeFixture();
         addTearDown(f.dispose);
-        for (var i = 0; i < 4; i++) {
-          final ts = DateTime.utc(2026, 1, 1 + i);
-          final name = '${_ts(ts)}-v$i-v${i + 1}.db';
-          final file = File(p.join(f.backupsDir, name));
-          await file.writeAsBytes([i]);
-          await f.prefs.addRecord(
-            BackupRecord(
-              id: 'r$i',
-              filename: name,
-              timestamp: ts,
-              sizeBytes: 1,
-              location: BackupLocation.local,
-              localPath: file.path,
-              type: BackupType.preMigration,
-              fromSchemaVersion: i,
-              toSchemaVersion: i + 1,
-            ),
-          );
-        }
-
-        final service = PreMigrationBackupService(
-          livePathProvider: () async => f.livePath,
-          backupsDirProvider: () async => f.backupsDir,
-          preferences: f.prefs,
-          clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
-          idGenerator: () => 'new',
+        await _seedPreMigration(f, id: 'floor', day: 1, fromSchemaVersion: 175);
+        await _seedPreMigration(f, id: 'mid', day: 2, fromSchemaVersion: 180);
+        await _seedPreMigration(f, id: 'third', day: 3, fromSchemaVersion: 185);
+        await _seedPreMigration(
+          f,
+          id: 'second',
+          day: 4,
+          fromSchemaVersion: 188,
         );
 
-        await service.backupIfMigrationPending(
-          stored: 63,
-          target: 64,
-          appVersion: '1.6.0.1241',
-        );
+        await _runMigration(f, stored: 190, target: 191);
 
-        final remaining = f.prefs
-            .getHistory()
-            .where((r) => r.type == BackupType.preMigration)
-            .toList();
+        final remaining = _preMigrationIds(f);
+        expect(
+          remaining,
+          hasLength(3),
+          reason: 'the retained count must not change',
+        );
+        expect(remaining, containsAll(<String>['new', 'second', 'floor']));
+        expect(remaining, isNot(contains('third')));
+        expect(remaining, isNot(contains('mid')));
+        expect(await _preMigrationFile(f, 'floor').exists(), isTrue);
+        expect(await _preMigrationFile(f, 'mid').exists(), isFalse);
+        expect(await _preMigrationFile(f, 'third').exists(), isFalse);
+      },
+    );
+
+    test(
+      'prefers the newer copy when two share the lowest fromSchemaVersion',
+      () async {
+        // Both open in the same older build, so the tie goes to the one
+        // holding more of the diver's data.
+        final f = await _makeFixture();
+        addTearDown(f.dispose);
+        await _seedPreMigration(
+          f,
+          id: 'older-175',
+          day: 1,
+          fromSchemaVersion: 175,
+        );
+        await _seedPreMigration(
+          f,
+          id: 'newer-175',
+          day: 2,
+          fromSchemaVersion: 175,
+        );
+        await _seedPreMigration(f, id: 'v180', day: 3, fromSchemaVersion: 180);
+        await _seedPreMigration(f, id: 'v185', day: 4, fromSchemaVersion: 185);
+
+        await _runMigration(f, stored: 190, target: 191);
+
+        final remaining = _preMigrationIds(f);
         expect(remaining, hasLength(3));
-        expect(
-          remaining.map((r) => r.id),
-          containsAll(<String>['new', 'r3', 'r2']),
+        expect(remaining, containsAll(<String>['new', 'v185', 'newer-175']));
+        expect(remaining, isNot(contains('older-175')));
+      },
+    );
+
+    test(
+      'a record with no fromSchemaVersion never takes the floor slot',
+      () async {
+        // Legacy records predate the schema pair. Reading a missing version as
+        // the lowest would keep a copy whose openability is unknown and delete
+        // the one that is known to work.
+        final f = await _makeFixture();
+        addTearDown(f.dispose);
+        await _seedPreMigration(
+          f,
+          id: 'legacy',
+          day: 1,
+          fromSchemaVersion: null,
         );
-        expect(remaining.map((r) => r.id), isNot(contains('r0')));
-        expect(remaining.map((r) => r.id), isNot(contains('r1')));
-        expect(
-          await File(
-            p.join(f.backupsDir, '${_ts(DateTime.utc(2026, 1, 1))}-v0-v1.db'),
-          ).exists(),
-          isFalse,
-        );
-        expect(
-          await File(
-            p.join(f.backupsDir, '${_ts(DateTime.utc(2026, 1, 2))}-v1-v2.db'),
-          ).exists(),
-          isFalse,
-        );
+        await _seedPreMigration(f, id: 'floor', day: 2, fromSchemaVersion: 175);
+        await _seedPreMigration(f, id: 'v180', day: 3, fromSchemaVersion: 180);
+        await _seedPreMigration(f, id: 'v185', day: 4, fromSchemaVersion: 185);
+
+        await _runMigration(f, stored: 190, target: 191);
+
+        final remaining = _preMigrationIds(f);
+        expect(remaining, hasLength(3));
+        expect(remaining, containsAll(<String>['new', 'v185', 'floor']));
+        expect(remaining, isNot(contains('legacy')));
       },
     );
 
@@ -698,3 +726,59 @@ String _ts(DateTime utc) {
       '${two(utc.hour)}${two(utc.minute)}${two(utc.second)}'
       '${three(utc.millisecond)}';
 }
+
+/// Registers an unpinned pre-migration record backed by a real file, named
+/// after [id] so prune assertions can look for it on disk. [day] places the
+/// record in January 2026, so a higher day is a newer copy.
+Future<void> _seedPreMigration(
+  _Fixture f, {
+  required String id,
+  required int day,
+  required int? fromSchemaVersion,
+}) async {
+  final file = _preMigrationFile(f, id);
+  await file.writeAsBytes([day]);
+  await f.prefs.addRecord(
+    BackupRecord(
+      id: id,
+      filename: p.basename(file.path),
+      timestamp: DateTime.utc(2026, 1, day),
+      sizeBytes: 1,
+      location: BackupLocation.local,
+      localPath: file.path,
+      type: BackupType.preMigration,
+      fromSchemaVersion: fromSchemaVersion,
+      toSchemaVersion: fromSchemaVersion == null ? null : fromSchemaVersion + 1,
+    ),
+  );
+}
+
+File _preMigrationFile(_Fixture f, String id) =>
+    File(p.join(f.backupsDir, '$id.db'));
+
+/// Runs one pre-migration backup, registered as 'new' and newer than anything
+/// [_seedPreMigration] writes, so the prune it triggers can be observed.
+Future<void> _runMigration(
+  _Fixture f, {
+  required int stored,
+  required int target,
+}) async {
+  final service = PreMigrationBackupService(
+    livePathProvider: () async => f.livePath,
+    backupsDirProvider: () async => f.backupsDir,
+    preferences: f.prefs,
+    clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+    idGenerator: () => 'new',
+  );
+  await service.backupIfMigrationPending(
+    stored: stored,
+    target: target,
+    appVersion: '1.6.0.1241',
+  );
+}
+
+List<String> _preMigrationIds(_Fixture f) => f.prefs
+    .getHistory()
+    .where((r) => r.type == BackupType.preMigration)
+    .map((r) => r.id)
+    .toList();


### PR DESCRIPTION
## Summary

Fixes #1590.

`PreMigrationBackupService._pruneExcess` sorted pre-migration records
newest-first and deleted the tail, so the copy it dropped first was always the
one with the lowest `fromSchemaVersion`. That is the only copy an older build
can open: `DatabaseService._openDatabase` refuses any database whose
`PRAGMA user_version` exceeds that build's own `currentSchemaVersion`.

Recoverability runs oldest-first, and retention was running newest-first. A
diver crossing several schema rungs (beta builds publish per merge, so the
ladder moves quickly) ended up holding three copies, none of which the build in
front of them could open, having deleted the one that it could.

Per the issue, this is fixed by changing **which** copies are kept, not how
many, so the tension with #1376 is left alone: `_retainN` is still 3.

## Changes

- `_pruneExcess` now retains the recovery floor in place of the third-newest:
  the record with the lowest `fromSchemaVersion`, plus the two newest of the
  rest. The retained count is unchanged at `_retainN`.
- New `_recoveryFloor` helper resolves ties toward the **newer** copy, since two
  copies at the same `fromSchemaVersion` open in exactly the same builds and the
  newer one holds more of the diver's data. The tie-break falls out of the
  already-newest-first ordering plus a strict `<`, so there is no second
  comparator.
- A record with no recorded `fromSchemaVersion` predates the schema pair, so
  nothing shows it opens anywhere. It never claims the floor slot and competes
  on recency like any other copy. Reading a missing version as the lowest would
  keep a copy of unknown openability and delete one that is known to work.
- Pinned records are still exempt from pruning entirely, unchanged.
- Docs on `_retainN` and `_pruneExcess` now state why oldest is the valuable
  end here, so the next reader does not "fix" it back to newest-first.

## Test Plan

- [x] `flutter test` passes (full `test/features/backup` + the pre-migration
      integration test: 385 passing)
- [x] `flutter analyze` passes (`No issues found!`)
- [ ] Manual testing on: not applicable, no UI surface changed

Three new tests in
`test/features/backup/data/services/pre_migration_backup_service_test.dart`,
each written failing first against the old prune (all three returned the three
newest, `['new', 'v185', 'v180']`):

- `keeps the lowest fromSchemaVersion copy in place of the third-newest`, which
  also asserts the retained count is still 3 and checks the files on disk, not
  just the registry.
- `prefers the newer copy when two share the lowest fromSchemaVersion`.
- `a record with no fromSchemaVersion never takes the floor slot`, which fails
  against an implementation that coerces null to zero.

The pre-existing `keeps newest 3 unpinned pre-migration backups, deletes older`
test encoded the bug (it asserted the v0 copy was deleted and the third-newest
kept), so it is replaced by the first of the three above.
