### PR TITLE
fix(checklists): make the trip checklist reachable on every trip (#1569)

### DIFF
--- a/lib/features/checklists/presentation/widgets/trip_checklist_section.dart
+++ b/lib/features/checklists/presentation/widgets/trip_checklist_section.dart
@@ -171,6 +171,10 @@ class TripChecklistSection extends ConsumerWidget {
     if (confirmed != true) return;
 
     await repository.deleteByTripId(trip.id);
+    // The wipe stands either way, being the user's confirmed intent, but its
+    // confirmation belongs to a page that may be gone: the route can be
+    // popped while the dialog is open or while the delete is in flight.
+    if (!context.mounted) return;
     messenger.showSnackBar(
       SnackBar(
         content: Text(l10n.checklists_clear_success(count)),

--- a/lib/features/checklists/presentation/widgets/trip_checklist_section.dart
+++ b/lib/features/checklists/presentation/widgets/trip_checklist_section.dart
@@ -11,9 +11,9 @@ import 'package:submersion/features/trips/domain/entities/trip.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Full checklist UI for a trip: items grouped by category, add-item
-/// affordance, and an overflow menu with apply/save-as-template actions.
-/// Embedded both as the Checklist tab (liveaboards) and as a card section
-/// on the overview (simple trips).
+/// affordance, and an overflow menu with apply-template, save-as-template
+/// and clear-checklist actions. Embedded both as the Checklist tab
+/// (liveaboards) and as a card section on the overview (simple trips).
 class TripChecklistSection extends ConsumerWidget {
   final Trip trip;
 
@@ -115,6 +115,9 @@ class TripChecklistSection extends ConsumerWidget {
         if (value == 'save') {
           showSaveAsTemplateDialog(context: context, trip: trip);
         }
+        if (value == 'clear') {
+          _clearChecklist(context, ref, items.length);
+        }
       },
       itemBuilder: (context) => [
         PopupMenuItem(
@@ -126,7 +129,54 @@ class TripChecklistSection extends ConsumerWidget {
           enabled: items.isNotEmpty,
           child: Text(context.l10n.checklists_menu_saveAsTemplate),
         ),
+        PopupMenuItem(
+          value: 'clear',
+          enabled: items.isNotEmpty,
+          child: Text(context.l10n.checklists_menu_clearAll),
+        ),
       ],
+    );
+  }
+
+  /// Drops the trip's whole checklist after confirming. The count is taken
+  /// from the items already on screen so the dialog cannot promise a number
+  /// the user never saw; the repository re-reads the rows it deletes and logs
+  /// a tombstone per item, so a concurrent edit cannot slip through unsynced.
+  Future<void> _clearChecklist(
+    BuildContext context,
+    WidgetRef ref,
+    int count,
+  ) async {
+    final l10n = context.l10n;
+    final messenger = ScaffoldMessenger.of(context);
+    final repository = ref.read(tripChecklistRepositoryProvider);
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.checklists_clear_title),
+        content: Text(l10n.checklists_clear_content(count)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(l10n.checklists_clear_confirm),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    await repository.deleteByTripId(trip.id);
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(l10n.checklists_clear_success(count)),
+        duration: const Duration(seconds: 4),
+        showCloseIcon: true,
+      ),
     );
   }
 

--- a/lib/features/trips/presentation/widgets/story/trip_story_view.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_view.dart
@@ -299,8 +299,17 @@ class _TripStoryViewState extends ConsumerState<TripStoryView>
     final story = widget.story;
     final trip = story.trip;
     final todayIndex = story.todayIndex;
-    final showChecklistAtEnd =
-        !trip.isUpcoming && !trip.isLiveaboard && !story.checklist.isEmpty;
+    // Every non-liveaboard trip gets the closer, in every state. It is the
+    // only editable checklist surface such a trip has, so gating it on the
+    // checklist already holding items left no way to apply a template in the
+    // first place, and gating it on the trip being over hid it from exactly
+    // the trips a prep list is for (#1569). Liveaboards stay out: they get a
+    // dedicated Checklist tab, and a second copy here would be two editors
+    // for one list.
+    final showChecklistAtEnd = !trip.isLiveaboard;
+    // Open where the checklist is the point of the page: a trip still being
+    // planned, or one with nothing in it yet and so nothing to collapse.
+    final openChecklist = trip.isUpcoming || story.checklist.isEmpty;
 
     return [
       SliverPadding(
@@ -358,26 +367,33 @@ class _TripStoryViewState extends ConsumerState<TripStoryView>
           sliver: SliverToBoxAdapter(
             child: Card(
               clipBehavior: Clip.antiAlias,
-              child: ExpansionTile(
-                title: Text(
-                  context.l10n.trips_story_checklistProgress(
-                    story.checklist.done,
-                    story.checklist.total,
-                  ),
-                  // Match the notes card's section title so the two closers
-                  // read as one family (ListTile would otherwise swap in its
-                  // own font role).
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: TripChecklistSection(trip: trip),
-                  ),
-                ],
-              ),
+              // Open, the section wears its own header (title, progress and
+              // the apply/save/clear menu), so an ExpansionTile title would
+              // only repeat it. Collapsed, that title is the whole card.
+              child: openChecklist
+                  ? Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: TripChecklistSection(trip: trip),
+                    )
+                  : ExpansionTile(
+                      title: Text(
+                        context.l10n.trips_story_checklistProgress(
+                          story.checklist.done,
+                          story.checklist.total,
+                        ),
+                        // Match the notes card's section title so the two
+                        // closers read as one family (ListTile would
+                        // otherwise swap in its own font role).
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(fontWeight: FontWeight.bold),
+                      ),
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: TripChecklistSection(trip: trip),
+                        ),
+                      ],
+                    ),
             ),
           ),
         ),

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -905,6 +905,25 @@
   "checklists_item_delete": "حذف العنصر",
   "checklists_menu_applyTemplate": "تطبيق قالب...",
   "checklists_menu_saveAsTemplate": "حفظ كقالب...",
+  "checklists_menu_clearAll": "مسح قائمة التحقق...",
+  "checklists_clear_title": "مسح قائمة التحقق",
+  "checklists_clear_content": "{count, plural, =1{هل تريد حذف العنصر الوحيد من قائمة التحقق هذه؟ لن تتأثر القوالب.} other{هل تريد حذف جميع العناصر البالغ عددها {count} من قائمة التحقق هذه؟ لن تتأثر القوالب.}}",
+  "@checklists_clear_content": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "checklists_clear_confirm": "مسح",
+  "checklists_clear_success": "{count, plural, =1{تمت إزالة عنصر واحد} other{تمت إزالة {count} عناصر}}",
+  "@checklists_clear_success": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "checklists_applySheet_title": "تطبيق القالب",
   "checklists_applySheet_empty": "لا توجد قوالب بعد. يمكنك إنشاؤها من الإعدادات.",
   "checklists_applySheet_itemCount": "{count, plural, =1{عنصر واحد} other{{count} عناصر}}",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -905,7 +905,7 @@
   "checklists_item_delete": "Eintrag löschen",
   "checklists_menu_applyTemplate": "Vorlage anwenden...",
   "checklists_menu_saveAsTemplate": "Als Vorlage speichern...",
-  "checklists_menu_clearAll": "Checkliste leeren ...",
+  "checklists_menu_clearAll": "Checkliste leeren...",
   "checklists_clear_title": "Checkliste leeren",
   "checklists_clear_content": "{count, plural, =1{Den einzigen Eintrag aus dieser Checkliste löschen? Vorlagen sind nicht betroffen.} other{Alle {count} Einträge aus dieser Checkliste löschen? Vorlagen sind nicht betroffen.}}",
   "@checklists_clear_content": {

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -905,6 +905,25 @@
   "checklists_item_delete": "Eintrag löschen",
   "checklists_menu_applyTemplate": "Vorlage anwenden...",
   "checklists_menu_saveAsTemplate": "Als Vorlage speichern...",
+  "checklists_menu_clearAll": "Checkliste leeren ...",
+  "checklists_clear_title": "Checkliste leeren",
+  "checklists_clear_content": "{count, plural, =1{Den einzigen Eintrag aus dieser Checkliste löschen? Vorlagen sind nicht betroffen.} other{Alle {count} Einträge aus dieser Checkliste löschen? Vorlagen sind nicht betroffen.}}",
+  "@checklists_clear_content": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "checklists_clear_confirm": "Leeren",
+  "checklists_clear_success": "{count, plural, =1{1 Eintrag entfernt} other{{count} Einträge entfernt}}",
+  "@checklists_clear_success": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "checklists_applySheet_title": "Vorlage anwenden",
   "checklists_applySheet_empty": "Noch keine Vorlagen vorhanden. Erstellen Sie sie in den Einstellungen.",
   "checklists_applySheet_itemCount": "{count, plural, =1{1 Eintrag} other{{count} Einträge}}",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1433,6 +1433,25 @@
   "checklists_item_delete": "Delete item",
   "checklists_menu_applyTemplate": "Apply template...",
   "checklists_menu_saveAsTemplate": "Save as template...",
+  "checklists_menu_clearAll": "Clear checklist...",
+  "checklists_clear_title": "Clear checklist",
+  "checklists_clear_content": "{count, plural, =1{Delete the only item from this checklist? Templates are not affected.} other{Delete all {count} items from this checklist? Templates are not affected.}}",
+  "@checklists_clear_content": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "checklists_clear_confirm": "Clear",
+  "checklists_clear_success": "{count, plural, =1{1 item removed} other{{count} items removed}}",
+  "@checklists_clear_success": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "checklists_applySheet_title": "Apply template",
   "checklists_applySheet_empty": "No templates yet. Create them in Settings.",
   "checklists_applySheet_itemCount": "{count, plural, =1{1 item} other{{count} items}}",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -905,6 +905,25 @@
   "checklists_item_delete": "Eliminar elemento",
   "checklists_menu_applyTemplate": "Aplicar plantilla...",
   "checklists_menu_saveAsTemplate": "Guardar como plantilla...",
+  "checklists_menu_clearAll": "Vaciar lista...",
+  "checklists_clear_title": "Vaciar lista",
+  "checklists_clear_content": "{count, plural, =1{¿Eliminar el único elemento de esta lista? Las plantillas no se ven afectadas.} other{¿Eliminar los {count} elementos de esta lista? Las plantillas no se ven afectadas.}}",
+  "@checklists_clear_content": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "checklists_clear_confirm": "Vaciar",
+  "checklists_clear_success": "{count, plural, =1{1 elemento eliminado} other{{count} elementos eliminados}}",
+  "@checklists_clear_success": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "checklists_applySheet_title": "Aplicar plantilla",
   "checklists_applySheet_empty": "Aún no hay plantillas. Créalas en Ajustes.",
   "checklists_applySheet_itemCount": "{count, plural, =1{1 elemento} other{{count} elementos}}",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -905,6 +905,25 @@
   "checklists_item_delete": "Supprimer l'élément",
   "checklists_menu_applyTemplate": "Appliquer un modèle...",
   "checklists_menu_saveAsTemplate": "Enregistrer comme modèle...",
+  "checklists_menu_clearAll": "Vider la check-list...",
+  "checklists_clear_title": "Vider la check-list",
+  "checklists_clear_content": "{count, plural, =1{Supprimer le seul élément de cette check-list ? Les modèles ne sont pas affectés.} other{Supprimer les {count} éléments de cette check-list ? Les modèles ne sont pas affectés.}}",
+  "@checklists_clear_content": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "checklists_clear_confirm": "Vider",
+  "checklists_clear_success": "{count, plural, =1{1 élément supprimé} other{{count} éléments supprimés}}",
+  "@checklists_clear_success": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "checklists_applySheet_title": "Appliquer un modèle",
   "checklists_applySheet_empty": "Aucun modèle pour l'instant. Créez-en dans les Paramètres.",
   "checklists_applySheet_itemCount": "{count, plural, =1{1 élément} other{{count} éléments}}",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -905,6 +905,25 @@
   "checklists_item_delete": "מחק פריט",
   "checklists_menu_applyTemplate": "החל תבנית...",
   "checklists_menu_saveAsTemplate": "שמור כתבנית...",
+  "checklists_menu_clearAll": "ניקוי רשימת המשימות...",
+  "checklists_clear_title": "ניקוי רשימת המשימות",
+  "checklists_clear_content": "{count, plural, =1{למחוק את הפריט היחיד מרשימה זו? התבניות לא יושפעו.} other{למחוק את כל {count} הפריטים מרשימה זו? התבניות לא יושפעו.}}",
+  "@checklists_clear_content": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "checklists_clear_confirm": "ניקוי",
+  "checklists_clear_success": "{count, plural, =1{פריט אחד הוסר} other{{count} פריטים הוסרו}}",
+  "@checklists_clear_success": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "checklists_applySheet_title": "החלת תבנית",
   "checklists_applySheet_empty": "עדיין אין תבניות. ניתן ליצור אותן בהגדרות.",
   "checklists_applySheet_itemCount": "{count, plural, =1{פריט אחד} other{{count} פריטים}}",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -905,6 +905,25 @@
   "checklists_item_delete": "Tétel törlése",
   "checklists_menu_applyTemplate": "Sablon alkalmazása...",
   "checklists_menu_saveAsTemplate": "Mentés sablonként...",
+  "checklists_menu_clearAll": "Ellenőrzőlista törlése...",
+  "checklists_clear_title": "Ellenőrzőlista törlése",
+  "checklists_clear_content": "{count, plural, =1{Törli az ellenőrzőlista egyetlen elemét? A sablonokat ez nem érinti.} other{Törli mind a(z) {count} elemet az ellenőrzőlistáról? A sablonokat ez nem érinti.}}",
+  "@checklists_clear_content": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "checklists_clear_confirm": "Törlés",
+  "checklists_clear_success": "{count, plural, =1{1 elem eltávolítva} other{{count} elem eltávolítva}}",
+  "@checklists_clear_success": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "checklists_applySheet_title": "Sablon alkalmazása",
   "checklists_applySheet_empty": "Még nincsenek sablonok. Hozza létre őket a Beállításokban.",
   "checklists_applySheet_itemCount": "{count, plural, =1{1 tétel} other{{count} tétel}}",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -905,6 +905,25 @@
   "checklists_item_delete": "Elimina elemento",
   "checklists_menu_applyTemplate": "Applica modello...",
   "checklists_menu_saveAsTemplate": "Salva come modello...",
+  "checklists_menu_clearAll": "Svuota checklist...",
+  "checklists_clear_title": "Svuota checklist",
+  "checklists_clear_content": "{count, plural, =1{Eliminare l'unico elemento da questa checklist? I modelli non vengono modificati.} other{Eliminare tutti i {count} elementi da questa checklist? I modelli non vengono modificati.}}",
+  "@checklists_clear_content": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "checklists_clear_confirm": "Svuota",
+  "checklists_clear_success": "{count, plural, =1{1 elemento rimosso} other{{count} elementi rimossi}}",
+  "@checklists_clear_success": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "checklists_applySheet_title": "Applica modello",
   "checklists_applySheet_empty": "Nessun modello disponibile. Creane uno nelle Impostazioni.",
   "checklists_applySheet_itemCount": "{count, plural, =1{1 elemento} other{{count} elementi}}",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -3797,6 +3797,36 @@ abstract class AppLocalizations {
   /// **'Save as template...'**
   String get checklists_menu_saveAsTemplate;
 
+  /// No description provided for @checklists_menu_clearAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear checklist...'**
+  String get checklists_menu_clearAll;
+
+  /// No description provided for @checklists_clear_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear checklist'**
+  String get checklists_clear_title;
+
+  /// No description provided for @checklists_clear_content.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Delete the only item from this checklist? Templates are not affected.} other{Delete all {count} items from this checklist? Templates are not affected.}}'**
+  String checklists_clear_content(int count);
+
+  /// No description provided for @checklists_clear_confirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear'**
+  String get checklists_clear_confirm;
+
+  /// No description provided for @checklists_clear_success.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 item removed} other{{count} items removed}}'**
+  String checklists_clear_success(int count);
+
   /// No description provided for @checklists_applySheet_title.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -2195,6 +2195,38 @@ class AppLocalizationsAr extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => 'حفظ كقالب...';
 
   @override
+  String get checklists_menu_clearAll => 'مسح قائمة التحقق...';
+
+  @override
+  String get checklists_clear_title => 'مسح قائمة التحقق';
+
+  @override
+  String checklists_clear_content(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'هل تريد حذف جميع العناصر البالغ عددها $count من قائمة التحقق هذه؟ لن تتأثر القوالب.',
+      one: 'هل تريد حذف العنصر الوحيد من قائمة التحقق هذه؟ لن تتأثر القوالب.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get checklists_clear_confirm => 'مسح';
+
+  @override
+  String checklists_clear_success(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'تمت إزالة $count عناصر',
+      one: 'تمت إزالة عنصر واحد',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get checklists_applySheet_title => 'تطبيق القالب';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -2249,7 +2249,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => 'Als Vorlage speichern...';
 
   @override
-  String get checklists_menu_clearAll => 'Checkliste leeren ...';
+  String get checklists_menu_clearAll => 'Checkliste leeren...';
 
   @override
   String get checklists_clear_title => 'Checkliste leeren';

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -2249,6 +2249,39 @@ class AppLocalizationsDe extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => 'Als Vorlage speichern...';
 
   @override
+  String get checklists_menu_clearAll => 'Checkliste leeren ...';
+
+  @override
+  String get checklists_clear_title => 'Checkliste leeren';
+
+  @override
+  String checklists_clear_content(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'Alle $count Einträge aus dieser Checkliste löschen? Vorlagen sind nicht betroffen.',
+      one:
+          'Den einzigen Eintrag aus dieser Checkliste löschen? Vorlagen sind nicht betroffen.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get checklists_clear_confirm => 'Leeren';
+
+  @override
+  String checklists_clear_success(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Einträge entfernt',
+      one: '1 Eintrag entfernt',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get checklists_applySheet_title => 'Vorlage anwenden';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -2199,6 +2199,39 @@ class AppLocalizationsEn extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => 'Save as template...';
 
   @override
+  String get checklists_menu_clearAll => 'Clear checklist...';
+
+  @override
+  String get checklists_clear_title => 'Clear checklist';
+
+  @override
+  String checklists_clear_content(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'Delete all $count items from this checklist? Templates are not affected.',
+      one:
+          'Delete the only item from this checklist? Templates are not affected.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get checklists_clear_confirm => 'Clear';
+
+  @override
+  String checklists_clear_success(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count items removed',
+      one: '1 item removed',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get checklists_applySheet_title => 'Apply template';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -2247,6 +2247,39 @@ class AppLocalizationsEs extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => 'Guardar como plantilla...';
 
   @override
+  String get checklists_menu_clearAll => 'Vaciar lista...';
+
+  @override
+  String get checklists_clear_title => 'Vaciar lista';
+
+  @override
+  String checklists_clear_content(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '¿Eliminar los $count elementos de esta lista? Las plantillas no se ven afectadas.',
+      one:
+          '¿Eliminar el único elemento de esta lista? Las plantillas no se ven afectadas.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get checklists_clear_confirm => 'Vaciar';
+
+  @override
+  String checklists_clear_success(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count elementos eliminados',
+      one: '1 elemento eliminado',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get checklists_applySheet_title => 'Aplicar plantilla';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -2250,6 +2250,39 @@ class AppLocalizationsFr extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => 'Enregistrer comme modèle...';
 
   @override
+  String get checklists_menu_clearAll => 'Vider la check-list...';
+
+  @override
+  String get checklists_clear_title => 'Vider la check-list';
+
+  @override
+  String checklists_clear_content(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'Supprimer les $count éléments de cette check-list ? Les modèles ne sont pas affectés.',
+      one:
+          'Supprimer le seul élément de cette check-list ? Les modèles ne sont pas affectés.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get checklists_clear_confirm => 'Vider';
+
+  @override
+  String checklists_clear_success(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count éléments supprimés',
+      one: '1 élément supprimé',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get checklists_applySheet_title => 'Appliquer un modèle';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -2175,6 +2175,37 @@ class AppLocalizationsHe extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => 'שמור כתבנית...';
 
   @override
+  String get checklists_menu_clearAll => 'ניקוי רשימת המשימות...';
+
+  @override
+  String get checklists_clear_title => 'ניקוי רשימת המשימות';
+
+  @override
+  String checklists_clear_content(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'למחוק את כל $count הפריטים מרשימה זו? התבניות לא יושפעו.',
+      one: 'למחוק את הפריט היחיד מרשימה זו? התבניות לא יושפעו.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get checklists_clear_confirm => 'ניקוי';
+
+  @override
+  String checklists_clear_success(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count פריטים הוסרו',
+      one: 'פריט אחד הוסר',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get checklists_applySheet_title => 'החלת תבנית';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -2230,6 +2230,39 @@ class AppLocalizationsHu extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => 'Mentés sablonként...';
 
   @override
+  String get checklists_menu_clearAll => 'Ellenőrzőlista törlése...';
+
+  @override
+  String get checklists_clear_title => 'Ellenőrzőlista törlése';
+
+  @override
+  String checklists_clear_content(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'Törli mind a(z) $count elemet az ellenőrzőlistáról? A sablonokat ez nem érinti.',
+      one:
+          'Törli az ellenőrzőlista egyetlen elemét? A sablonokat ez nem érinti.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get checklists_clear_confirm => 'Törlés';
+
+  @override
+  String checklists_clear_success(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count elem eltávolítva',
+      one: '1 elem eltávolítva',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get checklists_applySheet_title => 'Sablon alkalmazása';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -2243,6 +2243,39 @@ class AppLocalizationsIt extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => 'Salva come modello...';
 
   @override
+  String get checklists_menu_clearAll => 'Svuota checklist...';
+
+  @override
+  String get checklists_clear_title => 'Svuota checklist';
+
+  @override
+  String checklists_clear_content(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'Eliminare tutti i $count elementi da questa checklist? I modelli non vengono modificati.',
+      one:
+          'Eliminare l\'unico elemento da questa checklist? I modelli non vengono modificati.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get checklists_clear_confirm => 'Svuota';
+
+  @override
+  String checklists_clear_success(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count elementi rimossi',
+      one: '1 elemento rimosso',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get checklists_applySheet_title => 'Applica modello';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -2229,6 +2229,39 @@ class AppLocalizationsNl extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => 'Opslaan als sjabloon...';
 
   @override
+  String get checklists_menu_clearAll => 'Checklist wissen...';
+
+  @override
+  String get checklists_clear_title => 'Checklist wissen';
+
+  @override
+  String checklists_clear_content(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'Alle $count items uit deze checklist verwijderen? Sjablonen blijven ongewijzigd.',
+      one:
+          'Het enige item uit deze checklist verwijderen? Sjablonen blijven ongewijzigd.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get checklists_clear_confirm => 'Wissen';
+
+  @override
+  String checklists_clear_success(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count items verwijderd',
+      one: '1 item verwijderd',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get checklists_applySheet_title => 'Sjabloon toepassen';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -2240,6 +2240,38 @@ class AppLocalizationsPt extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => 'Salvar como modelo...';
 
   @override
+  String get checklists_menu_clearAll => 'Limpar lista...';
+
+  @override
+  String get checklists_clear_title => 'Limpar lista';
+
+  @override
+  String checklists_clear_content(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'Eliminar os $count itens desta lista? Os modelos não são afetados.',
+      one: 'Eliminar o único item desta lista? Os modelos não são afetados.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get checklists_clear_confirm => 'Limpar';
+
+  @override
+  String checklists_clear_success(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count itens removidos',
+      one: '1 item removido',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get checklists_applySheet_title => 'Aplicar modelo';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -2108,6 +2108,35 @@ class AppLocalizationsZh extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => '保存为模板…';
 
   @override
+  String get checklists_menu_clearAll => '清空清单...';
+
+  @override
+  String get checklists_clear_title => '清空清单';
+
+  @override
+  String checklists_clear_content(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '要删除此清单中的全部 $count 个项目吗？模板不受影响。',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get checklists_clear_confirm => '清空';
+
+  @override
+  String checklists_clear_success(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '已移除 $count 个项目',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get checklists_applySheet_title => '应用模板';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -2108,7 +2108,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get checklists_menu_saveAsTemplate => '保存为模板…';
 
   @override
-  String get checklists_menu_clearAll => '清空清单...';
+  String get checklists_menu_clearAll => '清空清单…';
 
   @override
   String get checklists_clear_title => '清空清单';

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -905,6 +905,25 @@
   "checklists_item_delete": "Item verwijderen",
   "checklists_menu_applyTemplate": "Sjabloon toepassen...",
   "checklists_menu_saveAsTemplate": "Opslaan als sjabloon...",
+  "checklists_menu_clearAll": "Checklist wissen...",
+  "checklists_clear_title": "Checklist wissen",
+  "checklists_clear_content": "{count, plural, =1{Het enige item uit deze checklist verwijderen? Sjablonen blijven ongewijzigd.} other{Alle {count} items uit deze checklist verwijderen? Sjablonen blijven ongewijzigd.}}",
+  "@checklists_clear_content": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "checklists_clear_confirm": "Wissen",
+  "checklists_clear_success": "{count, plural, =1{1 item verwijderd} other{{count} items verwijderd}}",
+  "@checklists_clear_success": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "checklists_applySheet_title": "Sjabloon toepassen",
   "checklists_applySheet_empty": "Nog geen sjablonen. Maak ze aan in Instellingen.",
   "checklists_applySheet_itemCount": "{count, plural, =1{1 item} other{{count} items}}",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -905,6 +905,25 @@
   "checklists_item_delete": "Excluir item",
   "checklists_menu_applyTemplate": "Aplicar modelo...",
   "checklists_menu_saveAsTemplate": "Salvar como modelo...",
+  "checklists_menu_clearAll": "Limpar lista...",
+  "checklists_clear_title": "Limpar lista",
+  "checklists_clear_content": "{count, plural, =1{Eliminar o único item desta lista? Os modelos não são afetados.} other{Eliminar os {count} itens desta lista? Os modelos não são afetados.}}",
+  "@checklists_clear_content": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "checklists_clear_confirm": "Limpar",
+  "checklists_clear_success": "{count, plural, =1{1 item removido} other{{count} itens removidos}}",
+  "@checklists_clear_success": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "checklists_applySheet_title": "Aplicar modelo",
   "checklists_applySheet_empty": "Ainda não há modelos. Crie-os em Configurações.",
   "checklists_applySheet_itemCount": "{count, plural, =1{1 item} other{{count} itens}}",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -999,6 +999,25 @@
   "checklists_item_delete": "删除事项",
   "checklists_menu_applyTemplate": "应用模板…",
   "checklists_menu_saveAsTemplate": "保存为模板…",
+  "checklists_menu_clearAll": "清空清单...",
+  "checklists_clear_title": "清空清单",
+  "checklists_clear_content": "{count, plural, other{要删除此清单中的全部 {count} 个项目吗？模板不受影响。}}",
+  "@checklists_clear_content": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "checklists_clear_confirm": "清空",
+  "checklists_clear_success": "{count, plural, other{已移除 {count} 个项目}}",
+  "@checklists_clear_success": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "checklists_applySheet_title": "应用模板",
   "checklists_applySheet_empty": "暂无模板。请在设置中创建。",
   "checklists_applySheet_itemCount": "{count, plural, =1{1 项事项} other{{count} 项事项}}",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -999,7 +999,7 @@
   "checklists_item_delete": "删除事项",
   "checklists_menu_applyTemplate": "应用模板…",
   "checklists_menu_saveAsTemplate": "保存为模板…",
-  "checklists_menu_clearAll": "清空清单...",
+  "checklists_menu_clearAll": "清空清单…",
   "checklists_clear_title": "清空清单",
   "checklists_clear_content": "{count, plural, other{要删除此清单中的全部 {count} 个项目吗？模板不受影响。}}",
   "@checklists_clear_content": {

--- a/test/features/checklists/presentation/widgets/trip_checklist_section_test.dart
+++ b/test/features/checklists/presentation/widgets/trip_checklist_section_test.dart
@@ -354,6 +354,9 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.text('Fins'), findsNothing);
       expect(await checklistRepository.getByTripId(trip.id), isEmpty);
+      // The section is still mounted here, so the mounted guard around the
+      // confirmation must not swallow it.
+      expect(find.text('3 items removed'), findsOneWidget);
     });
 
     testWidgets('cancelling the clear-checklist dialog keeps every item', (

--- a/test/features/checklists/presentation/widgets/trip_checklist_section_test.dart
+++ b/test/features/checklists/presentation/widgets/trip_checklist_section_test.dart
@@ -318,5 +318,83 @@ void main() {
       );
       expect(saveItem.enabled, isFalse);
     });
+
+    testWidgets('clear-checklist wipes every item after confirmation', (
+      tester,
+    ) async {
+      for (final title in ['Fins', 'Mask', 'Passport']) {
+        await checklistRepository.createItem(
+          TripChecklistItem(
+            id: '',
+            tripId: trip.id,
+            title: title,
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+      }
+      await pumpSection(tester);
+      expect(find.text('Fins'), findsOneWidget);
+
+      await tester.tap(find.byType(PopupMenuButton<String>).first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Clear checklist...'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          'Delete all 3 items from this checklist? '
+          'Templates are not affected.',
+        ),
+        findsOneWidget,
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Clear'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Fins'), findsNothing);
+      expect(await checklistRepository.getByTripId(trip.id), isEmpty);
+    });
+
+    testWidgets('cancelling the clear-checklist dialog keeps every item', (
+      tester,
+    ) async {
+      await checklistRepository.createItem(
+        TripChecklistItem(
+          id: '',
+          tripId: trip.id,
+          title: 'Fins',
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      );
+      await pumpSection(tester);
+
+      await tester.tap(find.byType(PopupMenuButton<String>).first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Clear checklist...'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Fins'), findsOneWidget);
+      expect(await checklistRepository.getByTripId(trip.id), hasLength(1));
+    });
+
+    testWidgets('clear-checklist is disabled in the overflow menu when the '
+        'checklist is empty', (tester) async {
+      await pumpSection(tester);
+
+      await tester.tap(find.byType(PopupMenuButton<String>).first);
+      await tester.pumpAndSettle();
+
+      final clearItem = tester.widget<PopupMenuItem<String>>(
+        find.ancestor(
+          of: find.text('Clear checklist...'),
+          matching: find.byType(PopupMenuItem<String>),
+        ),
+      );
+      expect(clearItem.enabled, isFalse);
+    });
   });
 }

--- a/test/features/trips/presentation/widgets/story/trip_story_view_test.dart
+++ b/test/features/trips/presentation/widgets/story/trip_story_view_test.dart
@@ -7,6 +7,7 @@ import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/trips/domain/entities/trip_day_weather.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/checklists/domain/entities/trip_checklist_item.dart';
+import 'package:submersion/features/checklists/presentation/providers/checklist_providers.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/trips/domain/entities/liveaboard_details.dart';
@@ -473,5 +474,151 @@ void main() {
 
     expect(calls, 0);
     expect(find.textContaining('°C'), findsNothing);
+  });
+
+  group('checklist closer reachability (#1569)', () {
+    // The checklist closer is the only editable checklist surface a
+    // non-liveaboard trip has. Hiding it while the trip is upcoming, or while
+    // the checklist is still empty, made it unreachable in every state: the
+    // section that applies a template was gated on a template already having
+    // been applied.
+    Trip relativeTrip({required bool upcoming}) {
+      final now = DateTime.now();
+      final today = DateTime(now.year, now.month, now.day);
+      final start = upcoming
+          ? today.add(const Duration(days: 10))
+          : today.subtract(const Duration(days: 20));
+      return Trip(
+        id: 'trip-1',
+        name: 'Bonaire',
+        startDate: start,
+        endDate: start.add(const Duration(days: 2)),
+        tripType: TripType.resort,
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+      );
+    }
+
+    TripStory relativeStory(Trip trip, List<TripChecklistItem> items) {
+      return buildTripStory(
+        trip: trip,
+        dives: [],
+        itineraryDays: [],
+        mediaByDiveId: {},
+        sightingsByDiveId: {},
+        checklistItems: items,
+        today: DateTime(
+          trip.startDate.year,
+          trip.startDate.month,
+          trip.startDate.day,
+        ),
+      );
+    }
+
+    testWidgets('upcoming trip with an empty checklist can still bootstrap '
+        'one', (tester) async {
+      final trip = relativeTrip(upcoming: true);
+      await pumpView(
+        tester,
+        relativeStory(trip, const []),
+        extra: [tripChecklistProvider(trip.id).overrideWith((ref) async => [])],
+      );
+
+      // Titled "Checklist" rather than "0 of 0 to-dos done", and expanded so
+      // the apply-template menu is reachable without a hunt.
+      expect(find.text('Checklist'), findsOneWidget);
+      expect(
+        find.text('Plan your trip - add to-dos or apply a template'),
+        findsOneWidget,
+      );
+      expect(find.text('Add item'), findsOneWidget);
+    });
+
+    testWidgets('upcoming trip with items opens expanded', (tester) async {
+      final trip = relativeTrip(upcoming: true);
+      final items = [
+        TripChecklistItem(
+          id: 'c1',
+          tripId: trip.id,
+          title: 'Service regulator',
+          createdAt: DateTime(2026, 1, 1),
+          updatedAt: DateTime(2026, 1, 1),
+        ),
+      ];
+      await pumpView(
+        tester,
+        relativeStory(trip, items),
+        extra: [
+          tripChecklistProvider(trip.id).overrideWith((ref) async => items),
+        ],
+      );
+
+      // Open, so the card wears the section's own header rather than an
+      // ExpansionTile title that would repeat it.
+      expect(find.text('Checklist'), findsOneWidget);
+      expect(find.text('0 of 1 to-dos done'), findsOneWidget);
+      // No tap needed: an upcoming trip's prep list is the point of the page.
+      expect(find.text('Service regulator'), findsOneWidget);
+    });
+
+    testWidgets('past trip with an empty checklist can still bootstrap one', (
+      tester,
+    ) async {
+      final trip = relativeTrip(upcoming: false);
+      await pumpView(
+        tester,
+        relativeStory(trip, const []),
+        extra: [tripChecklistProvider(trip.id).overrideWith((ref) async => [])],
+      );
+
+      expect(find.text('Checklist'), findsOneWidget);
+      expect(find.text('No checklist items'), findsOneWidget);
+    });
+
+    testWidgets('past trip with items stays collapsed', (tester) async {
+      final trip = relativeTrip(upcoming: false);
+      final items = [
+        TripChecklistItem(
+          id: 'c1',
+          tripId: trip.id,
+          title: 'Service regulator',
+          createdAt: DateTime(2026, 1, 1),
+          updatedAt: DateTime(2026, 1, 1),
+        ),
+      ];
+      await pumpView(
+        tester,
+        relativeStory(trip, items),
+        extra: [
+          tripChecklistProvider(trip.id).overrideWith((ref) async => items),
+        ],
+      );
+
+      expect(find.text('0 of 1 done'), findsOneWidget);
+      expect(find.text('Service regulator'), findsNothing);
+    });
+
+    testWidgets('liveaboard trips keep the closer out of the story', (
+      tester,
+    ) async {
+      final trip = Trip(
+        id: 'trip-1',
+        name: 'Bonaire',
+        startDate: DateTime.now().add(const Duration(days: 10)),
+        endDate: DateTime.now().add(const Duration(days: 12)),
+        tripType: TripType.liveaboard,
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+      );
+      await pumpView(
+        tester,
+        relativeStory(trip, const []),
+        extra: [tripChecklistProvider(trip.id).overrideWith((ref) async => [])],
+      );
+
+      // Liveaboards get a dedicated Checklist tab; a second copy in the story
+      // would be two editors for one list.
+      expect(find.text('Checklist'), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
Fixes #1569.

## The bug

The checklist feature from #164 shipped, but its only editable surface was unreachable on any trip that is not a liveaboard. `TripChecklistSection` (the widget with the apply-template menu, the add-item button and the item checkboxes) is mounted in exactly two places: the Checklist tab, which only exists in the liveaboard layout, and an end-of-story card in `TripStoryView` gated by

```dart
final showChecklistAtEnd =
    !trip.isUpcoming && !trip.isLiveaboard && !story.checklist.isEmpty;
```

That gate has two independent problems.

`!story.checklist.isEmpty` is a bootstrap deadlock: the section that applies a template is hidden until a template has already been applied, so there is no way to create the first item. `!trip.isUpcoming` hides it from exactly the trips a prep list is for. Together they mean a shore or resort trip could never get a checklist in any state, past or upcoming, which is what the reporter hit.

Upcoming trips did get `_ChecklistCard` in the story hero, but that is a read-only glance (progress bar plus next-due titles, no tap target), and it is gated on the checklist being non-empty too.

## The fix

**Show the closer on every non-liveaboard trip.** The gate is now `!trip.isLiveaboard`. Liveaboards stay out because they have their own Checklist tab, and a second copy in the story would be two editors for one list.

**Open it where the checklist is the point of the page** (`trip.isUpcoming || checklist.isEmpty`). Open, the card renders the section directly and lets the section's own header (title, progress, overflow menu) serve as the card header, because an `ExpansionTile` title would only repeat it. Collapsed, past trips with items keep today's tile byte for byte.

**Add a clear-checklist action** to the section's overflow menu, disabled when empty and behind a confirmation dialog, covering the issue's second ask. It reuses `TripChecklistRepository.deleteByTripId`, which re-reads the rows it deletes and logs a sync tombstone per item, so a concurrent sync insert cannot be orphaned locally.

Five new ARB keys across all 11 locales, with the generated localizations regenerated.

## Tests

Five cases in `trip_story_view_test.dart` and three in `trip_checklist_section_test.dart`.

Two of the five story-view cases pass before the change, on purpose: they pin the behavior being preserved rather than the behavior being fixed. "past trip with items stays collapsed" guards the existing collapsed presentation, and "liveaboard trips keep the closer out of the story" guards against the relaxed gate growing a second checklist editor on liveaboard trips, which nothing else would have caught.

The clear-checklist cases run against a real database and assert the rows are actually gone, that cancelling keeps them, and that the menu entry is disabled on an empty checklist.

`flutter test test/features/trips test/features/checklists` is green at 739 tests, and `flutter analyze` reports no issues across the project.

## Note for review

On an upcoming trip that already has items you now see the hero's read-only progress card and the full section below it. That is deliberate: the hero is the above-the-fold glance with next-due dates, the section is where you work. Easy to drop the hero card if you would rather have only one.
