### PR TITLE
fix(release): publish betas as pre-releases and warn on every route to them (#1591)

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -335,6 +335,25 @@ jobs:
           fi
           gh release upload appcast appcast-beta.xml --repo "$REPO" --clobber
 
+      # Every beta published before #1591 is still flagged a full release, so
+      # without this the Latest badge would sit on an old beta until pruning
+      # aged all 30 of them out. Runs after the pointer release exists, so
+      # releases/latest never has a moment with nothing to resolve to. Drains
+      # on the first run and is a no-op forever after.
+      - name: Backfill the pre-release flag on older betas
+        env:
+          GH_TOKEN: ${{ secrets.BETA_BUILDS_TOKEN }}
+        run: |
+          set -euo pipefail
+          REPO=submersion-app/beta-builds
+          gh release list --repo "$REPO" --json tagName,isPrerelease --limit 100 \
+            -q '.[] | select(.isPrerelease == false)
+                    | select(.tagName | test("^v[0-9]")) | .tagName' \
+            | while read -r tag; do
+            echo "Marking $tag as a pre-release"
+            gh release edit "$tag" --repo "$REPO" --prerelease
+          done
+
       - name: Prune old betas
         env:
           GH_TOKEN: ${{ secrets.BETA_BUILDS_TOKEN }}

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -205,11 +205,26 @@ jobs:
       # Play all describe the same build the same way. generate_changelog.sh is
       # scoped to the last stable tag, which on a mid-release beta meant a body
       # covering hundreds of commits already shipped in earlier betas.
+      # The warning goes on release-notes.md only, after the HTML is generated:
+      # release-notes.html feeds the appcast, and the people reading that
+      # already opted into the beta channel behind a confirmation dialog. The
+      # release page is the unguarded door (#1591).
       - name: Prepare release notes
         run: |
           set -euo pipefail
           cp artifacts/beta-notes.md release-notes.md
           ./scripts/generate_release_notes_html.sh < release-notes.md > release-notes.html
+          cat > body-warning.md <<'WARNING'
+          > [!WARNING]
+          > **This is a beta build, not the stable release.** It may upgrade your
+          > dive log database ahead of stable. Once it has, the stable build can no
+          > longer open your dive log and there is no way back short of restoring a
+          > backup. Install this only if you mean to run the beta channel.
+          >
+          > Stable downloads: https://github.com/submersion-app/submersion/releases
+
+          WARNING
+          cat body-warning.md release-notes.md > release-body.md
 
       - name: Generate checksums and metadata
         env:
@@ -277,9 +292,48 @@ jobs:
           set -euo pipefail
           gh release create "$TAG_NAME" --repo submersion-app/beta-builds \
             --title "Beta $TAG_NAME" \
-            --notes-file release-notes.md \
+            --prerelease \
+            --notes-file release-body.md \
             artifacts/Submersion* checksums-sha256.txt metadata.json appcast-beta.xml
           echo "Published beta $TAG_NAME from $SOURCE_SHA"
+
+      # --prerelease takes the whole repo out of reach of GitHub's "latest
+      # release", which excludes pre-releases and 404s when nothing else is
+      # left. Every shipped macOS and Windows beta has
+      # beta-builds/releases/latest/download/appcast-beta.xml baked into its
+      # binary, so that URL has to keep resolving for installs we can no longer
+      # change. This one permanent non-pre-release release keeps it alive: it
+      # holds the appcast and nothing else, so the Latest badge lands on a
+      # release with nothing to install by mistake. (Linux and Android poll the
+      # API instead; GithubUpdateService enumerates releases on the beta
+      # channel rather than asking for the latest one.)
+      - name: Refresh the appcast pointer release
+        env:
+          GH_TOKEN: ${{ secrets.BETA_BUILDS_TOKEN }}
+        run: |
+          set -euo pipefail
+          REPO=submersion-app/beta-builds
+          cat > pointer-notes.md <<'NOTES'
+          This release exists only to serve the beta update feed
+          (`appcast-beta.xml`) from a URL that does not move. There is nothing
+          here to install.
+
+          Beta builds are published as pre-releases. Pick the newest one from the
+          [releases list](https://github.com/submersion-app/beta-builds/releases),
+          and read the warning on it before installing anything.
+
+          Stable downloads live at
+          [submersion-app/submersion/releases](https://github.com/submersion-app/submersion/releases).
+          NOTES
+          if gh release view appcast --repo "$REPO" >/dev/null 2>&1; then
+            gh release edit appcast --repo "$REPO" --latest \
+              --notes-file pointer-notes.md
+          else
+            gh release create appcast --repo "$REPO" --latest \
+              --title "Beta update feed (not a download)" \
+              --notes-file pointer-notes.md
+          fi
+          gh release upload appcast appcast-beta.xml --repo "$REPO" --clobber
 
       - name: Prune old betas
         env:
@@ -287,7 +341,9 @@ jobs:
         run: |
           set -euo pipefail
           gh release list --repo submersion-app/beta-builds \
-            --json tagName --limit 100 -q '.[30:][].tagName' | while read -r tag; do
+            --json tagName --limit 100 \
+            -q '[.[] | select(.tagName | test("^v[0-9]"))] | .[30:][].tagName' \
+            | while read -r tag; do
             echo "Pruning $tag"
             gh release delete "$tag" --repo submersion-app/beta-builds --yes --cleanup-tag
           done

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -91,7 +91,18 @@ jobs:
         run: |
           set -euo pipefail
           PREV_SHA=""
-          if gh release download --repo submersion-app/beta-builds \
+          # Name the tag explicitly. A bare "gh release download" takes the
+          # latest release, which is now the appcast pointer (#1591): it holds
+          # no metadata.json, so the baseline would come back empty, the
+          # already-published gate would never fire, and the notes would fall
+          # back to the last stable tag.
+          PREV_TAG=$(gh release list --repo submersion-app/beta-builds \
+            --json tagName --limit 100 \
+            -q '[.[] | select(.tagName | test("^v[0-9]"))]
+                | if length == 0 then empty
+                  else max_by(.tagName | split(".") | last | tonumber) | .tagName end')
+          if [ -n "$PREV_TAG" ] && gh release download "$PREV_TAG" \
+               --repo submersion-app/beta-builds \
                --pattern metadata.json --dir /tmp/prev-beta 2>/dev/null; then
             PREV_SHA=$(python3 -c "import json;print(json.load(open('/tmp/prev-beta/metadata.json'))['sourceSha'])")
           fi

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -84,8 +84,11 @@ jobs:
             echo "::error::build-number must be digits only (got: ${BUILD})."
             exit 1
           fi
+          # --limit 100: the default page is 30, and the retained 30 betas
+          # plus the appcast pointer is 31, so the oldest would fall off.
           TAG=$(gh release list --repo submersion-app/beta-builds \
-            --json tagName -q ".[].tagName" | grep -E "\.${BUILD}$" | head -1)
+            --json tagName --limit 100 -q ".[].tagName" \
+            | grep -E "\.${BUILD}$" | head -1)
           if [ -z "$TAG" ]; then
             echo "::error::No beta release ending in .${BUILD} found (pruned or never built)."
             exit 1

--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ before any database upgrade.
   through the normal auto-updater), or download directly from
   [beta-builds](https://github.com/submersion-app/beta-builds/releases). Every
   build on that page is a pre-release: once one has upgraded your database, the
-  stable build will not open your dive log again.
+  stable build will not open your dive log again. The one entry badged "Latest"
+  there is not a build at all, only the update feed.
 - **Android:** [join the open test](https://play.google.com/apps/testing/app.submersion),
   then Play delivers beta updates automatically
 - **iOS / Mac App Store:** [join via TestFlight](https://testflight.apple.com/join/aMD393sB)

--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ before any database upgrade.
 
 - **Desktop:** Settings > About > Update channel > Beta (updates then arrive
   through the normal auto-updater), or download directly from
-  [beta-builds](https://github.com/submersion-app/beta-builds/releases)
+  [beta-builds](https://github.com/submersion-app/beta-builds/releases). Every
+  build on that page is a pre-release: once one has upgraded your database, the
+  stable build will not open your dive log again.
 - **Android:** [join the open test](https://play.google.com/apps/testing/app.submersion),
   then Play delivers beta updates automatically
 - **iOS / Mac App Store:** [join via TestFlight](https://testflight.apple.com/join/aMD393sB)
@@ -347,6 +349,14 @@ The built app will be at `build\windows\x64\runner\Release\`.
 > They reach the stable
 > [Releases page](https://github.com/submersion-app/submersion/releases) with
 > the next stable release; that page currently carries the tarball only.
+
+> **These are beta builds.** A beta may upgrade your dive log's database ahead
+> of the stable release, and once it has, the stable build can no longer open
+> that dive log. There is no downgrade. If you install a `.deb` or `.rpm` from
+> beta-builds, stay on beta builds, or restore the automatic pre-upgrade backup
+> before going back. To stay on stable instead, use the
+> [tarball](https://github.com/submersion-app/submersion/releases) until the
+> packages reach the stable Releases page.
 
 **Debian, Ubuntu, Mint, and derivatives**
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ before any database upgrade.
   build on that page is a pre-release: once one has upgraded your database, the
   stable build will not open your dive log again. The one entry badged "Latest"
   there is not a build at all, only the update feed.
+- **Already on the beta channel on Linux or Android?** Update once by hand from
+  [beta-builds](https://github.com/submersion-app/beta-builds/releases). Builds
+  from before betas became pre-releases look for an update in a place that no
+  longer answers, so they report no update available and stay quiet. One manual
+  update restores automatic beta update checks. Desktop macOS and Windows are
+  unaffected.
 - **Android:** [join the open test](https://play.google.com/apps/testing/app.submersion),
   then Play delivers beta updates automatically
 - **iOS / Mac App Store:** [join via TestFlight](https://testflight.apple.com/join/aMD393sB)

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -78,6 +78,10 @@ mistake. `beta.yml` refreshes its asset on every run, and the prune step skips
 it by matching version tags only. Do not delete it: every beta desktop install
 in the field would stop updating.
 
+A backfill step demotes any versioned release still flagged as a full release,
+so the Latest badge moves off the old betas on the first run rather than after
+30 more builds. It drains once and is a no-op after that.
+
 The API pollers are handled in the app instead: `GithubUpdateService` takes
 `includePrereleases` and, on the beta channel, enumerates `/releases` and picks
 the highest version rather than asking for the latest. Beta installs predating

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -78,6 +78,13 @@ mistake. `beta.yml` refreshes its asset on every run, and the prune step skips
 it by matching version tags only. Do not delete it: every beta desktop install
 in the field would stop updating.
 
+The trap this sets: in `beta-builds`, any `gh` command that means "the latest
+release" now resolves to the pointer, which carries no installers and no
+`metadata.json`. `gh release view` and `gh release download` with no tag both
+mean that. Name the tag explicitly, and select it by the highest build number
+rather than by list order. `gh release list` also needs `--limit 100`: its
+default page is 30, and the retained 30 betas plus the pointer is 31.
+
 A backfill step demotes any versioned release still flagged as a full release,
 so the Latest badge moves off the old betas on the first run rather than after
 30 more builds. It drains once and is a no-op after that.

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -15,8 +15,9 @@ User-facing channel documentation is on the wiki:
 merge PR to main
   -> CI/CD (ci.yaml)                       tests, analyze, all-platform smoke
   -> Beta (beta.yml, on CI success)        signed builds via build-all.yml
-       -> beta-builds release              dmg/exe/tar.gz/apk/aab/ipa/pkg
+       -> beta-builds pre-release          dmg/exe/tar.gz/apk/aab/ipa/pkg
           + appcast-beta.xml               Sparkle beta feed
+       -> beta-builds "appcast" release    the feed, at a URL that never moves
        -> TestFlight                       iOS + macOS, "Public Beta" group
        -> Play testing track               PLAY_BETA_TRACK (see below)
 
@@ -52,6 +53,36 @@ There is nothing to remember per merge.
 | Nothing shippable | Only docs/CI/image files changed since the last beta | Nothing to do; by design |
 | Build number > 65535 | Windows `VersionInfoVersion` parts are 16-bit | Requires a new numbering scheme; decades away at current commit rate |
 | Already published | HEAD is the same commit as the newest beta | Nothing to do; a rerun, not a failure |
+
+## Why beta-builds has an "appcast" release
+
+Every versioned beta is published with `--prerelease`, so the releases page
+never badges an installer "Latest" and a visitor who lands there cannot mistake
+a beta for the stable build (#1591). That has one consequence worth knowing
+before touching `beta.yml`.
+
+GitHub's notion of the latest release excludes pre-releases, in the API and in
+the `releases/latest/download/<asset>` redirect alike. With nothing but
+pre-releases in the repo, both resolve to 404. Two shipped consumers depend on
+them, and both are compiled into binaries already installed on people's
+machines:
+
+- Sparkle and WinSparkle fetch
+  `beta-builds/releases/latest/download/appcast-beta.xml`.
+- Linux and Android poll `api.github.com/repos/submersion-app/beta-builds/releases/latest`.
+
+The Sparkle URL is kept alive by one permanent non-pre-release release, tagged
+`appcast`, that carries the appcast and nothing else. It is the only release
+that can wear the Latest badge, and there is nothing on it to install by
+mistake. `beta.yml` refreshes its asset on every run, and the prune step skips
+it by matching version tags only. Do not delete it: every beta desktop install
+in the field would stop updating.
+
+The API pollers are handled in the app instead: `GithubUpdateService` takes
+`includePrereleases` and, on the beta channel, enumerates `/releases` and picks
+the highest version rather than asking for the latest. Beta installs predating
+that change see the `appcast` release, which parses as version 0, and simply
+report no update available until they are updated once by hand.
 
 ## Promoting a beta to stable
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -43,6 +43,14 @@ without any group membership or `usermod` step.
 > [Releases page](https://github.com/submersion-app/submersion/releases) with
 > the next stable release; that page currently carries the tarball only.
 
+> **These are beta builds.** A beta may upgrade your dive log's database ahead
+> of the stable release, and once it has, the stable build can no longer open
+> that dive log. There is no downgrade. If you install a `.deb` or `.rpm` from
+> beta-builds, stay on beta builds, or restore the automatic pre-upgrade backup
+> before going back. To stay on stable instead, use the
+> [tarball](https://github.com/submersion-app/submersion/releases) until the
+> packages reach the stable Releases page.
+
 <!-- tabs:start -->
 
 #### **Debian / Ubuntu / Mint**

--- a/lib/features/auto_update/data/services/github_update_service.dart
+++ b/lib/features/auto_update/data/services/github_update_service.dart
@@ -10,6 +10,17 @@ class GithubUpdateService extends UpdateService {
   final String repo;
   final String currentVersion;
   final String platformSuffix;
+
+  /// Whether pre-releases count as updates.
+  ///
+  /// The stable channel reads `/releases/latest`, which is exactly the release
+  /// GitHub badges "Latest". Every beta in `beta-builds` is published with
+  /// `--prerelease` (#1591) so that badge never lands on an installer, which
+  /// puts the whole repo out of reach of that endpoint: it excludes
+  /// pre-releases and 404s when nothing else remains. The beta channel
+  /// therefore enumerates releases and picks the highest version itself.
+  final bool includePrereleases;
+
   final http.Client httpClient;
 
   GithubUpdateService({
@@ -17,17 +28,22 @@ class GithubUpdateService extends UpdateService {
     required this.repo,
     required this.currentVersion,
     required this.platformSuffix,
+    this.includePrereleases = false,
     http.Client? httpClient,
   }) : httpClient = httpClient ?? http.Client();
+
+  /// Betas are pruned to the newest 30, so one page covers the whole repo.
+  Uri get _endpoint => Uri.parse(
+    includePrereleases
+        ? 'https://api.github.com/repos/$owner/$repo/releases?per_page=30'
+        : 'https://api.github.com/repos/$owner/$repo/releases/latest',
+  );
 
   @override
   Future<UpdateStatus> checkForUpdate() async {
     try {
-      final uri = Uri.parse(
-        'https://api.github.com/repos/$owner/$repo/releases/latest',
-      );
       final response = await httpClient.get(
-        uri,
+        _endpoint,
         headers: {'Accept': 'application/vnd.github+json'},
       );
 
@@ -37,25 +53,16 @@ class GithubUpdateService extends UpdateService {
         );
       }
 
-      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      final release = _selectRelease(jsonDecode(response.body));
+      if (release == null) return const UpToDate();
 
-      // Skip pre-releases (shouldn't happen with /releases/latest, but double-check)
-      final isPreRelease = json['prerelease'] as bool? ?? false;
-      if (isPreRelease) {
-        return const UpToDate();
-      }
-
-      final tagName = json['tag_name'] as String;
-      final remoteVersion = tagName.startsWith('v')
-          ? tagName.substring(1)
-          : tagName;
-
+      final remoteVersion = _versionOf(release);
       if (!isNewer(remoteVersion, currentVersion)) {
         return const UpToDate();
       }
 
       // Find the matching asset for this platform
-      final assets = json['assets'] as List<dynamic>;
+      final assets = release['assets'] as List<dynamic>;
       final matchingAsset = assets.cast<Map<String, dynamic>>().where((asset) {
         final name = asset['name'] as String;
         return name.endsWith(platformSuffix);
@@ -68,7 +75,7 @@ class GithubUpdateService extends UpdateService {
       }
 
       final downloadUrl = matchingAsset.first['browser_download_url'] as String;
-      final releaseNotes = json['body'] as String?;
+      final releaseNotes = release['body'] as String?;
 
       return UpdateAvailable(
         version: remoteVersion,
@@ -78,6 +85,36 @@ class GithubUpdateService extends UpdateService {
     } catch (e) {
       return UpdateError(message: e.toString());
     }
+  }
+
+  /// The release this check should consider, or null when there is none.
+  Map<String, dynamic>? _selectRelease(dynamic decoded) {
+    if (!includePrereleases) {
+      final release = decoded as Map<String, dynamic>;
+      // Skip pre-releases (shouldn't happen with /releases/latest, but double-check)
+      if (release['prerelease'] as bool? ?? false) return null;
+      return release;
+    }
+
+    // GitHub returns the list newest-first by tag creation date, but every
+    // beta-builds release shares one creation date, so that order says
+    // nothing about which build is newest. Compare versions instead. The
+    // permanent "appcast" pointer release, which exists only to keep the
+    // Sparkle feed URL resolving, parses as version 0 and so never wins.
+    Map<String, dynamic>? newest;
+    for (final release
+        in (decoded as List<dynamic>).cast<Map<String, dynamic>>()) {
+      if (release['draft'] as bool? ?? false) continue;
+      if (newest == null || isNewer(_versionOf(release), _versionOf(newest))) {
+        newest = release;
+      }
+    }
+    return newest;
+  }
+
+  static String _versionOf(Map<String, dynamic> release) {
+    final tagName = release['tag_name'] as String;
+    return tagName.startsWith('v') ? tagName.substring(1) : tagName;
   }
 
   /// Compares two version strings. Returns true if [remote] is newer than [current].

--- a/lib/features/auto_update/data/services/github_update_service.dart
+++ b/lib/features/auto_update/data/services/github_update_service.dart
@@ -32,10 +32,11 @@ class GithubUpdateService extends UpdateService {
     http.Client? httpClient,
   }) : httpClient = httpClient ?? http.Client();
 
-  /// Betas are pruned to the newest 30, so one page covers the whole repo.
+  /// The API maximum, not the 30 the prune step aims to keep: a prune that
+  /// fails or is delayed would otherwise push the newest beta off page one.
   Uri get _endpoint => Uri.parse(
     includePrereleases
-        ? 'https://api.github.com/repos/$owner/$repo/releases?per_page=30'
+        ? 'https://api.github.com/repos/$owner/$repo/releases?per_page=100'
         : 'https://api.github.com/repos/$owner/$repo/releases/latest',
   );
 

--- a/lib/features/auto_update/data/services/github_update_service.dart
+++ b/lib/features/auto_update/data/services/github_update_service.dart
@@ -97,11 +97,14 @@ class GithubUpdateService extends UpdateService {
       return release;
     }
 
-    // GitHub returns the list newest-first by tag creation date, but every
-    // beta-builds release shares one creation date, so that order says
-    // nothing about which build is newest. Compare versions instead. The
-    // permanent "appcast" pointer release, which exists only to keep the
-    // Sparkle feed URL resolving, parses as version 0 and so never wins.
+    // GitHub orders the list by each release's created_at, which is the
+    // date of the commit its tag points at rather than when the release was
+    // published. beta.yml cuts every beta tag from the beta-builds default
+    // branch, which has not moved since the repo was seeded, so all of them
+    // report the same created_at and the list order says nothing about which
+    // build is newest. Compare versions instead. The permanent "appcast"
+    // pointer release, which exists only to keep the Sparkle feed URL
+    // resolving, parses as version 0 and so never wins.
     Map<String, dynamic>? newest;
     for (final release
         in (decoded as List<dynamic>).cast<Map<String, dynamic>>()) {

--- a/lib/features/auto_update/presentation/providers/update_providers.dart
+++ b/lib/features/auto_update/presentation/providers/update_providers.dart
@@ -104,6 +104,9 @@ final updateServiceProvider = FutureProvider<UpdateService?>((ref) async {
     repo: githubRepoFor(channel),
     currentVersion: currentVersion,
     platformSuffix: _platformSuffix,
+    // beta-builds holds nothing but pre-releases (#1591), which /releases/latest
+    // refuses to return, so the beta channel enumerates the release list.
+    includePrereleases: channel == ReleaseChannel.beta,
   );
 });
 

--- a/lib/features/auto_update/presentation/providers/update_providers.dart
+++ b/lib/features/auto_update/presentation/providers/update_providers.dart
@@ -104,8 +104,10 @@ final updateServiceProvider = FutureProvider<UpdateService?>((ref) async {
     repo: githubRepoFor(channel),
     currentVersion: currentVersion,
     platformSuffix: _platformSuffix,
-    // beta-builds holds nothing but pre-releases (#1591), which /releases/latest
-    // refuses to return, so the beta channel enumerates the release list.
+    // Every versioned release in beta-builds is a pre-release (#1591), which
+    // /releases/latest refuses to return; the one non-pre-release there is the
+    // appcast pointer, which carries no installers. So the beta channel
+    // enumerates the release list instead.
     includePrereleases: channel == ReleaseChannel.beta,
   );
 });

--- a/scripts/release/promote.sh
+++ b/scripts/release/promote.sh
@@ -72,13 +72,26 @@ if $LATEST; then
     echo "Error: give either a build number or --latest, not both." >&2
     exit 1
   fi
-  TAG=$(gh release view --repo submersion-app/beta-builds --json tagName -q .tagName)
+  # Not "gh release view" with no tag: that means the latest release, which
+  # is now the appcast pointer rather than a build (#1591). Pick the highest
+  # build number instead, which is the commit count and only ever increases.
+  TAG=$(gh release list --repo submersion-app/beta-builds \
+    --json tagName --limit 100 \
+    -q '[.[] | select(.tagName | test("^v[0-9]"))]
+    | if length == 0 then empty
+      else max_by(.tagName | split(".") | last | tonumber) | .tagName end')
+  if [ -z "$TAG" ]; then
+    echo "Error: no beta releases found in beta-builds." >&2
+    exit 1
+  fi
   BUILD="${TAG##*.}"
   require_numeric_build "$BUILD"
 elif [ -n "$BUILD" ]; then
   require_numeric_build "$BUILD"
+  # --limit 100: the default page is 30, and the retained 30 betas plus the
+  # appcast pointer is 31, so the oldest beta would fall off the listing.
   TAG=$(gh release list --repo submersion-app/beta-builds --json tagName \
-    -q ".[].tagName" | grep -E "\.${BUILD}$" | head -1)
+    --limit 100 -q ".[].tagName" | grep -E "\.${BUILD}$" | head -1)
   if [ -z "$TAG" ]; then
     echo "Error: no beta release ending in .${BUILD} found in beta-builds." >&2
     exit 1

--- a/test/features/auto_update/data/services/github_update_service_test.dart
+++ b/test/features/auto_update/data/services/github_update_service_test.dart
@@ -478,7 +478,7 @@ void main() {
       expect((status as UpdateAvailable).version, '1.7.7.8070');
     });
 
-    test('never offers the assetless appcast pointer release', () async {
+    test('never offers the installer-less appcast pointer release', () async {
       final client = MockClient((request) async {
         return http.Response(jsonEncode([appcastPointer()]), 200);
       });

--- a/test/features/auto_update/data/services/github_update_service_test.dart
+++ b/test/features/auto_update/data/services/github_update_service_test.dart
@@ -302,6 +302,24 @@ void main() {
       expect(status, isA<UpToDate>());
     });
 
+    test('the stable channel asks GitHub for the latest release', () async {
+      late Uri requested;
+      final client = MockClient((request) async {
+        requested = request.url;
+        return http.Response(jsonEncode(makeRelease(tagName: 'v1.0.0')), 200);
+      });
+
+      await GithubUpdateService(
+        owner: owner,
+        repo: repo,
+        currentVersion: currentVersion,
+        platformSuffix: 'Linux.tar.gz',
+        httpClient: client,
+      ).checkForUpdate();
+
+      expect(requested.path, '/repos/$owner/$repo/releases/latest');
+    });
+
     test('returns UpdateError on malformed JSON response', () async {
       final client = MockClient((request) async {
         return http.Response('<html>Error</html>', 200);
@@ -370,6 +388,140 @@ void main() {
     test('isNewer compares 3-segment remote against 4-segment current', () {
       expect(GithubUpdateService.isNewer('1.2.21', '1.2.21.1'), false);
       expect(GithubUpdateService.isNewer('1.2.22', '1.2.21.99'), true);
+    });
+  });
+
+  // beta-builds publishes every versioned release with --prerelease so the
+  // releases page stops labelling a beta "Latest" (#1591). That takes the
+  // whole repo out of reach of /releases/latest, which excludes pre-releases,
+  // so the beta channel enumerates releases instead. The repo also carries one
+  // permanent non-pre-release "appcast" release whose only job is to keep the
+  // Sparkle feed URL resolving; it holds no installers and must never be
+  // offered as an update.
+  group('GithubUpdateService on the beta channel', () {
+    Map<String, dynamic> betaRelease(String tagName) => {
+      ...makeRelease(tagName: tagName),
+      'prerelease': true,
+      'draft': false,
+    };
+
+    Map<String, dynamic> appcastPointer() => {
+      'tag_name': 'appcast',
+      'body': 'Beta update feed. Not a download.',
+      'prerelease': false,
+      'draft': false,
+      'assets': [
+        {
+          'name': 'appcast-beta.xml',
+          'browser_download_url':
+              'https://github.com/$owner/$repo/releases/download/appcast/appcast-beta.xml',
+        },
+      ],
+    };
+
+    GithubUpdateService serviceFor(
+      http.Client client, {
+      String version = currentVersion,
+    }) => GithubUpdateService(
+      owner: owner,
+      repo: repo,
+      currentVersion: version,
+      platformSuffix: 'Linux.tar.gz',
+      includePrereleases: true,
+      httpClient: client,
+    );
+
+    test('enumerates releases rather than asking for the latest', () async {
+      late Uri requested;
+      final client = MockClient((request) async {
+        requested = request.url;
+        return http.Response(jsonEncode([betaRelease('v1.1.0')]), 200);
+      });
+
+      await serviceFor(client).checkForUpdate();
+
+      expect(requested.path, '/repos/$owner/$repo/releases');
+    });
+
+    test('offers a newer pre-release', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          jsonEncode([appcastPointer(), betaRelease('v1.1.0')]),
+          200,
+        );
+      });
+
+      final status = await serviceFor(client).checkForUpdate();
+      expect(status, isA<UpdateAvailable>());
+      expect((status as UpdateAvailable).version, '1.1.0');
+      expect(status.downloadUrl, endsWith('Linux.tar.gz'));
+    });
+
+    // Every beta in the live repo shares one created_at, so the list order
+    // GitHub returns cannot be trusted to put the newest build first.
+    test('picks the highest version, not the first entry', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          jsonEncode([
+            betaRelease('v1.7.7.8064'),
+            betaRelease('v1.7.7.8070'),
+            betaRelease('v1.7.7.8066'),
+          ]),
+          200,
+        );
+      });
+
+      final status = await serviceFor(
+        client,
+        version: '1.7.7.8064',
+      ).checkForUpdate();
+      expect((status as UpdateAvailable).version, '1.7.7.8070');
+    });
+
+    test('never offers the assetless appcast pointer release', () async {
+      final client = MockClient((request) async {
+        return http.Response(jsonEncode([appcastPointer()]), 200);
+      });
+
+      expect(await serviceFor(client).checkForUpdate(), isA<UpToDate>());
+    });
+
+    test('ignores drafts', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          jsonEncode([
+            {...betaRelease('v9.9.9.999'), 'draft': true},
+            betaRelease('v1.1.0'),
+          ]),
+          200,
+        );
+      });
+
+      final status = await serviceFor(client).checkForUpdate();
+      expect((status as UpdateAvailable).version, '1.1.0');
+    });
+
+    test('stays quiet when the newest beta is the running build', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          jsonEncode([appcastPointer(), betaRelease('v1.7.7.8070')]),
+          200,
+        );
+      });
+
+      final status = await serviceFor(
+        client,
+        version: '1.7.7.8070',
+      ).checkForUpdate();
+      expect(status, isA<UpToDate>());
+    });
+
+    test('an empty release list is not an error', () async {
+      final client = MockClient((request) async {
+        return http.Response('[]', 200);
+      });
+
+      expect(await serviceFor(client).checkForUpdate(), isA<UpToDate>());
     });
   });
 }

--- a/test/features/auto_update/presentation/providers/update_feed_selection_test.dart
+++ b/test/features/auto_update/presentation/providers/update_feed_selection_test.dart
@@ -56,8 +56,8 @@ void main() {
         (service as GithubUpdateService).repo,
         githubRepoFor(ReleaseChannel.beta),
       );
-      // beta-builds publishes only pre-releases (#1591), which
-      // /releases/latest refuses to return. Without this the Linux and
+      // Every versioned release in beta-builds is a pre-release (#1591),
+      // which /releases/latest refuses to return. Without this the Linux and
       // Android beta pollers go permanently quiet.
       expect(service.includePrereleases, isTrue);
     }

--- a/test/features/auto_update/presentation/providers/update_feed_selection_test.dart
+++ b/test/features/auto_update/presentation/providers/update_feed_selection_test.dart
@@ -56,6 +56,17 @@ void main() {
         (service as GithubUpdateService).repo,
         githubRepoFor(ReleaseChannel.beta),
       );
+      // beta-builds publishes only pre-releases (#1591), which
+      // /releases/latest refuses to return. Without this the Linux and
+      // Android beta pollers go permanently quiet.
+      expect(service.includePrereleases, isTrue);
+    }
+  });
+
+  test('the stable channel never accepts a pre-release', () async {
+    final service = await serviceFor(null);
+    if (service is GithubUpdateService) {
+      expect(service.includePrereleases, isFalse);
     }
   });
   test('stable channel uses the main repo appcast', () {


### PR DESCRIPTION
Fixes #1591. Related: #1568.

## The problem

`submersion-app/beta-builds` was indistinguishable from a stable download page. GitHub badged the newest beta **Latest** (`isPrerelease: false`), the assets were named exactly like stable assets, and the version number was higher, so a beta read as newer and better. Only the release title carried the word Beta.

That page is linked publicly from `README.md` and `docs/guide/installation.md`, and for Linux it is the only place a `.deb` or `.rpm` exists, so stable users are sent there by necessity. One accidental install advances the schema ladder past what the stable build can open, and there is no way back (#1568). The in-app channel picker gates beta behind a confirmation dialog; the direct-download route had nothing.

## What changed

- **`beta.yml` publishes with `--prerelease`.** GitHub now shows the pre-release badge and stops calling a beta Latest.
- **The release body leads with a warning block** (`> [!WARNING]`) saying the build may upgrade the dive log database ahead of stable and that stable will not open it afterwards. It is prepended after the appcast HTML is generated, so the in-app update dialog is unchanged: those readers already opted in behind a confirmation dialog.
- **Every beta-builds link in `README.md` and `docs/guide/installation.md` carries the same warning**, with the Linux package sections getting the longer version plus the tarball as the stay-on-stable alternative.

## The part the issue did not anticipate

The issue assumed no app code was required, and asked for the appcast to be confirmed first. It does break, in two places.

GitHub's "latest release" excludes pre-releases, in the API and in the `releases/latest/download/<asset>` redirect alike. With nothing but pre-releases in `beta-builds`, both 404. Two feed URLs are compiled into beta binaries already installed in the field and cannot be changed retroactively:

| Consumer | URL | Fix |
| --- | --- | --- |
| Sparkle / WinSparkle (macOS, Windows) | `beta-builds/releases/latest/download/appcast-beta.xml` | A permanent non-pre-release release tagged `appcast` |
| Linux, Android poller | `api.github.com/repos/.../beta-builds/releases/latest` | `GithubUpdateService.includePrereleases` |

**The `appcast` pointer release** carries `appcast-beta.xml` and nothing else. It is refreshed on every beta run and is the only release that can wear the Latest badge, so the badge lands on something with nothing to install by mistake. The prune step now matches version tags only (`^v[0-9]`) so it can never delete it. Verified against the live repo: the filter returns the same 30 releases it does today.

**`GithubUpdateService` gains `includePrereleases`.** On the beta channel it enumerates `/releases` and picks the highest version instead of asking for the latest one. Version order matters rather than list order: every release in the live `beta-builds` shares one `created_at`, so GitHub's ordering says nothing about which build is newest. The stable channel is untouched and still reads `/releases/latest`, still refusing anything flagged pre-release.

**A backfill step** demotes any versioned release still flagged as a full release. Without it the Latest badge would sit on an old beta until pruning aged all 30 of them out, which is 30 more builds. It runs after the pointer release exists, so `releases/latest` never has a moment with nothing to resolve to, and it is a no-op after the first run.

## Known limitation

Beta installs predating this change poll the API and will see the `appcast` pointer release, whose tag parses as version 0. They report no update available rather than erroring, and need one manual update to pick up the enumerate-releases code. This affects only people who explicitly opted into the beta channel in Settings; a Linux user who installed a `.deb` from beta-builds while left on the stable channel polls the main repo and is unaffected.

## The promotion path

An earlier revision of this description claimed promotion was unaffected. That was wrong, and three commands needed fixing (`7330f97`). All of them relied on the shorthand where "the latest release" means the newest beta, which is now the appcast pointer.

| Site | Was | Effect |
| --- | --- | --- |
| `beta.yml` shippability gate | `gh release download`, no tag | **Silent.** No `metadata.json` on the pointer, error swallowed by the existing `2>/dev/null`, so `PREV_SHA` came back empty every run: the "HEAD already published" skip never fires and the notes fall back to the last stable tag |
| `promote.sh --latest` | `gh release view`, no tag | Dies on `require_numeric_build` with `got: appcast` |
| `promote.sh` / `promote.yml` build lookup | `gh release list`, default page 30 | 30 retained betas plus the pointer is 31, so a beta falls off the listing, and with every release tied on `created_at` there is no saying which |

All three now pick the highest build number among version tags (the commit count, monotonic) and pass `--limit 100`. Verified against the live repo: the selector returns `v1.7.7.8072`, and yields nothing rather than erroring on an empty or pointer-only list.

The `beta.yml` one is the reason to look twice at the rest of this change: it would not have failed a check, it would have quietly restored a bug the workflow had already fixed once.

## Testing

- 8 new cases covering the beta channel: enumerating `/releases`, picking the highest version out of order, never offering the assetless pointer release, ignoring drafts, staying quiet on the running build, and an empty list.
- A new case pinning the stable channel to `/releases/latest`, and assertions that the flag is true for beta and false for stable in the provider wiring.
- `dart format .`, `flutter analyze` clean; affected suite green via the pre-push hook.

