### PR TITLE
feat(certifications): add FFESSM as a built-in agency

### DIFF
--- a/lib/core/constants/certification_levels.dart
+++ b/lib/core/constants/certification_levels.dart
@@ -116,6 +116,70 @@ abstract final class CertificationLevelCatalog {
     CertificationLevel.cmas3StarInstructor,
   ];
 
+  /// FFESSM progression ladder (issue #690): the youth cursus, then the
+  /// Niveaux, then the E1-E4 teaching track. The modular PE/PA aptitudes and
+  /// the Tek / safety qualifications are NOT rungs — a diver validates them
+  /// alongside a Niveau, not in place of one — so they live in
+  /// [_ffessmSpecialties]. CMAS-affiliated but distinctly named, so it does
+  /// not reuse [_cmasLadder].
+  static const List<CertificationLevel> _ffessmLadder = [
+    CertificationLevel.ffessmPlongeurBronze,
+    CertificationLevel.ffessmPlongeurArgent,
+    CertificationLevel.ffessmPlongeurOr,
+    CertificationLevel.ffessmN1,
+    CertificationLevel.ffessmN2,
+    CertificationLevel.ffessmN3,
+    CertificationLevel.ffessmN4,
+    CertificationLevel.ffessmN5,
+    CertificationLevel.ffessmInitiateur,
+    CertificationLevel.ffessmE2,
+    CertificationLevel.ffessmMf1,
+    CertificationLevel.ffessmMf2,
+  ];
+
+  /// FFESSM's modular qualifications, offered instead of the shared
+  /// [specialties] for this agency: the PE/PA aptitudes (validated on their
+  /// own, e.g. N1 + PA-20 + PE-40), the Tek mixed-gas / rebreather brevets,
+  /// the safety and the technical qualifications. FFESSM names its own, the
+  /// same way the CMAS/BSAC/GUE ratings are their own values.
+  static const List<CertificationLevel> _ffessmSpecialties = [
+    CertificationLevel.ffessmPe12,
+    CertificationLevel.ffessmPe40,
+    CertificationLevel.ffessmPe60,
+    CertificationLevel.ffessmPa12,
+    CertificationLevel.ffessmPa20,
+    CertificationLevel.ffessmPa40,
+    CertificationLevel.ffessmNitrox,
+    CertificationLevel.ffessmNitroxConfirme,
+    CertificationLevel.ffessmMoniteurNitroxConfirme,
+    CertificationLevel.ffessmTrimixElementaire,
+    CertificationLevel.ffessmTrimix,
+    CertificationLevel.ffessmMoniteurTrimix,
+    CertificationLevel.ffessmRecycleurScr,
+    CertificationLevel.ffessmRecycleurCcr,
+    CertificationLevel.ffessmMoniteurRecycleurCcr,
+    CertificationLevel.ffessmRifap,
+    CertificationLevel.ffessmAnteor,
+    CertificationLevel.ffessmVetementEtanche,
+    CertificationLevel.ffessmSidemount,
+    CertificationLevel.ffessmTiv,
+    CertificationLevel.ffessmFormateurTiv,
+    CertificationLevel.ffessmBio1,
+    CertificationLevel.ffessmBio2,
+    CertificationLevel.ffessmFormateurBio1,
+    CertificationLevel.ffessmFormateurBio2,
+    CertificationLevel.ffessmFormateurBio3,
+    CertificationLevel.ffessmSouterrain1,
+    CertificationLevel.ffessmSouterrain2,
+    CertificationLevel.ffessmSouterrain3,
+    CertificationLevel.ffessmPhoto1,
+    CertificationLevel.ffessmPhoto2,
+    CertificationLevel.ffessmPhoto3,
+    CertificationLevel.ffessmVideo1,
+    CertificationLevel.ffessmVideo2,
+    CertificationLevel.ffessmVideo3,
+  ];
+
   /// Core progression ladder for an agency, in rank order. A null agency
   /// (possible on buddies) behaves like [CertificationAgency.other].
   static List<CertificationLevel> ladderFor(CertificationAgency? agency) =>
@@ -130,6 +194,7 @@ abstract final class CertificationLevelCatalog {
         CertificationAgency.gue => _gueLadder,
         CertificationAgency.bsac => _bsacLadder,
         CertificationAgency.cmas => _cmasLadder,
+        CertificationAgency.ffessm => _ffessmLadder,
         CertificationAgency.other || null => _genericLadder,
       };
 
@@ -138,7 +203,10 @@ abstract final class CertificationLevelCatalog {
   /// level that the ladder already lists.
   static List<CertificationLevel> specialtiesFor(CertificationAgency? agency) {
     final ladder = ladderFor(agency);
-    return specialties.where((s) => !ladder.contains(s)).toList();
+    final pool = agency == CertificationAgency.ffessm
+        ? _ffessmSpecialties
+        : specialties;
+    return pool.where((s) => !ladder.contains(s)).toList();
   }
 
   /// Full dropdown list for an agency: ladder, then specialties not already

--- a/lib/core/constants/enums.dart
+++ b/lib/core/constants/enums.dart
@@ -248,8 +248,8 @@ enum CertificationLevel {
   // are first-class values in the specialties group, not ladder rungs.
   // Youth cursus (Plongée Jeunes)
   ffessmPlongeurBronze('Plongeur de Bronze'),
-  ffessmPlongeurArgent("Plongeur d'Argent"),
-  ffessmPlongeurOr("Plongeur d'Or"),
+  ffessmPlongeurArgent('Plongeur d\'Argent'),
+  ffessmPlongeurOr('Plongeur d\'Or'),
   // Niveaux (N4 and N5 also belong to the cadre cursus)
   ffessmN1('Plongeur Niveau 1'),
   ffessmN2('Plongeur Niveau 2'),
@@ -279,14 +279,14 @@ enum CertificationLevel {
   ffessmMoniteurTrimix('Moniteur Trimix'),
   ffessmRecycleurScr('Plongeur recycleur circuit semi-fermé (SCR)'),
   ffessmRecycleurCcr('Plongeur recycleur circuit fermé (CCR)'),
-  ffessmMoniteurRecycleurCcr('Moniteur recycleur circuit fermé'),
+  ffessmMoniteurRecycleurCcr('Moniteur recycleur circuit fermé (CCR)'),
   // Safety
   ffessmRifap('RIFA Plongée (RIFAP)'),
   ffessmAnteor('ANTEOR'),
   // Technical qualifications
   ffessmVetementEtanche('Qualification Vêtement étanche'),
   ffessmSidemount('Sidemount de loisir'),
-  ffessmTiv("Technicien d'Inspection Visuelle (TIV)"),
+  ffessmTiv('Technicien d\'Inspection Visuelle (TIV)'),
   ffessmFormateurTiv('Formateur de TIV'),
   // Scuba-diving activity commissions (biology, cave, underwater imaging).
   // Non-scuba disciplines (apnea, finswimming, hockey, spearfishing...) stay

--- a/lib/core/constants/enums.dart
+++ b/lib/core/constants/enums.dart
@@ -134,6 +134,7 @@ enum CertificationAgency {
   cmas('CMAS'),
   iantd('IANTD'),
   psai('PSAI'),
+  ffessm('FFESSM'),
   other('Other');
 
   final String displayName;
@@ -152,6 +153,7 @@ enum CertificationAgency {
     CertificationAgency.cmas => const Color(0xFF00695c),
     CertificationAgency.iantd => const Color(0xFF283593),
     CertificationAgency.psai => const Color(0xFF2e7d32),
+    CertificationAgency.ffessm => const Color(0xFF00529b),
     CertificationAgency.other => const Color(0xFF00838f),
   };
 
@@ -168,6 +170,7 @@ enum CertificationAgency {
     CertificationAgency.cmas => const Color(0xFF26a69a),
     CertificationAgency.iantd => const Color(0xFF5c6bc0),
     CertificationAgency.psai => const Color(0xFF66bb6a),
+    CertificationAgency.ffessm => const Color(0xFF1e88e5),
     CertificationAgency.other => const Color(0xFF26c6da),
   };
 }
@@ -235,6 +238,73 @@ enum CertificationLevel {
   gueCave1('Cave 1'),
   gueCave2('Cave 2'),
   gueDpv('DPV'),
+  // FFESSM — Fédération française d'études et de sports sous-marins (issue #690).
+  // French brevets are proper nouns, kept untranslated like the CMAS/BSAC/GUE
+  // ratings above. This is the scuba cursus of the FFESSM Manuel de Formation
+  // Technique (août 2023): youth track, modular PE/PA aptitudes, Niveaux,
+  // E-grade teaching ladder, Tek (mixed gas / rebreather), safety and a few
+  // technical qualifications. A diver routinely holds an aptitude or a Tek
+  // brevet without the "matching" Niveau (e.g. N1 + PA-20 + PE-40), so those
+  // are first-class values in the specialties group, not ladder rungs.
+  // Youth cursus (Plongée Jeunes)
+  ffessmPlongeurBronze('Plongeur de Bronze'),
+  ffessmPlongeurArgent("Plongeur d'Argent"),
+  ffessmPlongeurOr("Plongeur d'Or"),
+  // Niveaux (N4 and N5 also belong to the cadre cursus)
+  ffessmN1('Plongeur Niveau 1'),
+  ffessmN2('Plongeur Niveau 2'),
+  ffessmN3('Plongeur Niveau 3'),
+  ffessmN4('Guide de Palanquée (N4)'),
+  ffessmN5('Directeur de Plongée (N5)'),
+  // Teaching ladder
+  ffessmInitiateur('Initiateur'),
+  ffessmE2('Encadrant E2'),
+  ffessmMf1('Moniteur Fédéral 1er degré (MF1)'),
+  ffessmMf2('Moniteur Fédéral 2e degré (MF2)'),
+  // Modular aptitudes — PE = Plongeur Encadré (supervised), PA = Plongeur
+  // Autonome (autonomous). PE-20 is N1 and PA-60 is N3, so those two are not
+  // separately issued. The six below are (MFT Généralités p.3).
+  ffessmPe12('Plongeur encadré 12 m (PE-12)'),
+  ffessmPe40('Plongeur encadré 40 m (PE-40)'),
+  ffessmPe60('Plongeur encadré 60 m (PE-60)'),
+  ffessmPa12('Plongeur autonome 12 m (PA-12)'),
+  ffessmPa20('Plongeur autonome 20 m (PA-20)'),
+  ffessmPa40('Plongeur autonome 40 m (PA-40)'),
+  // Tek — nitrox, trimix, rebreather. FFESSM names its own.
+  ffessmNitrox('Plongeur Nitrox'),
+  ffessmNitroxConfirme('Plongeur Nitrox confirmé'),
+  ffessmMoniteurNitroxConfirme('Moniteur Nitrox confirmé'),
+  ffessmTrimixElementaire('Plongeur Trimix élémentaire'),
+  ffessmTrimix('Plongeur Trimix'),
+  ffessmMoniteurTrimix('Moniteur Trimix'),
+  ffessmRecycleurScr('Plongeur recycleur circuit semi-fermé (SCR)'),
+  ffessmRecycleurCcr('Plongeur recycleur circuit fermé (CCR)'),
+  ffessmMoniteurRecycleurCcr('Moniteur recycleur circuit fermé'),
+  // Safety
+  ffessmRifap('RIFA Plongée (RIFAP)'),
+  ffessmAnteor('ANTEOR'),
+  // Technical qualifications
+  ffessmVetementEtanche('Qualification Vêtement étanche'),
+  ffessmSidemount('Sidemount de loisir'),
+  ffessmTiv("Technicien d'Inspection Visuelle (TIV)"),
+  ffessmFormateurTiv('Formateur de TIV'),
+  // Scuba-diving activity commissions (biology, cave, underwater imaging).
+  // Non-scuba disciplines (apnea, finswimming, hockey, spearfishing...) stay
+  // out — see #690.
+  ffessmBio1('Plongeur Bio Niveau 1 (PB1)'),
+  ffessmBio2('Plongeur Bio Niveau 2 (PB2)'),
+  ffessmFormateurBio1('Formateur Bio Niveau 1 (FB1)'),
+  ffessmFormateurBio2('Formateur Bio Niveau 2 (FB2)'),
+  ffessmFormateurBio3('Formateur Bio Niveau 3 (FB3)'),
+  ffessmSouterrain1('Plongeur Souterrain Niveau 1 (PS1)'),
+  ffessmSouterrain2('Plongeur Souterrain Niveau 2 (PS2)'),
+  ffessmSouterrain3('Plongeur Souterrain Niveau 3 (PS3)'),
+  ffessmPhoto1('Photographe sous-marin Niveau 1'),
+  ffessmPhoto2('Photographe sous-marin Niveau 2'),
+  ffessmPhoto3('Photographe sous-marin Niveau 3'),
+  ffessmVideo1('Vidéaste sous-marin Niveau 1'),
+  ffessmVideo2('Vidéaste sous-marin Niveau 2'),
+  ffessmVideo3('Vidéaste sous-marin Niveau 3'),
   other('Other');
 
   final String displayName;
@@ -252,7 +322,9 @@ enum CertificationLevel {
     CertificationLevel.cmas3StarInstructor ||
     CertificationLevel.bsacOpenWaterInstructor ||
     CertificationLevel.bsacAdvancedInstructor ||
-    CertificationLevel.bsacNationalInstructor => true,
+    CertificationLevel.bsacNationalInstructor ||
+    CertificationLevel.ffessmMf1 ||
+    CertificationLevel.ffessmMf2 => true,
     _ => false,
   };
 }

--- a/test/core/constants/certification_agency_color_test.dart
+++ b/test/core/constants/certification_agency_color_test.dart
@@ -3,19 +3,22 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
 
 void main() {
-  test('every CertificationAgency has a distinct primary and secondary color', () {
-    for (final agency in CertificationAgency.values) {
-      // Both switches are exhaustive by value; touching each one keeps the
-      // new FFESSM arms (and any future agency) covered.
-      expect(agency.primaryColor, isA<Color>());
-      expect(agency.secondaryColor, isA<Color>());
-      expect(
-        agency.primaryColor,
-        isNot(equals(agency.secondaryColor)),
-        reason: '${agency.name}: the gradient needs two colors',
-      );
-    }
-  });
+  test(
+    'every CertificationAgency has a distinct primary and secondary color',
+    () {
+      for (final agency in CertificationAgency.values) {
+        // Both switches are exhaustive by value; touching each one keeps the
+        // new FFESSM arms (and any future agency) covered.
+        expect(agency.primaryColor, isA<Color>());
+        expect(agency.secondaryColor, isA<Color>());
+        expect(
+          agency.primaryColor,
+          isNot(equals(agency.secondaryColor)),
+          reason: '${agency.name}: the gradient needs two colors',
+        );
+      }
+    },
+  );
 
   test('FFESSM carries its own brand blue', () {
     expect(CertificationAgency.ffessm.primaryColor, const Color(0xFF00529b));

--- a/test/core/constants/certification_agency_color_test.dart
+++ b/test/core/constants/certification_agency_color_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+
+void main() {
+  test('every CertificationAgency has a distinct primary and secondary color', () {
+    for (final agency in CertificationAgency.values) {
+      // Both switches are exhaustive by value; touching each one keeps the
+      // new FFESSM arms (and any future agency) covered.
+      expect(agency.primaryColor, isA<Color>());
+      expect(agency.secondaryColor, isA<Color>());
+      expect(
+        agency.primaryColor,
+        isNot(equals(agency.secondaryColor)),
+        reason: '${agency.name}: the gradient needs two colors',
+      );
+    }
+  });
+
+  test('FFESSM carries its own brand blue', () {
+    expect(CertificationAgency.ffessm.primaryColor, const Color(0xFF00529b));
+    expect(CertificationAgency.ffessm.secondaryColor, const Color(0xFF1e88e5));
+  });
+}

--- a/test/core/constants/certification_level_instructor_test.dart
+++ b/test/core/constants/certification_level_instructor_test.dart
@@ -14,6 +14,8 @@ void main() {
       CertificationLevel.bsacOpenWaterInstructor,
       CertificationLevel.bsacAdvancedInstructor,
       CertificationLevel.bsacNationalInstructor,
+      CertificationLevel.ffessmMf1,
+      CertificationLevel.ffessmMf2,
     };
     for (final level in CertificationLevel.values) {
       expect(


### PR DESCRIPTION
## What

Adds the **Fédération française d'études et de sports sous-marins (FFESSM)** as a built-in `CertificationAgency`. FFESSM is CMAS-affiliated but issues its own distinctly-named brevets across a modular system, so French divers currently file everything under `Other`, which discards the name.

A **slice of #690** — one agency, following the CMAS/BSAC/GUE pattern. Does not touch the table-backed refactor; that stays #690.

## Scope

The **scuba** cursus of the FFESSM *Manuel de Formation Technique* (août 2023), plus the scuba-diving activity commissions (biology, cave, underwater imaging). **47 `CertificationLevel` values.**

### Progression ladder — `_ffessmLadder` (what `primaryCertification()` ranks by)

Youth (`Plongeur de Bronze / Argent / Or`) → Niveaux (`N1`, `N2`, `N3`, `Guide de Palanquée (N4)`, `Directeur de Plongée (N5)`) → teaching (`Initiateur`, `Encadrant E2`, `MF1`, `MF2`).

### Modular qualifications — `_ffessmSpecialties` (not ladder rungs)

Held *alongside* a Niveau, not in place of one, so they sit outside the progression ladder. This list replaces the shared `specialties` pool for FFESSM in `specialtiesFor()`.

- **Aptitudes** — `PE` = *Plongeur Encadré* (supervised), `PA` = *Plongeur Autonome* (autonomous): `PE-12` `PE-40` `PE-60` · `PA-12` `PA-20` `PA-40`. Registered on their own (MFT *Généralités* p.3). `PE-20` is exactly N1 and `PA-60` is N3, so those two are not separately issued.
- **Tek** — nitrox (`Plongeur Nitrox`, `Plongeur Nitrox confirmé`, `Moniteur Nitrox confirmé`), trimix (`Plongeur Trimix élémentaire`, `Plongeur Trimix`, `Moniteur Trimix`), rebreather (`Plongeur recycleur SCR / CCR`, `Moniteur recycleur CCR`).
- **Safety** — `RIFA Plongée (RIFAP)` (required before N3 / N4 / Initiateur), `ANTEOR`.
- **Technical** — `Vêtement étanche`, `Sidemount de loisir`, `TIV`, `Formateur de TIV`.
- **Activity commissions** — biology (`Plongeur Bio 1/2`, `Formateur Bio 1/2/3`), cave (`Plongeur Souterrain 1/2/3`), underwater imaging (`Photographe` / `Vidéaste sous-marin 1/2/3`).

## `isInstructorLevel`

`MF1` and `MF2` → **true**. Everything below (`Initiateur`, `Encadrant E2`) → **false**, the same treatment as the CMAS assistant grades.

## Names stay French

FFESSM brevet names are proper nouns, **not translated**, consistent with the existing CMAS (`1★ Diver`), BSAC and GUE ratings. Labels are self-describing (`Plongeur encadré 40 m (PE-40)`, `Guide de Palanquée (N4)`).

## No migration

`certifications.agency`, `certifications.level`, `courses.agency` and `buddy_roles.agency` persist as enum-name text in free `TEXT` columns. Existing data is untouched, and a stored `ffessm` (e.g. a UDDF import that previously collapsed to `other`) now round-trips.

## Deliberately out of scope

- **Non-scuba disciplines** — apnea (A1–A5, MEF), finswimming, underwater hockey, spearfishing, orientation-as-sport, PSP (pool sport). Separate FFESSM commissions, not scuba certifications you'd tag a dive with.
- **BPJEPS / DEJEPS** — State professional diplomas, not FFESSM federal brevets.
- **User-defined agencies/levels, ACUC, DAN, the table-backed refactor** — that is #690.

## Tests

`flutter analyze` (whole project) and `dart format` clean. Green: `certification_levels_test`, `certification_level_instructor_test`, `certification_title_test`, `uddf_round_trip_test`, full `test/features/certifications/` suite (747 tests). The generic per-agency tests already exercise the ladder + specialties (non-empty, duplicate-free, unique display names, `ladder + specialties + other == levelsFor`).

Refs #690.