### PR TITLE
fix(dive-list): keep the loaded pages when a dive is saved (#1610)

### DIFF
--- a/lib/features/dive_log/domain/entities/dive_summary.dart
+++ b/lib/features/dive_log/domain/entities/dive_summary.dart
@@ -240,12 +240,19 @@ class PaginatedDiveListState extends Equatable {
   final DiveSummaryCursor? nextCursor;
   final int totalCount;
 
+  /// The last attempt to load another page failed.
+  ///
+  /// Distinguishes "still fetching" from "gave up", so the list can offer a
+  /// retry instead of a spinner that will never resolve on its own (#1610).
+  final bool loadMoreFailed;
+
   const PaginatedDiveListState({
     this.dives = const [],
     this.isLoadingMore = false,
     this.hasMore = true,
     this.nextCursor,
     this.totalCount = 0,
+    this.loadMoreFailed = false,
   });
 
   PaginatedDiveListState copyWith({
@@ -255,6 +262,7 @@ class PaginatedDiveListState extends Equatable {
     DiveSummaryCursor? nextCursor,
     int? totalCount,
     bool clearNextCursor = false,
+    bool? loadMoreFailed,
   }) {
     return PaginatedDiveListState(
       dives: dives ?? this.dives,
@@ -262,6 +270,7 @@ class PaginatedDiveListState extends Equatable {
       hasMore: hasMore ?? this.hasMore,
       nextCursor: clearNextCursor ? null : (nextCursor ?? this.nextCursor),
       totalCount: totalCount ?? this.totalCount,
+      loadMoreFailed: loadMoreFailed ?? this.loadMoreFailed,
     );
   }
 
@@ -272,5 +281,6 @@ class PaginatedDiveListState extends Equatable {
     hasMore,
     nextCursor,
     totalCount,
+    loadMoreFailed,
   ];
 }

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -708,7 +708,9 @@ class PaginatedDiveListNotifier
     final current = state.valueOrNull;
     if (current == null || current.isLoadingMore || !current.hasMore) return;
 
-    state = AsyncValue.data(current.copyWith(isLoadingMore: true));
+    state = AsyncValue.data(
+      current.copyWith(isLoadingMore: true, loadMoreFailed: false),
+    );
     try {
       final filter = _ref.read(diveFilterProvider);
       final sort = _ref.read(diveSortProvider);
@@ -729,12 +731,17 @@ class PaginatedDiveListNotifier
           isLoadingMore: false,
           hasMore: newDives.length >= _pageSize,
           nextCursor: _isDateSort ? _cursorFromLastDive(newDives) : null,
+          loadMoreFailed: false,
         ),
       );
       // Pre-load downsampled profiles for the new page
       _loadBatchProfiles(newDives.map((d) => d.id).toList());
     } catch (_) {
-      state = AsyncValue.data(current.copyWith(isLoadingMore: false));
+      // Record the failure rather than silently going idle: the trailing row
+      // must be able to offer a retry instead of spinning on nothing (#1610).
+      state = AsyncValue.data(
+        current.copyWith(isLoadingMore: false, loadMoreFailed: true),
+      );
     }
   }
 

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -802,14 +802,26 @@ class PaginatedDiveListNotifier
   }
 
   /// Load downsampled profiles for a batch of dive IDs and merge into cache.
+  ///
+  /// Every caller starts this and walks away, so a throw here lands in the
+  /// zone with nobody to catch it. It holds its own [mounted] checks rather
+  /// than trusting the caller's, because the await is inside this method: the
+  /// notifier can go away after a caller has already checked.
+  ///
+  /// Measured, rather than assumed: what throws is the container going away
+  /// ("Cannot use the Ref of StateNotifierProvider<PaginatedDiveListNotifier,
+  /// ...> after it has been disposed"), which is app teardown. Invalidating
+  /// this provider on its own unmounts the notifier but leaves its Ref usable,
+  /// so that case is only wasted work. [mounted] is false in both.
   Future<void> _loadBatchProfiles(List<String> diveIds) async {
-    if (diveIds.isEmpty) return;
+    if (diveIds.isEmpty || !mounted) return;
     // Skip IDs already in cache
     final cache = _ref.read(batchProfileCacheProvider);
     final uncached = diveIds.where((id) => !cache.containsKey(id)).toList();
     if (uncached.isEmpty) return;
 
     final profiles = await _repository.getBatchProfileSummaries(uncached);
+    if (!mounted) return;
     // Merge into cache (immutable update)
     _ref.read(batchProfileCacheProvider.notifier).state = {
       ...cache,
@@ -867,31 +879,30 @@ class PaginatedDiveListNotifier
       final dives = hasMore ? fetched.sublist(0, limit) : fetched;
       _currentOffset = dives.length;
 
-      if (mounted) {
-        // Read at apply time, not before the await: loadNextPage flips
-        // isLoadingMore synchronously and queues its body behind this reload,
-        // so the flags can change while this query is running.
-        //
-        // Both are carried over rather than reset. isLoadingMore still marks a
-        // page load queued behind this one -- dropping it blinks the spinner
-        // off and lets the stranded-loader kick queue a second load for a page
-        // already coming. loadMoreFailed still marks a next page that could not
-        // be fetched, which refreshing the rows already loaded says nothing
-        // about -- dropping it swaps the retry row back for a spinner the kick
-        // then declines to touch, which is the dead end this all started from
-        // (#1610).
-        final flags = state.valueOrNull;
-        state = AsyncValue.data(
-          PaginatedDiveListState(
-            dives: dives,
-            hasMore: hasMore,
-            nextCursor: _isDateSort ? _cursorFromLastDive(dives) : null,
-            totalCount: totalCount,
-            isLoadingMore: flags?.isLoadingMore ?? false,
-            loadMoreFailed: flags?.loadMoreFailed ?? false,
-          ),
-        );
-      }
+      if (!mounted) return;
+      // Read at apply time, not before the await: loadNextPage flips
+      // isLoadingMore synchronously and queues its body behind this reload,
+      // so the flags can change while this query is running.
+      //
+      // Both are carried over rather than reset. isLoadingMore still marks a
+      // page load queued behind this one -- dropping it blinks the spinner
+      // off and lets the stranded-loader kick queue a second load for a page
+      // already coming. loadMoreFailed still marks a next page that could not
+      // be fetched, which refreshing the rows already loaded says nothing
+      // about -- dropping it swaps the retry row back for a spinner the kick
+      // then declines to touch, which is the dead end this all started from
+      // (#1610).
+      final flags = state.valueOrNull;
+      state = AsyncValue.data(
+        PaginatedDiveListState(
+          dives: dives,
+          hasMore: hasMore,
+          nextCursor: _isDateSort ? _cursorFromLastDive(dives) : null,
+          totalCount: totalCount,
+          isLoadingMore: flags?.isLoadingMore ?? false,
+          loadMoreFailed: flags?.loadMoreFailed ?? false,
+        ),
+      );
       // Pre-load downsampled profiles for mini charts (fire and forget)
       _loadBatchProfiles(dives.map((d) => d.id).toList());
     } catch (e, st) {

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -691,6 +691,10 @@ class PaginatedDiveListNotifier
   Future<void> loadFirstPage() => _enqueuePaging(_loadFirstPage);
 
   Future<void> _loadFirstPage() async {
+    // Queued work can reach its turn after the notifier is gone: this provider
+    // is invalidated from half a dozen places (imports, merges, renumbering),
+    // and writing state on a disposed StateNotifier throws.
+    if (!mounted) return;
     state = const AsyncValue.loading();
     _currentOffset = 0;
     try {
@@ -710,6 +714,7 @@ class PaginatedDiveListNotifier
       final totalCount = results[1] as int;
       _currentOffset = dives.length;
 
+      if (!mounted) return;
       state = AsyncValue.data(
         PaginatedDiveListState(
           dives: dives,
@@ -721,7 +726,7 @@ class PaginatedDiveListNotifier
       // Pre-load downsampled profiles for mini charts (fire and forget)
       _loadBatchProfiles(dives.map((d) => d.id).toList());
     } catch (e, st) {
-      state = AsyncValue.error(e, st);
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 
@@ -742,6 +747,7 @@ class PaginatedDiveListNotifier
   }
 
   Future<void> _loadNextPage() async {
+    if (!mounted) return;
     final current = state.valueOrNull;
     if (current == null) return;
     if (!current.hasMore) {
@@ -772,6 +778,7 @@ class PaginatedDiveListNotifier
           .where((d) => !loadedIds.contains(d.id))
           .toList(growable: false);
 
+      if (!mounted) return;
       state = AsyncValue.data(
         current.copyWith(
           dives: [...current.dives, ...added],
@@ -786,9 +793,11 @@ class PaginatedDiveListNotifier
     } catch (_) {
       // Record the failure rather than silently going idle: the trailing row
       // must be able to offer a retry instead of spinning on nothing (#1610).
-      state = AsyncValue.data(
-        current.copyWith(isLoadingMore: false, loadMoreFailed: true),
-      );
+      if (mounted) {
+        state = AsyncValue.data(
+          current.copyWith(isLoadingMore: false, loadMoreFailed: true),
+        );
+      }
     }
   }
 
@@ -835,6 +844,7 @@ class PaginatedDiveListNotifier
       _enqueuePaging(_silentReloadLoadedPagesNow);
 
   Future<void> _silentReloadLoadedPagesNow() async {
+    if (!mounted) return;
     final loadedCount = state.valueOrNull?.dives.length ?? 0;
     final limit = loadedCount > _pageSize ? loadedCount : _pageSize;
     _currentOffset = 0;

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -408,7 +408,9 @@ class DiveListNotifier extends StateNotifier<AsyncValue<List<domain.Dive>>> {
 
     // Reload silently when the `dives` table is written directly (e.g. a sync
     // applies remote changes) without going through this notifier's mutation
-    // methods. Silent so a multi-write sync doesn't flash a loading spinner.
+    // methods. Silent so a multi-write sync doesn't flash a loading spinner,
+    // and page-preserving so a local edit-save doesn't shrink the list out
+    // from under the diver (#1610).
     final divesChangeSub = _repository.watchDivesChanges().listen(
       (_) => _silentReload(),
     );
@@ -648,7 +650,7 @@ class PaginatedDiveListNotifier
       next,
     ) {
       if (previous != next) {
-        _silentReloadFirstPage();
+        _silentReloadLoadedPages();
       }
     });
     loadFirstPage();
@@ -657,7 +659,7 @@ class PaginatedDiveListNotifier
     // applies remote changes) without going through this notifier's mutation
     // methods. Silent so a multi-write sync doesn't flash a loading spinner.
     final divesChangeSub = _repository.watchDivesChanges().listen(
-      (_) => _silentReloadFirstPage(),
+      (_) => _silentReloadLoadedPages(),
     );
     _ref.onDispose(divesChangeSub.cancel);
   }
@@ -756,14 +758,13 @@ class PaginatedDiveListNotifier
     await loadFirstPage();
   }
 
-  /// Reload the pages already on screen without flashing a loading spinner.
+  /// Reload every page already loaded, without flashing a loading spinner.
   ///
   /// Mirrors [loadFirstPage] (same diver/filter/sort params, re-read from the
   /// top) but never sets `state = AsyncValue.loading()`, so table-change ticks
   /// from a sync update the data in place instead of flickering the UI.
   ///
-  /// The reload refetches as many rows as are currently loaded, not a single
-  /// page. Shrinking back to page one drops every row the diver scrolled past,
+  /// It refetches as many rows as are currently loaded, not a single page. Shrinking back to page one drops every row the diver scrolled past,
   /// puts the trailing "loading more" row back under their cursor with nothing
   /// below it to scroll toward, and throws the scroll offset away -- which is
   /// what made the list appear to hang after an edit was saved (#1610), since
@@ -772,7 +773,7 @@ class PaginatedDiveListNotifier
   /// One row beyond the loaded count is fetched purely to decide [hasMore], so
   /// a fully loaded list does not sprout a spinner row that no further page
   /// could ever clear.
-  Future<void> _silentReloadFirstPage() async {
+  Future<void> _silentReloadLoadedPages() async {
     final loadedCount = state.valueOrNull?.dives.length ?? 0;
     final limit = loadedCount > _pageSize ? loadedCount : _pageSize;
     _currentOffset = 0;

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -623,6 +623,15 @@ class PaginatedDiveListNotifier
   int _currentOffset = 0;
   static const _pageSize = 50;
 
+  /// Serializes every operation that rewrites the loaded rows.
+  ///
+  /// A reload and a page load each snapshot the list before awaiting their
+  /// query, so interleaving them lets whichever lands last overwrite the
+  /// other's work: the reload truncates the page just appended, or the page
+  /// append reinstates the rows the reload just refreshed. Running them one at
+  /// a time means each reads a snapshot that is still current when it writes.
+  Future<void> _pagingQueue = Future<void>.value();
+
   PaginatedDiveListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
     _currentDiverId = _ref.read(currentDiverIdProvider);
@@ -669,7 +678,19 @@ class PaginatedDiveListNotifier
     return sort.field == DiveSortField.date;
   }
 
-  Future<void> loadFirstPage() async {
+  /// Runs [op] after every paging operation queued before it.
+  ///
+  /// The returned future carries [op]'s own error; the queue keeps a swallowed
+  /// copy so one failed load cannot wedge every load after it.
+  Future<void> _enqueuePaging(Future<void> Function() op) {
+    final next = _pagingQueue.then((_) => op());
+    _pagingQueue = next.catchError((_) {});
+    return next;
+  }
+
+  Future<void> loadFirstPage() => _enqueuePaging(_loadFirstPage);
+
+  Future<void> _loadFirstPage() async {
     state = const AsyncValue.loading();
     _currentOffset = 0;
     try {
@@ -704,13 +725,32 @@ class PaginatedDiveListNotifier
     }
   }
 
-  Future<void> loadNextPage() async {
+  Future<void> loadNextPage() {
     final current = state.valueOrNull;
-    if (current == null || current.isLoadingMore || !current.hasMore) return;
-
+    // Cheap pre-check so a burst of scroll notifications cannot queue the same
+    // page a hundred times. The queued body re-reads the state and decides for
+    // real, since anything ahead of it in the queue may have changed the list.
+    if (current == null || current.isLoadingMore || !current.hasMore) {
+      return Future<void>.value();
+    }
+    // Flip the spinner on now rather than when the queue reaches this load, so
+    // the trailing row reflects the request the diver just made.
     state = AsyncValue.data(
       current.copyWith(isLoadingMore: true, loadMoreFailed: false),
     );
+    return _enqueuePaging(_loadNextPage);
+  }
+
+  Future<void> _loadNextPage() async {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    if (!current.hasMore) {
+      // A reload ahead of this one reached the end of the list.
+      if (current.isLoadingMore) {
+        state = AsyncValue.data(current.copyWith(isLoadingMore: false));
+      }
+      return;
+    }
     try {
       final filter = _ref.read(diveFilterProvider);
       final sort = _ref.read(diveSortProvider);
@@ -725,9 +765,16 @@ class PaginatedDiveListNotifier
       );
       _currentOffset += newDives.length;
 
+      // A reload that ran while this page was queued may already hold some of
+      // these rows; appending by id keeps the list from showing them twice.
+      final loadedIds = current.dives.map((d) => d.id).toSet();
+      final added = newDives
+          .where((d) => !loadedIds.contains(d.id))
+          .toList(growable: false);
+
       state = AsyncValue.data(
         current.copyWith(
-          dives: [...current.dives, ...newDives],
+          dives: [...current.dives, ...added],
           isLoadingMore: false,
           hasMore: newDives.length >= _pageSize,
           nextCursor: _isDateSort ? _cursorFromLastDive(newDives) : null,
@@ -735,7 +782,7 @@ class PaginatedDiveListNotifier
         ),
       );
       // Pre-load downsampled profiles for the new page
-      _loadBatchProfiles(newDives.map((d) => d.id).toList());
+      _loadBatchProfiles(added.map((d) => d.id).toList());
     } catch (_) {
       // Record the failure rather than silently going idle: the trailing row
       // must be able to offer a retry instead of spinning on nothing (#1610).
@@ -771,8 +818,9 @@ class PaginatedDiveListNotifier
   /// top) but never sets `state = AsyncValue.loading()`, so table-change ticks
   /// from a sync update the data in place instead of flickering the UI.
   ///
-  /// It refetches as many rows as are currently loaded, not a single page. Shrinking back to page one drops every row the diver scrolled past,
-  /// puts the trailing "loading more" row back under their cursor with nothing
+  /// It refetches as many rows as are currently loaded, not a single page.
+  /// Shrinking back to page one drops every row the diver scrolled past, puts
+  /// the trailing "loading more" row back under their cursor with nothing
   /// below it to scroll toward, and throws the scroll offset away -- which is
   /// what made the list appear to hang after an edit was saved (#1610), since
   /// the notifier's own writes tick this stream too.
@@ -780,7 +828,13 @@ class PaginatedDiveListNotifier
   /// One row beyond the loaded count is fetched purely to decide [hasMore], so
   /// a fully loaded list does not sprout a spinner row that no further page
   /// could ever clear.
-  Future<void> _silentReloadLoadedPages() async {
+  ///
+  /// Queued behind any page load already running, so the two cannot overwrite
+  /// each other's rows.
+  Future<void> _silentReloadLoadedPages() =>
+      _enqueuePaging(_silentReloadLoadedPagesNow);
+
+  Future<void> _silentReloadLoadedPagesNow() async {
     final loadedCount = state.valueOrNull?.dives.length ?? 0;
     final limit = loadedCount > _pageSize ? loadedCount : _pageSize;
     _currentOffset = 0;

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -858,12 +858,27 @@ class PaginatedDiveListNotifier
       _currentOffset = dives.length;
 
       if (mounted) {
+        // Read at apply time, not before the await: loadNextPage flips
+        // isLoadingMore synchronously and queues its body behind this reload,
+        // so the flags can change while this query is running.
+        //
+        // Both are carried over rather than reset. isLoadingMore still marks a
+        // page load queued behind this one -- dropping it blinks the spinner
+        // off and lets the stranded-loader kick queue a second load for a page
+        // already coming. loadMoreFailed still marks a next page that could not
+        // be fetched, which refreshing the rows already loaded says nothing
+        // about -- dropping it swaps the retry row back for a spinner the kick
+        // then declines to touch, which is the dead end this all started from
+        // (#1610).
+        final flags = state.valueOrNull;
         state = AsyncValue.data(
           PaginatedDiveListState(
             dives: dives,
             hasMore: hasMore,
             nextCursor: _isDateSort ? _cursorFromLastDive(dives) : null,
             totalCount: totalCount,
+            isLoadingMore: flags?.isLoadingMore ?? false,
+            loadMoreFailed: flags?.loadMoreFailed ?? false,
           ),
         );
       }

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -756,11 +756,25 @@ class PaginatedDiveListNotifier
     await loadFirstPage();
   }
 
-  /// Reload the first page without flashing a loading spinner. Mirrors
-  /// [loadFirstPage] (resetting to page 1 with the same diver/filter/sort
-  /// params) but never sets `state = AsyncValue.loading()`, so table-change
-  /// ticks from a sync update the data in place instead of flickering the UI.
+  /// Reload the pages already on screen without flashing a loading spinner.
+  ///
+  /// Mirrors [loadFirstPage] (same diver/filter/sort params, re-read from the
+  /// top) but never sets `state = AsyncValue.loading()`, so table-change ticks
+  /// from a sync update the data in place instead of flickering the UI.
+  ///
+  /// The reload refetches as many rows as are currently loaded, not a single
+  /// page. Shrinking back to page one drops every row the diver scrolled past,
+  /// puts the trailing "loading more" row back under their cursor with nothing
+  /// below it to scroll toward, and throws the scroll offset away -- which is
+  /// what made the list appear to hang after an edit was saved (#1610), since
+  /// the notifier's own writes tick this stream too.
+  ///
+  /// One row beyond the loaded count is fetched purely to decide [hasMore], so
+  /// a fully loaded list does not sprout a spinner row that no further page
+  /// could ever clear.
   Future<void> _silentReloadFirstPage() async {
+    final loadedCount = state.valueOrNull?.dives.length ?? 0;
+    final limit = loadedCount > _pageSize ? loadedCount : _pageSize;
     _currentOffset = 0;
     try {
       final filter = _ref.read(diveFilterProvider);
@@ -770,20 +784,22 @@ class PaginatedDiveListNotifier
           diverId: _currentDiverId,
           filter: filter,
           sort: sort,
-          limit: _pageSize,
+          limit: limit + 1,
           disabledSafetyRules: _ref.read(safetyReviewDisabledRulesProvider),
         ),
         _repository.getDiveCount(diverId: _currentDiverId, filter: filter),
       ]);
-      final dives = results[0] as List<DiveSummary>;
+      final fetched = results[0] as List<DiveSummary>;
       final totalCount = results[1] as int;
+      final hasMore = fetched.length > limit;
+      final dives = hasMore ? fetched.sublist(0, limit) : fetched;
       _currentOffset = dives.length;
 
       if (mounted) {
         state = AsyncValue.data(
           PaginatedDiveListState(
             dives: dives,
-            hasMore: dives.length >= _pageSize,
+            hasMore: hasMore,
             nextCursor: _isDateSort ? _cursorFromLastDive(dives) : null,
             totalCount: totalCount,
           ),

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -220,6 +220,14 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _autoLoadKickScheduled = false;
       if (!mounted) return;
+      // Re-read rather than trusting the state this was scheduled from. A load
+      // can start and fail between that build and the end of the frame, and
+      // this kick must not be the thing that clears loadMoreFailed and retries
+      // behind the diver's back -- after a failure the Retry button is the
+      // only way back.
+      final latest = ref.read(paginatedDiveListProvider).value;
+      if (latest == null || !latest.hasMore) return;
+      if (latest.isLoadingMore || latest.loadMoreFailed) return;
       ref.read(paginatedDiveListProvider.notifier).loadNextPage();
     });
   }

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -133,6 +133,12 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
   DiveMergeOutcome? _lastMergeOutcome;
   final ScrollController _scrollController = ScrollController();
   String? _lastScrolledToId;
+
+  /// Row count the trailing loader row last kicked a page load at.
+  ///
+  /// Keeps [_loadNextPageIfStranded] from retrying every frame when a load
+  /// fails: the next kick waits for the loaded count to actually change.
+  int? _autoLoadKickedAtCount;
   bool _selectionFromList =
       false; // Track if selection originated from list tap
 
@@ -175,6 +181,25 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
     if (maxScroll - currentScroll <= 200) {
       ref.read(paginatedDiveListProvider.notifier).loadNextPage();
     }
+  }
+
+  /// Load the next page when the trailing loader row is built with nothing in
+  /// flight to resolve it.
+  ///
+  /// [_onScroll] only fires on scroll activity, and when the list shrinks under
+  /// a position that is already at the bottom -- a reload, a bulk delete --
+  /// Flutter clamps the offset during layout without notifying scroll
+  /// listeners. The spinner then sits there until the diver scrolls by hand
+  /// (#1610). Building the row is itself the signal that it is on screen, so
+  /// that is where the load gets kicked.
+  void _loadNextPageIfStranded(PaginatedDiveListState paginatedState) {
+    if (!paginatedState.hasMore || paginatedState.isLoadingMore) return;
+    if (_autoLoadKickedAtCount == paginatedState.dives.length) return;
+    _autoLoadKickedAtCount = paginatedState.dives.length;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref.read(paginatedDiveListProvider.notifier).loadNextPage();
+    });
   }
 
   @override
@@ -1494,6 +1519,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
               itemBuilder: (context, index) {
                 // Loading indicator at the end
                 if (index >= dives.length) {
+                  _loadNextPageIfStranded(paginatedState);
                   return const Padding(
                     padding: EdgeInsets.symmetric(vertical: 16),
                     child: Center(child: CircularProgressIndicator()),

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -134,11 +134,12 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
   final ScrollController _scrollController = ScrollController();
   String? _lastScrolledToId;
 
-  /// Row count the trailing loader row last kicked a page load at.
+  /// True while a kick from the loader row is waiting for the frame to end.
   ///
-  /// Keeps [_loadNextPageIfStranded] from retrying every frame when a load
-  /// fails: the next kick waits for the loaded count to actually change.
-  int? _autoLoadKickedAtCount;
+  /// Several builds can ask before the callback runs, since a scroll pass
+  /// rebuilds the row each time it re-enters the viewport. One pending kick is
+  /// enough.
+  bool _autoLoadKickScheduled = false;
   bool _selectionFromList =
       false; // Track if selection originated from list tap
 
@@ -195,12 +196,20 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
   ///
   /// A page load that failed is left alone: the row shows a retry affordance
   /// instead of a spinner, so there is nothing stranded to rescue.
+  ///
+  /// This cannot become a retry storm. A kick flips `isLoadingMore` on the
+  /// spot, a load that fails raises `loadMoreFailed`, and a load with nothing
+  /// left to fetch drops `hasMore`, so every outcome closes the door behind it.
+  /// Deliberately no "already kicked at this row count" guard: the count comes
+  /// back to a value it has held before whenever the list shrinks -- a bulk
+  /// delete, a narrower reload -- and remembering it would decline the kick
+  /// exactly when the row is stranded again.
   void _loadNextPageIfStranded(PaginatedDiveListState paginatedState) {
     if (!paginatedState.hasMore || paginatedState.isLoadingMore) return;
-    if (paginatedState.loadMoreFailed) return;
-    if (_autoLoadKickedAtCount == paginatedState.dives.length) return;
-    _autoLoadKickedAtCount = paginatedState.dives.length;
+    if (paginatedState.loadMoreFailed || _autoLoadKickScheduled) return;
+    _autoLoadKickScheduled = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      _autoLoadKickScheduled = false;
       if (!mounted) return;
       ref.read(paginatedDiveListProvider.notifier).loadNextPage();
     });

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -176,6 +176,13 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
 
   void _onScroll() {
     if (!_scrollController.hasClients) return;
+    // Once a page load has failed, only the Retry button asks again, matching
+    // [_loadNextPageIfStranded]. Sitting at the bottom of the list produces a
+    // scroll notification on every settle and overscroll bounce, so retrying
+    // from here would swap the retry row back for a spinner under the diver's
+    // thumb again and again, and put a failing query behind each one.
+    final paginated = ref.read(paginatedDiveListProvider).value;
+    if (paginated?.loadMoreFailed ?? false) return;
     final maxScroll = _scrollController.position.maxScrollExtent;
     final currentScroll = _scrollController.offset;
     // Load next page when within 200px of bottom
@@ -195,7 +202,9 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
   /// that is where the load gets kicked.
   ///
   /// A page load that failed is left alone: the row shows a retry affordance
-  /// instead of a spinner, so there is nothing stranded to rescue.
+  /// instead of a spinner, so there is nothing stranded to rescue. [_onScroll]
+  /// bows out of a failed state for the same reason, so the Retry button is
+  /// the only way back.
   ///
   /// This cannot become a retry storm. A kick flips `isLoadingMore` on the
   /// spot, a load that fails raises `loadMoreFailed`, and a load with nothing

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -192,8 +192,12 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
   /// listeners. The spinner then sits there until the diver scrolls by hand
   /// (#1610). Building the row is itself the signal that it is on screen, so
   /// that is where the load gets kicked.
+  ///
+  /// A page load that failed is left alone: the row shows a retry affordance
+  /// instead of a spinner, so there is nothing stranded to rescue.
   void _loadNextPageIfStranded(PaginatedDiveListState paginatedState) {
     if (!paginatedState.hasMore || paginatedState.isLoadingMore) return;
+    if (paginatedState.loadMoreFailed) return;
     if (_autoLoadKickedAtCount == paginatedState.dives.length) return;
     _autoLoadKickedAtCount = paginatedState.dives.length;
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -1519,6 +1523,9 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
               itemBuilder: (context, index) {
                 // Loading indicator at the end
                 if (index >= dives.length) {
+                  if (paginatedState.loadMoreFailed) {
+                    return _buildLoadMoreFailedRow(context);
+                  }
                   _loadNextPageIfStranded(paginatedState);
                   return const Padding(
                     padding: EdgeInsets.symmetric(vertical: 16),
@@ -1858,6 +1865,35 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
             label: Text(context.l10n.diveLog_empty_logFirstDive),
           ),
         ],
+      ),
+    );
+  }
+
+  /// Trailing row shown when loading another page failed.
+  ///
+  /// A spinner here would claim work is happening when nothing is, and the
+  /// diver would have no way to ask again except by scrolling (#1610).
+  Widget _buildLoadMoreFailedRow(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              context.l10n.diveLog_error_loadingDives,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 8),
+            TextButton.icon(
+              key: const ValueKey('load_more_retry'),
+              onPressed: () =>
+                  ref.read(paginatedDiveListProvider.notifier).loadNextPage(),
+              icon: const Icon(Icons.refresh),
+              label: Text(context.l10n.diveLog_error_retry),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/test/features/dive_log/presentation/providers/dive_list_notifier_test.dart
+++ b/test/features/dive_log/presentation/providers/dive_list_notifier_test.dart
@@ -114,7 +114,7 @@ void main() {
       }
       expect(container.read(paginatedDiveListProvider).value?.dives, isEmpty);
 
-      // Remote dive applied straight to the DB; _silentReloadFirstPage must
+      // Remote dive applied straight to the DB; _silentReloadLoadedPages must
       // refresh the first page in place.
       await diveRepo.createDive(
         _makeDive(diverId: diver.id, notes: 'Synced Summary'),

--- a/test/features/dive_log/presentation/providers/paginated_dive_list_page_retention_test.dart
+++ b/test/features/dive_log/presentation/providers/paginated_dive_list_page_retention_test.dart
@@ -23,15 +23,16 @@ import '../../../../helpers/test_database.dart';
 /// first page. Mirrors `PaginatedDiveListNotifier._pageSize`.
 const _pageSize = 50;
 
-/// Serves the first page from the real database, then fails every later one,
-/// standing in for a transient read error while paging.
+/// Fails the [failCall]th `getDiveSummaries` call and serves every other one
+/// from the real database, standing in for a transient read error while paging.
 ///
 /// [DiveRepository]'s only public constructor is a factory, so this delegates
 /// rather than extends, forwarding the handful of methods the notifier calls.
-class _FailsAfterFirstPageRepository implements DiveRepository {
-  _FailsAfterFirstPageRepository(this._inner);
+class _FailsOnCallRepository implements DiveRepository {
+  _FailsOnCallRepository(this._inner, {required this.failCall});
 
   final DiveRepository _inner;
+  final int failCall;
   int _calls = 0;
 
   @override
@@ -45,7 +46,7 @@ class _FailsAfterFirstPageRepository implements DiveRepository {
     Set<String> disabledSafetyRules = const {},
   }) async {
     _calls++;
-    if (_calls > 1) throw StateError('page load failed');
+    if (_calls == failCall) throw StateError('page load failed');
     return _inner.getDiveSummaries(
       diverId: diverId,
       filter: filter,
@@ -300,7 +301,8 @@ void main() {
       final diver = await setUpCurrentDiver();
       await seedDives(diver.id, _pageSize * 2);
 
-      final failing = _FailsAfterFirstPageRepository(diveRepo);
+      // Call 1 is the initial first page; call 2 is the page load that fails.
+      final failing = _FailsOnCallRepository(diveRepo, failCall: 2);
       final container = ProviderContainer(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
@@ -399,5 +401,130 @@ void main() {
         reason: 'no row may appear twice after the two operations interleave',
       );
     });
+  });
+
+  group('PaginatedDiveListNotifier reload keeps transient paging flags', () {
+    test(
+      'a reload landing while a page load is queued keeps the spinner on',
+      () async {
+        final diver = await setUpCurrentDiver();
+        await seedDives(diver.id, _pageSize * 2);
+
+        // Call 1 is the initial first page; call 2 is the reload this test holds
+        // open while a page load queues up behind it.
+        final gated = _GatedRepository(diveRepo, gateCall: 2);
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            diveRepositoryProvider.overrideWithValue(gated),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final seen = <PaginatedDiveListState>[];
+        final sub = container.listen(paginatedDiveListProvider, (_, next) {
+          final value = next.value;
+          if (value != null) seen.add(value);
+        });
+        addTearDown(sub.close);
+
+        while (container.read(paginatedDiveListProvider).isLoading) {
+          await Future<void>.delayed(Duration.zero);
+        }
+
+        // A sync ticks the dives table, parking the reload inside the repository.
+        await diveRepo.createDive(
+          Dive(
+            id: '',
+            diverId: diver.id,
+            diveNumber: 999,
+            dateTime: DateTime(2030),
+            name: 'Synced dive',
+          ),
+        );
+        await gated.gateReached.future;
+
+        // The diver reaches the bottom of the list while that reload is parked.
+        seen.clear();
+        final pageLoad = container
+            .read(paginatedDiveListProvider.notifier)
+            .loadNextPage();
+        gated.release.complete();
+        await pageLoad;
+
+        expect(seen, isNotEmpty);
+        final beforeThePageLanded = seen
+            .takeWhile((s) => s.dives.length <= _pageSize)
+            .toList();
+        expect(
+          beforeThePageLanded.every((s) => s.isLoadingMore),
+          isTrue,
+          reason:
+              'the reload must not blink the spinner off while the page load it '
+              'is queued ahead of is still pending (#1610)',
+        );
+      },
+    );
+
+    test(
+      'a reload does not clear the retry state of a failed page load',
+      () async {
+        final diver = await setUpCurrentDiver();
+        final dives = await seedDives(diver.id, _pageSize * 2);
+
+        // Call 1 is the initial first page, call 2 the page load that fails;
+        // the reload that follows the write below must succeed.
+        final failing = _FailsOnCallRepository(diveRepo, failCall: 2);
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            diveRepositoryProvider.overrideWithValue(failing),
+          ],
+        );
+        addTearDown(container.dispose);
+        final sub = container.listen(paginatedDiveListProvider, (_, _) {});
+        addTearDown(sub.close);
+
+        while (container.read(paginatedDiveListProvider).isLoading) {
+          await Future<void>.delayed(Duration.zero);
+        }
+        await container.read(paginatedDiveListProvider.notifier).loadNextPage();
+        expect(
+          container.read(paginatedDiveListProvider).value!.loadMoreFailed,
+          isTrue,
+        );
+
+        // A sync refreshes the rows already loaded. That says nothing about
+        // whether the NEXT page can be fetched, so the retry row must survive.
+        await diveRepo.updateDive(dives.first.copyWith(name: 'Refreshed name'));
+
+        var names = <String?>[];
+        for (var i = 0; i < 100; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          names =
+              container
+                  .read(paginatedDiveListProvider)
+                  .value
+                  ?.dives
+                  .map((d) => d.name)
+                  .toList() ??
+              <String?>[];
+          if (names.contains('Refreshed name')) break;
+        }
+        expect(
+          names,
+          contains('Refreshed name'),
+          reason: 'reload should have run',
+        );
+
+        expect(
+          container.read(paginatedDiveListProvider).value!.loadMoreFailed,
+          isTrue,
+          reason:
+              'clearing this swaps the retry row back for a spinner the stranded '
+              'loader kick then declines to touch (#1610)',
+        );
+      },
+    );
   });
 }

--- a/test/features/dive_log/presentation/providers/paginated_dive_list_page_retention_test.dart
+++ b/test/features/dive_log/presentation/providers/paginated_dive_list_page_retention_test.dart
@@ -123,11 +123,23 @@ class _GatedRepository implements DiveRepository {
   @override
   Stream<void> watchDivesChanges() => _inner.watchDivesChanges();
 
+  /// Set to park the first batch-profile fetch, the fire-and-forget tail of
+  /// every load, until [releaseProfiles] completes.
+  Completer<void>? profileGate;
+  final Completer<void> profileGateReached = Completer<void>();
+
   @override
   Future<Map<String, List<DiveProfilePoint>>> getBatchProfileSummaries(
     List<String> diveIds, {
     int maxSamples = 120,
-  }) => _inner.getBatchProfileSummaries(diveIds, maxSamples: maxSamples);
+  }) async {
+    final gate = profileGate;
+    if (gate != null && !gate.isCompleted) {
+      if (!profileGateReached.isCompleted) profileGateReached.complete();
+      await gate.future;
+    }
+    return _inner.getBatchProfileSummaries(diveIds, maxSamples: maxSamples);
+  }
 
   @override
   Future<domain_dive.Dive?> getDiveById(String id) => _inner.getDiveById(id);
@@ -564,5 +576,42 @@ void main() {
       // complete without error rather than surfacing an unhandled exception.
       await expectLater(pageLoad, completes);
     });
+
+    test(
+      'the fire-and-forget profile preload survives the container going away',
+      () async {
+        final diver = await setUpCurrentDiver();
+        await seedDives(diver.id, 3);
+
+        // gateCall 0 never matches, so only the profile preload is parked.
+        final gated = _GatedRepository(diveRepo, gateCall: 0);
+        gated.profileGate = Completer<void>();
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            diveRepositoryProvider.overrideWithValue(gated),
+          ],
+        );
+        final sub = container.listen(paginatedDiveListProvider, (_, _) {});
+
+        // The first page has landed and its profile preload is parked
+        // mid-fetch.
+        await gated.profileGateReached.future;
+
+        // The app shuts down while that fetch is parked. Reading a provider
+        // from a disposed container throws, and nobody awaits this preload, so
+        // the throw would escape into the zone and fail this test.
+        //
+        // Disposing the container, not just invalidating the provider:
+        // invalidation unmounts the notifier but leaves the container
+        // readable, so it never throws and cannot tell the guard from its
+        // absence.
+        sub.close();
+        container.dispose();
+        gated.profileGate!.complete();
+
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      },
+    );
   });
 }

--- a/test/features/dive_log/presentation/providers/paginated_dive_list_page_retention_test.dart
+++ b/test/features/dive_log/presentation/providers/paginated_dive_list_page_retention_test.dart
@@ -527,4 +527,42 @@ void main() {
       },
     );
   });
+
+  group('PaginatedDiveListNotifier disposal', () {
+    test('a page load finishing after disposal writes nothing', () async {
+      final diver = await setUpCurrentDiver();
+      await seedDives(diver.id, _pageSize * 2);
+
+      // Call 1 is the initial first page; call 2 is the page load held open
+      // while the provider is invalidated out from under it.
+      final gated = _GatedRepository(diveRepo, gateCall: 2);
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          diveRepositoryProvider.overrideWithValue(gated),
+        ],
+      );
+      addTearDown(container.dispose);
+      final sub = container.listen(paginatedDiveListProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      while (container.read(paginatedDiveListProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      final pageLoad = container
+          .read(paginatedDiveListProvider.notifier)
+          .loadNextPage();
+      await gated.gateReached.future;
+
+      // An import or a merge invalidates the provider, disposing the notifier
+      // while its query is still running.
+      container.invalidate(paginatedDiveListProvider);
+      gated.release.complete();
+
+      // Writing state on a disposed StateNotifier throws, so this must
+      // complete without error rather than surfacing an unhandled exception.
+      await expectLater(pageLoad, completes);
+    });
+  });
 }

--- a/test/features/dive_log/presentation/providers/paginated_dive_list_page_retention_test.dart
+++ b/test/features/dive_log/presentation/providers/paginated_dive_list_page_retention_test.dart
@@ -1,0 +1,179 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Pages the notifier keeps in memory once the user has scrolled past the
+/// first page. Mirrors `PaginatedDiveListNotifier._pageSize`.
+const _pageSize = 50;
+
+void main() {
+  late SharedPreferences prefs;
+  late DiveRepository diveRepo;
+  late DiverRepository diverRepo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+    diveRepo = DiveRepository();
+    diverRepo = DiverRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  Future<Diver> setUpCurrentDiver() async {
+    final diver = await diverRepo.createDiver(
+      Diver(
+        id: '',
+        name: 'D',
+        isDefault: true,
+        createdAt: DateTime(2024),
+        updatedAt: DateTime(2024),
+      ),
+    );
+    await prefs.setString(currentDiverIdKey, diver.id);
+    return diver;
+  }
+
+  /// Creates [count] dives, newest first, so the default date sort is stable.
+  Future<List<Dive>> seedDives(String diverId, int count) async {
+    final created = <Dive>[];
+    for (var i = 0; i < count; i++) {
+      created.add(
+        await diveRepo.createDive(
+          Dive(
+            id: '',
+            diverId: diverId,
+            diveNumber: count - i,
+            dateTime: DateTime(2024, 1, 1).add(Duration(days: count - i)),
+            name: 'Dive ${count - i}',
+          ),
+        ),
+      );
+    }
+    return created;
+  }
+
+  /// Drives the list to [pages] loaded pages and returns the resulting state.
+  Future<PaginatedDiveListState> loadPages(
+    ProviderContainer container,
+    int pages,
+  ) async {
+    while (container.read(paginatedDiveListProvider).isLoading) {
+      await Future<void>.delayed(Duration.zero);
+    }
+    final notifier = container.read(paginatedDiveListProvider.notifier);
+    for (var i = 1; i < pages; i++) {
+      await notifier.loadNextPage();
+    }
+    return container.read(paginatedDiveListProvider).value!;
+  }
+
+  group('PaginatedDiveListNotifier page retention on a change tick', () {
+    test('keeps every loaded page when the edited dive is saved', () async {
+      final diver = await setUpCurrentDiver();
+      final dives = await seedDives(diver.id, _pageSize * 2 + 10);
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      final sub = container.listen(paginatedDiveListProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      final loaded = await loadPages(container, 3);
+      expect(loaded.dives, hasLength(_pageSize * 2 + 10));
+      expect(loaded.hasMore, isFalse);
+
+      // The user edits a dive on the detail pane and saves. The write ticks
+      // watchDivesChanges, which must not shrink the list back to page one.
+      final edited = dives.first.copyWith(name: 'Edited name');
+      await container
+          .read(paginatedDiveListProvider.notifier)
+          .updateDive(edited);
+
+      // Wait past the change-tick debounce so the silent reload has landed.
+      await Future<void>.delayed(
+        DiveRepository.changeTickDebounce + const Duration(milliseconds: 400),
+      );
+
+      final after = container.read(paginatedDiveListProvider).value!;
+      expect(
+        after.dives,
+        hasLength(_pageSize * 2 + 10),
+        reason:
+            'saving an edit must not discard the pages the user scrolled '
+            'through (#1610)',
+      );
+      expect(
+        after.hasMore,
+        isFalse,
+        reason:
+            'the whole list is loaded, so no trailing spinner row may reappear',
+      );
+      expect(
+        after.dives.firstWhere((d) => d.id == edited.id).name,
+        'Edited name',
+      );
+    });
+
+    test(
+      'keeps every loaded page when a sync writes a dive directly',
+      () async {
+        final diver = await setUpCurrentDiver();
+        final dives = await seedDives(diver.id, _pageSize * 2 + 10);
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+        final sub = container.listen(paginatedDiveListProvider, (_, _) {});
+        addTearDown(sub.close);
+
+        final loaded = await loadPages(container, 3);
+        expect(loaded.dives, hasLength(_pageSize * 2 + 10));
+
+        // A sync applies a remote change straight to the DB, bypassing the
+        // notifier's mutation methods. Only the silent reload can surface it.
+        await diveRepo.updateDive(dives.first.copyWith(name: 'Synced name'));
+
+        var names = <String?>[];
+        var length = 0;
+        for (var i = 0; i < 100; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          final state = container.read(paginatedDiveListProvider).value;
+          names = state?.dives.map((d) => d.name).toList() ?? <String?>[];
+          length = state?.dives.length ?? 0;
+          if (names.contains('Synced name')) break;
+        }
+
+        expect(
+          names,
+          contains('Synced name'),
+          reason: 'reload should have run',
+        );
+        expect(
+          length,
+          _pageSize * 2 + 10,
+          reason:
+              'the silent reload must refresh in place, not truncate (#1610)',
+        );
+      },
+    );
+  });
+}

--- a/test/features/dive_log/presentation/providers/paginated_dive_list_page_retention_test.dart
+++ b/test/features/dive_log/presentation/providers/paginated_dive_list_page_retention_test.dart
@@ -5,6 +5,8 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/core/constants/sort_options.dart';
+import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
@@ -16,6 +18,59 @@ import '../../../../helpers/test_database.dart';
 /// Pages the notifier keeps in memory once the user has scrolled past the
 /// first page. Mirrors `PaginatedDiveListNotifier._pageSize`.
 const _pageSize = 50;
+
+/// Serves the first page from the real database, then fails every later one,
+/// standing in for a transient read error while paging.
+///
+/// [DiveRepository]'s only public constructor is a factory, so this delegates
+/// rather than extends, forwarding the handful of methods the notifier calls.
+class _FailsAfterFirstPageRepository implements DiveRepository {
+  _FailsAfterFirstPageRepository(this._inner);
+
+  final DiveRepository _inner;
+  int _calls = 0;
+
+  @override
+  Future<List<DiveSummary>> getDiveSummaries({
+    String? diverId,
+    DiveFilterState filter = const DiveFilterState(),
+    DiveSummaryCursor? cursor,
+    int? offset,
+    int limit = 50,
+    SortState<DiveSortField>? sort,
+    Set<String> disabledSafetyRules = const {},
+  }) async {
+    _calls++;
+    if (_calls > 1) throw StateError('page load failed');
+    return _inner.getDiveSummaries(
+      diverId: diverId,
+      filter: filter,
+      cursor: cursor,
+      offset: offset,
+      limit: limit,
+      sort: sort,
+      disabledSafetyRules: disabledSafetyRules,
+    );
+  }
+
+  @override
+  Future<int> getDiveCount({
+    String? diverId,
+    DiveFilterState filter = const DiveFilterState(),
+  }) => _inner.getDiveCount(diverId: diverId, filter: filter);
+
+  @override
+  Stream<void> watchDivesChanges() => _inner.watchDivesChanges();
+
+  @override
+  Future<Map<String, List<DiveProfilePoint>>> getBatchProfileSummaries(
+    List<String> diveIds, {
+    int maxSamples = 120,
+  }) => _inner.getBatchProfileSummaries(diveIds, maxSamples: maxSamples);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 void main() {
   late SharedPreferences prefs;
@@ -175,5 +230,43 @@ void main() {
         );
       },
     );
+  });
+
+  group('PaginatedDiveListNotifier load-more failures', () {
+    test('records the failure instead of going quietly idle', () async {
+      final diver = await setUpCurrentDiver();
+      await seedDives(diver.id, _pageSize * 2);
+
+      final failing = _FailsAfterFirstPageRepository(diveRepo);
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          diveRepositoryProvider.overrideWithValue(failing),
+        ],
+      );
+      addTearDown(container.dispose);
+      final sub = container.listen(paginatedDiveListProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      while (container.read(paginatedDiveListProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(
+        container.read(paginatedDiveListProvider).value?.dives,
+        hasLength(_pageSize),
+      );
+
+      await container.read(paginatedDiveListProvider.notifier).loadNextPage();
+
+      final state = container.read(paginatedDiveListProvider).value!;
+      expect(state.isLoadingMore, isFalse);
+      expect(
+        state.loadMoreFailed,
+        isTrue,
+        reason:
+            'a swallowed failure leaves the trailing spinner spinning on '
+            'nothing, with no way back except a manual scroll (#1610)',
+      );
+    });
   });
 }

--- a/test/features/dive_log/presentation/providers/paginated_dive_list_page_retention_test.dart
+++ b/test/features/dive_log/presentation/providers/paginated_dive_list_page_retention_test.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain_dive;
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/core/constants/sort_options.dart';
 import 'package:submersion/core/models/sort_state.dart';
@@ -67,6 +71,65 @@ class _FailsAfterFirstPageRepository implements DiveRepository {
     List<String> diveIds, {
     int maxSamples = 120,
   }) => _inner.getBatchProfileSummaries(diveIds, maxSamples: maxSamples);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Holds the Nth `getDiveSummaries` call open until the test releases it, so a
+/// change tick can be made to land while a page load is genuinely in flight.
+class _GatedRepository implements DiveRepository {
+  _GatedRepository(this._inner, {required this.gateCall});
+
+  final DiveRepository _inner;
+  final int gateCall;
+  final Completer<void> gateReached = Completer<void>();
+  final Completer<void> release = Completer<void>();
+  int _calls = 0;
+
+  @override
+  Future<List<DiveSummary>> getDiveSummaries({
+    String? diverId,
+    DiveFilterState filter = const DiveFilterState(),
+    DiveSummaryCursor? cursor,
+    int? offset,
+    int limit = 50,
+    SortState<DiveSortField>? sort,
+    Set<String> disabledSafetyRules = const {},
+  }) async {
+    _calls++;
+    if (_calls == gateCall) {
+      if (!gateReached.isCompleted) gateReached.complete();
+      await release.future;
+    }
+    return _inner.getDiveSummaries(
+      diverId: diverId,
+      filter: filter,
+      cursor: cursor,
+      offset: offset,
+      limit: limit,
+      sort: sort,
+      disabledSafetyRules: disabledSafetyRules,
+    );
+  }
+
+  @override
+  Future<int> getDiveCount({
+    String? diverId,
+    DiveFilterState filter = const DiveFilterState(),
+  }) => _inner.getDiveCount(diverId: diverId, filter: filter);
+
+  @override
+  Stream<void> watchDivesChanges() => _inner.watchDivesChanges();
+
+  @override
+  Future<Map<String, List<DiveProfilePoint>>> getBatchProfileSummaries(
+    List<String> diveIds, {
+    int maxSamples = 120,
+  }) => _inner.getBatchProfileSummaries(diveIds, maxSamples: maxSamples);
+
+  @override
+  Future<domain_dive.Dive?> getDiveById(String id) => _inner.getDiveById(id);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -266,6 +329,74 @@ void main() {
         reason:
             'a swallowed failure leaves the trailing spinner spinning on '
             'nothing, with no way back except a manual scroll (#1610)',
+      );
+    });
+  });
+
+  group('PaginatedDiveListNotifier paging is serialized', () {
+    test('a change tick landing mid page-load keeps both the new page and the '
+        'refreshed rows', () async {
+      final diver = await setUpCurrentDiver();
+      final dives = await seedDives(diver.id, _pageSize * 2);
+
+      // Call 1 is the initial first page; call 2 is the page load this test
+      // holds open while a change tick arrives.
+      final gated = _GatedRepository(diveRepo, gateCall: 2);
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          diveRepositoryProvider.overrideWithValue(gated),
+        ],
+      );
+      addTearDown(container.dispose);
+      final sub = container.listen(paginatedDiveListProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      while (container.read(paginatedDiveListProvider).isLoading) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      // Page two is now in flight and parked inside the repository.
+      final pageLoad = container
+          .read(paginatedDiveListProvider.notifier)
+          .loadNextPage();
+      await gated.gateReached.future;
+
+      // A sync rewrites a row on page one while that load is parked.
+      await diveRepo.updateDive(dives.first.copyWith(name: 'Refreshed name'));
+      await Future<void>.delayed(
+        DiveRepository.changeTickDebounce + const Duration(milliseconds: 200),
+      );
+
+      gated.release.complete();
+      await pageLoad;
+
+      var names = <String?>[];
+      var length = 0;
+      for (var i = 0; i < 100; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        final state = container.read(paginatedDiveListProvider).value;
+        names = state?.dives.map((d) => d.name).toList() ?? <String?>[];
+        length = state?.dives.length ?? 0;
+        if (names.contains('Refreshed name') && length == _pageSize * 2) break;
+      }
+
+      expect(
+        length,
+        _pageSize * 2,
+        reason: 'the reload must not truncate the page that just landed',
+      );
+      expect(
+        names,
+        contains('Refreshed name'),
+        reason:
+            'the page append must not reinstate rows the reload refreshed '
+            '(#1610)',
+      );
+      expect(
+        names.toSet(),
+        hasLength(names.length),
+        reason: 'no row may appear twice after the two operations interleave',
       );
     });
   });

--- a/test/features/dive_log/presentation/widgets/dive_list_scroll_retention_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_scroll_retention_test.dart
@@ -201,4 +201,57 @@ void main() {
       reason: 'the retry affordance must actually ask for the page again',
     );
   });
+
+  testWidgets('a second shrink to a row count already seen still loads', (
+    tester,
+  ) async {
+    final summaries = [for (var i = 110; i >= 1; i--) _summary(i)];
+    final notifier = _FakePaginatedNotifier(summaries);
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...base,
+          diveListViewModeProvider.overrideWith((ref) => ListViewMode.compact),
+          highlightedDiveIdProvider.overrideWith((ref) => null),
+          paginatedDiveListProvider.overrideWith((ref) => notifier),
+        ],
+        child: const DiveListContent(showAppBar: true),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final listFinder = find.byType(Scrollable).last;
+    for (var i = 0; i < 12; i++) {
+      await tester.drag(listFinder, const Offset(0, -500));
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> shrinkAndPump() async {
+      notifier.shrinkToFirstPage(summaries.take(50).toList());
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+    }
+
+    notifier.loadNextPageCalls = 0;
+    await shrinkAndPump();
+    expect(notifier.loadNextPageCalls, greaterThan(0));
+
+    // The pages come back, then the list shrinks to that same count again --
+    // a bulk delete, or a narrower reload. The row is stranded exactly as
+    // before, so remembering the count it was last kicked at would refuse the
+    // one kick that is needed (#1610).
+    notifier.reloadInPlace(summaries);
+    await tester.pumpAndSettle();
+
+    notifier.loadNextPageCalls = 0;
+    await shrinkAndPump();
+    expect(
+      notifier.loadNextPageCalls,
+      greaterThan(0),
+      reason: 'the kick must not be suppressed by a row count seen before',
+    );
+  });
 }

--- a/test/features/dive_log/presentation/widgets/dive_list_scroll_retention_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_scroll_retention_test.dart
@@ -41,6 +41,14 @@ class _FakePaginatedNotifier
     );
   }
 
+  /// Replay a page load that failed, which the notifier now records rather
+  /// than swallowing.
+  void failLoadMore(List<DiveSummary> dives) {
+    state = AsyncValue.data(
+      PaginatedDiveListState(dives: dives, hasMore: true, loadMoreFailed: true),
+    );
+  }
+
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
@@ -96,7 +104,7 @@ void main() {
 
     expect(
       tester.state<ScrollableState>(listFinder).position.pixels,
-      offsetBefore,
+      moreOrLessEquals(offsetBefore, epsilon: 0.5),
       reason: 'refreshing the loaded rows must not move the list (#1610)',
     );
     expect(
@@ -149,6 +157,48 @@ void main() {
       reason:
           'the trailing spinner must never be a dead end the diver has to '
           'scroll out of by hand (#1610)',
+    );
+  });
+
+  testWidgets('a failed page load offers a retry instead of a spinner that '
+      'never resolves', (tester) async {
+    final summaries = [for (var i = 60; i >= 1; i--) _summary(i)];
+    final notifier = _FakePaginatedNotifier(summaries);
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...base,
+          diveListViewModeProvider.overrideWith((ref) => ListViewMode.compact),
+          highlightedDiveIdProvider.overrideWith((ref) => null),
+          paginatedDiveListProvider.overrideWith((ref) => notifier),
+        ],
+        child: const DiveListContent(showAppBar: true),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The next page could not be fetched. hasMore stays true and the row count
+    // never changes, so nothing else can ever kick another load: a spinner here
+    // would spin on nothing (#1610).
+    notifier.failLoadMore(summaries);
+    await tester.pumpAndSettle();
+
+    final retry = find.byKey(const ValueKey('load_more_retry'));
+    await tester.scrollUntilVisible(retry, 200);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(retry, findsOneWidget);
+
+    notifier.loadNextPageCalls = 0;
+    await tester.tap(retry);
+    await tester.pumpAndSettle();
+    expect(
+      notifier.loadNextPageCalls,
+      1,
+      reason: 'the retry affordance must actually ask for the page again',
     );
   });
 }

--- a/test/features/dive_log/presentation/widgets/dive_list_scroll_retention_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_scroll_retention_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/highlight_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_list_content.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_app.dart';
+
+/// Stands in for [PaginatedDiveListNotifier] so a test can replay exactly what
+/// a change tick does to the list state.
+class _FakePaginatedNotifier
+    extends StateNotifier<AsyncValue<PaginatedDiveListState>>
+    implements PaginatedDiveListNotifier {
+  _FakePaginatedNotifier(List<DiveSummary> dives)
+    : super(
+        AsyncValue.data(PaginatedDiveListState(dives: dives, hasMore: false)),
+      );
+
+  int loadNextPageCalls = 0;
+
+  @override
+  Future<void> loadNextPage() async => loadNextPageCalls++;
+
+  /// Replay a silent reload that refreshes the loaded rows in place, which is
+  /// what the notifier does after a dive is written (#1610).
+  void reloadInPlace(List<DiveSummary> dives) {
+    state = AsyncValue.data(
+      PaginatedDiveListState(dives: dives, hasMore: false),
+    );
+  }
+
+  /// Replay a reload that drops the loaded pages, leaving more to fetch.
+  void shrinkToFirstPage(List<DiveSummary> dives) {
+    state = AsyncValue.data(
+      PaginatedDiveListState(dives: dives, hasMore: true),
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+DiveSummary _summary(int n) => DiveSummary(
+  id: 'd$n',
+  diveNumber: n,
+  name: 'Dive $n',
+  dateTime: DateTime(2024, 1, 1).add(Duration(days: n)),
+  sortTimestamp: DateTime(
+    2024,
+    1,
+    1,
+  ).add(Duration(days: n)).millisecondsSinceEpoch,
+);
+
+void main() {
+  testWidgets('an in-place reload keeps the scroll offset and shows no loading '
+      'row', (tester) async {
+    final summaries = [for (var i = 60; i >= 1; i--) _summary(i)];
+    final notifier = _FakePaginatedNotifier(summaries);
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...base,
+          diveListViewModeProvider.overrideWith((ref) => ListViewMode.compact),
+          highlightedDiveIdProvider.overrideWith((ref) => null),
+          paginatedDiveListProvider.overrideWith((ref) => notifier),
+        ],
+        child: const DiveListContent(showAppBar: true),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final listFinder = find.byType(Scrollable).last;
+    await tester.drag(listFinder, const Offset(0, -400));
+    await tester.pumpAndSettle();
+
+    final offsetBefore = tester
+        .state<ScrollableState>(listFinder)
+        .position
+        .pixels;
+    expect(offsetBefore, greaterThan(0));
+
+    // The diver saves an edit: the same rows come back, one of them changed.
+    notifier.reloadInPlace([
+      summaries.first.copyWith(name: 'Edited name'),
+      ...summaries.skip(1),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.state<ScrollableState>(listFinder).position.pixels,
+      offsetBefore,
+      reason: 'refreshing the loaded rows must not move the list (#1610)',
+    );
+    expect(
+      find.byType(CircularProgressIndicator),
+      findsNothing,
+      reason: 'a fully loaded list must not sprout a trailing spinner row',
+    );
+  });
+
+  testWidgets('a loader row stranded by a shrinking list loads the next page '
+      'without a scroll gesture', (tester) async {
+    final summaries = [for (var i = 110; i >= 1; i--) _summary(i)];
+    final notifier = _FakePaginatedNotifier(summaries);
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...base,
+          diveListViewModeProvider.overrideWith((ref) => ListViewMode.compact),
+          highlightedDiveIdProvider.overrideWith((ref) => null),
+          paginatedDiveListProvider.overrideWith((ref) => notifier),
+        ],
+        child: const DiveListContent(showAppBar: true),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Scroll well past where a single page of rows would end.
+    final listFinder = find.byType(Scrollable).last;
+    for (var i = 0; i < 12; i++) {
+      await tester.drag(listFinder, const Offset(0, -500));
+      await tester.pumpAndSettle();
+    }
+    notifier.loadNextPageCalls = 0;
+
+    // The list shrinks under the scroll position. Flutter clamps the offset
+    // during layout without notifying scroll listeners, so nothing but the
+    // loader row itself can ask for the next page (#1610).
+    notifier.shrinkToFirstPage(summaries.take(50).toList());
+    // A running CircularProgressIndicator never lets pumpAndSettle settle.
+    for (var i = 0; i < 5; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(
+      notifier.loadNextPageCalls,
+      greaterThan(0),
+      reason:
+          'the trailing spinner must never be a dead end the diver has to '
+          'scroll out of by hand (#1610)',
+    );
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_list_scroll_retention_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_scroll_retention_test.dart
@@ -254,4 +254,63 @@ void main() {
       reason: 'the kick must not be suppressed by a row count seen before',
     );
   });
+
+  testWidgets('scrolling at the bottom does not retry a failed page load', (
+    tester,
+  ) async {
+    final summaries = [for (var i = 60; i >= 1; i--) _summary(i)];
+    final notifier = _FakePaginatedNotifier(summaries);
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...base,
+          diveListViewModeProvider.overrideWith((ref) => ListViewMode.compact),
+          highlightedDiveIdProvider.overrideWith((ref) => null),
+          paginatedDiveListProvider.overrideWith((ref) => notifier),
+        ],
+        child: const DiveListContent(showAppBar: true),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    notifier.failLoadMore(summaries);
+    await tester.pump();
+
+    // Park at the bottom of the list, where the retry row is.
+    final listFinder = find.byType(Scrollable).last;
+    final retry = find.byKey(const ValueKey('load_more_retry'));
+    await tester.scrollUntilVisible(retry, 200);
+    await tester.pumpAndSettle();
+    expect(
+      tester.state<ScrollableState>(listFinder).position.pixels,
+      greaterThan(0),
+    );
+
+    // Jitter within the bottom 200px, which is what riding the end of the list
+    // looks like: every one of these is a scroll notification inside the
+    // threshold that would normally ask for the next page.
+    notifier.loadNextPageCalls = 0;
+    for (var i = 0; i < 4; i++) {
+      await tester.drag(listFinder, const Offset(0, 60));
+      await tester.pumpAndSettle();
+      await tester.drag(listFinder, const Offset(0, -60));
+      await tester.pumpAndSettle();
+    }
+
+    expect(
+      notifier.loadNextPageCalls,
+      0,
+      reason:
+          'scrolling must not bypass the Retry button and put a failing query '
+          'behind every settle (#1610)',
+    );
+
+    // The button is still the way forward.
+    notifier.loadNextPageCalls = 0;
+    await tester.tap(retry);
+    await tester.pump();
+    expect(notifier.loadNextPageCalls, 1);
+  });
 }

--- a/test/features/dive_log/presentation/widgets/dive_list_scroll_retention_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_scroll_retention_test.dart
@@ -313,4 +313,51 @@ void main() {
     await tester.pump();
     expect(notifier.loadNextPageCalls, 1);
   });
+
+  testWidgets('a kick scheduled before a load fails does not retry it', (
+    tester,
+  ) async {
+    // Short enough that the loader row is on screen from the first frame, so
+    // the kick is scheduled during that frame's layout.
+    final summaries = [for (var i = 3; i >= 1; i--) _summary(i)];
+    final notifier = _FakePaginatedNotifier(summaries)
+      ..shrinkToFirstPage(summaries);
+    final base = await getBaseOverrides();
+
+    // Post-frame callbacks run in registration order, and a parent builds
+    // before the child whose layout schedules the kick. So this lands first
+    // and stands in for a page load that started and failed inside the same
+    // frame the kick was scheduled in.
+    var flipped = false;
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...base,
+          diveListViewModeProvider.overrideWith((ref) => ListViewMode.compact),
+          highlightedDiveIdProvider.overrideWith((ref) => null),
+          paginatedDiveListProvider.overrideWith((ref) => notifier),
+        ],
+        child: Builder(
+          builder: (context) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (flipped) return;
+              flipped = true;
+              notifier.failLoadMore(summaries);
+            });
+            return const DiveListContent(showAppBar: true);
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(flipped, isTrue, reason: 'the interleaving under test must happen');
+    expect(
+      notifier.loadNextPageCalls,
+      0,
+      reason:
+          'a kick scheduled before the failure must re-read the state, not '
+          'clear loadMoreFailed and retry behind the Retry button (#1610)',
+    );
+  });
 }


### PR DESCRIPTION
## Summary

Fixes #1610. Saving an edit left the dive list in the master pane spinning
forever, with a spinner that scrolling down would not clear, and lost the
diver's place in the list.

`PaginatedDiveListNotifier` subscribes to `watchDivesChanges()` so a sync
writing dives straight to the DB refreshes the list. That Drift `tableUpdates`
stream cannot tell a remote write from the diver's own edit-save, and its
handler `_silentReloadFirstPage()` always refetched exactly one page. A list
scrolled to dive #300 therefore collapsed back to 50 rows on every save.

The consequence was measured with a probe widget test (110 rows, scrolled to
offset 5760 of max 6136, then replaced by 50 rows with `hasMore: true`):

```
offset after = 2604, max = 2604   // clamped hard to the new bottom
loadNextPage calls = 0            // the scroll listener never fired
spinner on screen = 1             // and nothing could resolve it
```

Flutter corrects an out-of-range offset inside layout (`correctPixels`), and a
correction is deliberately not a scroll notification, so the `ScrollController`
listener never fires. Wheeling down does nothing because the position is
already pinned at max; only a wheel up produces a delta, which is exactly the
"scroll up a tiny bit" workaround the reporter found.

## Changes

- `dive_providers.dart`: the silent reload refetches as many rows as are
  currently loaded instead of a single page, and asks for one row beyond that
  purely to decide `hasMore`, so a fully loaded list never sprouts a spinner
  that no further page could clear.
- `dive_list_content.dart`: defense in depth. The trailing loader row kicks its
  own page load when it is built with nothing in flight, since building the row
  is proof it is inside the viewport. A loaded-count guard keeps a failing load
  from retrying every frame. This also closes the same dead end reachable from
  an optimistic bulk delete, which shrinks the list the same way.
- Regression tests: the notifier keeps every loaded page across an edit-save and
  across a sync write; the list holds its scroll offset through an in-place
  reload; a stranded loader row loads the next page with no scroll gesture.

## Test Plan

- [x] `flutter test` passes (25073 passed, 21 skipped, 0 failures)
- [x] `flutter analyze` passes (no issues)
- [x] New tests verified to fail without their respective fix (110 rows
      truncating to 50; `loadNextPage` calls `Actual: <0>`)
- [ ] Manual testing on: Windows 11 (the reporting platform)
