### PR TITLE
fix(import): read MacDive surface interval as minutes (#1606)

### DIFF
--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -828,8 +828,11 @@ class MacDiveDiveMapper {
     // column and `<surfaceInterval>` carrying the identical number, and
     // MacDive's UDDF export of that number is `value * 60` seconds. A 0
     // means "no prior dive", so it stays unset.
-    if (d.surfaceInterval != null && d.surfaceInterval! > 0) {
-      map['surfaceInterval'] = Duration(minutes: d.surfaceInterval!.round());
+    // The column is a float, so round before the guard: testing the raw
+    // value would let a fraction of a minute through as Duration.zero.
+    final surfaceIntervalMinutes = d.surfaceInterval?.round();
+    if (surfaceIntervalMinutes != null && surfaceIntervalMinutes > 0) {
+      map['surfaceInterval'] = Duration(minutes: surfaceIntervalMinutes);
     }
 
     final waterTemp = c.tempToCelsius(d.tempLow);

--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -823,8 +823,13 @@ class MacDiveDiveMapper {
       map['runtime'] = runtime;
       map['duration'] = runtime;
     }
+    // `ZSURFACEINTERVAL` is minutes, not seconds (#1606). Joining a real
+    // MacDive.sqlite against the XML export of the same logbook shows the
+    // column and `<surfaceInterval>` carrying the identical number, and
+    // MacDive's UDDF export of that number is `value * 60` seconds. A 0
+    // means "no prior dive", so it stays unset.
     if (d.surfaceInterval != null && d.surfaceInterval! > 0) {
-      map['surfaceInterval'] = Duration(seconds: d.surfaceInterval!.round());
+      map['surfaceInterval'] = Duration(minutes: d.surfaceInterval!.round());
     }
 
     final waterTemp = c.tempToCelsius(d.tempLow);

--- a/lib/features/universal_import/data/services/macdive_xml_reader.dart
+++ b/lib/features/universal_import/data/services/macdive_xml_reader.dart
@@ -65,9 +65,12 @@ class MacDiveXmlReader {
       cns: _double(_text(el, 'cns')),
       decoModel: _text(el, 'decoModel'),
       duration: _durationSeconds(_int(_text(el, 'duration'))),
-      // MacDive's real files emit surfaceInterval in seconds (observed in
-      // the Apr 4 Socorro sample: 142 between adjacent liveaboard dives).
-      surfaceInterval: _durationSeconds(_int(_text(el, 'surfaceInterval'))),
+      // MacDive's XML is mixed-unit: `duration` and `sampleInterval` are
+      // seconds, but `surfaceInterval` is minutes (#1606). MacDive's own UDDF
+      // exporter writes `passedtime` (seconds, per the UDDF spec) as this
+      // value times 60, for every dive in a real 540-dive logbook. Reading it
+      // as seconds showed a reported 2h18m interval as 2m.
+      surfaceInterval: _durationMinutes(_int(_text(el, 'surfaceInterval'))),
       sampleInterval: _durationSeconds(_int(_text(el, 'sampleInterval'))),
       gasModel: _text(el, 'gasModel'),
       airTempCelsius: c.tempToCelsius(_double(_text(el, 'tempAir'))),
@@ -277,6 +280,18 @@ class MacDiveXmlReader {
   static Duration? _durationSeconds(int? seconds) {
     if (seconds == null) return null;
     return Duration(seconds: seconds);
+  }
+
+  /// MacDive's surface interval, in minutes.
+  ///
+  /// Non-positive values mean "no prior dive" rather than a zero-length
+  /// interval. MacDive stores 0 for the first dive of a series, and did so
+  /// for 110 of the 540 dives in the reference logbook. Returning null keeps
+  /// those dives blank instead of stamping them with 0m, and matches how the
+  /// SQLite path and UDDF's `<infinity/>` are already handled.
+  static Duration? _durationMinutes(int? minutes) {
+    if (minutes == null || minutes <= 0) return null;
+    return Duration(minutes: minutes);
   }
 
   static List<String> _childList(

--- a/test/features/universal_import/data/parsers/macdive_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/macdive_xml_parser_test.dart
@@ -205,6 +205,44 @@ void main() {
       expect(site['waterType'], 'salt');
     });
 
+    // #1606: MacDive writes surfaceInterval in minutes even though the
+    // neighbouring duration/sampleInterval fields are seconds. Reading it as
+    // seconds landed a reported 2h18m interval in the log as 2m.
+    test('surfaceInterval reaches the payload as minutes', () async {
+      const xml = '''<?xml version="1.0"?>
+<dives><units>Metric</units><schema>2.2.0</schema>
+  <dive>
+    <date>2024-01-01 09:00:00</date><identifier>d1</identifier>
+    <maxDepth>20</maxDepth><duration>1800</duration>
+    <surfaceInterval>138</surfaceInterval>
+    <samples/>
+  </dive>
+</dives>''';
+      final bytes = Uint8List.fromList(utf8.encode(xml));
+      final payload = await const MacDiveXmlParser().parse(bytes);
+      final dive = payload.entitiesOf(ImportEntityType.dives).first;
+      expect(dive['surfaceInterval'], const Duration(minutes: 138));
+    });
+
+    test('surfaceInterval of 0 is omitted from the payload', () async {
+      const xml = '''<?xml version="1.0"?>
+<dives><units>Metric</units><schema>2.2.0</schema>
+  <dive>
+    <date>2024-01-01 09:00:00</date><identifier>d1</identifier>
+    <maxDepth>20</maxDepth><duration>1800</duration>
+    <surfaceInterval>0</surfaceInterval>
+    <samples/>
+  </dive>
+</dives>''';
+      final bytes = Uint8List.fromList(utf8.encode(xml));
+      final payload = await const MacDiveXmlParser().parse(bytes);
+      final dive = payload.entitiesOf(ImportEntityType.dives).first;
+      // MacDive stores 0 for "no prior dive"; the SQLite path already skips
+      // it, and the importer should leave the field unset rather than write
+      // a 0m interval.
+      expect(dive.containsKey('surfaceInterval'), isFalse);
+    });
+
     test('maps MacDive entryType "Boat" to EntryMethod.boat.name', () async {
       const xml = '''<?xml version="1.0"?>
 <dives><units>Metric</units><schema>2.2.0</schema>

--- a/test/features/universal_import/data/parsers/macdive_xml_real_sample_test.dart
+++ b/test/features/universal_import/data/parsers/macdive_xml_real_sample_test.dart
@@ -91,6 +91,37 @@ void main() {
       },
     );
 
+    // #1606: surface interval is minutes in MacDive's XML, and was being
+    // read as seconds. Rather than pin a personal logbook's exact values,
+    // this asserts the scale: 271 of these 540 dives carry a surface
+    // interval whose median raw value is 128. Read as minutes that is 2h08m;
+    // read as seconds it collapses to 2m08s, so a 30-minute median is a wide
+    // margin either side of the regression.
+    test('surface intervals are minute-scale, and no dive gets 0m', () async {
+      if (skipIfNoFixture()) return;
+      final payload = await const MacDiveXmlParser().parse(bytes);
+      final intervals = payload
+          .entitiesOf(ImportEntityType.dives)
+          .map((d) => d['surfaceInterval'])
+          .whereType<Duration>()
+          .toList(growable: false);
+
+      expect(intervals, isNotEmpty);
+      expect(
+        intervals.any((i) => i == Duration.zero),
+        isFalse,
+        reason: 'MacDive stores 0 for "no prior dive", not a 0m interval',
+      );
+
+      final sorted = [...intervals]..sort();
+      final median = sorted[sorted.length ~/ 2];
+      expect(
+        median,
+        greaterThan(const Duration(minutes: 30)),
+        reason: 'a seconds misread drops the median by a factor of 60',
+      );
+    });
+
     test('every dive has a sourceUuid from <identifier>', () async {
       if (skipIfNoFixture()) return;
       final payload = await const MacDiveXmlParser().parse(bytes);

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -709,6 +709,17 @@ void main() {
         final dive = payload.entitiesOf(ImportEntityType.dives).single;
         expect(dive.containsKey('surfaceInterval'), isFalse);
       });
+
+      test('a fraction of a minute rounds away rather than to 0m', () async {
+        // The column is a float. Guarding on the raw value before rounding
+        // let anything under half a minute through as Duration.zero, which
+        // is the 0m interval this field is meant to never produce.
+        final payload = await MacDiveDiveMapper.toPayload(
+          _surfaceIntervalLogbook(0.4),
+        );
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        expect(dive.containsKey('surfaceInterval'), isFalse);
+      });
     });
 
     group('ZSAMPLES', () {

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -688,6 +688,29 @@ void main() {
       );
     });
 
+    // #1606: `ZSURFACEINTERVAL` holds minutes. Confirmed by joining a real
+    // MacDive.sqlite against the XML export of the same logbook: the column
+    // and `<surfaceInterval>` carry the identical number for all 381
+    // dives present in both, and MacDive's UDDF export of that number is
+    // `value * 60` seconds.
+    group('ZSURFACEINTERVAL', () {
+      test('maps to minutes, not seconds', () async {
+        final payload = await MacDiveDiveMapper.toPayload(
+          _surfaceIntervalLogbook(138),
+        );
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        expect(dive['surfaceInterval'], const Duration(minutes: 138));
+      });
+
+      test('zero is omitted (MacDive uses it for no prior dive)', () async {
+        final payload = await MacDiveDiveMapper.toPayload(
+          _surfaceIntervalLogbook(0),
+        );
+        final dive = payload.entitiesOf(ImportEntityType.dives).single;
+        expect(dive.containsKey('surfaceInterval'), isFalse);
+      });
+    });
+
     group('ZSAMPLES', () {
       test('a dive with only ZSAMPLES gets its profile from them', () async {
         // The 83 "(no computer)" dives of the reference library, and every
@@ -1475,5 +1498,30 @@ pigeon.ParsedDive _parsedDive({required List<pigeon.ProfileSample> samples}) {
     tanks: [],
     gasMixes: [],
     events: [],
+  );
+}
+
+/// One dive whose only interesting column is `ZSURFACEINTERVAL`.
+MacDiveRawLogbook _surfaceIntervalLogbook(double surfaceInterval) {
+  return MacDiveRawLogbook(
+    dives: [
+      MacDiveRawDive(pk: 1, uuid: 'dive-1', surfaceInterval: surfaceInterval),
+    ],
+    sitesByPk: const {},
+    buddiesByPk: const {},
+    tagsByPk: const {},
+    gearByPk: const {},
+    tanksByPk: const {},
+    gasesByPk: const {},
+    tankAndGases: const [],
+    crittersByPk: const {},
+    certifications: const [],
+    serviceRecords: const [],
+    events: const [],
+    diveToBuddyPks: const {},
+    diveToTagPks: const {},
+    diveToGearPks: const {},
+    diveToCritterPks: const {},
+    unitsPreference: 'Metric',
   );
 }

--- a/test/features/universal_import/data/services/macdive_xml_reader_test.dart
+++ b/test/features/universal_import/data/services/macdive_xml_reader_test.dart
@@ -227,6 +227,52 @@ void main() {
     });
   });
 
+  // #1606: MacDive's XML is mixed-unit. `duration` and `sampleInterval` are
+  // seconds, but `surfaceInterval` is MINUTES. Verified two ways against a
+  // real 540-dive export: MacDive's own UDDF exporter writes
+  // `passedtime = surfaceInterval * 60` for all 256 comparable dives, and the
+  // Core Data column `ZSURFACEINTERVAL` holds the identical raw number.
+  // Reading it as seconds showed a 2h18m interval as 2m.
+  group('MacDiveXmlReader surfaceInterval', () {
+    String xmlWithSurfaceInterval(String value) =>
+        '''<?xml version="1.0"?>
+<dives>
+  <units>Metric</units>
+  <schema>2.2.0</schema>
+  <dive>
+    <date>2024-01-01 00:00:00</date>
+    <maxDepth>20</maxDepth>
+    <duration>1800</duration>
+    <surfaceInterval>$value</surfaceInterval>
+    <samples/>
+  </dive>
+</dives>''';
+
+    test('reads surfaceInterval as minutes, not seconds', () {
+      final dive = MacDiveXmlReader.parse(
+        xmlWithSurfaceInterval('138'),
+      ).dives.first;
+      expect(dive.surfaceInterval, const Duration(minutes: 138));
+    });
+
+    test('zero means no prior dive, not a zero-length interval', () {
+      // 110 of the 540 dives in the real export carry `0` here, which
+      // MacDive uses for "unknown / first dive of the series". Importing
+      // Duration.zero would stamp every one of them with a 0m interval.
+      final dive = MacDiveXmlReader.parse(
+        xmlWithSurfaceInterval('0'),
+      ).dives.first;
+      expect(dive.surfaceInterval, isNull);
+    });
+
+    test('empty surfaceInterval element produces null', () {
+      final dive = MacDiveXmlReader.parse(
+        xmlWithSurfaceInterval(''),
+      ).dives.first;
+      expect(dive.surfaceInterval, isNull);
+    });
+  });
+
   group('MacDiveXmlReader (imperial fixture)', () {
     late String content;
 


### PR DESCRIPTION
## Summary

Fixes #1606. MacDive's native XML is mixed-unit: `duration` and `sampleInterval` are seconds, but `surfaceInterval` is minutes. The importer read it as seconds, so the reporter's `<surfaceInterval>138</surfaceInterval>` (an actual 2h18m interval) landed in the log as 2m.

The unit was confirmed against a real 540-dive logbook two independent ways, not inferred:

| Check | Result |
| --- | --- |
| MacDive's own UDDF export of the same library | `passedtime = surfaceInterval * 60` for all 256 comparable dives, no exceptions. UDDF defines `passedtime` as seconds, so MacDive itself treats the stored number as minutes. |
| Core Data `ZSURFACEINTERVAL` vs XML `<surfaceInterval>` | Identical raw number on all 381 dives present in both, so the `.sqlite` import path carried the same factor-of-60 error. |
| Value vs the real gap between adjacent same-day dives | Minutes fits 147 dives, seconds fits 11 (a 2018 block whose values are bad in MacDive's own data; MacDive still exports those as minutes). |

The original design spec had this right (`final int? surfaceInterval; // minutes (per schema)`); the implementation deviated, and the code comment justifying it cited a value that actually argues the other way: 142 seconds between two liveaboard dives is impossible, 142 minutes is typical.

A second defect fell out of the same read. MacDive stores `0` for "no prior dive", which is 110 of those 540 dives, and the XML path was importing `Duration.zero` and stamping each of them with a literal 0m interval. The SQLite path already guarded against this.

## Changes

- `macdive_xml_reader.dart`: read `<surfaceInterval>` through a new `_durationMinutes` helper, which also returns null for non-positive values so `0` means "no prior dive", matching the SQLite path and UDDF's `<infinity/>` handling.
- `macdive_dive_mapper.dart`: map `ZSURFACEINTERVAL` to `Duration(minutes:)`.
- Tests, written before the fix and confirmed red for the right reasons: reader unit tests, parser payload tests, and SQLite mapper tests for both the minutes reading and the zero case.
- Real-sample suite: a guard asserting surface intervals are minute-scale (median above 30 minutes; a seconds misread drops the median by 60x) and that no dive receives 0m. Verified it genuinely catches the regression by temporarily reverting the reader, which fails the guard, then restoring it.

## Known limitation

Dives already imported from MacDive keep their 60x-too-small stored interval; this changes future imports only. No repair migration is included: nothing in the `dives` table distinguishes a MacDive-sourced interval from a correct one written by another importer, so a blanket correction would corrupt other rows and double-correct anything re-imported after this lands. A targeted repair keyed on import provenance can follow separately if wanted.

## Test Plan

- [x] `flutter test` passes (2320 tests across `universal_import`, `dive_import`, and the UDDF suites)
- [x] `flutter analyze` passes, `dart format` clean
- [x] Real-sample suite run against a 540-dive MacDive XML export: 11/11 pass
- [ ] Manual testing on: not required, parser-level change covered by the real-sample export
