### PR TITLE
fix(dive-profile): draw the active source's tank pressures on a multi-computer dive

### DIFF
--- a/lib/features/dive_log/data/repositories/tank_pressure_repository.dart
+++ b/lib/features/dive_log/data/repositories/tank_pressure_repository.dart
@@ -8,6 +8,8 @@ import 'package:submersion/features/dive_log/data/repositories/tank_pressure_ser
 import 'package:submersion/features/dive_log/domain/codecs/tank_pressure_series_codec.dart'
     show TankPressureSample;
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/profile_series.dart'
+    as domain;
 import 'package:submersion/features/dive_log/domain/services/profile_series_merge.dart';
 
 /// Repository for managing per-tank time-series pressure data
@@ -27,18 +29,34 @@ class TankPressureRepository {
   /// store: v183 dropped `tank_pressure_profiles`.
   Future<Map<String, List<TankPressurePoint>>> getTankPressuresForDive(
     String diveId,
-  ) async {
-    final series = await _tankSeries.getSeriesForDive(diveId);
+  ) async => _groupByTank(await _tankSeries.getSeriesForDive(diveId));
+
+  /// [getTankPressuresForDive] as one computer saw the dive: on a tank that
+  /// [computerId] logged, only its series; on any other tank, every series.
+  /// See [selectTankSeriesForComputer] for why a consolidated dive needs
+  /// this (two computers on one transmitter interleave on one tank).
+  Future<Map<String, List<TankPressurePoint>>> getTankPressuresForComputer(
+    String diveId,
+    String? computerId,
+  ) async => _groupByTank(
+    selectTankSeriesForComputer(
+      await _tankSeries.getSeriesForDive(diveId),
+      computerId,
+    ),
+  );
+
+  Map<String, List<TankPressurePoint>> _groupByTank(
+    List<domain.TankPressureSeries> series,
+  ) {
     if (series.isEmpty) return const <String, List<TankPressurePoint>>{};
-    final byTank = <String, List<dynamic>>{};
+    final byTank = <String, List<domain.TankPressureSeries>>{};
     for (final s in series) {
       byTank.putIfAbsent(s.tankId, () => []).add(s);
     }
-    final result = <String, List<TankPressurePoint>>{};
-    for (final entry in byTank.entries) {
-      result[entry.key] = mergeTankSeriesPoints(entry.value.cast());
-    }
-    return result;
+    return {
+      for (final entry in byTank.entries)
+        entry.key: mergeTankSeriesPoints(entry.value),
+    };
   }
 
   /// Get pressure data for a specific tank.

--- a/lib/features/dive_log/domain/services/profile_series_merge.dart
+++ b/lib/features/dive_log/domain/services/profile_series_merge.dart
@@ -87,6 +87,38 @@ List<TankPressurePoint> mergeTankSeriesPoints(List<TankPressureSeries> series) {
   return [for (final e in entries) e.$3];
 }
 
+/// The series a single computer's view of a dive should draw, per tank.
+///
+/// Consolidating two computers that were paired to the same transmitter
+/// files both computers' pressure series under one tank (the tanks match on
+/// gas mix, so the secondary's tank merges into the primary's). Merging
+/// those two series interleaves rival readings of the same cylinder, and
+/// because the computers sample on offset seconds the line alternates
+/// between them every sample: a fuzzy band wherever the two disagree by a
+/// fraction of a bar. This is the pressure twin of the depth rule in
+/// `activeSourceProfileProvider` (#543).
+///
+/// For each tank, keeps only the series logged by [computerId] (null keeps
+/// the series with no computer) when it logged that tank at all; a tank the
+/// computer never logged keeps every series it has, so a stage read by the
+/// other computer is not hidden. Input order is preserved.
+List<TankPressureSeries> selectTankSeriesForComputer(
+  List<TankPressureSeries> series,
+  String? computerId,
+) {
+  if (series.isEmpty) return const [];
+  final tanksLoggedByComputer = <String>{
+    for (final s in series)
+      if (s.computerId == computerId) s.tankId,
+  };
+  return [
+    for (final s in series)
+      if (!tanksLoggedByComputer.contains(s.tankId) ||
+          s.computerId == computerId)
+        s,
+  ];
+}
+
 /// Series-level twin of `DiveRepository._dropSupersededOriginals`.
 ///
 /// A saved profile edit demotes the originals and inserts a null-computer

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -48,6 +48,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive_data_source.da
 import 'package:submersion/features/dive_log/presentation/formatters/dive_mode_label.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_detail_ui_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/chart_tank_pressures_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_mode_badge.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_sighting_row.dart';
@@ -1878,7 +1879,9 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     final gasSwitchesAsync = ref.watch(gasSwitchesProvider(dive.id));
 
     // Get per-tank pressure data for multi-tank visualization
-    final tankPressuresAsync = ref.watch(tankPressuresProvider(dive.id));
+    final tankPressuresAsync = ref.watch(
+      activeSourceTankPressuresProvider(dive.id),
+    );
     final tankPressures = tankPressuresAsync.value;
     // Chart-only: real pressures augmented with linear estimates (#197).
     final estimatedTankPressures = ref

--- a/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+++ b/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
@@ -10,6 +10,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/readout_card_p
 import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
 import 'package:submersion/features/dive_log/domain/services/source_name_resolver.dart';
 import 'package:submersion/features/dive_log/presentation/providers/active_source_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/chart_tank_pressures_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
@@ -187,7 +188,9 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
         ref.watch(diveDataSourcesProvider(widget.diveId)).value ?? const [];
     final overlayIds = ref.watch(overlaySourcesProvider(widget.diveId));
     final gasSwitches = ref.watch(gasSwitchesProvider(widget.diveId)).value;
-    final tankPressures = ref.watch(tankPressuresProvider(widget.diveId)).value;
+    final tankPressures = ref
+        .watch(activeSourceTankPressuresProvider(widget.diveId))
+        .value;
     // Chart-only: real pressures augmented with linear estimates (#197).
     final estimatedTankPressures = ref
         .watch(estimatedTankPressuresProvider(widget.diveId))

--- a/lib/features/dive_log/presentation/providers/chart_tank_pressures_provider.dart
+++ b/lib/features/dive_log/presentation/providers/chart_tank_pressures_provider.dart
@@ -1,0 +1,89 @@
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    show TankPressurePoint;
+import 'package:submersion/features/dive_log/presentation/providers/active_source_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// The tank pressure curves the profile chart surfaces draw.
+///
+/// A module of its own: [activeSourceTankPressuresProvider] needs
+/// `activeSourceProfileProvider`, which already imports `dive_providers`,
+/// so neither of these can live there without an import cycle.
+
+/// The per-tank pressure curves the profile chart draws for [diveId]: the
+/// active source's computer's own series on a multi-source dive, the plain
+/// [tankPressuresProvider] union otherwise.
+///
+/// Tank-pressure twin of [activeSourceProfileProvider]. Two computers paired
+/// to one transmitter both log the same cylinder, and consolidation files
+/// both series under one tank because the tanks match on gas mix. The
+/// unscoped read interleaves them, and since the two computers sample on
+/// offset seconds the single line alternates between them every sample: a
+/// fuzzy band wherever they disagree by a fraction of a bar (#543's
+/// pressure counterpart). Chart surfaces read this; SAC, exports and the
+/// buoyancy twins keep the union, which is every reading the dive holds.
+final activeSourceTankPressuresProvider = FutureProvider.autoDispose
+    .family<Map<String, List<TankPressurePoint>>, String>((ref, diveId) {
+      final active = ref.watch(activeSourceProfileProvider(diveId));
+      if (active == null) {
+        return ref.watch(tankPressuresProvider(diveId).future);
+      }
+      final repository = ref.watch(tankPressureRepositoryProvider);
+      // Same tick as tankPressuresProvider: tank_pressure_series writes.
+      ref.invalidateSelfWhen(
+        ref.watch(diveRepositoryProvider).watchAnalysisInputChanges(),
+      );
+      return repository.getTankPressuresForComputer(diveId, active.computerId);
+    });
+
+/// Real per-tank pressures augmented with in-memory linear estimates for tanks
+/// that have start/end pressures but no transmitter data. Chart-only; the
+/// estimates are never persisted, so SAC analysis and exports (which read the
+/// repository directly) still see real measured data only.
+final estimatedTankPressuresProvider =
+    FutureProvider.family<EstimatedTankPressures, String>((ref, diveId) async {
+      // Start the independent fetches concurrently to avoid a request waterfall
+      // on the chart load path.
+      final realFuture = ref.watch(
+        activeSourceTankPressuresProvider(diveId).future,
+      );
+      final diveFuture = ref.watch(diveProvider(diveId).future);
+      final switchesFuture = ref.watch(gasSwitchesProvider(diveId).future);
+      // Read synchronously, before the first await, so the dependency is
+      // registered while the provider is certainly still alive.
+      final showEstimates = ref.watch(
+        settingsProvider.select((s) => s.defaultShowEstimatedTankPressure),
+      );
+      final real = await realFuture;
+      final dive = await diveFuture;
+      if (dive == null) {
+        return EstimatedTankPressures(real, const <String>{});
+      }
+      // A gauge (bottom-timer) dive models no gas at all, so a synthesized
+      // pressure trace would be fabricated rather than measured (issue #731).
+      // Real transmitter samples, if the dive has any, still pass through.
+      if (dive.isGauge) {
+        return EstimatedTankPressures(real, const <String>{});
+      }
+      // The diver can switch estimates off entirely (issue #731). Gating here
+      // rather than at the chart means the series never exists, so no legend
+      // chip, tooltip row, or "(est.)" label survives anywhere.
+      if (!showEstimates) {
+        return EstimatedTankPressures(real, const <String>{});
+      }
+      final switches = await switchesFuture;
+      return synthesizeEstimatedTankPressures(
+        existing: real,
+        tanks: dive.tanks,
+        gasSwitches: switches,
+        diveDurationSeconds: dive.profile.isEmpty
+            ? 0
+            : dive.profile.last.timestamp,
+        firstSampleSeconds: dive.profile.isEmpty
+            ? 0
+            : dive.profile.first.timestamp,
+      );
+    });

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -12,9 +12,7 @@ import 'package:submersion/features/dive_log/data/services/dive_consolidation_se
 import 'package:submersion/features/dive_log/data/services/dive_merge_service.dart';
 import 'package:submersion/features/dive_log/data/services/dive_split_service.dart';
 import 'package:submersion/features/dive_log/data/services/dive_uncombine_service.dart';
-import 'package:submersion/features/dive_log/data/services/estimated_tank_pressure_synthesizer.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
-import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
 import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
@@ -1115,53 +1113,6 @@ final tankPressuresProvider =
         ref.watch(diveRepositoryProvider).watchAnalysisInputChanges(),
       );
       return repository.getTankPressuresForDive(diveId);
-    });
-
-/// Real per-tank pressures augmented with in-memory linear estimates for tanks
-/// that have start/end pressures but no transmitter data. Chart-only; the
-/// estimates are never persisted, so SAC analysis and exports (which read the
-/// repository directly) still see real measured data only.
-final estimatedTankPressuresProvider =
-    FutureProvider.family<EstimatedTankPressures, String>((ref, diveId) async {
-      // Start the independent fetches concurrently to avoid a request waterfall
-      // on the chart load path.
-      final realFuture = ref.watch(tankPressuresProvider(diveId).future);
-      final diveFuture = ref.watch(diveProvider(diveId).future);
-      final switchesFuture = ref.watch(gasSwitchesProvider(diveId).future);
-      // Read synchronously, before the first await, so the dependency is
-      // registered while the provider is certainly still alive.
-      final showEstimates = ref.watch(
-        settingsProvider.select((s) => s.defaultShowEstimatedTankPressure),
-      );
-      final real = await realFuture;
-      final dive = await diveFuture;
-      if (dive == null) {
-        return EstimatedTankPressures(real, const <String>{});
-      }
-      // A gauge (bottom-timer) dive models no gas at all, so a synthesized
-      // pressure trace would be fabricated rather than measured (issue #731).
-      // Real transmitter samples, if the dive has any, still pass through.
-      if (dive.isGauge) {
-        return EstimatedTankPressures(real, const <String>{});
-      }
-      // The diver can switch estimates off entirely (issue #731). Gating here
-      // rather than at the chart means the series never exists, so no legend
-      // chip, tooltip row, or "(est.)" label survives anywhere.
-      if (!showEstimates) {
-        return EstimatedTankPressures(real, const <String>{});
-      }
-      final switches = await switchesFuture;
-      return synthesizeEstimatedTankPressures(
-        existing: real,
-        tanks: dive.tanks,
-        gasSwitches: switches,
-        diveDurationSeconds: dive.profile.isEmpty
-            ? 0
-            : dive.profile.last.timestamp,
-        firstSampleSeconds: dive.profile.isEmpty
-            ? 0
-            : dive.profile.first.timestamp,
-      );
     });
 
 /// Provider to load data sources for a dive.

--- a/lib/features/dive_log/presentation/widgets/dive_profile_panel.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_panel.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/providers/active_source_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/chart_tank_pressures_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/highlight_providers.dart';
@@ -271,7 +272,9 @@ class _DiveProfilePanelContentState
         )
         .value;
     final gasSwitches = ref.watch(gasSwitchesProvider(widget.diveId)).value;
-    final tankPressures = ref.watch(tankPressuresProvider(widget.diveId)).value;
+    final tankPressures = ref
+        .watch(activeSourceTankPressuresProvider(widget.diveId))
+        .value;
     // Chart-only: real pressures augmented with linear estimates (#197).
     final estimatedTankPressures = ref
         .watch(estimatedTankPressuresProvider(widget.diveId))

--- a/lib/features/media/presentation/pages/media_viewer_page.dart
+++ b/lib/features/media/presentation/pages/media_viewer_page.dart
@@ -17,6 +17,7 @@ import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
 import 'package:submersion/features/dive_log/presentation/providers/active_source_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/chart_tank_pressures_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
@@ -382,7 +383,7 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
             final gasSwitches =
                 ref.watch(gasSwitchesProvider(currentDiveId)).value ?? const [];
             final tankPressures = ref
-                .watch(tankPressuresProvider(currentDiveId))
+                .watch(activeSourceTankPressuresProvider(currentDiveId))
                 .value;
             final primarySource =
                 dataSources.where((s) => s.isPrimary).firstOrNull ??

--- a/test/features/dive_log/data/repositories/tank_pressure_series_reads_test.dart
+++ b/test/features/dive_log/data/repositories/tank_pressure_series_reads_test.dart
@@ -140,4 +140,67 @@ void main() {
     expect(await tanks.getTankPressuresForDive('dive-1'), isEmpty);
     expect(await tanks.hasTankPressures('dive-1'), isFalse);
   });
+
+  test('getTankPressuresForComputer keeps one computer per shared tank and '
+      'falls back for tanks it did not log', () async {
+    // Two computers on one transmitter (#543's tank-pressure twin): both
+    // series land on tank-a and alternate seconds because of the time
+    // offset between the computers.
+    for (final computer in ['dc-black', 'dc-bronze']) {
+      await db
+          .into(db.diveComputers)
+          .insert(
+            DiveComputersCompanion.insert(
+              id: computer,
+              name: computer,
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+    }
+    await series.insertSeries(
+      diveId: 'dive-1',
+      tankId: 'tank-a',
+      computerId: 'dc-black',
+      samples: const [
+        TankPressureSample(timestamp: 2, pressure: 225.5),
+        TankPressureSample(timestamp: 4, pressure: 225.0),
+      ],
+      now: now,
+    );
+    await series.insertSeries(
+      diveId: 'dive-1',
+      tankId: 'tank-a',
+      computerId: 'dc-bronze',
+      samples: const [
+        TankPressureSample(timestamp: 3, pressure: 223.5),
+        TankPressureSample(timestamp: 5, pressure: 223.3),
+      ],
+      now: now,
+    );
+    await series.insertSeries(
+      diveId: 'dive-1',
+      tankId: 'tank-b',
+      computerId: 'dc-black',
+      samples: const [TankPressureSample(timestamp: 0, pressure: 200.0)],
+      now: now,
+    );
+
+    final forBronze = await tanks.getTankPressuresForComputer(
+      'dive-1',
+      'dc-bronze',
+    );
+    expect(forBronze['tank-a']!.map((p) => p.pressure), [223.5, 223.3]);
+    expect(forBronze['tank-b']!.map((p) => p.pressure), [200.0]);
+
+    final forBlack = await tanks.getTankPressuresForComputer(
+      'dive-1',
+      'dc-black',
+    );
+    expect(forBlack['tank-a']!.map((p) => p.timestamp), [2, 4]);
+
+    // The unscoped read is unchanged: the interleaved union.
+    final union = await tanks.getTankPressuresForDive('dive-1');
+    expect(union['tank-a']!.map((p) => p.timestamp), [2, 3, 4, 5]);
+  });
 }

--- a/test/features/dive_log/domain/services/profile_series_merge_test.dart
+++ b/test/features/dive_log/domain/services/profile_series_merge_test.dart
@@ -302,4 +302,61 @@ void main() {
       expect(mergeTankSeriesPoints(const []), isEmpty);
     });
   });
+
+  group('selectTankSeriesForComputer', () {
+    // Two computers paired to one transmitter each log the same cylinder,
+    // and consolidation files both series under one tank. Interleaving them
+    // alternates between the two computers' readings sample by sample.
+    final black = tankSeries(
+      'black',
+      computerId: 'dc-black',
+      samples: const [
+        TankPressureSample(timestamp: 2, pressure: 225.5),
+        TankPressureSample(timestamp: 4, pressure: 225.5),
+      ],
+    );
+    final bronze = tankSeries(
+      'bronze',
+      computerId: 'dc-bronze',
+      samples: const [
+        TankPressureSample(timestamp: 3, pressure: 223.5),
+        TankPressureSample(timestamp: 5, pressure: 223.5),
+      ],
+    );
+
+    test('keeps only the requested computer\'s series on a shared tank', () {
+      final kept = selectTankSeriesForComputer([black, bronze], 'dc-bronze');
+      expect(kept.map((s) => s.id), ['bronze']);
+    });
+
+    test('falls back to every series of a tank the computer did not log', () {
+      final stage = tankSeries(
+        'stage',
+        tankId: 'tank-stage',
+        computerId: 'dc-black',
+        samples: const [TankPressureSample(timestamp: 0, pressure: 200.0)],
+      );
+      final kept = selectTankSeriesForComputer([
+        black,
+        bronze,
+        stage,
+      ], 'dc-bronze');
+      expect(kept.map((s) => s.id), ['bronze', 'stage']);
+    });
+
+    test('a null computer prefers series with no computer', () {
+      final manual = tankSeries(
+        'manual',
+        samples: const [TankPressureSample(timestamp: 0, pressure: 210.0)],
+      );
+      final kept = selectTankSeriesForComputer([black, manual], null);
+      expect(kept.map((s) => s.id), ['manual']);
+    });
+
+    test('preserves input order within the kept series', () {
+      final kept = selectTankSeriesForComputer([bronze, black], 'dc-black');
+      expect(kept.map((s) => s.id), ['black']);
+      expect(selectTankSeriesForComputer(const [], 'dc-black'), isEmpty);
+    });
+  });
 }

--- a/test/features/dive_log/presentation/pages/dive_detail_profile_section_reload_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_profile_section_reload_test.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive_data_source.da
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
 import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
 import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/chart_tank_pressures_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';

--- a/test/features/dive_log/presentation/providers/active_source_tank_pressures_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/active_source_tank_pressures_provider_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
+import 'package:submersion/features/dive_log/presentation/providers/active_source_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/chart_tank_pressures_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Tank-pressure twin of the #543 depth rule.
+///
+/// Two computers paired to one transmitter both log the same cylinder, and
+/// consolidation files both series under one tank. The unscoped read
+/// interleaves them, so on a multi-source dive the chart must read the
+/// active source's computer only; a single-source dive keeps the plain read.
+class _FakeTankPressureRepository implements TankPressureRepository {
+  final List<String?> scopedCalls = [];
+  int unscopedCalls = 0;
+
+  static const _scoped = <String, List<TankPressurePoint>>{
+    'tank-a': [TankPressurePoint(tankId: 'tank-a', timestamp: 3, pressure: 1)],
+  };
+  static const _union = <String, List<TankPressurePoint>>{
+    'tank-a': [
+      TankPressurePoint(tankId: 'tank-a', timestamp: 2, pressure: 2),
+      TankPressurePoint(tankId: 'tank-a', timestamp: 3, pressure: 1),
+    ],
+  };
+
+  @override
+  Future<Map<String, List<TankPressurePoint>>> getTankPressuresForDive(
+    String diveId,
+  ) async {
+    unscopedCalls++;
+    return _union;
+  }
+
+  @override
+  Future<Map<String, List<TankPressurePoint>>> getTankPressuresForComputer(
+    String diveId,
+    String? computerId,
+  ) async {
+    scopedCalls.add(computerId);
+    return _scoped;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  const diveId = 'dive-1';
+  final now = DateTime(2026, 5, 6);
+
+  setUp(() async {
+    await setUpTestDatabase();
+  });
+  tearDown(tearDownTestDatabase);
+
+  DiveDataSource source(
+    String id, {
+    required bool isPrimary,
+    String? computer,
+  }) => DiveDataSource(
+    id: id,
+    diveId: diveId,
+    computerId: computer,
+    isPrimary: isPrimary,
+    importedAt: now,
+    createdAt: now,
+  );
+
+  // Overlapping in time, so the dive renders per source rather than as the
+  // sequential halves of a Combine (#1451).
+  const points = [
+    DiveProfilePoint(timestamp: 0, depth: 0.0),
+    DiveProfilePoint(timestamp: 600, depth: 10.0),
+  ];
+  final twoSources = [
+    source('src-black', isPrimary: true, computer: 'dc-black'),
+    source('src-file', isPrimary: false),
+  ];
+  final twoProfiles = {
+    'src-black': const SourceProfile(
+      sourceId: 'src-black',
+      computerId: 'dc-black',
+      isEdited: false,
+      points: points,
+    ),
+    'src-file': const SourceProfile(
+      sourceId: 'src-file',
+      computerId: null,
+      isEdited: false,
+      points: points,
+    ),
+  };
+
+  Future<(ProviderContainer, _FakeTankPressureRepository)> containerWith({
+    required List<DiveDataSource> sources,
+    required Map<String, SourceProfile> profiles,
+    String? activeSourceId,
+  }) async {
+    final repo = _FakeTankPressureRepository();
+    final container = ProviderContainer(
+      overrides: [
+        tankPressureRepositoryProvider.overrideWithValue(repo),
+        diveDataSourcesProvider(
+          diveId,
+        ).overrideWith((ref) => Future.value(sources)),
+        sourceProfilesProvider(
+          diveId,
+        ).overrideWith((ref) => Future.value(profiles)),
+        if (activeSourceId != null)
+          activeDiveSourceProvider(
+            diveId,
+          ).overrideWith((ref) => activeSourceId),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.listen(activeSourceTankPressuresProvider(diveId), (_, _) {});
+    await container.read(diveDataSourcesProvider(diveId).future);
+    await container.read(sourceProfilesProvider(diveId).future);
+    return (container, repo);
+  }
+
+  test('a multi-source dive reads the primary computer by default', () async {
+    final (container, repo) = await containerWith(
+      sources: twoSources,
+      profiles: twoProfiles,
+    );
+
+    final pressures = await container.read(
+      activeSourceTankPressuresProvider(diveId).future,
+    );
+
+    // The frame before the data sources resolve falls back to the union,
+    // exactly as activeSourceProfileProvider sends callers to dive.profile;
+    // what matters is the state the chart settles on.
+    expect(repo.scopedCalls, ['dc-black']);
+    expect(pressures['tank-a']!.map((p) => p.timestamp), [3]);
+  });
+
+  test('an active file-import source reads the null computer', () async {
+    final (container, repo) = await containerWith(
+      sources: twoSources,
+      profiles: twoProfiles,
+      activeSourceId: 'src-file',
+    );
+
+    await container.read(activeSourceTankPressuresProvider(diveId).future);
+
+    expect(repo.scopedCalls, [null]);
+  });
+
+  test('a single-source dive keeps the unscoped read', () async {
+    final (container, repo) = await containerWith(
+      sources: [twoSources.first],
+      profiles: {'src-black': twoProfiles['src-black']!},
+    );
+
+    final pressures = await container.read(
+      activeSourceTankPressuresProvider(diveId).future,
+    );
+
+    expect(repo.scopedCalls, isEmpty);
+    expect(repo.unscopedCalls, 1);
+    expect(pressures['tank-a']!.map((p) => p.timestamp), [2, 3]);
+  });
+}

--- a/test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart
@@ -290,4 +290,33 @@ void main() {
     expect(result.estimatedTankIds, isEmpty);
     expect(result.pressures['t1']!.map((p) => p.timestamp), [2, 4]);
   });
+
+  test('passes the real map through when the dive no longer exists', () async {
+    // A deleted dive mid-navigation: nothing to estimate against, so the
+    // measured series (if any) are returned unchanged and nothing is marked
+    // as an estimate.
+    const real = <String, List<TankPressurePoint>>{
+      't1': [TankPressurePoint(tankId: 't1', timestamp: 0, pressure: 200)],
+    };
+    final container = ProviderContainer(
+      overrides: [
+        settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        activeSourceTankPressuresProvider(
+          'd1',
+        ).overrideWith((ref) async => real),
+        diveProvider('d1').overrideWith((ref) async => null),
+        gasSwitchesProvider(
+          'd1',
+        ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container.read(
+      estimatedTankPressuresProvider('d1').future,
+    );
+
+    expect(result.estimatedTankIds, isEmpty);
+    expect(result.pressures, same(real));
+  });
 }

--- a/test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart
@@ -3,6 +3,7 @@ import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+import 'package:submersion/features/dive_log/presentation/providers/chart_tank_pressures_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -236,5 +237,57 @@ void main() {
 
   test('estimates pressures by default', () async {
     expect(const AppSettings().defaultShowEstimatedTankPressure, isTrue);
+  });
+
+  test('builds on the active source\'s pressures, not the union', () async {
+    // Two computers on one transmitter (#543's pressure twin): the union
+    // interleaves both computers' readings on t1, the active-source read
+    // keeps one. The chart draws this provider, so it must start from the
+    // scoped map or the fuzzy union comes straight back.
+    const scoped = <String, List<TankPressurePoint>>{
+      't1': [
+        TankPressurePoint(tankId: 't1', timestamp: 2, pressure: 225.5),
+        TankPressurePoint(tankId: 't1', timestamp: 4, pressure: 225.0),
+      ],
+    };
+    const union = <String, List<TankPressurePoint>>{
+      't1': [
+        TankPressurePoint(tankId: 't1', timestamp: 2, pressure: 225.5),
+        TankPressurePoint(tankId: 't1', timestamp: 3, pressure: 223.5),
+        TankPressurePoint(tankId: 't1', timestamp: 4, pressure: 225.0),
+        TankPressurePoint(tankId: 't1', timestamp: 5, pressure: 223.3),
+      ],
+    };
+    final dive = Dive(
+      id: 'd1',
+      dateTime: DateTime(2026, 5, 6),
+      tanks: const [DiveTank(id: 't1', gasMix: GasMix(o2: 32))],
+      profile: const [
+        DiveProfilePoint(timestamp: 0, depth: 0),
+        DiveProfilePoint(timestamp: 6, depth: 0),
+      ],
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        tankPressuresProvider('d1').overrideWith((ref) async => union),
+        activeSourceTankPressuresProvider(
+          'd1',
+        ).overrideWith((ref) async => scoped),
+        diveProvider('d1').overrideWith((ref) async => dive),
+        gasSwitchesProvider(
+          'd1',
+        ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container.read(
+      estimatedTankPressuresProvider('d1').future,
+    );
+
+    expect(result.estimatedTankIds, isEmpty);
+    expect(result.pressures['t1']!.map((p) => p.timestamp), [2, 4]);
   });
 }

--- a/test/features/dive_log/presentation/widgets/dive_profile_panel_reload_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_panel_reload_test.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
 import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
+import 'package:submersion/features/dive_log/presentation/providers/chart_tank_pressures_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/highlight_providers.dart';


### PR DESCRIPTION
## Summary

Two Shearwater Terics paired to the same transmitter both log the same cylinder. When the programmed gas mixes match, consolidation merges the secondary's tank into the primary's (the tank match keys on gas mix), so both computers' pressure series land on one tank. The chart read grouped series by tank only and interleaved them. Because the computers sample on offset seconds, the single pressure line alternated between the two computers every sample: a fuzzy band wherever they disagreed by a fraction of a bar (dive 17 in the reporting logbook), and an invisible second computer where they agreed within a tenth of a bar (dive 20).

This is the tank-pressure twin of #543, which fixed the same interleaving for the depth profile.

## Changes

- `selectTankSeriesForComputer` (domain): per tank, keep only the requested computer's series when it logged that tank at all; a tank the computer never logged keeps every series, so a stage read by the other computer is not hidden. Null is a legitimate computer (file imports).
- `TankPressureRepository.getTankPressuresForComputer`: the scoped read on top of it. The unscoped `getTankPressuresForDive` is unchanged and still feeds SAC analysis, exports, the buoyancy twins and the cylinders card.
- `activeSourceTankPressuresProvider`: follows the active source chip exactly as `activeSourceProfileProvider` does for depth, and falls back to the unscoped read on single-source dives and sequential Combines (#1451).
- The detail page, fullscreen page, dive-list side panel and media viewer face read the scoped provider. `estimatedTankPressuresProvider` now builds on it.
- Both chart providers live in a new `chart_tank_pressures_provider.dart`. The estimate provider had to move out of `dive_providers.dart`: the scoped provider depends on `active_source_provider.dart`, which already imports `dive_providers.dart`, so leaving it there would have created an import cycle.

## Not changed, on purpose

- SAC analysis: `combineMultiTankPressures` takes an exact-timestamp point first, and each computer's own series shares its profile's timestamps, so the interleaving never reached the SAC curve.
- Consolidation's tank match. When the two computers had different programmed mixes (31% vs 32% on the same cylinder), the secondary keeps a duplicate tank and the chart still draws it twice. Collapsing that needs the transmitter serial carried through the parser and stored, which is a separate change.

## Testing

- New tests, written first and watched fail: the domain selector, the scoped repository read (real in-memory database), the provider (multi-source default, active file import, single-source fallback), and the estimate provider building on the scoped map.
- `flutter test` over dive_log presentation, media, dive_3d, data_quality repairs, the export loader, and the dive_log data and domain trees: 4717 passed.
- `dart analyze`: no issues. `dart format .`: clean.