### PR TITLE
feat(release): give a beta build an in-app identity (#1592)

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -175,6 +175,11 @@ jobs:
       version-tag: ${{ needs.precheck.outputs.tag }}
       build-number: ${{ needs.precheck.outputs.build-number }}
       ref: ${{ needs.precheck.outputs.sha }}
+      # Stamps BUILD_TRAIN=beta into every artifact. The version string and the
+      # asset filenames stay identical to stable (tags and the appcast compare
+      # against them), so this define is the only thing that tells a user who
+      # direct-downloaded from beta-builds which train they are on (#1592).
+      build-train: beta
     secrets: inherit
 
   publish-beta:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -22,6 +22,14 @@ on:
         required: false
         type: string
         default: ''
+      build-train:
+        description: >-
+          Release train stamped into every artifact as the BUILD_TRAIN
+          dart-define, so the app can tell the user which train it came off.
+          Only beta.yml passes "beta"; everything else builds stable.
+        required: false
+        type: string
+        default: 'stable'
     outputs:
       eddsa-signature:
         description: 'Sparkle EdDSA signature of the macOS DMG'
@@ -46,6 +54,12 @@ on:
         required: false
         type: string
         default: ''
+      build-train:
+        description: 'Release train stamped into the artifact'
+        required: false
+        type: choice
+        options: [stable, beta]
+        default: stable
 
 permissions:
   contents: read
@@ -195,7 +209,7 @@ jobs:
           echo 'CODE_SIGN_IDENTITY = ' >> macos/Runner/Configs/Release.xcconfig
 
       - name: Build macOS release
-        run: flutter build macos --release --dart-define=UPDATE_CHANNEL=github --dart-define=GOOGLE_DRIVE_CLIENT_SECRET=${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+        run: flutter build macos --release --dart-define=UPDATE_CHANNEL=github --dart-define=GOOGLE_DRIVE_CLIENT_SECRET=${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }} --dart-define=BUILD_TRAIN=${{ inputs.build-train }}
 
       # -- Developer ID DMG (for GitHub Release) --
 
@@ -388,6 +402,7 @@ jobs:
           APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
+          BUILD_TRAIN: ${{ inputs.build-train }}
         run: bundle exec fastlane build
 
       - name: Upload Mac App Store pkg artifact
@@ -465,7 +480,7 @@ jobs:
           grep '^version:' pubspec.yaml
 
       - name: Build Windows release
-        run: flutter build windows --release --dart-define=UPDATE_CHANNEL=github --dart-define=GOOGLE_DRIVE_CLIENT_SECRET=${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+        run: flutter build windows --release --dart-define=UPDATE_CHANNEL=github --dart-define=GOOGLE_DRIVE_CLIENT_SECRET=${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }} --dart-define=BUILD_TRAIN=${{ inputs.build-train }}
 
       - name: Check bundled native assets
         # Runs before the installer is compiled: the .iss packages whatever is
@@ -618,7 +633,7 @@ jobs:
           grep '^version:' pubspec.yaml
 
       - name: Build Linux release
-        run: flutter build linux --release --dart-define=UPDATE_CHANNEL=github --dart-define=GOOGLE_DRIVE_CLIENT_SECRET=${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+        run: flutter build linux --release --dart-define=UPDATE_CHANNEL=github --dart-define=GOOGLE_DRIVE_CLIENT_SECRET=${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }} --dart-define=BUILD_TRAIN=${{ inputs.build-train }}
 
       - name: Check bundled native assets
         # Runs before the tarball is rolled, for the same reason as the Windows
@@ -826,10 +841,10 @@ jobs:
           chmod 600 android/key.properties android/app/release.keystore
 
       - name: Build Android APK
-        run: flutter build apk --release --dart-define=UPDATE_CHANNEL=github
+        run: flutter build apk --release --dart-define=UPDATE_CHANNEL=github --dart-define=BUILD_TRAIN=${{ inputs.build-train }}
 
       - name: Build Android App Bundle
-        run: flutter build appbundle --release --dart-define=HEALTH_CONNECT_ENABLED=false --dart-define=UPDATE_CHANNEL=playstore
+        run: flutter build appbundle --release --dart-define=HEALTH_CONNECT_ENABLED=false --dart-define=UPDATE_CHANNEL=playstore --dart-define=BUILD_TRAIN=${{ inputs.build-train }}
 
       # Guards against issue #318: a 4 KB-aligned native lib (liblibdc_jni.so)
       # silently shipped in v1.5.5.107 and crashed the app on Android 15+
@@ -1009,6 +1024,7 @@ jobs:
           APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
+          BUILD_TRAIN: ${{ inputs.build-train }}
         run: bundle exec fastlane build
 
       - name: Rename IPA

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -491,7 +491,12 @@ platform :ios do
 
     # Build the Flutter app (version comes from pubspec.yaml -> Generated.xcconfig -> Info.plist)
     UI.message("Building Flutter app...")
-    sh("cd ../.. && flutter build ios --release --no-codesign --dart-define=UPDATE_CHANNEL=appstore")
+    # The train comes from the environment rather than a hardcoded value:
+    # this same lane builds the App Store submission and the TestFlight beta,
+    # and only the caller knows which. Defaults to stable so a local run of
+    # this lane behaves as it did before the define existed.
+    build_train = ENV.fetch("BUILD_TRAIN", "stable")
+    sh("cd ../.. && flutter build ios --release --no-codesign --dart-define=UPDATE_CHANNEL=appstore --dart-define=BUILD_TRAIN=#{build_train}")
 
     # Build and sign the IPA
     UI.message("Building and signing IPA...")

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -144,6 +144,10 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
 
     await showBetaBuildNotice(navContext);
     await prefs.setBetaBuildNoticeSeen(true);
+    // The dialog can outlive this State when the app is quit with it open, and
+    // invalidating through a disposed ref throws. The write above is the part
+    // that has to land; the invalidate only refreshes readers still on screen.
+    if (!mounted) return;
     ref.invalidate(updatePreferencesProvider);
   }
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -17,6 +17,8 @@ import 'package:submersion/core/router/app_router.dart';
 import 'package:submersion/features/settings/presentation/providers/display_zoom_menu_channel.dart';
 import 'package:submersion/features/settings/presentation/providers/display_zoom_provider.dart';
 import 'package:submersion/features/auto_update/presentation/providers/update_menu_channel.dart';
+import 'package:submersion/features/auto_update/presentation/providers/update_providers.dart';
+import 'package:submersion/features/auto_update/presentation/widgets/beta_build_notice.dart';
 import 'package:submersion/features/backup/presentation/pages/restore_complete_page.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_barrier.dart';
@@ -110,10 +112,39 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
     );
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeSyncOnLaunch();
+      _maybeShowBetaBuildNotice();
       _resumeMediaTransfers();
       _republishOwnedMedia();
       _fileShareHandler.initialize();
     });
+  }
+
+  /// Tell the user, once, that this binary came off the beta train.
+  ///
+  /// The in-app channel picker warns before switching to beta, but a build
+  /// installed by direct download from the beta-builds repository never passes
+  /// through it. That user only discovers the train when a later stable build
+  /// refuses to open the database their beta build upgraded (#1568), which is
+  /// too late to decide anything.
+  ///
+  /// The flag is written after the dialog closes, not before: if the app is
+  /// killed with the notice on screen the warning is still owed, and showing
+  /// it twice costs far less than never showing it at all.
+  Future<void> _maybeShowBetaBuildNotice() async {
+    final prefs = ref.read(updatePreferencesProvider);
+    if (!shouldShowBetaBuildNotice(
+      train: ref.read(buildTrainProvider),
+      alreadySeen: prefs.betaBuildNoticeSeen,
+    )) {
+      return;
+    }
+
+    final navContext = rootNavigatorKey.currentContext;
+    if (navContext == null) return;
+
+    await showBetaBuildNotice(navContext);
+    await prefs.setBetaBuildNoticeSeen(true);
+    ref.invalidate(updatePreferencesProvider);
   }
 
   @override

--- a/lib/core/services/log_environment.dart
+++ b/lib/core/services/log_environment.dart
@@ -6,6 +6,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:submersion/core/models/log_entry.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/utils/app_version.dart';
+import 'package:submersion/features/auto_update/domain/entities/build_train.dart';
 
 /// Value shown wherever a field could not be determined.
 const _unknown = 'unknown';
@@ -36,6 +37,15 @@ class LogEnvironment {
   /// Flutter build mode: `release`, `profile` or `debug`.
   final String buildMode;
 
+  /// Release train that produced the binary: `stable` or `beta`.
+  ///
+  /// Separate from [appVersion] because beta and stable binaries share a
+  /// version string: nothing in the four segments distinguishes them, so a
+  /// report from a beta build was indistinguishable from a stable one. #1568
+  /// is the worked example, where the whole diagnosis turned on which train
+  /// the reporter was on.
+  final String buildTrain;
+
   /// When this snapshot was taken.
   ///
   /// A field rather than a `DateTime.now()` inside [toExportHeader] so the
@@ -50,6 +60,7 @@ class LogEnvironment {
     required this.osVersion,
     required this.locale,
     required this.buildMode,
+    required this.buildTrain,
     required this.capturedAt,
   });
 
@@ -105,6 +116,9 @@ class LogEnvironment {
           : kProfileMode
           ? 'profile'
           : 'release',
+      // A compile-time constant, so unlike every field above it cannot fail
+      // to resolve and needs no _unknown fallback.
+      buildTrain: BuildTrainConfig.current.name,
       capturedAt: DateTime.now(),
     );
   }
@@ -117,7 +131,8 @@ class LogEnvironment {
       'Session start: Submersion $appVersion'
       ' | $platform $osVersion'
       ' | locale $locale'
-      ' | $buildMode build';
+      ' | $buildMode build'
+      ' | $buildTrain train';
 
   /// Multi-line header prepended to an exported or copied log.
   ///
@@ -132,6 +147,7 @@ app:      Submersion $appVersion
 platform: $platform $osVersion
 locale:   $locale
 build:    $buildMode
+train:    $buildTrain
 exported: $exportedAt
 ============================
 ''';

--- a/lib/features/auto_update/data/repositories/update_preferences.dart
+++ b/lib/features/auto_update/data/repositories/update_preferences.dart
@@ -9,6 +9,7 @@ class UpdatePreferences {
   static const _keyLastCheckTime = 'auto_update_last_check';
   static const _keyCheckIntervalHours = 'auto_update_check_interval_hours';
   static const _keyReleaseChannel = 'update_release_channel';
+  static const _keyBetaBuildNoticeSeen = 'beta_build_notice_seen';
 
   UpdatePreferences(this._prefs);
 
@@ -31,6 +32,19 @@ class UpdatePreferences {
 
   Future<void> setReleaseChannel(ReleaseChannel value) =>
       _prefs.setString(_keyReleaseChannel, value.name);
+
+  /// Whether the user has already read the beta warning: either by confirming
+  /// the in-app channel switch, or by dismissing the first-launch notice a
+  /// beta binary shows.
+  ///
+  /// One flag for both paths so the same text is never shown twice. It is not
+  /// scoped to a version: the warning is about the beta train, not about any
+  /// particular build.
+  bool get betaBuildNoticeSeen =>
+      _prefs.getBool(_keyBetaBuildNoticeSeen) ?? false;
+
+  Future<void> setBetaBuildNoticeSeen(bool value) =>
+      _prefs.setBool(_keyBetaBuildNoticeSeen, value);
 
   int get checkIntervalHours => _prefs.getInt(_keyCheckIntervalHours) ?? 4;
 

--- a/lib/features/auto_update/domain/entities/build_train.dart
+++ b/lib/features/auto_update/domain/entities/build_train.dart
@@ -1,0 +1,49 @@
+/// The release train that produced this binary: the stable release pipeline,
+/// or the per-merge beta pipeline.
+///
+/// Deliberately distinct from the two channel concepts it sits beside:
+///
+/// - `ReleaseChannel` is the user's *preference* for which feed to update
+///   from. A direct download from the beta-builds repository leaves it on
+///   stable, so it never reveals that the running binary is a beta.
+/// - `UpdateChannel` is the compile-time *distribution* channel
+///   (github/appstore/playstore/...), which says how the binary was delivered,
+///   not which train built it.
+///
+/// Neither answers "did this binary come off the beta train?", which is the
+/// fact a user needs before a beta build upgrades their dive log's database
+/// ahead of stable (#1568).
+enum BuildTrain { stable, beta }
+
+/// Reads the build train stamped into the artifact at compile time.
+///
+/// Mirrors `UpdateChannelConfig`: a `--dart-define` set by the release
+/// workflow, defaulting to stable so a build that sets nothing (a local
+/// `flutter run`, or any pipeline predating this define) is unchanged.
+class BuildTrainConfig {
+  BuildTrainConfig._();
+
+  static const _raw = String.fromEnvironment(
+    'BUILD_TRAIN',
+    defaultValue: 'stable',
+  );
+
+  /// The train this binary was built on, parsed from the BUILD_TRAIN
+  /// compile-time environment variable.
+  static BuildTrain get current => fromName(_raw);
+
+  /// Parses a train name, falling back to [BuildTrain.stable] for null or
+  /// unrecognised values.
+  ///
+  /// Stable is the fallback for the same reason it is in
+  /// `ReleaseChannel.fromName`: only the release pipeline ever sets this, so a
+  /// value that fails to parse is a misconfigured build rather than a user
+  /// choice, and the quiet outcome is preferable to a stable build that
+  /// announces itself as a beta.
+  static BuildTrain fromName(String? name) {
+    for (final train in BuildTrain.values) {
+      if (train.name == name) return train;
+    }
+    return BuildTrain.stable;
+  }
+}

--- a/lib/features/auto_update/presentation/providers/update_providers.dart
+++ b/lib/features/auto_update/presentation/providers/update_providers.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/auto_update/data/services/github_update_serv
 import 'package:submersion/features/auto_update/data/services/linux_install_method_reader.dart';
 import 'package:submersion/features/auto_update/data/services/sparkle_update_service.dart';
 import 'package:submersion/features/auto_update/data/services/update_service.dart';
+import 'package:submersion/features/auto_update/domain/entities/build_train.dart';
 import 'package:submersion/features/auto_update/domain/entities/linux_install_method.dart';
 import 'package:submersion/features/auto_update/domain/linux_upgrade_command.dart';
 import 'package:submersion/features/auto_update/domain/entities/release_channel.dart';
@@ -78,6 +79,16 @@ final updatePreferencesProvider = Provider<UpdatePreferences>((ref) {
   final prefs = ref.watch(sharedPreferencesProvider);
   return UpdatePreferences(prefs);
 });
+
+/// The release train that produced this binary.
+///
+/// A provider rather than a bare [BuildTrainConfig.current] read at each call
+/// site, for the same reason as [linuxInstallMethodProvider]: the value comes
+/// from a compile-time `String.fromEnvironment` constant, so an override is
+/// the only way a widget test can reach the beta case at all.
+final buildTrainProvider = Provider<BuildTrain>(
+  (ref) => BuildTrainConfig.current,
+);
 
 /// The user-selected release channel, re-evaluated when preferences reload.
 final releaseChannelProvider = Provider<ReleaseChannel>((ref) {

--- a/lib/features/auto_update/presentation/widgets/beta_build_notice.dart
+++ b/lib/features/auto_update/presentation/widgets/beta_build_notice.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/features/auto_update/domain/entities/build_train.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Whether this launch should show the beta-build warning.
+///
+/// A beta binary reached by direct download from the beta-builds repository
+/// never passes through the in-app channel picker, so its user has never seen
+/// the warning that switching to beta carries: a beta build may upgrade the
+/// dive log's database ahead of stable, and stable will then refuse to open it
+/// (#1568). This is the one moment that text can reach them.
+///
+/// Pure, and separate from [showBetaBuildNotice], so the decision can be
+/// tested without a widget tree.
+bool shouldShowBetaBuildNotice({
+  required BuildTrain train,
+  required bool alreadySeen,
+}) => train == BuildTrain.beta && !alreadySeen;
+
+/// Show the beta-build warning, reusing the channel picker's wording.
+///
+/// The body is deliberately the same string the picker shows before switching
+/// to beta (`settings_updates_betaDialogBody`): one text to
+/// keep accurate, and a user who arrives by either route reads the same
+/// promise about backups and about sync partners sharing a channel. Only the
+/// framing differs, because here the choice has already been made.
+Future<void> showBetaBuildNotice(BuildContext context) {
+  return showDialog<void>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      icon: const Icon(Icons.science_outlined),
+      title: Text(ctx.l10n.settings_updates_betaBuildNoticeTitle),
+      content: Text(
+        '${ctx.l10n.settings_updates_betaBuildNoticeIntro}\n\n'
+        '${ctx.l10n.settings_updates_betaDialogBody}',
+      ),
+      actions: [
+        FilledButton(
+          onPressed: () => Navigator.pop(ctx),
+          child: Text(MaterialLocalizations.of(ctx).okButtonLabel),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -51,6 +51,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/dive_import/domain/services/health_import_service.dart';
 import 'package:submersion/features/dive_import/presentation/providers/dive_import_providers.dart';
 import 'package:submersion/features/auto_update/domain/beta_program_links.dart';
+import 'package:submersion/features/auto_update/domain/entities/build_train.dart';
 import 'package:submersion/features/auto_update/domain/entities/release_channel.dart';
 import 'package:submersion/features/auto_update/domain/entities/update_channel.dart';
 import 'package:submersion/features/auto_update/domain/entities/update_status.dart';
@@ -3113,14 +3114,18 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
   @override
   Widget build(BuildContext context) {
     final packageInfoAsync = ref.watch(packageInfoProvider);
-    final isBetaChannel =
-        UpdateChannelConfig.isAutoUpdateEnabled &&
-        ref.watch(releaseChannelProvider) == ReleaseChannel.beta;
+    // The badge names the train that BUILT this binary, not the channel the
+    // user has selected. Those differ exactly where it matters: a direct
+    // download from the beta-builds repository runs a beta binary while the
+    // preference is still stable (#1592), and reading the preference here left
+    // that user with no badge at all. The selected channel is still shown, on
+    // the update channel tile in the updates card below.
+    final isBetaBuild = ref.watch(buildTrainProvider) == BuildTrain.beta;
     final versionString = packageInfoAsync.when(
       data: (info) {
         final version = formatAppVersion(info);
         final base = context.l10n.settings_about_version(version);
-        return isBetaChannel
+        return isBetaBuild
             ? context.l10n.settings_updates_channelBadgeBeta(base)
             : base;
       },
@@ -3381,6 +3386,12 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
     }
 
     final prefs = ref.read(updatePreferencesProvider);
+    if (selected == ReleaseChannel.beta) {
+      // The confirm dialog above is the same text the first-launch notice
+      // shows, so record it as read here too: a user who opts in from
+      // settings must not be shown it again once a beta binary arrives.
+      await prefs.setBetaBuildNoticeSeen(true);
+    }
     await prefs.setReleaseChannel(selected);
     ref.invalidate(updatePreferencesProvider);
     // releaseChannelProvider and updateServiceProvider re-derive from the

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -5280,6 +5280,8 @@
   "settings_units_weight_pounds": "أرطال (lbs)",
   "settings_updates_automaticUpdates": "التحديثات التلقائية",
   "settings_updates_automaticUpdatesSubtitle": "التحقق من التحديثات بشكل دوري",
+  "settings_updates_betaBuildNoticeIntro": "جاء هذا الإصدار من Submersion من قناة البيتا، وليس من إصدار مستقر.",
+  "settings_updates_betaBuildNoticeTitle": "أنت تستخدم إصدار بيتا",
   "settings_updates_betaDialogBody": "تُنشر إصدارات البيتا مع كل تغيير وقد تقوم بترقية قاعدة بيانات سجل الغوص قبل الإصدار المستقر. العودة لاحقًا إلى القناة المستقرة لن تعيد التطبيق إلى إصدار أقدم، وينبغي أن تستخدم جميع الأجهزة التي تتزامن معًا القناة نفسها. يتم إنشاء نسخة احتياطية تلقائيًا قبل أي ترقية لقاعدة البيانات.",
   "settings_updates_betaDialogConfirm": "التبديل إلى البيتا",
   "settings_updates_betaDialogTitle": "هل تريد تلقي تحديثات البيتا؟",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -5280,6 +5280,8 @@
   "settings_units_weight_pounds": "Pfund (lbs)",
   "settings_updates_automaticUpdates": "Automatische Updates",
   "settings_updates_automaticUpdatesSubtitle": "Regelmäßig nach Updates suchen",
+  "settings_updates_betaBuildNoticeIntro": "Diese Kopie von Submersion stammt aus dem Beta-Kanal, nicht aus einer stabilen Version.",
+  "settings_updates_betaBuildNoticeTitle": "Sie verwenden einen Beta-Build",
   "settings_updates_betaDialogBody": "Beta-Builds werden aus jeder Änderung veröffentlicht und können die Datenbank Ihres Tauchlogbuchs vor der stabilen Version aktualisieren. Ein späterer Wechsel zurück zu Stabil stuft die App nicht herab, und alle Geräte, die miteinander synchronisieren, sollten denselben Kanal verwenden. Vor jedem Datenbank-Upgrade wird automatisch ein Backup erstellt.",
   "settings_updates_betaDialogConfirm": "Zu Beta wechseln",
   "settings_updates_betaDialogTitle": "Beta-Updates erhalten?",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -10303,6 +10303,8 @@
   "settings_units_weight_pounds": "Pounds (lbs)",
   "settings_updates_automaticUpdates": "Automatic updates",
   "settings_updates_automaticUpdatesSubtitle": "Check for updates periodically",
+  "settings_updates_betaBuildNoticeIntro": "This copy of Submersion came from the beta channel, not from a stable release.",
+  "settings_updates_betaBuildNoticeTitle": "You are running a beta build",
   "settings_updates_betaDialogBody": "Beta builds are published from every change and may upgrade your dive log's database before the stable release does. Switching back to stable later will not downgrade the app, and all devices that sync together should use the same channel. A backup is taken automatically before any database upgrade.",
   "settings_updates_betaDialogConfirm": "Switch to Beta",
   "settings_updates_betaDialogTitle": "Receive beta updates?",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -5280,6 +5280,8 @@
   "settings_units_weight_pounds": "Libras (lbs)",
   "settings_updates_automaticUpdates": "Actualizaciones automáticas",
   "settings_updates_automaticUpdatesSubtitle": "Buscar actualizaciones periódicamente",
+  "settings_updates_betaBuildNoticeIntro": "Esta copia de Submersion proviene del canal beta, no de una versión estable.",
+  "settings_updates_betaBuildNoticeTitle": "Estás usando una versión beta",
   "settings_updates_betaDialogBody": "Las versiones beta se publican con cada cambio y pueden actualizar la base de datos de tu registro de buceo antes que la versión estable. Volver luego al canal estable no revertirá la app a una versión anterior, y todos los dispositivos que se sincronizan entre sí deberían usar el mismo canal. Se realiza una copia de seguridad automáticamente antes de cualquier actualización de la base de datos.",
   "settings_updates_betaDialogConfirm": "Cambiar a Beta",
   "settings_updates_betaDialogTitle": "¿Recibir actualizaciones beta?",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -5196,6 +5196,8 @@
   "settings_units_weight_pounds": "Livres (lbs)",
   "settings_updates_automaticUpdates": "Mises à jour automatiques",
   "settings_updates_automaticUpdatesSubtitle": "Rechercher les mises à jour périodiquement",
+  "settings_updates_betaBuildNoticeIntro": "Cette copie de Submersion provient du canal bêta, et non d'une version stable.",
+  "settings_updates_betaBuildNoticeTitle": "Vous utilisez une version bêta",
   "settings_updates_betaDialogBody": "Les versions bêta sont publiées à chaque modification et peuvent mettre à niveau la base de données de votre carnet de plongée avant la version stable. Revenir ensuite au canal stable ne rétrogradera pas l'application, et tous les appareils qui se synchronisent ensemble devraient utiliser le même canal. Une sauvegarde est effectuée automatiquement avant toute mise à niveau de la base de données.",
   "settings_updates_betaDialogConfirm": "Passer à la bêta",
   "settings_updates_betaDialogTitle": "Recevoir les mises à jour bêta ?",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -5280,6 +5280,8 @@
   "settings_units_weight_pounds": "ליברות (lbs)",
   "settings_updates_automaticUpdates": "עדכונים אוטומטיים",
   "settings_updates_automaticUpdatesSubtitle": "בדיקת עדכונים מעת לעת",
+  "settings_updates_betaBuildNoticeIntro": "עותק זה של Submersion הגיע מערוץ הבטא, ולא מגרסה יציבה.",
+  "settings_updates_betaBuildNoticeTitle": "אתה מריץ גרסת בטא",
   "settings_updates_betaDialogBody": "גרסאות בטא מתפרסמות מכל שינוי ועשויות לשדרג את מסד הנתונים של יומן הצלילה שלך לפני הגרסה היציבה. חזרה מאוחר יותר לערוץ היציב לא תחזיר את האפליקציה לגרסה קודמת, וכל המכשירים שמסתנכרנים יחד צריכים להשתמש באותו ערוץ. גיבוי נוצר אוטומטית לפני כל שדרוג של מסד הנתונים.",
   "settings_updates_betaDialogConfirm": "מעבר לבטא",
   "settings_updates_betaDialogTitle": "לקבל עדכוני בטא?",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -5196,6 +5196,8 @@
   "settings_units_weight_pounds": "Font (lbs)",
   "settings_updates_automaticUpdates": "Automatikus frissítések",
   "settings_updates_automaticUpdatesSubtitle": "Frissítések rendszeres keresése",
+  "settings_updates_betaBuildNoticeIntro": "A Submersion ezen példánya a béta csatornáról származik, nem stabil kiadásból.",
+  "settings_updates_betaBuildNoticeTitle": "Béta buildet használsz",
   "settings_updates_betaDialogBody": "A béta buildek minden változtatásból megjelennek, és a merülési napló adatbázisát a stabil kiadás előtt frissíthetik. Ha később visszaváltasz a stabil csatornára, az alkalmazás nem áll vissza korábbi verzióra, és az együtt szinkronizáló eszközöknek ugyanazt a csatornát érdemes használniuk. Minden adatbázis-frissítés előtt automatikusan biztonsági mentés készül.",
   "settings_updates_betaDialogConfirm": "Váltás bétára",
   "settings_updates_betaDialogTitle": "Szeretnél béta frissítéseket kapni?",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -5192,6 +5192,8 @@
   "settings_units_weight_pounds": "Libbre (lbs)",
   "settings_updates_automaticUpdates": "Aggiornamenti automatici",
   "settings_updates_automaticUpdatesSubtitle": "Controlla periodicamente gli aggiornamenti",
+  "settings_updates_betaBuildNoticeIntro": "Questa copia di Submersion proviene dal canale beta, non da una versione stabile.",
+  "settings_updates_betaBuildNoticeTitle": "Stai usando una build beta",
   "settings_updates_betaDialogBody": "Le build beta vengono pubblicate a ogni modifica e possono aggiornare il database del tuo diario immersioni prima della versione stabile. Tornare in seguito al canale stabile non riporterà l'app a una versione precedente, e tutti i dispositivi che si sincronizzano tra loro dovrebbero usare lo stesso canale. Prima di ogni aggiornamento del database viene eseguito automaticamente un backup.",
   "settings_updates_betaDialogConfirm": "Passa alla Beta",
   "settings_updates_betaDialogTitle": "Ricevere aggiornamenti beta?",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -29579,6 +29579,18 @@ abstract class AppLocalizations {
   /// **'Check for updates periodically'**
   String get settings_updates_automaticUpdatesSubtitle;
 
+  /// No description provided for @settings_updates_betaBuildNoticeIntro.
+  ///
+  /// In en, this message translates to:
+  /// **'This copy of Submersion came from the beta channel, not from a stable release.'**
+  String get settings_updates_betaBuildNoticeIntro;
+
+  /// No description provided for @settings_updates_betaBuildNoticeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'You are running a beta build'**
+  String get settings_updates_betaBuildNoticeTitle;
+
   /// No description provided for @settings_updates_betaDialogBody.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -17532,6 +17532,13 @@ class AppLocalizationsAr extends AppLocalizations {
       'التحقق من التحديثات بشكل دوري';
 
   @override
+  String get settings_updates_betaBuildNoticeIntro =>
+      'جاء هذا الإصدار من Submersion من قناة البيتا، وليس من إصدار مستقر.';
+
+  @override
+  String get settings_updates_betaBuildNoticeTitle => 'أنت تستخدم إصدار بيتا';
+
+  @override
   String get settings_updates_betaDialogBody =>
       'تُنشر إصدارات البيتا مع كل تغيير وقد تقوم بترقية قاعدة بيانات سجل الغوص قبل الإصدار المستقر. العودة لاحقًا إلى القناة المستقرة لن تعيد التطبيق إلى إصدار أقدم، وينبغي أن تستخدم جميع الأجهزة التي تتزامن معًا القناة نفسها. يتم إنشاء نسخة احتياطية تلقائيًا قبل أي ترقية لقاعدة البيانات.';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -17830,6 +17830,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Regelmäßig nach Updates suchen';
 
   @override
+  String get settings_updates_betaBuildNoticeIntro =>
+      'Diese Kopie von Submersion stammt aus dem Beta-Kanal, nicht aus einer stabilen Version.';
+
+  @override
+  String get settings_updates_betaBuildNoticeTitle =>
+      'Sie verwenden einen Beta-Build';
+
+  @override
   String get settings_updates_betaDialogBody =>
       'Beta-Builds werden aus jeder Änderung veröffentlicht und können die Datenbank Ihres Tauchlogbuchs vor der stabilen Version aktualisieren. Ein späterer Wechsel zurück zu Stabil stuft die App nicht herab, und alle Geräte, die miteinander synchronisieren, sollten denselben Kanal verwenden. Vor jedem Datenbank-Upgrade wird automatisch ein Backup erstellt.';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -17550,6 +17550,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'Check for updates periodically';
 
   @override
+  String get settings_updates_betaBuildNoticeIntro =>
+      'This copy of Submersion came from the beta channel, not from a stable release.';
+
+  @override
+  String get settings_updates_betaBuildNoticeTitle =>
+      'You are running a beta build';
+
+  @override
   String get settings_updates_betaDialogBody =>
       'Beta builds are published from every change and may upgrade your dive log\'s database before the stable release does. Switching back to stable later will not downgrade the app, and all devices that sync together should use the same channel. A backup is taken automatically before any database upgrade.';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -17866,6 +17866,14 @@ class AppLocalizationsEs extends AppLocalizations {
       'Buscar actualizaciones periódicamente';
 
   @override
+  String get settings_updates_betaBuildNoticeIntro =>
+      'Esta copia de Submersion proviene del canal beta, no de una versión estable.';
+
+  @override
+  String get settings_updates_betaBuildNoticeTitle =>
+      'Estás usando una versión beta';
+
+  @override
   String get settings_updates_betaDialogBody =>
       'Las versiones beta se publican con cada cambio y pueden actualizar la base de datos de tu registro de buceo antes que la versión estable. Volver luego al canal estable no revertirá la app a una versión anterior, y todos los dispositivos que se sincronizan entre sí deberían usar el mismo canal. Se realiza una copia de seguridad automáticamente antes de cualquier actualización de la base de datos.';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -17926,6 +17926,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'Rechercher les mises à jour périodiquement';
 
   @override
+  String get settings_updates_betaBuildNoticeIntro =>
+      'Cette copie de Submersion provient du canal bêta, et non d\'une version stable.';
+
+  @override
+  String get settings_updates_betaBuildNoticeTitle =>
+      'Vous utilisez une version bêta';
+
+  @override
   String get settings_updates_betaDialogBody =>
       'Les versions bêta sont publiées à chaque modification et peuvent mettre à niveau la base de données de votre carnet de plongée avant la version stable. Revenir ensuite au canal stable ne rétrogradera pas l\'application, et tous les appareils qui se synchronisent ensemble devraient utiliser le même canal. Une sauvegarde est effectuée automatiquement avant toute mise à niveau de la base de données.';
 

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -17407,6 +17407,13 @@ class AppLocalizationsHe extends AppLocalizations {
       'בדיקת עדכונים מעת לעת';
 
   @override
+  String get settings_updates_betaBuildNoticeIntro =>
+      'עותק זה של Submersion הגיע מערוץ הבטא, ולא מגרסה יציבה.';
+
+  @override
+  String get settings_updates_betaBuildNoticeTitle => 'אתה מריץ גרסת בטא';
+
+  @override
   String get settings_updates_betaDialogBody =>
       'גרסאות בטא מתפרסמות מכל שינוי ועשויות לשדרג את מסד הנתונים של יומן הצלילה שלך לפני הגרסה היציבה. חזרה מאוחר יותר לערוץ היציב לא תחזיר את האפליקציה לגרסה קודמת, וכל המכשירים שמסתנכרנים יחד צריכים להשתמש באותו ערוץ. גיבוי נוצר אוטומטית לפני כל שדרוג של מסד הנתונים.';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -17801,6 +17801,13 @@ class AppLocalizationsHu extends AppLocalizations {
       'Frissítések rendszeres keresése';
 
   @override
+  String get settings_updates_betaBuildNoticeIntro =>
+      'A Submersion ezen példánya a béta csatornáról származik, nem stabil kiadásból.';
+
+  @override
+  String get settings_updates_betaBuildNoticeTitle => 'Béta buildet használsz';
+
+  @override
   String get settings_updates_betaDialogBody =>
       'A béta buildek minden változtatásból megjelennek, és a merülési napló adatbázisát a stabil kiadás előtt frissíthetik. Ha később visszaváltasz a stabil csatornára, az alkalmazás nem áll vissza korábbi verzióra, és az együtt szinkronizáló eszközöknek ugyanazt a csatornát érdemes használniuk. Minden adatbázis-frissítés előtt automatikusan biztonsági mentés készül.';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -17856,6 +17856,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'Controlla periodicamente gli aggiornamenti';
 
   @override
+  String get settings_updates_betaBuildNoticeIntro =>
+      'Questa copia di Submersion proviene dal canale beta, non da una versione stabile.';
+
+  @override
+  String get settings_updates_betaBuildNoticeTitle =>
+      'Stai usando una build beta';
+
+  @override
   String get settings_updates_betaDialogBody =>
       'Le build beta vengono pubblicate a ogni modifica e possono aggiornare il database del tuo diario immersioni prima della versione stabile. Tornare in seguito al canale stabile non riporterà l\'app a una versione precedente, e tutti i dispositivi che si sincronizzano tra loro dovrebbero usare lo stesso canale. Prima di ogni aggiornamento del database viene eseguito automaticamente un backup.';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -17710,6 +17710,14 @@ class AppLocalizationsNl extends AppLocalizations {
       'Periodiek controleren op updates';
 
   @override
+  String get settings_updates_betaBuildNoticeIntro =>
+      'Deze kopie van Submersion komt van het bètakanaal, niet van een stabiele versie.';
+
+  @override
+  String get settings_updates_betaBuildNoticeTitle =>
+      'Je gebruikt een bètabuild';
+
+  @override
   String get settings_updates_betaDialogBody =>
       'Bètabuilds worden bij elke wijziging gepubliceerd en kunnen de database van je duiklogboek upgraden vóór de stabiele versie. Later terugschakelen naar stabiel zet de app niet terug naar een oudere versie, en alle apparaten die met elkaar synchroniseren moeten hetzelfde kanaal gebruiken. Vóór elke database-upgrade wordt automatisch een back-up gemaakt.';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -17866,6 +17866,14 @@ class AppLocalizationsPt extends AppLocalizations {
       'Verificar atualizações periodicamente';
 
   @override
+  String get settings_updates_betaBuildNoticeIntro =>
+      'Esta cópia do Submersion veio do canal beta, não de uma versão estável.';
+
+  @override
+  String get settings_updates_betaBuildNoticeTitle =>
+      'Você está usando uma versão beta';
+
+  @override
   String get settings_updates_betaDialogBody =>
       'As versões beta são publicadas a cada alteração e podem atualizar o banco de dados do seu registro de mergulhos antes da versão estável. Voltar depois para o canal estável não fará downgrade do app, e todos os dispositivos que sincronizam entre si devem usar o mesmo canal. Um backup é feito automaticamente antes de qualquer atualização do banco de dados.';
 

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -16948,6 +16948,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_updates_automaticUpdatesSubtitle => '定期检查更新';
 
   @override
+  String get settings_updates_betaBuildNoticeIntro =>
+      '此 Submersion 副本来自 Beta 渠道，而非稳定版。';
+
+  @override
+  String get settings_updates_betaBuildNoticeTitle => '您正在运行 Beta 版本';
+
+  @override
   String get settings_updates_betaDialogBody =>
       'Beta 版本会随每次更改发布，可能会先于稳定版升级您的潜水日志数据库。之后切换回稳定版不会降级应用，并且所有相互同步的设备应使用相同的更新渠道。每次数据库升级前都会自动创建备份。';
 

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -5280,6 +5280,8 @@
   "settings_units_weight_pounds": "Pond (lbs)",
   "settings_updates_automaticUpdates": "Automatische updates",
   "settings_updates_automaticUpdatesSubtitle": "Periodiek controleren op updates",
+  "settings_updates_betaBuildNoticeIntro": "Deze kopie van Submersion komt van het bètakanaal, niet van een stabiele versie.",
+  "settings_updates_betaBuildNoticeTitle": "Je gebruikt een bètabuild",
   "settings_updates_betaDialogBody": "Bètabuilds worden bij elke wijziging gepubliceerd en kunnen de database van je duiklogboek upgraden vóór de stabiele versie. Later terugschakelen naar stabiel zet de app niet terug naar een oudere versie, en alle apparaten die met elkaar synchroniseren moeten hetzelfde kanaal gebruiken. Vóór elke database-upgrade wordt automatisch een back-up gemaakt.",
   "settings_updates_betaDialogConfirm": "Overschakelen naar bèta",
   "settings_updates_betaDialogTitle": "Bèta-updates ontvangen?",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -5280,6 +5280,8 @@
   "settings_units_weight_pounds": "Libras (lbs)",
   "settings_updates_automaticUpdates": "Atualizações automáticas",
   "settings_updates_automaticUpdatesSubtitle": "Verificar atualizações periodicamente",
+  "settings_updates_betaBuildNoticeIntro": "Esta cópia do Submersion veio do canal beta, não de uma versão estável.",
+  "settings_updates_betaBuildNoticeTitle": "Você está usando uma versão beta",
   "settings_updates_betaDialogBody": "As versões beta são publicadas a cada alteração e podem atualizar o banco de dados do seu registro de mergulhos antes da versão estável. Voltar depois para o canal estável não fará downgrade do app, e todos os dispositivos que sincronizam entre si devem usar o mesmo canal. Um backup é feito automaticamente antes de qualquer atualização do banco de dados.",
   "settings_updates_betaDialogConfirm": "Mudar para Beta",
   "settings_updates_betaDialogTitle": "Receber atualizações beta?",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5471,6 +5471,8 @@
   "settings_units_weight_pounds": "磅 (lbs)",
   "settings_updates_automaticUpdates": "自动更新",
   "settings_updates_automaticUpdatesSubtitle": "定期检查更新",
+  "settings_updates_betaBuildNoticeIntro": "此 Submersion 副本来自 Beta 渠道，而非稳定版。",
+  "settings_updates_betaBuildNoticeTitle": "您正在运行 Beta 版本",
   "settings_updates_betaDialogBody": "Beta 版本会随每次更改发布，可能会先于稳定版升级您的潜水日志数据库。之后切换回稳定版不会降级应用，并且所有相互同步的设备应使用相同的更新渠道。每次数据库升级前都会自动创建备份。",
   "settings_updates_betaDialogConfirm": "切换到 Beta",
   "settings_updates_betaDialogTitle": "接收 Beta 更新？",

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -546,7 +546,12 @@ platform :mac do
 
       # Regenerate Flutter configs and plugin registrant (without auto_updater)
       UI.message("Building Flutter app...")
-      sh("cd ../.. && flutter build macos --release --config-only --dart-define=UPDATE_CHANNEL=appstore")
+      # The train comes from the environment rather than a hardcoded value:
+      # this same lane builds the App Store submission and the TestFlight beta,
+      # and only the caller knows which. Defaults to stable so a local run of
+      # this lane behaves as it did before the define existed.
+      build_train = ENV.fetch("BUILD_TRAIN", "stable")
+      sh("cd ../.. && flutter build macos --release --config-only --dart-define=UPDATE_CHANNEL=appstore --dart-define=BUILD_TRAIN=#{build_train}")
 
       # Reinstall pods without auto_updater_macos / Sparkle
       # Clear Bundler env so system CocoaPods doesn't inherit fastlane's

--- a/test/core/services/log_environment_test.dart
+++ b/test/core/services/log_environment_test.dart
@@ -15,11 +15,12 @@ void main() {
     osVersion: 'Version 26.6 (Build 23G93)',
     locale: 'de_DE.UTF-8',
     buildMode: 'release',
+    buildTrain: 'beta',
     capturedAt: DateTime(2026, 8, 25, 20, 25, 19),
   );
 
   group('toSummaryLine', () {
-    test('names the build, platform, locale and build mode', () {
+    test('names the build, platform, locale, build mode and train', () {
       final line = environment.toSummaryLine();
 
       expect(line, contains('1.7.6.123'));
@@ -27,6 +28,9 @@ void main() {
       expect(line, contains('Version 26.6 (Build 23G93)'));
       expect(line, contains('de_DE.UTF-8'));
       expect(line, contains('release'));
+      // Beta and stable binaries share a version string, so the train is the
+      // only thing in the marker that separates them (#1592).
+      expect(line, contains('beta train'));
     });
 
     test('is a single line so it survives the log-line parser', () {
@@ -46,6 +50,7 @@ void main() {
       expect(header, contains('Version 26.6 (Build 23G93)'));
       expect(header, contains('de_DE.UTF-8'));
       expect(header, contains('release'));
+      expect(header, contains('train:    beta'));
       expect(header, contains('exported:'));
     });
 
@@ -157,6 +162,15 @@ void main() {
       final captured = await LogEnvironment.capture();
 
       expect(captured.buildMode, anyOf('debug', 'profile', 'release'));
+    });
+
+    test('reports the train the test host was compiled on', () async {
+      // Unlike every other field, the train cannot degrade to 'unknown': it
+      // reads a compile-time constant. The test host passes no BUILD_TRAIN
+      // define, which is the stable case.
+      final captured = await LogEnvironment.capture();
+
+      expect(captured.buildTrain, 'stable');
     });
 
     test(

--- a/test/features/auto_update/data/repositories/update_preferences_test.dart
+++ b/test/features/auto_update/data/repositories/update_preferences_test.dart
@@ -66,6 +66,17 @@ void main() {
       expect(prefs.releaseChannel, ReleaseChannel.beta);
     });
 
+    test('betaBuildNoticeSeen defaults to false', () {
+      // A fresh install of a beta binary is owed the warning, so the absent
+      // key must never read as "already shown".
+      expect(prefs.betaBuildNoticeSeen, false);
+    });
+
+    test('setBetaBuildNoticeSeen round-trips', () async {
+      await prefs.setBetaBuildNoticeSeen(true);
+      expect(prefs.betaBuildNoticeSeen, true);
+    });
+
     test('releaseChannel tolerates an unknown stored value', () async {
       SharedPreferences.setMockInitialValues({
         'update_release_channel': 'nightly',

--- a/test/features/auto_update/domain/entities/build_train_test.dart
+++ b/test/features/auto_update/domain/entities/build_train_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/auto_update/domain/entities/build_train.dart';
+
+void main() {
+  group('BuildTrainConfig.fromName', () {
+    test('parses every declared train', () {
+      for (final train in BuildTrain.values) {
+        expect(BuildTrainConfig.fromName(train.name), train);
+      }
+    });
+
+    test('falls back to stable for null, empty and unknown values', () {
+      // Only the release pipeline sets BUILD_TRAIN, so an unparseable value is
+      // a misconfigured build. A stable binary must never claim to be a beta.
+      expect(BuildTrainConfig.fromName(null), BuildTrain.stable);
+      expect(BuildTrainConfig.fromName(''), BuildTrain.stable);
+      expect(BuildTrainConfig.fromName('BETA'), BuildTrain.stable);
+      expect(BuildTrainConfig.fromName('nightly'), BuildTrain.stable);
+    });
+  });
+
+  group('BuildTrainConfig.current', () {
+    test('is stable when no dart-define was passed', () {
+      // The test host compiles without --dart-define=BUILD_TRAIN, which is the
+      // same state as a local flutter run and as any build predating the
+      // define. Both must read as stable.
+      expect(BuildTrainConfig.current, BuildTrain.stable);
+    });
+  });
+}

--- a/test/features/auto_update/presentation/widgets/beta_build_notice_test.dart
+++ b/test/features/auto_update/presentation/widgets/beta_build_notice_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/auto_update/domain/entities/build_train.dart';
+import 'package:submersion/features/auto_update/presentation/widgets/beta_build_notice.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  group('shouldShowBetaBuildNotice', () {
+    test('shows on a beta build the user has not been warned about', () {
+      // The #1568 case: a direct download from beta-builds, so the channel
+      // picker never ran and the warning was never read.
+      expect(
+        shouldShowBetaBuildNotice(train: BuildTrain.beta, alreadySeen: false),
+        isTrue,
+      );
+    });
+
+    test('stays silent on a stable build', () {
+      expect(
+        shouldShowBetaBuildNotice(train: BuildTrain.stable, alreadySeen: false),
+        isFalse,
+      );
+    });
+
+    test('stays silent once the warning has been read', () {
+      // Set either by dismissing this notice, or by confirming the in-app
+      // switch to beta, which shows the same body text.
+      expect(
+        shouldShowBetaBuildNotice(train: BuildTrain.beta, alreadySeen: true),
+        isFalse,
+      );
+    });
+
+    test('never fires on a stable build, warned or not', () {
+      expect(
+        shouldShowBetaBuildNotice(train: BuildTrain.stable, alreadySeen: true),
+        isFalse,
+      );
+    });
+  });
+
+  group('showBetaBuildNotice', () {
+    testWidgets('carries the channel picker warning verbatim', (tester) async {
+      late AppLocalizations l10n;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          home: Builder(
+            builder: (context) {
+              l10n = AppLocalizations.of(context);
+              return TextButton(
+                onPressed: () => showBetaBuildNotice(context),
+                child: const Text('open'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.settings_updates_betaBuildNoticeTitle), findsOne);
+      // The database warning is the whole point of the dialog: the same string
+      // the picker shows before switching to beta, so there is one text to
+      // keep accurate rather than two that can drift.
+      expect(
+        find.textContaining(l10n.settings_updates_betaDialogBody),
+        findsOne,
+      );
+    });
+
+    testWidgets('closes on acknowledgement', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          home: Builder(
+            builder: (context) => TextButton(
+              onPressed: () => showBetaBuildNotice(context),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      expect(find.byType(AlertDialog), findsOne);
+
+      await tester.tap(find.byType(FilledButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+  });
+}

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -10,6 +10,7 @@ import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/features/auto_update/domain/entities/build_train.dart';
 import 'package:submersion/features/auto_update/domain/entities/update_status.dart';
 import 'package:submersion/features/auto_update/presentation/providers/update_providers.dart';
 // ignore: implementation_imports
@@ -963,6 +964,7 @@ void main() {
       Map<String, Object> extraPrefs = const {},
       UpdateStatus? status,
       AppSettings settings = const AppSettings(),
+      BuildTrain train = BuildTrain.stable,
     }) async {
       SharedPreferences.setMockInitialValues({
         'auto_update_enabled': false,
@@ -986,6 +988,9 @@ void main() {
         // No real update service: channel-switch tests exercise the settings
         // flow, not Sparkle/GitHub polling.
         updateServiceProvider.overrideWith((ref) async => null),
+        // BuildTrainConfig reads a compile-time const, so an override is the
+        // only way a test can stand in a beta binary.
+        buildTrainProvider.overrideWithValue(train),
         if (status != null)
           updateStatusProvider.overrideWith(
             (ref) => UpdateStatusNotifier(ref)..state = status,
@@ -1097,6 +1102,72 @@ void main() {
       );
     });
 
+    /// Pin a version so the badge assertions can match the whole rendered
+    /// string rather than a substring.
+    void mockPackageVersion() {
+      PackageInfo.setMockInitialValues(
+        appName: 'Submersion',
+        packageName: 'app.submersion',
+        version: '1.7.2',
+        buildNumber: '119',
+        buildSignature: '',
+        installerStore: null,
+      );
+    }
+
+    testWidgets('a beta binary badges its version, whatever the channel', (
+      tester,
+    ) async {
+      // The #1568 case: reached by direct download from beta-builds, so the
+      // stored channel is still stable and only the binary knows the truth.
+      mockPackageVersion();
+      await tester.pumpWidget(
+        buildAboutWidget(await aboutOverrides(train: BuildTrain.beta)),
+      );
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+
+      expect(find.text('Version 1.7.2.119 (Beta)'), findsWidgets);
+    });
+
+    testWidgets('a stable binary is unbadged even on the beta channel', (
+      tester,
+    ) async {
+      // Selecting beta only changes which feed is polled. Until a beta build
+      // actually lands, badging this binary would be a lie, and a lie here
+      // masks the badge that matters (#1592).
+      mockPackageVersion();
+      await tester.pumpWidget(
+        buildAboutWidget(await aboutOverrides(channel: 'beta')),
+      );
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+
+      expect(find.text('Version 1.7.2.119'), findsWidgets);
+      expect(find.textContaining('(Beta)'), findsNothing);
+    });
+
+    testWidgets('confirming the beta switch records the warning as read', (
+      tester,
+    ) async {
+      // Same body text as the first-launch notice, so reading it here must
+      // stop that notice firing when a beta build later arrives.
+      await tester.pumpWidget(buildAboutWidget(await aboutOverrides()));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+
+      await tester.scrollUntilVisible(find.text('Update channel'), 100);
+      await tester.tap(find.text('Update channel'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Beta'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Switch to Beta'));
+      await tester.pumpAndSettle();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('beta_build_notice_seen'), isTrue);
+    });
+
     testWidgets('status text renders the downloading and ready states', (
       tester,
     ) async {
@@ -1169,26 +1240,6 @@ void main() {
       expect(find.text('Never'), findsNothing);
       // The old hand-rolled shape, which no preference could ever produce.
       expect(find.text('7/4/2026 09:05'), findsNothing);
-    });
-
-    testWidgets('version row shows a beta badge on the beta channel', (
-      tester,
-    ) async {
-      PackageInfo.setMockInitialValues(
-        appName: 'Submersion',
-        packageName: 'app.submersion',
-        version: '1.7.2',
-        buildNumber: '119',
-        buildSignature: '',
-        installerStore: null,
-      );
-      await tester.pumpWidget(
-        buildAboutWidget(await aboutOverrides(channel: 'beta')),
-      );
-      await tester.pumpAndSettle();
-      await tester.pump(const Duration(seconds: 6));
-
-      expect(find.textContaining('(Beta)'), findsOneWidget);
     });
   });
 

--- a/test/features/settings/presentation/providers/debug_log_providers_test.dart
+++ b/test/features/settings/presentation/providers/debug_log_providers_test.dart
@@ -25,6 +25,7 @@ final _environment = LogEnvironment(
   osVersion: 'Version 26.6 (Build 23G93)',
   locale: 'de_DE.UTF-8',
   buildMode: 'release',
+  buildTrain: 'stable',
   capturedAt: DateTime(2026, 8, 25, 20, 25, 19),
 );
 


### PR DESCRIPTION
Closes #1592. Related: #1568.

## Problem

Beta binaries are configuration-identical to stable ones: beta-ness lives only in which repository publishes them. That is correct for the updater and wrong for the person using the app.

Someone who reaches a beta by direct download from `beta-builds`, which the README and `docs/guide/installation.md` link publicly, never learns they are on one. They never see the database warning the in-app channel picker shows before switching, and they find out when a later stable build refuses to open their dive log (#1568).

Neither existing concept answers "is this binary a beta?":

| | What it means | Why it does not answer the question |
| --- | --- | --- |
| `ReleaseChannel` | The user's update preference | A direct download leaves it on `stable` |
| `UpdateChannel` | Compile-time distribution store | Says how it was delivered, not which train built it |

## Change

**1. Stamp the train into the artifact.** `BuildTrain` / `BuildTrainConfig` read a `BUILD_TRAIN` dart-define exactly the way `UpdateChannelConfig` reads `UPDATE_CHANNEL`, defaulting to `stable` so nothing changes for a local `flutter run` or for any pipeline predating the define. Exposed as `buildTrainProvider`, because a compile-time const cannot otherwise be varied from a test.

**2. Show it.** The About badge now follows the *binary* rather than the *selected channel*. Those differ exactly where it matters: a direct-download beta user still has the stable preference, so reading the preference left that user with no badge at all. The selected channel is still shown, unchanged, on the update channel tile below.

**3. Warn on first launch.** A beta build shows the channel picker's own body text (`settings_updates_betaDialogBody`), so both routes onto the train read the same promise about backups and about sync partners sharing a channel. One `SharedPreferences` flag covers both routes, set when the picker is confirmed as well, so nobody reads the same text twice.

**4. Put it in the logs.** `LogEnvironment` carries the train in the session marker and the export header. Beta and stable share a version string, so nothing else in a pasted log separates them; this is what makes a report like #1568 diagnosable from the report alone.

The version string itself is deliberately untouched: release tags and the appcast compare against it.

## CI

`build-all.yml` takes a `build-train` input (default `stable`) and threads `BUILD_TRAIN` through all five `flutter build` steps, and via the environment through the two fastlane store lanes, which build both the App Store submission and the TestFlight beta from one lane. Only `beta.yml` passes `beta`; `release.yml` takes the default.

## Testing

- `build_train_test.dart`: parses every train, falls back to stable for null/empty/unknown, and reads stable when no define was passed.
- `beta_build_notice_test.dart`: the four-way decision table, plus the dialog rendering the picker's warning verbatim and closing on acknowledgement.
- `settings_page_test.dart`: a beta binary badges its version whatever the channel; a stable binary stays unbadged even on the beta channel (this replaces the old test that asserted the badge came from the channel, which is the behaviour being corrected); confirming the beta switch records the warning as read.
- `update_preferences_test.dart`: the new flag defaults to false and round-trips.
- `log_environment_test.dart`: the train appears in both the summary line and the export header, and `capture()` reads stable on an undefined host.

`flutter analyze` clean; the pre-push affected-test selection passed 631 tests.