### PR TITLE
suunto cloud: import the full dive-event set, not just three types

### DIFF
--- a/lib/core/services/suunto_cloud/suunto_cloud_event_map.dart
+++ b/lib/core/services/suunto_cloud/suunto_cloud_event_map.dart
@@ -1,0 +1,87 @@
+/// Maps a Suunto cloud/app `sml` dive-event -- `DiveEvents.<Subgroup>.Type` as
+/// a descriptor string -- to a libdivecomputer-style event-type string
+/// (consumed by the dive-computer repository's `_mapEventTypeString`) plus the
+/// watch's native `(sub-group << 8) | type` code.
+///
+/// The string ⇄ code correspondence is Suunto's own descriptor library, as
+/// decoded from a Nautic's `/Logbook/byId/<id>/Descriptors` (5 enums under
+/// `com.stt.android.domain.sml`: `AlarmMarkType`, `WarningMarkType`,
+/// `NotifyMarkType`, `StateMarkType`, `OoamMarkType`).
+///
+/// A cloud dive-event carries `Active: true` on its begin edge and, on some
+/// generations, `Active: false` on the end edge; only the begin edge is a
+/// marker. The older `DiveEvents` *object* shape has no `Active` field -- treat
+/// it as a begin.
+///
+/// The native code is stored on `DownloadedEvent.value` and is inert today; a
+/// consumer that decodes it (`suuntoNauticEventLabel`, currently on the
+/// Suunto Nautic fork) can render the exact Suunto wording.
+library;
+
+/// The libdivecomputer event-type string and native code for one cloud event.
+class SuuntoCloudEvent {
+  const SuuntoCloudEvent(this.downloadedType, this.nativeCode);
+
+  /// A value `_mapEventTypeString` understands.
+  final String downloadedType;
+
+  /// `(sub-group << 8) | type`.
+  final int nativeCode;
+}
+
+const int _alarm = 0x18;
+const int _warning = 0x19;
+const int _notify = 0x1A;
+const int _state = 0x1B;
+const int _ooam = 0x1D;
+
+/// `subgroup key` → (`Type` string → mapping). Types deliberately left out
+/// (Battery, Sidemount, "... Ahead" predictive states, Recovery time, Setpoint
+/// on an OC watch, bearings/stopwatch) resolve to `null` and are not imported.
+///
+/// `Warning "NoDecoTime"` and `State "Ndl exceeded"` are also left out for now:
+/// they map to informational states (low no-deco time / became a deco dive)
+/// with no libdivecomputer event type yet.
+const Map<String, Map<String, SuuntoCloudEvent>> _table = {
+  'Alarm': {
+    'PO2 Low': SuuntoCloudEvent('PO2', (_alarm << 8) | 1),
+    'PO2 High': SuuntoCloudEvent('PO2', (_alarm << 8) | 2),
+    'Tank Pressure': SuuntoCloudEvent('airtime', (_alarm << 8) | 3),
+    'Gas Time': SuuntoCloudEvent('airtime', (_alarm << 8) | 4),
+    'Ascent Speed': SuuntoCloudEvent('ascent', (_alarm << 8) | 5),
+    'Ascent too fast': SuuntoCloudEvent('ascent', (_alarm << 8) | 5),
+    'CNS100%': SuuntoCloudEvent('cnsCritical', (_alarm << 8) | 7),
+    'OTU300': SuuntoCloudEvent('cnsCritical', (_alarm << 8) | 8),
+    'Deco Stop Broken': SuuntoCloudEvent('ceiling', (_alarm << 8) | 10),
+    'Deep Stop Broken': SuuntoCloudEvent('deepstop', (_alarm << 8) | 12),
+    'Safety Stop Broken': SuuntoCloudEvent('missedStop', (_alarm << 8) | 13),
+  },
+  'Warning': {
+    'User PO2 High': SuuntoCloudEvent('PO2', (_warning << 8) | 6),
+    'CNS80%': SuuntoCloudEvent('cnsWarning', (_warning << 8) | 14),
+    'OTU250': SuuntoCloudEvent('cnsWarning', (_warning << 8) | 15),
+    'User Tank Pressure': SuuntoCloudEvent('airtime', (_warning << 8) | 28),
+    'User Gas Time': SuuntoCloudEvent('airtime', (_warning << 8) | 29),
+  },
+  'State': {
+    'At Deco Stop': SuuntoCloudEvent('deco', (_state << 8) | 35),
+    'At Deep Stop': SuuntoCloudEvent('deepstop', (_state << 8) | 36),
+    'At Safety Stop': SuuntoCloudEvent('safetystop', (_state << 8) | 37),
+  },
+  'Notify': {
+    'Gas Switch': SuuntoCloudEvent('gaschange', (_notify << 8) | 11),
+    'User Tank Pressure': SuuntoCloudEvent('airtime', (_notify << 8) | 28),
+    'User Gas Time': SuuntoCloudEvent('airtime', (_notify << 8) | 29),
+    // Some generations announce a safety stop through Notify rather than State.
+    'Safety Stop': SuuntoCloudEvent('safetystop', (_state << 8) | 37),
+  },
+  'Ooam': {'Ceiling broken': SuuntoCloudEvent('ceiling', (_ooam << 8) | 2)},
+};
+
+/// Looks up a cloud dive-event. [subgroup] is the JSON key
+/// (`Alarm`/`Warning`/`Notify`/`State`/`Ooam`); [type] is its `Type` string.
+/// Returns `null` for an unknown or deliberately-unimported event.
+SuuntoCloudEvent? suuntoCloudEvent(String subgroup, String? type) {
+  if (type == null) return null;
+  return _table[subgroup]?[type];
+}

--- a/lib/core/services/suunto_cloud/suunto_cloud_event_map.dart
+++ b/lib/core/services/suunto_cloud/suunto_cloud_event_map.dart
@@ -20,13 +20,14 @@ library;
 
 /// The libdivecomputer event-type string and native code for one cloud event.
 class SuuntoCloudEvent {
-  const SuuntoCloudEvent(this.downloadedType, this.nativeCode);
+  const SuuntoCloudEvent(this.downloadedType, [this.nativeCode]);
 
   /// A value `_mapEventTypeString` understands.
   final String downloadedType;
 
-  /// `(sub-group << 8) | type`.
-  final int nativeCode;
+  /// `(sub-group << 8) | type` for the sub-group it was found under, or null
+  /// for a legacy string that has no place in the Nautic descriptor.
+  final int? nativeCode;
 }
 
 const int _alarm = 0x18;
@@ -72,8 +73,10 @@ const Map<String, Map<String, SuuntoCloudEvent>> _table = {
     'Gas Switch': SuuntoCloudEvent('gaschange', (_notify << 8) | 11),
     'User Tank Pressure': SuuntoCloudEvent('airtime', (_notify << 8) | 28),
     'User Gas Time': SuuntoCloudEvent('airtime', (_notify << 8) | 29),
-    // Some generations announce a safety stop through Notify rather than State.
-    'Safety Stop': SuuntoCloudEvent('safetystop', (_state << 8) | 37),
+    // An older, non-Nautic string (the Nautic descriptor announces the stop
+    // through State "At Safety Stop"); it has no Notify type number, so no
+    // native code.
+    'Safety Stop': SuuntoCloudEvent('safetystop'),
   },
   'Ooam': {'Ceiling broken': SuuntoCloudEvent('ceiling', (_ooam << 8) | 2)},
 };

--- a/lib/core/services/suunto_cloud/suunto_dive_parser.dart
+++ b/lib/core/services/suunto_cloud/suunto_dive_parser.dart
@@ -1,3 +1,4 @@
+import 'package:submersion/core/services/suunto_cloud/suunto_cloud_event_map.dart';
 import 'package:submersion/features/dive_computer/domain/entities/downloaded_dive.dart';
 
 /// A dive parsed from a Suunto export, plus the device identity fields
@@ -248,6 +249,9 @@ class SuuntoDiveParser {
 
     var lastElapsedSecs = -1;
     var lastDepth = 0.0;
+    // Keys of dive-events currently in their active window, so a begin edge
+    // that the watch holds across several samples is imported once.
+    final activeEventKeys = <String>{};
 
     for (final sample in samples) {
       final sampleMs = _parseTimestampMs(sample);
@@ -314,6 +318,7 @@ class SuuntoDiveParser {
         lastDepth,
         gasSwitches,
         events,
+        activeEventKeys,
       );
     }
 
@@ -353,6 +358,15 @@ class SuuntoDiveParser {
     }
   }
 
+  /// The sub-group keys that carry a dive-event.
+  static const List<String> _eventSubgroups = [
+    'Alarm',
+    'Warning',
+    'Notify',
+    'State',
+    'Ooam',
+  ];
+
   static void _collectEvents(
     Map<String, dynamic> sample,
     int gasOffset,
@@ -360,10 +374,24 @@ class SuuntoDiveParser {
     double currentDepth,
     List<GasSwitchEvent> gasSwitches,
     List<DownloadedEvent> events,
+    Set<String> activeEventKeys,
   ) {
-    final diveEvents = sample['DiveEvents'] as Map<String, dynamic>?;
-    if (diveEvents != null) {
-      final gasSwitch = diveEvents['GasSwitch'] as Map<String, dynamic>?;
+    // Two container shapes: older computers put one event under a `DiveEvents`
+    // object, the "Seal" generation an `Events[]` array of them.
+    final containers = <Map<String, dynamic>>[
+      if (sample['DiveEvents'] is Map)
+        sample['DiveEvents'] as Map<String, dynamic>,
+      for (final e in (sample['Events'] as List<dynamic>? ?? const []))
+        if (e is Map<String, dynamic>) e,
+    ];
+
+    // Which (subgroup, type) events are asserted on *this* sample.
+    final nowActive = <String>{};
+
+    for (final container in containers) {
+      // Gas switch: also drives tank assignment, so it keeps its own path.
+      // A switch is instantaneous -- emit it every time it appears.
+      final gasSwitch = container['GasSwitch'] as Map<String, dynamic>?;
       final gasNumber = (gasSwitch?['GasNumber'] as num?)?.toInt();
       if (gasNumber != null) {
         gasSwitches.add(
@@ -374,51 +402,46 @@ class SuuntoDiveParser {
           ),
         );
         events.add(
-          DownloadedEvent(timeSeconds: elapsedSecs, type: 'gaschange'),
+          DownloadedEvent(
+            timeSeconds: elapsedSecs,
+            type: 'gaschange',
+            value: (0x1A << 8) | 11,
+          ),
         );
       }
 
-      final state = diveEvents['State'] as Map<String, dynamic>?;
-      if (state?['Type'] == 'At Safety Stop') {
-        events.add(
-          DownloadedEvent(timeSeconds: elapsedSecs, type: 'safetystop'),
-        );
+      for (final subgroup in _eventSubgroups) {
+        final block = container[subgroup] as Map<String, dynamic>?;
+        if (block == null) continue;
+        // Begin edge only. `Active` is present on the array shape (true on
+        // begin, false on end); the object shape omits it (always a begin).
+        if (block['Active'] == false) continue;
+        nowActive.add('$subgroup/${block['Type']}');
       }
     }
 
-    final eventsArray = sample['Events'] as List<dynamic>?;
-    if (eventsArray != null) {
-      for (final entry in eventsArray) {
-        final eo = entry as Map<String, dynamic>;
-
-        final gasSwitch = eo['GasSwitch'] as Map<String, dynamic>?;
-        final gasNumber = (gasSwitch?['GasNumber'] as num?)?.toInt();
-        if (gasNumber != null) {
-          gasSwitches.add(
-            GasSwitchEvent(
-              timeSeconds: elapsedSecs,
-              depth: currentDepth,
-              toTankIndex: gasNumber - gasOffset,
-            ),
-          );
-          events.add(
-            DownloadedEvent(timeSeconds: elapsedSecs, type: 'gaschange'),
-          );
-        }
-
-        final notify = eo['Notify'] as Map<String, dynamic>?;
-        if (notify?['Active'] == true && notify?['Type'] == 'Safety Stop') {
-          events.add(
-            DownloadedEvent(timeSeconds: elapsedSecs, type: 'safetystop'),
-          );
-        }
-
-        final alarm = eo['Alarm'] as Map<String, dynamic>?;
-        if (alarm?['Active'] == true && alarm?['Type'] == 'Ascent Speed') {
-          events.add(DownloadedEvent(timeSeconds: elapsedSecs, type: 'ascent'));
-        }
-      }
+    // Rising edge = active now, wasn't on the previous sample. A begin the
+    // watch holds across several samples is imported once; a condition that
+    // clears and re-triggers later is imported again.
+    for (final key in nowActive.difference(activeEventKeys)) {
+      final slash = key.indexOf('/');
+      final mapped = suuntoCloudEvent(
+        key.substring(0, slash),
+        key.substring(slash + 1),
+      );
+      if (mapped == null) continue;
+      events.add(
+        DownloadedEvent(
+          timeSeconds: elapsedSecs,
+          type: mapped.downloadedType,
+          value: mapped.nativeCode,
+        ),
+      );
     }
+
+    activeEventKeys
+      ..clear()
+      ..addAll(nowActive);
   }
 
   /// Reads every "Pressure"/"Pressure2"/"Pressure3"... transmitter reading

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -2087,6 +2087,12 @@ class DiveComputerRepository {
         // Remaining bottom time (Uwatec) and air time (Suunto) alarms both
         // mean the gas supply is running short at the current rate.
         return 'lowGas';
+      // The Suunto Cloud parser (suunto_cloud_event_map) names these
+      // ProfileEventType values directly -- no libdivecomputer equivalent.
+      case 'cnsWarning':
+      case 'cnsCritical':
+      case 'missedStop':
+        return type;
       default:
         return null;
     }
@@ -2099,9 +2105,12 @@ class DiveComputerRepository {
     switch (eventType) {
       case 'decoViolation':
       case 'ppO2High':
+      case 'cnsCritical':
+      case 'missedStop':
         return 'alert';
       case 'ascentRateWarning':
       case 'lowGas':
+      case 'cnsWarning':
         return 'warning';
       case 'safetyStopStart':
       case 'decoStopStart':

--- a/test/core/services/suunto_cloud/suunto_cloud_event_map_test.dart
+++ b/test/core/services/suunto_cloud/suunto_cloud_event_map_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/suunto_cloud/suunto_cloud_event_map.dart';
+
+void main() {
+  group('suuntoCloudEvent', () {
+    test('maps a known event to a libdc type + native code', () {
+      final e = suuntoCloudEvent('Alarm', 'Ascent Speed')!;
+      expect(e.downloadedType, 'ascent');
+      expect(e.nativeCode, (0x18 << 8) | 5);
+    });
+
+    test('covers every sub-group', () {
+      expect(
+        suuntoCloudEvent('Alarm', 'Tank Pressure')?.downloadedType,
+        'airtime',
+      );
+      expect(
+        suuntoCloudEvent('Warning', 'CNS80%')?.downloadedType,
+        'cnsWarning',
+      );
+      expect(
+        suuntoCloudEvent('Notify', 'Gas Switch')?.downloadedType,
+        'gaschange',
+      );
+      expect(suuntoCloudEvent('State', 'At Deco Stop')?.downloadedType, 'deco');
+      expect(
+        suuntoCloudEvent('State', 'At Safety Stop')?.downloadedType,
+        'safetystop',
+      );
+      expect(
+        suuntoCloudEvent('Ooam', 'Ceiling broken')?.downloadedType,
+        'ceiling',
+      );
+    });
+
+    test('the native code is (sub-group << 8) | type', () {
+      expect(
+        suuntoCloudEvent('State', 'At Deco Stop')!.nativeCode,
+        (0x1B << 8) | 35,
+      );
+      expect(
+        suuntoCloudEvent('Ooam', 'Ceiling broken')!.nativeCode,
+        (0x1D << 8) | 2,
+      );
+    });
+
+    test('returns null for an unknown or deliberately-dropped event', () {
+      expect(suuntoCloudEvent('Alarm', 'Battery'), isNull);
+      expect(suuntoCloudEvent('State', 'Deco Stop Ahead'), isNull);
+      expect(suuntoCloudEvent('Notify', 'Bearing set'), isNull);
+      expect(suuntoCloudEvent('Nope', 'Ascent Speed'), isNull);
+      expect(suuntoCloudEvent('Alarm', null), isNull);
+    });
+  });
+}

--- a/test/core/services/suunto_cloud/suunto_cloud_event_map_test.dart
+++ b/test/core/services/suunto_cloud/suunto_cloud_event_map_test.dart
@@ -33,16 +33,32 @@ void main() {
       );
     });
 
-    test('the native code is (sub-group << 8) | type', () {
-      expect(
-        suuntoCloudEvent('State', 'At Deco Stop')!.nativeCode,
-        (0x1B << 8) | 35,
-      );
-      expect(
-        suuntoCloudEvent('Ooam', 'Ceiling broken')!.nativeCode,
-        (0x1D << 8) | 2,
-      );
-    });
+    test(
+      'the native code is (sub-group << 8) | type, keyed to its sub-group',
+      () {
+        for (final entry in const [
+          ('Alarm', 'Ascent Speed', 0x18),
+          ('Warning', 'CNS80%', 0x19),
+          ('Notify', 'Gas Switch', 0x1A),
+          ('State', 'At Deco Stop', 0x1B),
+          ('Ooam', 'Ceiling broken', 0x1D),
+        ]) {
+          final code = suuntoCloudEvent(entry.$1, entry.$2)!.nativeCode!;
+          expect(code >> 8, entry.$3, reason: '${entry.$1}/${entry.$2}');
+        }
+      },
+    );
+
+    test(
+      'a legacy string with no Nautic type number carries no native code',
+      () {
+        // "Safety Stop" via Notify is a pre-Nautic string; the Nautic descriptor
+        // announces the stop through State "At Safety Stop".
+        final e = suuntoCloudEvent('Notify', 'Safety Stop')!;
+        expect(e.downloadedType, 'safetystop');
+        expect(e.nativeCode, isNull);
+      },
+    );
 
     test('returns null for an unknown or deliberately-dropped event', () {
       expect(suuntoCloudEvent('Alarm', 'Battery'), isNull);

--- a/test/core/services/suunto_cloud/suunto_dive_parser_test.dart
+++ b/test/core/services/suunto_cloud/suunto_dive_parser_test.dart
@@ -651,4 +651,111 @@ void main() {
       expect(byIndex[1]!.o2Percent, closeTo(50.0, 1e-9));
     });
   });
+
+  group('full dive-event extraction', () {
+    Map<String, dynamic> header() => {
+      'DateTime': '2026-08-26T13:48:11Z',
+      'ActivityType': 51,
+      'Device': {'Name': 'Porvoo'},
+      'DiveTime': 2255,
+    };
+
+    Map<String, dynamic> eventSample(String iso, Map<String, dynamic> event) =>
+        {
+          'TimeISO8601': iso,
+          'Depth': 12.0,
+          'Events': [
+            {
+              'State': {'Active': true, 'Type': 'Dive Active'},
+            },
+            event,
+          ],
+        };
+
+    test(
+      'emits the Alarm / Notify / State events the old importer dropped',
+      () {
+        final result = SuuntoDiveParser.parse(
+          header: header(),
+          samples: [
+            eventSample('2026-08-26T13:48:11Z', const {
+              'State': {'Active': true, 'Type': 'Dive Active'},
+            }),
+            eventSample('2026-08-26T14:06:01Z', const {
+              'Alarm': {'Active': true, 'Type': 'Ascent Speed'},
+            }),
+            eventSample('2026-08-26T14:09:40Z', const {
+              'Notify': {'Active': true, 'Type': 'User Tank Pressure'},
+            }),
+            eventSample('2026-08-26T14:12:53Z', const {
+              'State': {'Active': true, 'Type': 'At Deco Stop'},
+            }),
+            eventSample('2026-08-26T14:16:28Z', const {
+              'State': {'Active': true, 'Type': 'At Safety Stop'},
+            }),
+            eventSample('2026-08-26T14:18:00Z', const {
+              'Warning': {'Active': true, 'Type': 'CNS80%'},
+            }),
+          ],
+        );
+
+        final types = result.dive.events.map((e) => e.type).toList();
+        expect(types, containsAll(['ascent', 'airtime', 'deco', 'safetystop']));
+        expect(types, contains('cnsWarning'));
+      },
+    );
+
+    test('stamps DownloadedEvent.value with the native (subgroup<<8|type)', () {
+      final result = SuuntoDiveParser.parse(
+        header: header(),
+        samples: [
+          eventSample('2026-08-26T14:06:01Z', const {
+            'Alarm': {'Active': true, 'Type': 'Ascent Speed'},
+          }),
+        ],
+      );
+      final ascent = result.dive.events.singleWhere((e) => e.type == 'ascent');
+      expect(ascent.value, (0x18 << 8) | 5);
+    });
+
+    test(
+      'a begin held across samples is imported once; a re-trigger again',
+      () {
+        final held = SuuntoDiveParser.parse(
+          header: header(),
+          samples: [
+            eventSample('2026-08-26T14:06:01Z', const {
+              'Alarm': {'Active': true, 'Type': 'Ascent Speed'},
+            }),
+            eventSample('2026-08-26T14:06:11Z', const {
+              'Alarm': {'Active': true, 'Type': 'Ascent Speed'},
+            }),
+            eventSample('2026-08-26T14:06:21Z', const {
+              'Alarm': {'Active': false, 'Type': 'Ascent Speed'},
+            }),
+          ],
+        );
+        expect(held.dive.events.where((e) => e.type == 'ascent'), hasLength(1));
+
+        final retrigger = SuuntoDiveParser.parse(
+          header: header(),
+          samples: [
+            eventSample('2026-08-26T14:06:01Z', const {
+              'Alarm': {'Active': true, 'Type': 'Ascent Speed'},
+            }),
+            eventSample('2026-08-26T14:06:11Z', const {
+              'Alarm': {'Active': false, 'Type': 'Ascent Speed'},
+            }),
+            eventSample('2026-08-26T14:07:41Z', const {
+              'Alarm': {'Active': true, 'Type': 'Ascent Speed'},
+            }),
+          ],
+        );
+        expect(
+          retrigger.dive.events.where((e) => e.type == 'ascent'),
+          hasLength(2),
+        );
+      },
+    );
+  });
 }

--- a/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
@@ -940,6 +940,44 @@ void main() {
       expect(dive.diveType, 'recreational');
     });
 
+    test('the Suunto-cloud-only event strings pass through with their own '
+        'severity', () async {
+      // suunto_cloud_event_map names these ProfileEventType values directly;
+      // _mapEventTypeString returns them unchanged and _eventSeverity assigns
+      // the right band (no libdivecomputer download ever emits these strings).
+      final computerId = await insertComputer();
+      final entryTime = DateTime(2026, 4, 1, 12, 5);
+
+      final diveId = await repository.importProfile(
+        computerId: computerId,
+        profileStartTime: entryTime,
+        points: const [
+          ProfilePointData(timestamp: 0, depth: 1.0, ndl: 3600),
+          ProfilePointData(timestamp: 600, depth: 18.0, ndl: 1200),
+        ],
+        durationSeconds: 1800,
+        maxDepth: 18.0,
+        events: const [
+          EventData(timestamp: 300, type: 'cnsWarning'),
+          EventData(timestamp: 600, type: 'cnsCritical'),
+          EventData(timestamp: 900, type: 'missedStop'),
+        ],
+        forceNew: true,
+      );
+
+      final events =
+          await (db.select(db.diveProfileEvents)
+                ..where((t) => t.diveId.equals(diveId))
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+      expect(events.map((e) => e.eventType), [
+        'cnsWarning',
+        'cnsCritical',
+        'missedStop',
+      ]);
+      expect(events.map((e) => e.severity), ['warning', 'alert', 'alert']);
+    });
+
     test('a no-deco profile defaults the dive type to recreational', () async {
       final computerId = await insertComputer();
       final entryTime = DateTime(2026, 4, 1, 12, 0);


### PR DESCRIPTION
## What

The Suunto Cloud import (`suunto_cloud/`, a Dart port of Subsurface's `import-suunto-json.cpp`) only recognised three events: gas switches, "At Safety Stop", and the ascent-speed alarm. A real dive's Suunto app view shows a dozen; the rest were silently dropped by `_collectEvents`.

## Change

The `sml` JSON carries every event per sample under `DiveEvents.<Alarm|Warning|Notify|State|Ooam>.Type` as a descriptor string. New `suunto_cloud_event_map.dart` maps `(subgroup, Type)` -> a libdivecomputer-style event type string (built from Suunto's own descriptor enums, `com.stt.android.domain.sml`), so the existing shared `_mapEventTypeString` pipeline turns them into `ProfileEventType` markers:

| Suunto event | ProfileEventType |
|---|---|
| Alarm/Warning/Notify tank-pressure + gas-time | `lowGas` |
| Alarm ascent-speed | `ascentRateWarning` |
| Alarm/Warning CNS% / OTU | `cnsWarning` / `cnsCritical` |
| Alarm/Ooam deco-ceiling / deep-stop broken | `decoViolation` |
| State "At Deco/Deep/Safety Stop" | `decoStopStart` / `safetyStopStart` |
| Alarm "Safety Stop Broken" | `missedStop` |

- `_collectEvents` now walks every sub-group on **both** container shapes (the `DiveEvents` object and the `Events[]` array), rising-edge only -- a begin the watch holds across several samples imports once, a re-trigger imports again.
- It also stamps `DownloadedEvent.value` with the watch's native `(subgroup << 8 | type)` code. Inert today; ready for a consumer that renders the exact Suunto wording.
- `_mapEventTypeString` / `_eventSeverity` gain `cnsWarning` / `cnsCritical` / `missedStop` passthrough (Suunto-cloud-only strings; no effect on any dive-computer download path).

**Deliberately not imported** (unchanged): battery, sidemount, recovery-time, bearings/stopwatch, and the predictive "... Ahead" states. Two informational states ("low no-deco time", "became a deco dive") are noted as a follow-up -- they have no `ProfileEventType` yet.

## Testing

`flutter analyze` clean. New `suunto_cloud_event_map_test.dart`; `suunto_dive_parser_test.dart` gains a "full dive-event extraction" group (the newly-imported events, the native-code stamp, the held-begin / re-trigger edge behaviour). `test/core/services/suunto_cloud`, `test/features/dive_log/data` and the import-wizard suites are green.