### PR TITLE
fix(dive-profile): land range-stats handles on the chart's plot rect (#1579)

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -96,7 +96,6 @@ import 'package:submersion/features/dive_log/presentation/widgets/o2_toxicity_ca
 import 'package:submersion/features/dive_log/presentation/widgets/photo_marker_layout.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/playback_controls.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/playback_stats_panel.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/range_selection_overlay.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/range_stats_panel.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_detail_properties_menu.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_section_fold.dart';
@@ -2307,6 +2306,20 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                               dismissed: true,
                             ),
                         onSafetyFindingDetails: (_) => _scrollToSafetySection(),
+                        // Range handles are drawn by the chart itself so they
+                        // land on the plot rect at any zoom (issue #1579).
+                        rangeSelection: rangeState.isEnabled
+                            ? (
+                                startSeconds: rangeState.startTimestamp ?? 0,
+                                endSeconds:
+                                    rangeState.endTimestamp ??
+                                    rangeState.maxTimestamp,
+                                maxSeconds: rangeState.maxTimestamp,
+                              )
+                            : null,
+                        onRangeChanged: (start, end) => ref
+                            .read(rangeSelectionProvider(dive.id).notifier)
+                            .setRange(start, end),
                         onPointSelected: (index) {
                           ref
                                   .read(
@@ -2319,20 +2332,6 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                         },
                       ),
                     ),
-                    // Range selection overlay (positioned on top of chart)
-                    if (rangeState.isEnabled)
-                      Positioned.fill(
-                        child: RangeSelectionOverlay(
-                          diveId: dive.id,
-                          chartWidth: constraints.maxWidth,
-                          leftPadding:
-                              DiveProfileChart.leftAxisSize(
-                                constraints.maxWidth,
-                              ) +
-                              5,
-                          rightPadding: 16,
-                        ),
-                      ),
                   ],
                 );
               },

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -35,6 +35,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/profile_decima
 import 'package:submersion/features/dive_log/presentation/widgets/profile_metric_band.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_metric_bands.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_metric_colors.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/range_selection_overlay.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/gas_colors.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/gas_timeline_strip.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/photo_marker_layout.dart';
@@ -260,6 +261,15 @@ class DiveProfileChart extends ConsumerStatefulWidget {
 
   /// Height of the safety findings lane in logical pixels.
   static const double safetyLaneHeight = 24.0;
+
+  /// Range-statistics selection in seconds from the start of the dive, or
+  /// null when range mode is off. Drawn as draggable handles over the plot
+  /// rect; [maxSeconds] is the profile's last timestamp, where the end
+  /// handle stops.
+  final ({int startSeconds, int endSeconds, int maxSeconds})? rangeSelection;
+
+  /// New range reported while a handle is dragged.
+  final void Function(int startSeconds, int endSeconds)? onRangeChanged;
 
   // Advanced decompression/gas curves
   /// ppO2 curve in bar
@@ -578,6 +588,8 @@ class DiveProfileChart extends ConsumerStatefulWidget {
     this.onSafetyFindingTap,
     this.onSafetyFindingDismiss,
     this.onSafetyFindingDetails,
+    this.rangeSelection,
+    this.onRangeChanged,
     this.ppO2Curve,
     this.o2SensorCurves,
     this.o2CellMvCurves,
@@ -961,6 +973,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   // The Listener only pans a touch drag when claimed, so a long-press scrub
   // (which wins the arena before any movement) is never fought by a pan.
   bool _touchDragClaimed = false;
+
+  // True while a range-selection handle is being dragged. The handle's
+  // recognizer wins the arena, but this Listener sees the same pointer
+  // moves (it is an ancestor), so without this the chart would pan under
+  // the handle. Only event handlers read it, so no rebuild is needed.
+  bool _rangeDragActive = false;
 
   // The two pointer ids driving the current two-finger gesture, plus its
   // start geometry. Cumulative scale/pan is applied against
@@ -1939,10 +1957,13 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     );
   }
 
-  /// The plot-rect insets (reserved axis gutters) for the current build, so a
-  /// gesture's local position can be mapped to a plot-area fraction. Mirrors
-  /// the axis reservations used for the gas-strip overlay (left/right at
-  /// :2265-2270, bottom at :1379-1382). Top has no titles, so its inset is 0.
+  /// The plot-rect insets (reserved axis gutters) for the current build: the
+  /// single source of the plot rect, both for mapping a gesture's local
+  /// position to a plot-area fraction and for positioning every layer drawn
+  /// over the chart (gas strip, cursors, photo markers, safety lane, range
+  /// handles). These must match what fl_chart itself reserves from the
+  /// FlTitlesData below, which reserves a side only while that side shows an
+  /// axis name or side titles. Top has no titles, so its inset is 0.
   ({double left, double top, double right, double bottom}) _plotInsets(
     double availableWidth,
     UnitFormatter units,
@@ -1968,9 +1989,13 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
           DiveProfileChart._leftRightAxisNameSize +
           DiveProfileChart.leftAxisSize(availableWidth),
       top: 0,
-      right:
-          (hasRightAxisName ? DiveProfileChart._leftRightAxisNameSize : 0) +
-          DiveProfileChart.rightAxisSize(availableWidth),
+      // fl_chart reserves a side's tick gutter only while that side shows
+      // titles, and the right axis shows none without a metric -- so with no
+      // right-axis metric the plot rect runs to the chart's right edge.
+      right: hasRightAxisName
+          ? DiveProfileChart._leftRightAxisNameSize +
+                DiveProfileChart.rightAxisSize(availableWidth)
+          : 0,
       bottom:
           DiveProfileChart._bottomAxisNameSize +
           DiveProfileChart._bottomTickReservedSize +
@@ -2369,6 +2394,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                 }
               },
               onPointerMove: (event) {
+                if (_rangeDragActive) return;
                 final prev = _lastPointerLocal;
                 _lastPointerLocal = event.localPosition;
                 if (event.kind == PointerDeviceKind.touch) {
@@ -2737,12 +2763,17 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     final visibleMinDepth = _viewport.offsetY * totalMaxDepth;
     final visibleMaxDepth = visibleMinDepth + visibleRangeY;
 
+    // One plot rect for every layer drawn over the chart (highlight band, gas
+    // strip, cursor extensions, photo markers, safety lane, range handles):
+    // they all have to agree with fl_chart's own axis reservations, so they
+    // all read them from here.
+    final plotInsets = _plotInsets(availableWidth, units);
+
     // Highlight band, inflated to a 12 px minimum so short/instant findings
     // stay visible (spec: safety-findings-lane). Computed once and shared by
     // the band annotation and its edge lines.
     ({double x1, double x2})? highlightSpan;
     if (widget.highlightRange != null) {
-      final plotInsets = _plotInsets(availableWidth, units);
       final plotWidth = (availableWidth - plotInsets.left - plotInsets.right)
           .clamp(1.0, double.infinity);
       highlightSpan = highlightBandSpan(
@@ -4294,24 +4325,14 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
             ),
           ),
         // Gas-usage timeline strip rendered between the plot area and the
-        // X-axis tick labels. Sized to exactly the chart's plot width by
-        // mirroring the chart's left/right axis reservations, and offset
-        // from the bottom so it lands in the gap reserved above by
-        // `_hasGasStrip` (_bottomAxisNameSize + _bottomTickReservedSize).
-        //
-        // Plot bounds = _leftRightAxisNameSize + sideTitles reservedSize
-        // on each side that has an axisNameWidget. Left axis always renders
-        // its name; the right axis only does so when a metric is selected.
+        // X-axis tick labels. Sized to exactly the chart's plot width from
+        // the shared plot rect, and offset from the bottom so it lands in
+        // the gap reserved above by `_hasGasStrip`
+        // (_bottomAxisNameSize + _bottomTickReservedSize).
         if (_hasGasStrip)
           Positioned(
-            left:
-                DiveProfileChart._leftRightAxisNameSize +
-                DiveProfileChart.leftAxisSize(availableWidth),
-            right:
-                (effectiveRightAxisMetric != null && rightAxisRange != null
-                    ? DiveProfileChart._leftRightAxisNameSize
-                    : 0) +
-                DiveProfileChart.rightAxisSize(availableWidth),
+            left: plotInsets.left,
+            right: plotInsets.right,
             bottom:
                 DiveProfileChart._bottomAxisNameSize +
                 DiveProfileChart._bottomTickReservedSize +
@@ -4333,16 +4354,14 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
         // the same horizontal position to bridge the gap visually.
         if (_hasGasStrip)
           ..._buildGasStripCursorExtensions(
+            insets: plotInsets,
             availableWidth: availableWidth,
             visibleMinX: visibleMinX,
             visibleMaxX: visibleMaxX,
-            hasRightAxisName:
-                effectiveRightAxisMetric != null && rightAxisRange != null,
           ),
         // Photo markers: tappable camera chips at each photo's (time, depth).
         // A widget layer (not an fl_chart element) so its taps never enter
-        // the chart's gesture arena; insets mirror the plot-rect math used
-        // by the gas strip above.
+        // the chart's gesture arena; positioned by the shared plot rect.
         if (_showPhotoMarkers &&
             widget.photoMarkers != null &&
             widget.photoMarkers!.isNotEmpty)
@@ -4353,7 +4372,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               visibleMaxSeconds: visibleMaxX,
               visibleMinDepth: visibleMinDepth,
               visibleMaxDepth: visibleMaxDepth,
-              insets: _plotInsets(availableWidth, units),
+              insets: plotInsets,
               units: units,
             ),
           ),
@@ -4368,7 +4387,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               selectedFindingId: widget.selectedSafetyFindingId,
               visibleMinSeconds: visibleMinX,
               visibleMaxSeconds: visibleMaxX,
-              insets: _plotInsets(availableWidth, units),
+              insets: plotInsets,
               laneHeight: DiveProfileChart.safetyLaneHeight,
               laneBottomOffset:
                   DiveProfileChart._bottomAxisNameSize +
@@ -4379,6 +4398,22 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               onFindingDetails: widget.onSafetyFindingDetails,
             ),
           ),
+        // Range-statistics handles. Topmost so a handle wins the pointer
+        // over the layers below it, and inside the chart so it shares the
+        // plot rect and visible window (issue #1579).
+        if (widget.rangeSelection != null)
+          Positioned.fill(
+            child: RangeSelectionOverlay(
+              startSeconds: widget.rangeSelection!.startSeconds,
+              endSeconds: widget.rangeSelection!.endSeconds,
+              maxSeconds: widget.rangeSelection!.maxSeconds,
+              visibleMinSeconds: visibleMinX,
+              visibleMaxSeconds: visibleMaxX,
+              insets: plotInsets,
+              onRangeChanged: widget.onRangeChanged ?? (_, _) {},
+              onDragActiveChanged: (active) => _rangeDragActive = active,
+            ),
+          ),
       ],
     );
   }
@@ -4387,10 +4422,10 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   /// active cursors (hover highlight + step-through playback) so the line
   /// visually continues past the chart's plot area.
   List<Widget> _buildGasStripCursorExtensions({
+    required ({double left, double top, double right, double bottom}) insets,
     required double availableWidth,
     required double visibleMinX,
     required double visibleMaxX,
-    required bool hasRightAxisName,
   }) {
     final colorScheme = Theme.of(context).colorScheme;
     final cursors = <(int timestamp, Color color, double width)>[
@@ -4405,12 +4440,8 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     ];
     if (cursors.isEmpty) return const [];
 
-    final left =
-        DiveProfileChart._leftRightAxisNameSize +
-        DiveProfileChart.leftAxisSize(availableWidth);
-    final right =
-        (hasRightAxisName ? DiveProfileChart._leftRightAxisNameSize : 0) +
-        DiveProfileChart.rightAxisSize(availableWidth);
+    final left = insets.left;
+    final right = insets.right;
     final stripWidth = (availableWidth - left - right).clamp(
       0.0,
       double.infinity,

--- a/lib/features/dive_log/presentation/widgets/range_selection_layout.dart
+++ b/lib/features/dive_log/presentation/widgets/range_selection_layout.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/foundation.dart';
+
+/// Maps range-selection timestamps to horizontal positions inside the dive
+/// profile chart's plot rect, and back.
+///
+/// The plot rect is the chart area minus the gutters fl_chart reserves for
+/// axis names and tick labels, and [visibleMinSeconds]/[visibleMaxSeconds]
+/// are the chart's current X window (which narrows as the user zooms). Both
+/// come from the chart itself, so a handle drawn through this axis lands on
+/// the same pixel as the depth trace at that time (issue #1579).
+@immutable
+class RangePlotAxis {
+  /// Left edge of the plot rect, in chart-local pixels.
+  final double plotLeft;
+
+  /// Width of the plot rect in pixels.
+  final double plotWidth;
+
+  /// The chart's visible time window in seconds.
+  final double visibleMinSeconds;
+  final double visibleMaxSeconds;
+
+  const RangePlotAxis({
+    required this.plotLeft,
+    required this.plotWidth,
+    required this.visibleMinSeconds,
+    required this.visibleMaxSeconds,
+  });
+
+  /// Right edge of the plot rect, in chart-local pixels.
+  double get plotRight => plotLeft + plotWidth;
+
+  /// Length of the visible time window in seconds.
+  double get visibleSpan => visibleMaxSeconds - visibleMinSeconds;
+
+  /// How many seconds one pixel of horizontal drag covers. Zero for a
+  /// degenerate plot rect or time window, so callers never scale by NaN.
+  double get secondsPerPixel {
+    if (plotWidth <= 0 || visibleSpan <= 0) return 0;
+    return visibleSpan / plotWidth;
+  }
+
+  /// Whether [seconds] falls inside the visible window. A handle outside it
+  /// has no honest position on screen, so it is not drawn.
+  bool isVisible(num seconds) =>
+      seconds >= visibleMinSeconds && seconds <= visibleMaxSeconds;
+
+  /// Chart-local x for [seconds]. Values outside the visible window map
+  /// outside the plot rect; use [clampedXForSeconds] for shading bounds.
+  double xForSeconds(num seconds) {
+    if (visibleSpan <= 0) return plotLeft;
+    return plotLeft + ((seconds - visibleMinSeconds) / visibleSpan) * plotWidth;
+  }
+
+  /// [xForSeconds] pinned to the plot rect, for spans (such as the shaded
+  /// out-of-range areas) that stay meaningful when one end is off screen.
+  double clampedXForSeconds(num seconds) =>
+      xForSeconds(seconds).clamp(plotLeft, plotRight);
+
+  /// Seconds at chart-local [x].
+  double secondsForX(double x) {
+    if (plotWidth <= 0) return visibleMinSeconds;
+    return visibleMinSeconds + ((x - plotLeft) / plotWidth) * visibleSpan;
+  }
+}

--- a/lib/features/dive_log/presentation/widgets/range_selection_overlay.dart
+++ b/lib/features/dive_log/presentation/widgets/range_selection_overlay.dart
@@ -1,122 +1,185 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_range_provider.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/range_selection_layout.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
-/// Overlay widget for selecting a time range on the dive profile chart.
+/// Draggable start/end handles for the profile chart's range statistics.
 ///
-/// Displays two draggable vertical handles that define the start and end
-/// of a selected range. The area outside the selection is shaded.
-class RangeSelectionOverlay extends ConsumerStatefulWidget {
-  /// The dive ID for scoping the range selection provider
-  final String diveId;
+/// Rendered as a widget layer inside the chart's Stack (like the photo and
+/// safety-finding overlays) so it shares the chart's plot rect and visible
+/// time window. That is what keeps a handle on the same pixel as the depth
+/// trace at its timestamp: positions come from the chart's own axis gutters
+/// and zoom window rather than from an approximation of them (issue #1579).
+class RangeSelectionOverlay extends StatefulWidget {
+  static const Key startHandleKey = Key('rangeSelection.startHandle');
+  static const Key endHandleKey = Key('rangeSelection.endHandle');
+  static const Key leadingShadeKey = Key('rangeSelection.leadingShade');
+  static const Key trailingShadeKey = Key('rangeSelection.trailingShade');
 
-  /// The total width available for the overlay (chart width)
-  final double chartWidth;
+  /// Selected range, in seconds from the start of the dive.
+  final int startSeconds;
+  final int endSeconds;
 
-  /// Left padding to align with chart area (y-axis labels width)
-  final double leftPadding;
+  /// Last timestamp of the profile; the end handle stops here.
+  final int maxSeconds;
 
-  /// Right padding to align with chart area
-  final double rightPadding;
+  /// The chart's visible time window in seconds (narrows as it zooms).
+  final double visibleMinSeconds;
+  final double visibleMaxSeconds;
+
+  /// Reserved axis gutters around the plot rect (the chart's _plotInsets).
+  final ({double left, double top, double right, double bottom}) insets;
+
+  /// Called with the new range while a handle is dragged.
+  final void Function(int startSeconds, int endSeconds) onRangeChanged;
+
+  /// Called when a handle drag starts and ends, so the chart can hold off
+  /// panning while the pointer belongs to a handle.
+  final void Function(bool active)? onDragActiveChanged;
 
   const RangeSelectionOverlay({
     super.key,
-    required this.diveId,
-    required this.chartWidth,
-    this.leftPadding = 40,
-    this.rightPadding = 16,
+    required this.startSeconds,
+    required this.endSeconds,
+    required this.maxSeconds,
+    required this.visibleMinSeconds,
+    required this.visibleMaxSeconds,
+    required this.insets,
+    required this.onRangeChanged,
+    this.onDragActiveChanged,
   });
 
   @override
-  ConsumerState<RangeSelectionOverlay> createState() =>
-      _RangeSelectionOverlayState();
+  State<RangeSelectionOverlay> createState() => _RangeSelectionOverlayState();
 }
 
-class _RangeSelectionOverlayState extends ConsumerState<RangeSelectionOverlay> {
+class _RangeSelectionOverlayState extends State<RangeSelectionOverlay> {
   /// Which handle is currently being dragged
   _DragTarget? _activeDrag;
 
-  /// The usable width for range selection (excluding axis padding)
-  double get _selectableWidth =>
-      widget.chartWidth - widget.leftPadding - widget.rightPadding;
+  /// The dragged handle's position in seconds, accumulated across the drag.
+  /// Held here (not recomputed from the widget) so a drag stays smooth when
+  /// the caller clamps or rounds the value it is handed back.
+  double _dragSeconds = 0;
+
+  @override
+  void dispose() {
+    // Leaving range mode mid-drag takes the handle away without a drag-end,
+    // so release the caller's hold here or the chart would stay unpannable.
+    if (_activeDrag != null) widget.onDragActiveChanged?.call(false);
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final rangeState = ref.watch(rangeSelectionProvider(widget.diveId));
-
-    if (!rangeState.isEnabled) {
-      return const SizedBox.shrink();
-    }
-
     final colorScheme = Theme.of(context).colorScheme;
 
-    // Calculate handle positions
-    final startX =
-        widget.leftPadding + (rangeState.startProgress * _selectableWidth);
-    final endX =
-        widget.leftPadding + (rangeState.endProgress * _selectableWidth);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final axis = RangePlotAxis(
+          plotLeft: widget.insets.left,
+          plotWidth:
+              (constraints.maxWidth - widget.insets.left - widget.insets.right)
+                  .clamp(0.0, double.infinity),
+          visibleMinSeconds: widget.visibleMinSeconds,
+          visibleMaxSeconds: widget.visibleMaxSeconds,
+        );
+        final plotTop = widget.insets.top;
+        final plotHeight =
+            (constraints.maxHeight - widget.insets.top - widget.insets.bottom)
+                .clamp(0.0, double.infinity);
+        if (axis.plotWidth <= 0 || plotHeight <= 0) {
+          return const SizedBox.shrink();
+        }
 
-    return SizedBox(
-      width: widget.chartWidth,
-      child: Stack(
-        children: [
-          // Left shaded area (before selection)
-          Positioned(
-            left: widget.leftPadding,
-            top: 0,
-            bottom: 0,
-            width: startX - widget.leftPadding,
-            child: Container(color: colorScheme.surface.withValues(alpha: 0.7)),
-          ),
-          // Right shaded area (after selection)
-          Positioned(
-            left: endX,
-            top: 0,
-            bottom: 0,
-            right: widget.rightPadding,
-            child: Container(color: colorScheme.surface.withValues(alpha: 0.7)),
-          ),
-          // Selected area highlight border
-          Positioned(
-            left: startX,
-            top: 0,
-            bottom: 0,
-            width: endX - startX,
-            child: Container(
-              decoration: BoxDecoration(
-                border: Border.symmetric(
-                  vertical: BorderSide(
-                    color: colorScheme.primary.withValues(alpha: 0.3),
-                    width: 1,
+        final startX = axis.clampedXForSeconds(widget.startSeconds);
+        final endX = axis.clampedXForSeconds(widget.endSeconds);
+        final shade = colorScheme.surface.withValues(alpha: 0.7);
+
+        return Stack(
+          children: [
+            // Out-of-range areas, shaded only across the plot rect so the
+            // axis labels stay legible.
+            if (startX > axis.plotLeft)
+              Positioned(
+                left: axis.plotLeft,
+                width: startX - axis.plotLeft,
+                top: plotTop,
+                height: plotHeight,
+                child: IgnorePointer(
+                  key: RangeSelectionOverlay.leadingShadeKey,
+                  child: ColoredBox(color: shade),
+                ),
+              ),
+            if (endX < axis.plotRight)
+              Positioned(
+                left: endX,
+                width: axis.plotRight - endX,
+                top: plotTop,
+                height: plotHeight,
+                child: IgnorePointer(
+                  key: RangeSelectionOverlay.trailingShadeKey,
+                  child: ColoredBox(color: shade),
+                ),
+              ),
+            // Selected area highlight border
+            if (endX > startX)
+              Positioned(
+                left: startX,
+                width: endX - startX,
+                top: plotTop,
+                height: plotHeight,
+                child: IgnorePointer(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      border: Border.symmetric(
+                        vertical: BorderSide(
+                          color: colorScheme.primary.withValues(alpha: 0.3),
+                        ),
+                      ),
+                    ),
                   ),
                 ),
               ),
-            ),
-          ),
-          // Start handle
-          _buildHandle(
-            context,
-            position: startX,
-            isStart: true,
-            colorScheme: colorScheme,
-          ),
-          // End handle
-          _buildHandle(
-            context,
-            position: endX,
-            isStart: false,
-            colorScheme: colorScheme,
-          ),
-        ],
-      ),
+            // Handles are drawn only where they have an honest position: one
+            // scrolled out of the visible window is left undrawn rather than
+            // pinned to an edge that would misreport its time.
+            if (axis.isVisible(widget.startSeconds))
+              _buildHandle(
+                context,
+                axis: axis,
+                position: startX,
+                plotTop: plotTop,
+                plotHeight: plotHeight,
+                isStart: true,
+                colorScheme: colorScheme,
+              ),
+            if (axis.isVisible(widget.endSeconds))
+              _buildHandle(
+                context,
+                axis: axis,
+                position: endX,
+                plotTop: plotTop,
+                plotHeight: plotHeight,
+                isStart: false,
+                colorScheme: colorScheme,
+              ),
+          ],
+        );
+      },
     );
   }
 
   Widget _buildHandle(
     BuildContext context, {
+    required RangePlotAxis axis,
     required double position,
+    required double plotTop,
+    required double plotHeight,
     required bool isStart,
     required ColorScheme colorScheme,
   }) {
@@ -125,22 +188,21 @@ class _RangeSelectionOverlayState extends ConsumerState<RangeSelectionOverlay> {
 
     return Positioned(
       left: position - 16, // Center the handle on the position
-      top: 0,
-      bottom: 0,
+      top: plotTop,
+      height: plotHeight,
       width: 32,
       child: Semantics(
+        key: isStart
+            ? RangeSelectionOverlay.startHandleKey
+            : RangeSelectionOverlay.endHandleKey,
         label: context.l10n.diveLog_rangeSelection_semantics_adjust,
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
-          onHorizontalDragStart: (_) {
-            setState(() => _activeDrag = target);
-          },
-          onHorizontalDragUpdate: (details) {
-            _handleDrag(details.delta.dx, isStart);
-          },
-          onHorizontalDragEnd: (_) {
-            setState(() => _activeDrag = null);
-          },
+          onHorizontalDragStart: (_) => _startDrag(target, isStart),
+          onHorizontalDragUpdate: (details) =>
+              _updateDrag(details.delta.dx, isStart, axis),
+          onHorizontalDragEnd: (_) => _endDrag(),
+          onHorizontalDragCancel: _endDrag,
           child: Column(
             children: [
               // Top grip circle
@@ -174,22 +236,40 @@ class _RangeSelectionOverlayState extends ConsumerState<RangeSelectionOverlay> {
     );
   }
 
-  void _handleDrag(double deltaX, bool isStart) {
-    // Convert pixel delta to progress delta (0.0 to 1.0 scale)
-    final rangeState = ref.read(rangeSelectionProvider(widget.diveId));
-    final currentProgress = isStart
-        ? rangeState.startProgress
-        : rangeState.endProgress;
-    final progressDelta = deltaX / _selectableWidth;
-    final newProgress = (currentProgress + progressDelta).clamp(0.0, 1.0);
+  void _startDrag(_DragTarget target, bool isStart) {
+    setState(() {
+      _activeDrag = target;
+      _dragSeconds = (isStart ? widget.startSeconds : widget.endSeconds)
+          .toDouble();
+    });
+    widget.onDragActiveChanged?.call(true);
+  }
 
-    final notifier = ref.read(rangeSelectionProvider(widget.diveId).notifier);
+  void _updateDrag(double deltaX, bool isStart, RangePlotAxis axis) {
+    // Pixels convert through the visible window, so a drag covers less time
+    // the further the chart is zoomed in.
+    final lower = isStart
+        ? 0.0
+        : math.min(widget.startSeconds + 1, widget.maxSeconds).toDouble();
+    final upper = isStart
+        ? math.max(widget.endSeconds - 1, 0).toDouble()
+        : widget.maxSeconds.toDouble();
+    if (upper < lower) return;
 
-    if (isStart) {
-      notifier.setStartProgress(newProgress);
-    } else {
-      notifier.setEndProgress(newProgress);
-    }
+    _dragSeconds = (_dragSeconds + deltaX * axis.secondsPerPixel).clamp(
+      lower,
+      upper,
+    );
+    final seconds = _dragSeconds.round();
+    widget.onRangeChanged(
+      isStart ? seconds : widget.startSeconds,
+      isStart ? widget.endSeconds : seconds,
+    );
+  }
+
+  void _endDrag() {
+    setState(() => _activeDrag = null);
+    widget.onDragActiveChanged?.call(false);
   }
 }
 

--- a/test/features/dive_log/presentation/pages/dive_detail_range_selection_wiring_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_range_selection_wiring_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_range_provider.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// The seam between the range-selection provider and the chart that now draws
+/// the handles (issue #1579): the page hands the chart the selected window and
+/// writes a dragged window back.
+void main() {
+  const profile = [
+    DiveProfilePoint(timestamp: 0, depth: 0.0),
+    DiveProfilePoint(timestamp: 60, depth: 10.0),
+    DiveProfilePoint(timestamp: 120, depth: 20.0),
+    DiveProfilePoint(timestamp: 180, depth: 0.0),
+  ];
+
+  late Dive dive;
+
+  setUp(() {
+    dive = createTestDiveWithBottomTime().copyWith(profile: profile);
+  });
+
+  Future<void> pumpPage(WidgetTester tester) async {
+    final base = await getBaseOverrides();
+    final originalOnError = FlutterError.onError;
+    addTearDown(() => FlutterError.onError = originalOnError);
+    FlutterError.onError = (d) {
+      if (d.toString().contains('overflowed')) return;
+      originalOnError?.call(d);
+    };
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          diveProvider(dive.id).overrideWith((ref) async => dive),
+          gasSwitchesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+          tankPressuresProvider(
+            dive.id,
+          ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: DiveDetailPage(diveId: dive.id, embedded: true)),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    FlutterError.onError = originalOnError;
+  }
+
+  DiveProfileChart chartOf(WidgetTester tester) =>
+      tester.widget<DiveProfileChart>(find.byType(DiveProfileChart));
+
+  ProviderContainer containerOf(WidgetTester tester) =>
+      ProviderScope.containerOf(tester.element(find.byType(DiveProfileChart)));
+
+  testWidgets('the chart is given no range while range mode is off', (
+    tester,
+  ) async {
+    await pumpPage(tester);
+    expect(chartOf(tester).rangeSelection, isNull);
+  });
+
+  testWidgets('enabling range mode hands the chart the selected window', (
+    tester,
+  ) async {
+    await pumpPage(tester);
+    final container = containerOf(tester);
+
+    container.read(rangeSelectionProvider(dive.id).notifier).enableRangeMode();
+    await tester.pump();
+
+    final state = container.read(rangeSelectionProvider(dive.id));
+    final selection = chartOf(tester).rangeSelection;
+    expect(selection, isNotNull);
+    expect(selection!.startSeconds, state.startTimestamp);
+    expect(selection.endSeconds, state.endTimestamp);
+    // The chart clamps the end handle at the last drawn sample, so the range
+    // can never run past the profile the user is measuring.
+    expect(selection.maxSeconds, 180);
+  });
+
+  testWidgets('a dragged window is written back to the provider', (
+    tester,
+  ) async {
+    await pumpPage(tester);
+    final container = containerOf(tester);
+    container.read(rangeSelectionProvider(dive.id).notifier).enableRangeMode();
+    await tester.pump();
+
+    chartOf(tester).onRangeChanged!(30, 90);
+    await tester.pump();
+
+    final state = container.read(rangeSelectionProvider(dive.id));
+    expect(state.startTimestamp, 30);
+    expect(state.endTimestamp, 90);
+    expect(chartOf(tester).rangeSelection!.startSeconds, 30);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_range_selection_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_range_selection_test.dart
@@ -1,0 +1,206 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/data/services/gas_usage_segments_service.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/gas_timeline_strip.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/range_selection_overlay.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Range-statistics handles must sit on the chart's plot rect: at 0:00 the
+/// start handle belongs on the depth axis, not left of it (issue #1579).
+void main() {
+  const chartWidth = 400.0;
+  const maxSeconds = 570; // 20 samples, 30 s apart
+
+  final profile = List.generate(
+    20,
+    (i) => DiveProfilePoint(
+      timestamp: i * 30,
+      depth: i < 10 ? i * 3.0 : (20 - i) * 3.0,
+    ),
+  );
+
+  const gasSegments = [
+    GasUsageSegment(
+      startSeconds: 0,
+      endSeconds: maxSeconds,
+      gasMix: GasMix(o2: 21),
+      label: 'Air',
+    ),
+  ];
+
+  Future<void> pumpChart(
+    WidgetTester tester, {
+    int startSeconds = 0,
+    int endSeconds = maxSeconds,
+    bool rangeMode = true,
+    bool gasStrip = false,
+    void Function(int start, int end)? onRangeChanged,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          settingsProvider.overrideWith(
+            (ref) => MockSettingsNotifier(
+              // The gas strip is the alignment oracle: it is positioned by
+              // the same plot rect as the range handles.
+              const AppSettings(defaultShowGasTimeline: true),
+            ),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: chartWidth,
+              height: 300,
+              child: DiveProfileChart(
+                profile: profile,
+                gasSegments: gasStrip ? gasSegments : null,
+                diveDurationSeconds: gasStrip ? maxSeconds : null,
+                rangeSelection: rangeMode
+                    ? (
+                        startSeconds: startSeconds,
+                        endSeconds: endSeconds,
+                        maxSeconds: maxSeconds,
+                      )
+                    : null,
+                onRangeChanged: onRangeChanged,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  LineChartData chartData(WidgetTester tester) =>
+      tester.widget<LineChart>(find.byType(LineChart).first).data;
+
+  double handleX(WidgetTester tester, Key key) =>
+      tester.getCenter(find.byKey(key)).dx;
+
+  /// Mouse-wheel zoom in at the chart center, as in the gesture tests.
+  Future<void> wheelZoomIn(WidgetTester tester, {int clicks = 4}) async {
+    final center = tester.getCenter(find.byType(LineChart).first);
+    for (var i = 0; i < clicks; i++) {
+      await tester.sendEventToBinding(
+        PointerScrollEvent(
+          position: center,
+          scrollDelta: const Offset(0, -100),
+        ),
+      );
+      await tester.pump();
+    }
+  }
+
+  testWidgets('range mode off renders no handles', (tester) async {
+    await pumpChart(tester, rangeMode: false);
+    expect(find.byType(RangeSelectionOverlay), findsNothing);
+  });
+
+  testWidgets('0:00 lands on the depth axis, not left of the plot area', (
+    tester,
+  ) async {
+    await pumpChart(tester);
+
+    // fl_chart reserves the axis-name band (16, its default axisNameSize)
+    // plus the tick gutter for the left axis; the plot rect starts there.
+    const plotLeft = 16 + 32.0;
+    expect(DiveProfileChart.leftAxisSize(chartWidth), 32);
+    expect(
+      handleX(tester, RangeSelectionOverlay.startHandleKey),
+      closeTo(plotLeft, 0.5),
+    );
+    // The old placement (tick gutter + 5) sat 11 px inside the axis labels.
+    expect(
+      handleX(tester, RangeSelectionOverlay.startHandleKey),
+      greaterThan(DiveProfileChart.leftAxisSize(chartWidth) + 5),
+    );
+  });
+
+  testWidgets('handles align with the gas timeline strip, layer to layer', (
+    tester,
+  ) async {
+    await pumpChart(tester, gasStrip: true);
+
+    final strip = tester.getRect(find.byType(GasTimelineStrip));
+    expect(
+      handleX(tester, RangeSelectionOverlay.startHandleKey),
+      closeTo(strip.left, 0.5),
+    );
+    expect(
+      handleX(tester, RangeSelectionOverlay.endHandleKey),
+      closeTo(strip.right, 0.5),
+    );
+  });
+
+  testWidgets('handles track the visible window when the chart is zoomed', (
+    tester,
+  ) async {
+    await pumpChart(tester, gasStrip: true, startSeconds: 240, endSeconds: 330);
+    final before = handleX(tester, RangeSelectionOverlay.startHandleKey);
+
+    await wheelZoomIn(tester);
+    await tester.pumpAndSettle();
+
+    final data = chartData(tester);
+    expect(data.maxX - data.minX, lessThan(maxSeconds), reason: 'zoom applied');
+
+    final strip = tester.getRect(find.byType(GasTimelineStrip));
+    final expected =
+        strip.left +
+        ((240 - data.minX) / (data.maxX - data.minX)) * strip.width;
+    expect(
+      handleX(tester, RangeSelectionOverlay.startHandleKey),
+      closeTo(expected, 0.5),
+    );
+    expect(
+      handleX(tester, RangeSelectionOverlay.startHandleKey),
+      isNot(closeTo(before, 1)),
+      reason: 'a zoom must move the handle with the trace under it',
+    );
+  });
+
+  testWidgets('dragging a handle reports seconds without panning the chart', (
+    tester,
+  ) async {
+    final changes = <(int, int)>[];
+    await pumpChart(
+      tester,
+      gasStrip: true,
+      startSeconds: 120,
+      endSeconds: 450,
+      onRangeChanged: (start, end) => changes.add((start, end)),
+    );
+    final minXBefore = chartData(tester).minX;
+    final strip = tester.getRect(find.byType(GasTimelineStrip));
+
+    // A mouse drag on the chart pans it; on a handle it must not.
+    await tester.drag(
+      find.byKey(RangeSelectionOverlay.startHandleKey),
+      Offset(strip.width / 4, 0),
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pumpAndSettle();
+
+    expect(changes, isNotEmpty);
+    expect(changes.last.$1, closeTo(120 + maxSeconds / 4, 2));
+    expect(changes.last.$2, 450);
+    expect(
+      chartData(tester).minX,
+      minXBefore,
+      reason: 'the chart must not pan',
+    );
+  });
+}

--- a/test/features/dive_log/presentation/widgets/range_selection_layout_test.dart
+++ b/test/features/dive_log/presentation/widgets/range_selection_layout_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/presentation/widgets/range_selection_layout.dart';
+
+void main() {
+  group('RangePlotAxis', () {
+    // A 400 px chart with the profile chart's real gutters: 48 px of
+    // axis name + depth ticks on the left, 54 px of right axis, leaving a
+    // 298 px plot rect that starts at x = 48.
+    const axis = RangePlotAxis(
+      plotLeft: 48,
+      plotWidth: 298,
+      visibleMinSeconds: 0,
+      visibleMaxSeconds: 3600,
+    );
+
+    test('the start of the dive sits on the left edge of the plot rect', () {
+      expect(axis.xForSeconds(0), 48);
+    });
+
+    test('the end of the dive sits on the right edge of the plot rect', () {
+      expect(axis.xForSeconds(3600), 48 + 298);
+    });
+
+    test('interpolates linearly between the plot edges', () {
+      expect(axis.xForSeconds(1800), closeTo(48 + 149, 0.001));
+    });
+
+    test('secondsForX inverts xForSeconds', () {
+      expect(axis.secondsForX(axis.xForSeconds(900)), closeTo(900, 0.001));
+    });
+
+    test('reports whether a timestamp is inside the visible window', () {
+      expect(axis.isVisible(0), isTrue);
+      expect(axis.isVisible(3600), isTrue);
+      expect(axis.isVisible(-1), isFalse);
+      expect(axis.isVisible(3601), isFalse);
+    });
+
+    test('clamps positions of off-window timestamps to the plot rect', () {
+      expect(axis.clampedXForSeconds(-600), 48);
+      expect(axis.clampedXForSeconds(7200), 48 + 298);
+    });
+
+    group('when the chart is zoomed', () {
+      // Zoomed 2x onto the second half of the same dive.
+      const zoomed = RangePlotAxis(
+        plotLeft: 48,
+        plotWidth: 298,
+        visibleMinSeconds: 1800,
+        visibleMaxSeconds: 3600,
+      );
+
+      test('maps the visible window across the whole plot rect', () {
+        expect(zoomed.xForSeconds(1800), 48);
+        expect(zoomed.xForSeconds(3600), 48 + 298);
+        expect(zoomed.xForSeconds(2700), closeTo(48 + 149, 0.001));
+      });
+
+      test('reports timestamps scrolled off the left as not visible', () {
+        expect(zoomed.isVisible(0), isFalse);
+      });
+
+      test('scales a drag by the visible window, not the whole dive', () {
+        // Half the plot width is half of the visible 1800 s window.
+        expect(zoomed.secondsPerPixel * 149, closeTo(900, 0.001));
+      });
+    });
+
+    group('degenerate geometry', () {
+      test('a zero-width plot rect does not divide by zero', () {
+        const flat = RangePlotAxis(
+          plotLeft: 48,
+          plotWidth: 0,
+          visibleMinSeconds: 0,
+          visibleMaxSeconds: 3600,
+        );
+        expect(flat.xForSeconds(1800), 48);
+        expect(flat.secondsForX(48), 0);
+      });
+
+      test('an empty time window does not divide by zero', () {
+        const frozen = RangePlotAxis(
+          plotLeft: 48,
+          plotWidth: 298,
+          visibleMinSeconds: 100,
+          visibleMaxSeconds: 100,
+        );
+        expect(frozen.xForSeconds(100), 48);
+        expect(frozen.secondsPerPixel, 0);
+      });
+    });
+  });
+}

--- a/test/features/dive_log/presentation/widgets/range_selection_overlay_test.dart
+++ b/test/features/dive_log/presentation/widgets/range_selection_overlay_test.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/presentation/widgets/range_selection_overlay.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  // A 400x300 chart with the profile chart's real gutters: the plot rect
+  // runs from x = 48 to x = 346 and from y = 0 to y = 204.
+  const insets = (left: 48.0, top: 0.0, right: 54.0, bottom: 96.0);
+  const plotLeft = 48.0;
+  const plotWidth = 298.0;
+
+  Future<void> pumpOverlay(
+    WidgetTester tester, {
+    int startSeconds = 900,
+    int endSeconds = 2700,
+    int maxSeconds = 3600,
+    double visibleMinSeconds = 0,
+    double visibleMaxSeconds = 3600,
+    void Function(int start, int end)? onRangeChanged,
+    void Function(bool active)? onDragActiveChanged,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            height: 300,
+            child: RangeSelectionOverlay(
+              startSeconds: startSeconds,
+              endSeconds: endSeconds,
+              maxSeconds: maxSeconds,
+              visibleMinSeconds: visibleMinSeconds,
+              visibleMaxSeconds: visibleMaxSeconds,
+              insets: insets,
+              onRangeChanged: onRangeChanged ?? (_, _) {},
+              onDragActiveChanged: onDragActiveChanged,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('handle placement', () {
+    testWidgets('the dive start sits on the plot rect edge, not left of it', (
+      tester,
+    ) async {
+      await pumpOverlay(tester, startSeconds: 0, endSeconds: 3600);
+
+      expect(
+        tester.getCenter(find.byKey(RangeSelectionOverlay.startHandleKey)).dx,
+        closeTo(plotLeft, 0.001),
+      );
+      expect(
+        tester.getCenter(find.byKey(RangeSelectionOverlay.endHandleKey)).dx,
+        closeTo(plotLeft + plotWidth, 0.001),
+      );
+    });
+
+    testWidgets('places handles at their timestamps inside the plot rect', (
+      tester,
+    ) async {
+      await pumpOverlay(tester);
+
+      expect(
+        tester.getCenter(find.byKey(RangeSelectionOverlay.startHandleKey)).dx,
+        closeTo(plotLeft + plotWidth * 0.25, 0.001),
+      );
+      expect(
+        tester.getCenter(find.byKey(RangeSelectionOverlay.endHandleKey)).dx,
+        closeTo(plotLeft + plotWidth * 0.75, 0.001),
+      );
+    });
+
+    testWidgets('spans the plot rect vertically, not the whole chart', (
+      tester,
+    ) async {
+      await pumpOverlay(tester);
+
+      final rect = tester.getRect(
+        find.byKey(RangeSelectionOverlay.startHandleKey),
+      );
+      expect(rect.top, closeTo(0, 0.001));
+      expect(rect.bottom, closeTo(204, 0.001));
+    });
+
+    testWidgets('follows the visible window when the chart is zoomed', (
+      tester,
+    ) async {
+      await pumpOverlay(
+        tester,
+        visibleMinSeconds: 1800,
+        visibleMaxSeconds: 3600,
+      );
+
+      // Start (900 s) has scrolled off the left of the window.
+      expect(find.byKey(RangeSelectionOverlay.startHandleKey), findsNothing);
+      expect(
+        tester.getCenter(find.byKey(RangeSelectionOverlay.endHandleKey)).dx,
+        closeTo(plotLeft + plotWidth * 0.5, 0.001),
+      );
+    });
+  });
+
+  group('dragging', () {
+    testWidgets('reports the dragged start in seconds', (tester) async {
+      final changes = <(int, int)>[];
+      await pumpOverlay(
+        tester,
+        onRangeChanged: (start, end) => changes.add((start, end)),
+      );
+
+      // A quarter of the plot rect is a quarter of the 3600 s window.
+      await tester.drag(
+        find.byKey(RangeSelectionOverlay.startHandleKey),
+        const Offset(plotWidth * 0.25, 0),
+      );
+      await tester.pump();
+
+      expect(changes.last.$1, closeTo(1800, 1));
+      expect(changes.last.$2, 2700);
+    });
+
+    testWidgets('scales the drag by the visible window when zoomed', (
+      tester,
+    ) async {
+      final changes = <(int, int)>[];
+      await pumpOverlay(
+        tester,
+        visibleMinSeconds: 1800,
+        visibleMaxSeconds: 3600,
+        onRangeChanged: (start, end) => changes.add((start, end)),
+      );
+
+      // Half the plot rect is 900 s at 2x zoom, not 1800 s.
+      await tester.drag(
+        find.byKey(RangeSelectionOverlay.endHandleKey),
+        const Offset(plotWidth * 0.5, 0),
+      );
+      await tester.pump();
+
+      expect(changes.last.$2, closeTo(3600, 1));
+    });
+
+    testWidgets('keeps the start handle behind the end handle', (tester) async {
+      final changes = <(int, int)>[];
+      await pumpOverlay(
+        tester,
+        onRangeChanged: (start, end) => changes.add((start, end)),
+      );
+
+      await tester.drag(
+        find.byKey(RangeSelectionOverlay.startHandleKey),
+        const Offset(plotWidth, 0),
+      );
+      await tester.pump();
+
+      expect(changes.last.$1, 2699);
+    });
+
+    testWidgets('releases the chart when range mode ends mid-drag', (
+      tester,
+    ) async {
+      final active = <bool>[];
+      await pumpOverlay(tester, onDragActiveChanged: active.add);
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byKey(RangeSelectionOverlay.endHandleKey)),
+      );
+      await gesture.moveBy(const Offset(30, 0));
+      await tester.pump();
+      expect(active, [true]);
+
+      // Range mode is switched off while the finger is still down.
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: SizedBox(width: 400))),
+      );
+      await gesture.up();
+
+      expect(active, [true, false]);
+    });
+
+    testWidgets('announces drag start and end so the chart can stop panning', (
+      tester,
+    ) async {
+      final active = <bool>[];
+      await pumpOverlay(tester, onDragActiveChanged: active.add);
+
+      await tester.drag(
+        find.byKey(RangeSelectionOverlay.endHandleKey),
+        const Offset(10, 0),
+      );
+      await tester.pump();
+
+      expect(active, [true, false]);
+    });
+  });
+
+  testWidgets('shades only the plot rect outside the selection', (
+    tester,
+  ) async {
+    await pumpOverlay(tester);
+
+    final before = tester.getRect(
+      find.byKey(RangeSelectionOverlay.leadingShadeKey),
+    );
+    final after = tester.getRect(
+      find.byKey(RangeSelectionOverlay.trailingShadeKey),
+    );
+    expect(before.left, closeTo(plotLeft, 0.001));
+    expect(before.right, closeTo(plotLeft + plotWidth * 0.25, 0.001));
+    expect(before.bottom, closeTo(204, 0.001));
+    expect(after.left, closeTo(plotLeft + plotWidth * 0.75, 0.001));
+    expect(after.right, closeTo(plotLeft + plotWidth, 0.001));
+  });
+}


### PR DESCRIPTION
Fixes #1579

## The bug

At 0:00 the left range-stats handle sat ~11 px left of the depth axis, outside the
plot area, so the marker never matched the time and depth it reported. Zooming did
not change the offset, and the reporter rightly did not trust the readout for
multi-segment gas planning.

## Cause

The handles were drawn by an overlay in `dive_detail_page`, which re-derived the
chart's plot rect from the outside and got it wrong in two ways:

- **Left inset.** fl_chart insets its plot area by the axis-name band (16, the
  package default `axisNameSize`, used by the "Depth" label) *plus* the tick
  gutter `DiveProfileChart.leftAxisSize()` (32). The overlay used
  `leftAxisSize() + 5` = 37 instead of 48. That 11 px is exactly the gap in the
  screenshot.
- **Zoom.** Handle positions came from a 0..1 progress over the whole dive, while
  the chart draws a visible window (`minX`..`maxX`) that narrows with zoom, so any
  zoom multiplied the error.

## Fix

Move the range handles into the chart's own Stack, alongside the layers that are
already aligned to the plot rect (gas timeline strip, photo markers, safety lane).
They now take the same `_plotInsets` and the same visible time window, and map
timestamps through a small pure helper (`RangePlotAxis`) instead of a progress
fraction:

- 0:00 lands on the depth axis; the end handle lands on the plot's right edge.
- Handles track the trace under them at any zoom, and a drag converts pixels
  through the visible window (a drag covers less time the further you are zoomed
  in). A handle scrolled out of the visible window is not drawn rather than pinned
  to an edge where it would misreport its time.
- Handles and shading now span the plot rect vertically instead of the whole
  chart column, so they no longer cross the legend row or the time-axis labels.
- The shaded out-of-range areas no longer swallow pointer events, so the chart
  still pans, zooms and scrubs while range mode is on. A handle drag suppresses
  the chart's own pan for the duration.

While in there, `_plotInsets` had a latent error of the same family: it always
added the right-axis tick gutter, but fl_chart reserves a side only while that
side shows titles, and the right axis shows none when no right-axis metric is
selected. In that state the plot rect actually runs to the chart's right edge, so
the gas strip, cursor extensions, photo markers, safety chips and hover mapping
were all off by ~32-38 px on the right. `_plotInsets` is now correct and is the
single source of the plot rect for every layer, including the range handles.

## Tests

- `range_selection_layout_test.dart` (new): time-to-pixel mapping, the zoomed
  window, and degenerate geometry.
- `range_selection_overlay_test.dart` (new): handle placement at the plot edges,
  vertical extent, off-window handles, drag-to-seconds at 1x and while zoomed,
  clamping against the other handle, drag-active reporting, shading bounds.
- `dive_profile_chart_range_selection_test.dart` (new): in the real chart, 0:00
  lands on the depth axis (and right of the old placement), handles line up with
  the gas timeline strip layer, they follow a wheel zoom, and dragging a handle
  reports seconds without panning the chart.

Full suite run locally.
