### PR TITLE
refactor(dive-detail): split lives only in the Data Sources card

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -2353,9 +2353,9 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
             // follows usesPerSourceRendering rather than the source count:
             // on a dive whose sources are consecutive halves there is no
             // "other source" to switch to or overlay, only the rest of the
-            // same dive. Set primary and Split do not disappear with it --
-            // the Data Sources section carries its own copy of both, gated
-            // on the source count alone (data_sources_section.dart).
+            // same dive. Set primary does not disappear with it: the Data
+            // Sources section carries its own copy, gated on the source
+            // count alone. Split lives only there (data_sources_section.dart).
             if (isMultiSource)
               SourceBar(
                 sources: [
@@ -2390,8 +2390,12 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                   ref.read(overlaySourcesProvider(dive.id).notifier).state =
                       overlaid ? {...current, id} : ({...current}..remove(id));
                 },
-                onMenuAction: (id, action) =>
-                    _handleSourceMenuAction(dive, id, action),
+                onSetPrimary: (id) => _onSetPrimaryDataSource(
+                  context,
+                  ref,
+                  diveId: dive.id,
+                  readingId: id,
+                ),
               ),
             // O2 toxicity section moved to _buildDecoO2Panel (side by side)
             // Playback controls and stats (when playback mode is active)
@@ -5567,24 +5571,6 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         }
       },
     );
-  }
-
-  void _handleSourceMenuAction(
-    Dive dive,
-    String sourceId,
-    SourceMenuAction action,
-  ) {
-    switch (action) {
-      case SourceMenuAction.setPrimary:
-        _onSetPrimaryDataSource(
-          context,
-          ref,
-          diveId: dive.id,
-          readingId: sourceId,
-        );
-      case SourceMenuAction.split:
-        _confirmAndSplit(dive, sourceId);
-    }
   }
 
   Future<void> _confirmAndSplit(Dive dive, String sourceId) async {

--- a/lib/features/dive_log/presentation/widgets/source_bar.dart
+++ b/lib/features/dive_log/presentation/widgets/source_bar.dart
@@ -21,9 +21,6 @@ Color sourceColorAt(int index) {
   return baseColor;
 }
 
-/// Management actions available from a source chip's overflow menu.
-enum SourceMenuAction { setPrimary, split }
-
 /// One data source entry in the [SourceBar].
 class SourceBarItem {
   const SourceBarItem({
@@ -56,7 +53,9 @@ class SourceBarItem {
 /// A row of source chips below the profile chart. Tapping a chip makes that
 /// source active (driving every line on the chart and every derived card on
 /// the page); the eye on non-active chips overlays that source's data in its
-/// color; the overflow menu carries per-source management actions.
+/// color; the overflow menu carries Set as primary. Split lives only in the
+/// Data Sources section, which is the one place that owns destructive
+/// per-source management (data_sources_section.dart).
 ///
 /// Renders nothing when the dive has fewer than two sources.
 class SourceBar extends StatelessWidget {
@@ -65,17 +64,17 @@ class SourceBar extends StatelessWidget {
     required this.sources,
     required this.onActivate,
     required this.onToggleOverlay,
-    this.onMenuAction,
+    this.onSetPrimary,
   });
 
   final List<SourceBarItem> sources;
   final void Function(String sourceId) onActivate;
   final void Function(String sourceId, bool overlaid) onToggleOverlay;
 
-  /// Per-source management actions. Null hides the chips' overflow menu
-  /// (e.g. the fullscreen chart, where management lives on the detail
-  /// page).
-  final void Function(String sourceId, SourceMenuAction action)? onMenuAction;
+  /// Promotes a source to the dive's primary. Null hides the chips'
+  /// overflow menu (e.g. the fullscreen chart, where management lives on
+  /// the detail page).
+  final void Function(String sourceId)? onSetPrimary;
 
   @override
   Widget build(BuildContext context) {
@@ -109,9 +108,9 @@ class SourceBar extends StatelessWidget {
                     onActivate: () => onActivate(item.sourceId),
                     onToggleOverlay: () =>
                         onToggleOverlay(item.sourceId, !item.isOverlaid),
-                    onMenuAction: onMenuAction == null
+                    onSetPrimary: onSetPrimary == null
                         ? null
-                        : (action) => onMenuAction!(item.sourceId, action),
+                        : () => onSetPrimary!(item.sourceId),
                   ),
               ],
             ),
@@ -127,18 +126,22 @@ class _SourceChip extends StatelessWidget {
     required this.item,
     required this.onActivate,
     required this.onToggleOverlay,
-    required this.onMenuAction,
+    required this.onSetPrimary,
   });
 
   final SourceBarItem item;
   final VoidCallback onActivate;
   final VoidCallback onToggleOverlay;
-  final void Function(SourceMenuAction action)? onMenuAction;
+  final VoidCallback? onSetPrimary;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
+
+    // Set as primary is the chip menu's only entry, so the primary chip has
+    // nothing to show: without this the button would open an empty menu.
+    final showMenu = onSetPrimary != null && !item.isPrimary;
 
     // The whole pill activates the source; the eye and menu buttons sit
     // inside it and win their own taps. Icon buttons are tightly
@@ -159,10 +162,7 @@ class _SourceChip extends StatelessWidget {
         child: SizedBox(
           height: 28,
           child: Padding(
-            padding: EdgeInsets.only(
-              left: 10,
-              right: onMenuAction == null ? 10 : 2,
-            ),
+            padding: EdgeInsets.only(left: 10, right: showMenu ? 2 : 10),
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -208,24 +208,14 @@ class _SourceChip extends StatelessWidget {
                     padding: EdgeInsets.zero,
                     onPressed: item.hasProfile ? onToggleOverlay : null,
                   ),
-                if (onMenuAction != null)
-                  PopupMenuButton<SourceMenuAction>(
-                    onSelected: onMenuAction,
+                if (showMenu)
+                  PopupMenuButton<void>(
                     itemBuilder: (context) => [
-                      if (!item.isPrimary)
-                        PopupMenuItem(
-                          value: SourceMenuAction.setPrimary,
-                          child: ListTile(
-                            leading: const Icon(Icons.star_outline),
-                            title: Text(l10n.diveLog_sources_menu_setPrimary),
-                            contentPadding: EdgeInsets.zero,
-                          ),
-                        ),
                       PopupMenuItem(
-                        value: SourceMenuAction.split,
+                        onTap: onSetPrimary,
                         child: ListTile(
-                          leading: const Icon(Icons.call_split),
-                          title: Text(l10n.diveLog_sources_menu_split),
+                          leading: const Icon(Icons.star_outline),
+                          title: Text(l10n.diveLog_sources_menu_setPrimary),
                           contentPadding: EdgeInsets.zero,
                         ),
                       ),

--- a/test/features/dive_log/presentation/pages/dive_detail_multi_source_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_multi_source_test.dart
@@ -19,6 +19,18 @@ import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/mock_providers.dart';
 
+class _RecordingDiveRepository extends Fake implements DiveRepository {
+  final setPrimaryCalls = <(String, String)>[];
+
+  @override
+  Future<void> setPrimaryDataSource({
+    required String diveId,
+    required String computerReadingId,
+  }) async {
+    setPrimaryCalls.add((diveId, computerReadingId));
+  }
+}
+
 class _RecordingSplitService extends DiveSplitService {
   _RecordingSplitService() : super(DiveRepository());
 
@@ -71,6 +83,7 @@ void main() {
   late List<DiveDataSource> sources;
   late Map<String, SourceProfile> profiles;
   late _RecordingSplitService splitService;
+  late _RecordingDiveRepository repository;
 
   setUp(() {
     dive = createTestDiveWithBottomTime().copyWith(profile: _points(6));
@@ -103,6 +116,7 @@ void main() {
       ),
     };
     splitService = _RecordingSplitService();
+    repository = _RecordingDiveRepository();
   });
 
   Future<void> pumpPage(WidgetTester tester) async {
@@ -126,6 +140,7 @@ void main() {
             dive.id,
           ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
           diveSplitServiceProvider.overrideWithValue(splitService),
+          diveRepositoryProvider.overrideWithValue(repository),
           computersForDiveProvider(dive.id).overrideWith(
             (ref) async => [
               DiveComputer(
@@ -144,6 +159,10 @@ void main() {
           ),
         ],
         child: MaterialApp(
+          // flutter_test forwards the host machine's locale list, so an
+          // unpinned MaterialApp renders a translated UI on a non-English
+          // machine and every English literal below stops matching.
+          locale: const Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(body: DiveDetailPage(diveId: dive.id, embedded: true)),
@@ -243,6 +262,22 @@ void main() {
 
     expect(find.text('Set as primary'), findsOneWidget);
     expect(find.text('Split into separate dive'), findsNothing);
+  });
+
+  testWidgets('the sources bar chip menu promotes a source to primary', (
+    tester,
+  ) async {
+    await pumpPage(tester);
+
+    await tester.ensureVisible(inSourceBar(find.byIcon(Icons.more_vert)).last);
+    await tester.pump();
+    await tester.tap(inSourceBar(find.byIcon(Icons.more_vert)).last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Set as primary'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(repository.setPrimaryCalls, [(dive.id, 'src-b')]);
   });
 
   testWidgets(

--- a/test/features/dive_log/presentation/pages/dive_detail_multi_source_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_multi_source_test.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/data_sources_section.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/source_bar.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
@@ -232,22 +233,46 @@ void main() {
     expect(chart.overlays!.single.name, 'Erics Teric');
   });
 
+  testWidgets('the sources bar chip menu does not offer split', (tester) async {
+    await pumpPage(tester);
+
+    await tester.ensureVisible(inSourceBar(find.byIcon(Icons.more_vert)).last);
+    await tester.pump();
+    await tester.tap(inSourceBar(find.byIcon(Icons.more_vert)).last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Set as primary'), findsOneWidget);
+    expect(find.text('Split into separate dive'), findsNothing);
+  });
+
   testWidgets(
-    'split menu action shows a confirmation; confirming calls the service '
-    'and shows a snackbar; cancel does not',
+    'the Data Sources card split action shows a confirmation; confirming '
+    'calls the service and shows a snackbar; cancel does not',
     (tester) async {
+      // The detail page is far taller than the default 600px test surface,
+      // and the Data Sources card sits below the profile: at the default
+      // size the card's overflow menu stays off screen even at max scroll.
+      await tester.binding.setSurfaceSize(const Size(800, 2400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
       await pumpPage(tester);
 
-      // Open the secondary chip's menu (menus render in SourceBar order).
-      await tester.ensureVisible(
-        inSourceBar(find.byIcon(Icons.more_vert)).last,
-      );
-      await tester.pump();
-      await tester.tap(inSourceBar(find.byIcon(Icons.more_vert)).last);
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Split into separate dive'));
-      await tester.pumpAndSettle();
+      Finder secondaryCardMenu() => find
+          .descendant(
+            of: find.byType(DataSourcesSection),
+            matching: find.byIcon(Icons.more_vert),
+          )
+          .last;
 
+      Future<void> openSplitDialog() async {
+        await tester.ensureVisible(secondaryCardMenu());
+        await tester.pumpAndSettle();
+        await tester.tap(secondaryCardMenu());
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Split into separate dive'));
+        await tester.pumpAndSettle();
+      }
+
+      await openSplitDialog();
       expect(find.text('Split into separate dive?'), findsOneWidget);
 
       // Cancel first: no call.
@@ -256,14 +281,7 @@ void main() {
       expect(splitService.calls, isEmpty);
 
       // Again, confirming this time.
-      await tester.ensureVisible(
-        inSourceBar(find.byIcon(Icons.more_vert)).last,
-      );
-      await tester.pump();
-      await tester.tap(inSourceBar(find.byIcon(Icons.more_vert)).last);
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Split into separate dive'));
-      await tester.pumpAndSettle();
+      await openSplitDialog();
       await tester.tap(find.text('Split'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
@@ -272,6 +290,7 @@ void main() {
       expect(find.text('Dive split'), findsOneWidget);
     },
   );
+
   testWidgets('the Details card Dive Computer row follows the active source', (
     tester,
   ) async {

--- a/test/features/dive_log/presentation/widgets/source_bar_test.dart
+++ b/test/features/dive_log/presentation/widgets/source_bar_test.dart
@@ -41,7 +41,7 @@ void main() {
           ],
           onActivate: (_) {},
           onToggleOverlay: (_, _) {},
-          onMenuAction: (_, _) {},
+          onSetPrimary: (_) {},
         ),
       ),
     );
@@ -66,7 +66,7 @@ void main() {
           ],
           onActivate: (_) {},
           onToggleOverlay: (_, _) {},
-          onMenuAction: (_, _) {},
+          onSetPrimary: (_) {},
         ),
       ),
     );
@@ -94,7 +94,7 @@ void main() {
           ],
           onActivate: activated.add,
           onToggleOverlay: (_, _) {},
-          onMenuAction: (_, _) {},
+          onSetPrimary: (_) {},
         ),
       ),
     );
@@ -121,7 +121,7 @@ void main() {
           ],
           onActivate: (_) {},
           onToggleOverlay: (id, overlaid) => toggles.add((id, overlaid)),
-          onMenuAction: (_, _) {},
+          onSetPrimary: (_) {},
         ),
       ),
     );
@@ -147,7 +147,7 @@ void main() {
           ],
           onActivate: (_) {},
           onToggleOverlay: (_, _) {},
-          onMenuAction: (_, _) {},
+          onSetPrimary: (_) {},
         ),
       ),
     );
@@ -155,8 +155,10 @@ void main() {
     expect(find.byIcon(Icons.star), findsOneWidget);
   });
 
-  testWidgets('menu offers set primary and split; split fires', (tester) async {
-    final actions = <(String, SourceMenuAction)>[];
+  testWidgets('menu offers set primary only; split is not offered', (
+    tester,
+  ) async {
+    final promoted = <String>[];
     await tester.pumpWidget(
       _harness(
         SourceBar(
@@ -171,25 +173,24 @@ void main() {
           ],
           onActivate: (_) {},
           onToggleOverlay: (_, _) {},
-          onMenuAction: (id, action) => actions.add((id, action)),
+          onSetPrimary: promoted.add,
         ),
       ),
     );
 
-    // Open the non-primary chip's menu (the second more_vert icon).
-    await tester.tap(find.byIcon(Icons.more_vert).last);
+    await tester.tap(find.byIcon(Icons.more_vert));
     await tester.pumpAndSettle();
 
     expect(find.text('Set as primary'), findsOneWidget);
-    expect(find.text('Split into separate dive'), findsOneWidget);
+    expect(find.text('Split into separate dive'), findsNothing);
 
-    await tester.tap(find.text('Split into separate dive'));
+    await tester.tap(find.text('Set as primary'));
     await tester.pumpAndSettle();
 
-    expect(actions, [('src-b', SourceMenuAction.split)]);
+    expect(promoted, ['src-b']);
   });
 
-  testWidgets('primary chip menu omits set primary', (tester) async {
+  testWidgets('the primary chip has no overflow menu at all', (tester) async {
     await tester.pumpWidget(
       _harness(
         SourceBar(
@@ -204,16 +205,13 @@ void main() {
           ],
           onActivate: (_) {},
           onToggleOverlay: (_, _) {},
-          onMenuAction: (_, _) {},
+          onSetPrimary: (_) {},
         ),
       ),
     );
 
-    await tester.tap(find.byIcon(Icons.more_vert).first);
-    await tester.pumpAndSettle();
-
-    expect(find.text('Set as primary'), findsNothing);
-    expect(find.text('Split into separate dive'), findsOneWidget);
+    // Only the non-primary chip carries a menu button.
+    expect(find.byIcon(Icons.more_vert), findsOneWidget);
   });
 
   testWidgets('profile-less source has a disabled eye', (tester) async {
@@ -231,7 +229,7 @@ void main() {
           ],
           onActivate: (_) {},
           onToggleOverlay: (_, _) {},
-          onMenuAction: (_, _) {},
+          onSetPrimary: (_) {},
         ),
       ),
     );

--- a/test/features/dive_log/presentation/widgets/source_bar_test.dart
+++ b/test/features/dive_log/presentation/widgets/source_bar_test.dart
@@ -6,6 +6,10 @@ import 'package:submersion/l10n/arb/app_localizations.dart';
 
 Widget _harness(Widget child) {
   return MaterialApp(
+    // flutter_test forwards the host machine's locale list, so an unpinned
+    // MaterialApp renders a translated UI on a non-English machine and every
+    // English literal below stops matching.
+    locale: const Locale('en'),
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
     home: Scaffold(body: child),


### PR DESCRIPTION
## Summary

On a multi-source dive, the source chips under the profile chart carried their own copy of "Split into separate dive", duplicating the Data Sources card. That put a destructive per-source action one tap away from a chart marker. This removes it from the chip menu, leaving the Data Sources card as the only place a dive can be split.

Set as primary was the chip menu's only other entry, and it is already hidden on the primary chip. So the overflow button itself now renders only for non-primary chips: left as it was, the primary chip's button would open an empty menu. With a single action remaining, `SourceMenuAction` and the detail page's `switch` over it collapse into a plain `onSetPrimary` callback.

## Changes

- `source_bar.dart`: drop the split menu item and the now single-valued `SourceMenuAction` enum; `onMenuAction` becomes `onSetPrimary(sourceId)`.
- `source_bar.dart`: gate the chip's overflow button on `onSetPrimary != null && !item.isPrimary`, so the primary chip shows no button instead of an empty menu. The pill's right padding follows the same flag.
- `dive_detail_page.dart`: wire `SourceBar` straight to `_onSetPrimaryDataSource` and delete `_handleSourceMenuAction`. `_confirmAndSplit` is unchanged and still reached from `DataSourcesSection.onSplit`.
- `fullscreen_profile_page.dart` needed no change: it never passed a menu callback.
- Tests: chip-menu coverage now asserts Set as primary alone, no split, and no overflow button on the primary chip. The split confirm/cancel/snackbar coverage moves to the Data Sources card's menu.

## Test Plan

- [x] `flutter test` passes (`test/features/dive_log`: 3745 passed, 4 skipped)
- [x] `flutter analyze` passes (whole project, no issues)
- [x] Manual testing on: not yet run against a real multi-source dive

One test note worth flagging for review: at the default 800x600 widget-test surface the Data Sources card sits below the page's maximum scroll extent, so `ensureVisible` cannot bring its overflow menu on screen and the tap misses with only a `warnIfMissed` warning. The relocated split test raises the surface height rather than relying on scrolling.