### PR TITLE
feat(consolidation): match tanks on the transmitter serial before the gas mix

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -961,6 +961,11 @@ class DiveTanks extends Table {
       text().nullable()(); // user-friendly name like "Primary AL80"
   TextColumn get presetName =>
       text().nullable()(); // preset name (e.g., 'al80', 'hp100')
+  // Serial of the air-integration transmitter that reported this tank, as the
+  // computer logged it (v194). Null for manual tanks and computers that report
+  // none. Two computers paired to one transmitter logged the same cylinder,
+  // so consolidation matches tanks on this before falling back to gas mix.
+  TextColumn get transmitterSerial => text().nullable()();
   // Which computer contributed this tank (null = primary source / manual).
   // Same null-means-primary semantics as dive_profiles.computerId; deletes
   // set null.
@@ -3410,7 +3415,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 191;
+  static const int currentSchemaVersion = 194;
 
   /// The oldest schema whose reader can apply this build's sync payloads
   /// without loss or misinterpretation (the compatibility floor).
@@ -3896,6 +3901,7 @@ class AppDatabase extends _$AppDatabase {
     // recompression rungs (188-190) while this branch was open, and a rung
     // at or below the shipped version never runs its onUpgrade step.
     191,
+    194,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -6098,6 +6104,19 @@ class AppDatabase extends _$AppDatabase {
   /// moment an item leaves pending and cleared on reset. Self-guards on the
   /// table existing. Same dual-call contract (onUpgrade + beforeOpen
   /// backstop) as the other column-assert helpers.
+  /// Idempotent DDL for the v194 dive_tanks.transmitter_serial column. Called
+  /// from the v194 rung and re-asserted in beforeOpen (parallel-branch
+  /// version-collision backstop) like the other column-assert helpers.
+  Future<void> _assertTankTransmitterSerialColumn() async {
+    final cols = await customSelect("PRAGMA table_info('dive_tanks')").get();
+    if (cols.isEmpty) return;
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    if (names.contains('transmitter_serial')) return;
+    await customStatement(
+      'ALTER TABLE dive_tanks ADD COLUMN transmitter_serial TEXT',
+    );
+  }
+
   Future<void> _assertSessionItemOverdueServicesColumn() async {
     final cols = await customSelect(
       "PRAGMA table_info('pre_dive_session_items')",
@@ -10300,6 +10319,15 @@ class AppDatabase extends _$AppDatabase {
           await _assertPlanAscentRateColumns();
         }
         if (from < 191) await reportProgress();
+        // v194: dive_tanks.transmitter_serial, the air-integration
+        // transmitter each downloaded tank was read from. Nullable, no
+        // backfill: the serial is only known from a fresh download or
+        // re-parse of the stored raw data. 192 and 193 are held by other
+        // open branches.
+        if (from < 194) {
+          await _assertTankTransmitterSerialColumn();
+        }
+        if (from < 194) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -10678,6 +10706,12 @@ class AppDatabase extends _$AppDatabase {
         // every open: column-and-index only, no backfill, so it cannot
         // resurrect or overwrite diver data.
         await _assertMediaEquipmentIdColumn();
+
+        // v194 backstop: re-assert dive_tanks.transmitter_serial. Every tank
+        // read selects the whole row, so a database that arrives by restore
+        // or sync-adopt without the rung would throw on the first read.
+        // Column only, no backfill, so it cannot touch diver data.
+        await _assertTankTransmitterSerialColumn();
 
         // v145 backstop: re-assert the gps_tracks provenance and trim columns.
         await _assertGpsTrackColumns();

--- a/lib/core/services/export/uddf/uddf_export_builders.dart
+++ b/lib/core/services/export/uddf/uddf_export_builders.dart
@@ -481,6 +481,15 @@ class UddfExportBuilders {
                 }
                 // Tank order (for multi-tank configurations)
                 builder.element('tankorder', nest: tank.order.toString());
+                // Air-integration transmitter serial (app-specific): UDDF
+                // has no element for it, and it is the cylinder's identity
+                // across computers, so our own round trip must keep it.
+                if (tank.transmitterSerial != null) {
+                  builder.element(
+                    'transmitterserial',
+                    nest: tank.transmitterSerial,
+                  );
+                }
               },
             );
           }

--- a/lib/core/services/export/uddf/uddf_export_builders.dart
+++ b/lib/core/services/export/uddf/uddf_export_builders.dart
@@ -24,6 +24,7 @@ import 'package:submersion/features/equipment/domain/entities/equipment_set.dart
 import 'package:submersion/features/marine_life/domain/entities/species.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
+import 'package:submersion/features/dive_log/domain/services/transmitter_serial.dart';
 
 /// Static XML builder methods for comprehensive UDDF export.
 ///
@@ -484,11 +485,11 @@ class UddfExportBuilders {
                 // Air-integration transmitter serial (app-specific): UDDF
                 // has no element for it, and it is the cylinder's identity
                 // across computers, so our own round trip must keep it.
-                if (tank.transmitterSerial != null) {
-                  builder.element(
-                    'transmitterserial',
-                    nest: tank.transmitterSerial,
-                  );
+                final transmitterSerial = normalizeTransmitterSerial(
+                  tank.transmitterSerial,
+                );
+                if (transmitterSerial != null) {
+                  builder.element('transmitterserial', nest: transmitterSerial);
                 }
               },
             );

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -1886,6 +1886,16 @@ class UddfFullImportService {
         tankInfo['order'] = UddfImportParsers.parseUddfInt(tankOrder) ?? 0;
       }
 
+      // Air-integration transmitter serial (app-specific, written by our
+      // own export)
+      final transmitterSerial = UddfImportParsers.getElementText(
+        tankDataElement,
+        'transmitterserial',
+      )?.trim();
+      if (transmitterSerial != null && transmitterSerial.isNotEmpty) {
+        tankInfo['transmitterSerial'] = transmitterSerial;
+      }
+
       // Validate tank data before adding
       final startPressure = (tankInfo['startPressure'] as num?)?.toDouble();
       final endPressure = (tankInfo['endPressure'] as num?)?.toDouble();

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -9,6 +9,7 @@ import 'package:submersion/core/services/export/uddf/uddf_dump_codec.dart';
 import 'package:submersion/core/services/export/uddf/uddf_import_parsers.dart';
 import 'package:submersion/core/services/export/uddf/uddf_normalizer.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/services/transmitter_serial.dart';
 
 /// Handles comprehensive UDDF import including all application data.
 ///
@@ -1888,11 +1889,10 @@ class UddfFullImportService {
 
       // Air-integration transmitter serial (app-specific, written by our
       // own export)
-      final transmitterSerial = UddfImportParsers.getElementText(
-        tankDataElement,
-        'transmitterserial',
-      )?.trim();
-      if (transmitterSerial != null && transmitterSerial.isNotEmpty) {
+      final transmitterSerial = normalizeTransmitterSerial(
+        UddfImportParsers.getElementText(tankDataElement, 'transmitterserial'),
+      );
+      if (transmitterSerial != null) {
         tankInfo['transmitterSerial'] = transmitterSerial;
       }
 

--- a/lib/core/services/export/uddf/uddf_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_import_service.dart
@@ -3,6 +3,7 @@ import 'package:xml/xml.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/export/uddf/uddf_import_parsers.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/services/transmitter_serial.dart';
 
 /// Handles simple UDDF dive import.
 ///
@@ -472,11 +473,10 @@ class UddfImportService {
 
       // Air-integration transmitter serial (app-specific, written by our
       // own export)
-      final transmitterSerial = _getElementText(
-        tankDataElement,
-        'transmitterserial',
-      )?.trim();
-      if (transmitterSerial != null && transmitterSerial.isNotEmpty) {
+      final transmitterSerial = normalizeTransmitterSerial(
+        _getElementText(tankDataElement, 'transmitterserial'),
+      );
+      if (transmitterSerial != null) {
         tankInfo['transmitterSerial'] = transmitterSerial;
       }
 

--- a/lib/core/services/export/uddf/uddf_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_import_service.dart
@@ -470,6 +470,16 @@ class UddfImportService {
         tankInfo['order'] = UddfImportParsers.parseUddfInt(tankOrder) ?? 0;
       }
 
+      // Air-integration transmitter serial (app-specific, written by our
+      // own export)
+      final transmitterSerial = _getElementText(
+        tankDataElement,
+        'transmitterserial',
+      )?.trim();
+      if (transmitterSerial != null && transmitterSerial.isNotEmpty) {
+        tankInfo['transmitterSerial'] = transmitterSerial;
+      }
+
       // Validate tank data before adding
       final startPressure = (tankInfo['startPressure'] as num?)?.toDouble();
       final endPressure = (tankInfo['endPressure'] as num?)?.toDouble();

--- a/lib/features/data_quality/domain/detectors/tank_assignment_detector.dart
+++ b/lib/features/data_quality/domain/detectors/tank_assignment_detector.dart
@@ -116,6 +116,20 @@ class TankAssignmentDetector extends QualityDetector {
   static String? _serial(DiveTank tank) =>
       normalizeTransmitterSerial(tank.transmitterSerial);
 
+  /// The series in ascending time order. Stored series already are, so the
+  /// common case returns the input itself rather than cloning and sorting
+  /// it for every tank pair of every dive in a library scan.
+  static List<QualityPressureSample> _inTimeOrder(
+    List<QualityPressureSample> series,
+  ) {
+    for (var i = 1; i < series.length; i++) {
+      if (series[i].t < series[i - 1].t) {
+        return [...series]..sort((x, y) => x.t.compareTo(y.t));
+      }
+    }
+    return series;
+  }
+
   /// Mean absolute pressure difference between two series at their nearest
   /// samples, or null when they never come within the gap tolerance of each
   /// other. Both series are compared in time order with a single walk.
@@ -124,8 +138,8 @@ class TankAssignmentDetector extends QualityDetector {
     List<QualityPressureSample> b,
   ) {
     if (a.isEmpty || b.isEmpty) return null;
-    final sortedA = [...a]..sort((x, y) => x.t.compareTo(y.t));
-    final sortedB = [...b]..sort((x, y) => x.t.compareTo(y.t));
+    final sortedA = _inTimeOrder(a);
+    final sortedB = _inTimeOrder(b);
     const gap = QualityThresholds.twinSeriesMaxTimeGapSeconds;
     var n = 0;
     var sum = 0.0;

--- a/lib/features/data_quality/domain/detectors/tank_assignment_detector.dart
+++ b/lib/features/data_quality/domain/detectors/tank_assignment_detector.dart
@@ -2,6 +2,7 @@ import 'package:submersion/features/data_quality/domain/entities/dive_quality_co
 import 'package:submersion/features/data_quality/domain/entities/quality_finding.dart';
 import 'package:submersion/features/data_quality/domain/quality_thresholds.dart';
 import 'package:submersion/features/data_quality/domain/detectors/quality_detector.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 
 class TankAssignmentDetector extends QualityDetector {
   const TankAssignmentDetector();
@@ -9,7 +10,7 @@ class TankAssignmentDetector extends QualityDetector {
   @override
   String get id => 'tank_assignment';
   @override
-  int get version => 1;
+  int get version => 2;
   @override
   QualityCategory get category => QualityCategory.tank;
 
@@ -18,38 +19,46 @@ class TankAssignmentDetector extends QualityDetector {
     if (ctx.tanks.length < 2) return const [];
     final out = <QualityFinding>[];
 
-    // Double-assigned transmitter: two tanks carrying the same series.
-    final tankIds = ctx.pressuresByTankId.keys.toList()..sort();
+    // Double-assigned transmitter: the same cylinder on the dive twice.
+    //
+    // Two tanks that carry the same transmitter serial are the same
+    // cylinder by definition (the usual cause: two computers paired to one
+    // transmitter, consolidated before serials were stored). Two tanks with
+    // different serials are two cylinders however alike their curves, so
+    // the series heuristic is skipped for them. Without serials on both
+    // sides, matching pressure series are the evidence.
+    final tanksById = {for (final t in ctx.tanks) t.id: t};
+    final tankIds = tanksById.keys.toList()..sort();
     for (var i = 0; i < tankIds.length; i++) {
       for (var j = i + 1; j < tankIds.length; j++) {
-        final a = ctx.pressuresByTankId[tankIds[i]]!;
-        final b = {
-          for (final p in ctx.pressuresByTankId[tankIds[j]]!) p.t: p.bar,
-        };
-        var n = 0;
-        var sum = 0.0;
-        for (final p in a) {
-          final q = b[p.t];
-          if (q != null) {
-            n++;
-            sum += (p.bar - q).abs();
-          }
-        }
-        if (n >= QualityThresholds.twinSeriesMinSamples &&
-            sum / n < QualityThresholds.twinSeriesMeanDiffBar) {
-          out.add(
-            make(
-              ctx,
-              discriminator: 'twin:${tankIds[i]}|${tankIds[j]}',
-              severity: QualitySeverity.warning,
-              params: {
-                'tankIdA': tankIds[i],
-                'tankIdB': tankIds[j],
-                'meanDiffBar': sum / n,
-              },
-            ),
-          );
-        }
+        final serialA = _serial(tanksById[tankIds[i]]!);
+        final serialB = _serial(tanksById[tankIds[j]]!);
+        final sameTransmitter = serialA != null && serialA == serialB;
+        if (serialA != null && serialB != null && !sameTransmitter) continue;
+
+        final agreement = _seriesAgreement(
+          ctx.pressuresByTankId[tankIds[i]] ?? const [],
+          ctx.pressuresByTankId[tankIds[j]] ?? const [],
+        );
+        final twinSeries =
+            agreement != null &&
+            agreement.samples >= QualityThresholds.twinSeriesMinSamples &&
+            agreement.meanDiffBar < QualityThresholds.twinSeriesMeanDiffBar;
+        if (!sameTransmitter && !twinSeries) continue;
+
+        out.add(
+          make(
+            ctx,
+            discriminator: 'twin:${tankIds[i]}|${tankIds[j]}',
+            severity: QualitySeverity.warning,
+            params: {
+              'tankIdA': tankIds[i],
+              'tankIdB': tankIds[j],
+              'meanDiffBar': agreement?.meanDiffBar ?? 0.0,
+              'sameTransmitter': sameTransmitter,
+            },
+          ),
+        );
       }
     }
 
@@ -101,5 +110,38 @@ class TankAssignmentDetector extends QualityDetector {
       }
     }
     return out;
+  }
+
+  static String? _serial(DiveTank tank) {
+    final serial = tank.transmitterSerial;
+    return serial == null || serial.isEmpty ? null : serial;
+  }
+
+  /// Mean absolute pressure difference between two series at their nearest
+  /// samples, or null when they never come within the gap tolerance of each
+  /// other. Both series are compared in time order with a single walk.
+  static ({int samples, double meanDiffBar})? _seriesAgreement(
+    List<QualityPressureSample> a,
+    List<QualityPressureSample> b,
+  ) {
+    if (a.isEmpty || b.isEmpty) return null;
+    final sortedA = [...a]..sort((x, y) => x.t.compareTo(y.t));
+    final sortedB = [...b]..sort((x, y) => x.t.compareTo(y.t));
+    const gap = QualityThresholds.twinSeriesMaxTimeGapSeconds;
+    var n = 0;
+    var sum = 0.0;
+    var j = 0;
+    for (final p in sortedA) {
+      while (j + 1 < sortedB.length &&
+          (sortedB[j + 1].t - p.t).abs() <= (sortedB[j].t - p.t).abs()) {
+        j++;
+      }
+      final q = sortedB[j];
+      if ((q.t - p.t).abs() > gap) continue;
+      n++;
+      sum += (p.bar - q.bar).abs();
+    }
+    if (n == 0) return null;
+    return (samples: n, meanDiffBar: sum / n);
   }
 }

--- a/lib/features/data_quality/domain/detectors/tank_assignment_detector.dart
+++ b/lib/features/data_quality/domain/detectors/tank_assignment_detector.dart
@@ -3,6 +3,7 @@ import 'package:submersion/features/data_quality/domain/entities/quality_finding
 import 'package:submersion/features/data_quality/domain/quality_thresholds.dart';
 import 'package:submersion/features/data_quality/domain/detectors/quality_detector.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/services/transmitter_serial.dart';
 
 class TankAssignmentDetector extends QualityDetector {
   const TankAssignmentDetector();
@@ -112,10 +113,8 @@ class TankAssignmentDetector extends QualityDetector {
     return out;
   }
 
-  static String? _serial(DiveTank tank) {
-    final serial = tank.transmitterSerial;
-    return serial == null || serial.isEmpty ? null : serial;
-  }
+  static String? _serial(DiveTank tank) =>
+      normalizeTransmitterSerial(tank.transmitterSerial);
 
   /// Mean absolute pressure difference between two series at their nearest
   /// samples, or null when they never come within the gap tolerance of each

--- a/lib/features/data_quality/domain/quality_thresholds.dart
+++ b/lib/features/data_quality/domain/quality_thresholds.dart
@@ -62,6 +62,10 @@ abstract final class QualityThresholds {
   static const double wrongTankMinTotalDropBar = 20.0;
   static const double twinSeriesMeanDiffBar = 2.0;
   static const int twinSeriesMinSamples = 10;
+  // Two computers rarely sample on the same second, so twin series are
+  // compared at their nearest samples within this gap rather than at
+  // identical timestamps.
+  static const int twinSeriesMaxTimeGapSeconds = 5;
 
   // source_conflict
   static const double sourceDepthDiffFraction = 0.05;

--- a/lib/features/dive_computer/data/services/dive_parser.dart
+++ b/lib/features/dive_computer/data/services/dive_parser.dart
@@ -79,6 +79,7 @@ class DiveParser {
           endPressure: tank.endPressure,
           volumeLiters: tank.volumeLiters,
           role: tank.role,
+          transmitterSerial: tank.transmitterSerial,
         ),
       );
     }

--- a/lib/features/dive_computer/data/services/downloaded_tank_defaults.dart
+++ b/lib/features/dive_computer/data/services/downloaded_tank_defaults.dart
@@ -43,6 +43,7 @@ List<TankData> applyDefaultPresetToTanks(
       material: tank.material ?? preset.material.name,
       presetName: tank.presetName ?? preset.name,
       role: tank.role,
+      transmitterSerial: tank.transmitterSerial,
     );
   }).toList();
 }

--- a/lib/features/dive_computer/data/services/parsed_tank_resolver.dart
+++ b/lib/features/dive_computer/data/services/parsed_tank_resolver.dart
@@ -157,6 +157,7 @@ _ResolvedCylinders _resolveCylinders(
         ),
         volumeLiters: tank.volumeLiters,
         role: _inferRole(tank.usage, o2, he),
+        transmitterSerial: _transmitterSerial(tank.transmitterSerial),
       ),
     );
   }
@@ -186,6 +187,11 @@ _ResolvedCylinders _resolveCylinders(
 /// [usage] (libdivecomputer `dc_usage_t`: 1=oxygen, 2=diluent) is authoritative
 /// when present; otherwise fall back to an open-circuit gas heuristic where a
 /// nitrox mix of 41% O2 or more is a deco gas. Everything else is back gas.
+/// The native layer sends zero for "no transmitter"; keep that out of the
+/// stored identity so two serial-less tanks never look like the same cylinder.
+String? _transmitterSerial(int? serial) =>
+    serial == null || serial <= 0 ? null : '$serial';
+
 String _inferRole(int? usage, double o2Percent, double hePercent) {
   switch (usage) {
     case 1: // DC_USAGE_OXYGEN

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -722,6 +722,11 @@ class ReparseService {
             endPressure: Value(tank.endPressure),
             o2Percent: Value(tank.o2Percent),
             hePercent: Value(tank.hePercent),
+            // The transmitter serial is computer-owned and written
+            // unconditionally, so a re-parse is how a tank downloaded
+            // before the serial was stored gains it (and a parse that stops
+            // reporting one clears the stale value).
+            transmitterSerial: Value(tank.transmitterSerial),
             // tankName, presetName, equipmentId, tankRole, tankMaterial
             // are user-authored -- NOT touched
           ),
@@ -744,6 +749,7 @@ class ReparseService {
                 hePercent: Value(tank.hePercent),
                 tankOrder: Value(tank.index),
                 tankRole: Value(tank.role ?? 'backGas'),
+                transmitterSerial: Value(tank.transmitterSerial),
               ),
             );
       }

--- a/lib/features/dive_computer/domain/entities/downloaded_dive.dart
+++ b/lib/features/dive_computer/domain/entities/downloaded_dive.dart
@@ -325,6 +325,11 @@ class DownloadedTank {
   /// the default. Derived from the computer's tank usage / the gas mix.
   final String? role;
 
+  /// Serial of the air-integration transmitter that reported this tank, or
+  /// null when the computer did not report one. Two computers paired to the
+  /// same transmitter logged the same cylinder.
+  final String? transmitterSerial;
+
   const DownloadedTank({
     required this.index,
     required this.o2Percent,
@@ -333,6 +338,7 @@ class DownloadedTank {
     this.endPressure,
     this.volumeLiters,
     this.role,
+    this.transmitterSerial,
   });
 
   /// Whether this is air (21% O2)

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -2363,6 +2363,7 @@ class UddfEntityImporter {
           material: material,
           role: role,
           order: t['order'] as int? ?? 0,
+          transmitterSerial: t['transmitterSerial'] as String?,
         );
       }).toList();
     }

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -1431,6 +1431,7 @@ class DiveComputerRepository {
                 hePercent: Value(tank.hePercent),
                 tankOrder: Value(tank.index),
                 tankRole: Value(tank.role ?? 'backGas'),
+                transmitterSerial: Value(tank.transmitterSerial),
               ),
             );
             _log.info(
@@ -2303,6 +2304,10 @@ class TankData {
   /// Inferred cylinder role (a [TankRole] name), or null for the default.
   final String? role;
 
+  /// Serial of the air-integration transmitter the computer read this tank
+  /// from, or null when it reported none.
+  final String? transmitterSerial;
+
   const TankData({
     required this.index,
     required this.o2Percent,
@@ -2314,6 +2319,7 @@ class TankData {
     this.material,
     this.presetName,
     this.role,
+    this.transmitterSerial,
   });
 }
 

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1411,6 +1411,7 @@ class DiveRepository {
                 tankName: Value(tank.name),
                 presetName: Value(tank.presetName),
                 computerId: Value(tank.computerId),
+                transmitterSerial: Value(tank.transmitterSerial),
               ),
             );
           }
@@ -1652,6 +1653,10 @@ class DiveRepository {
               tankMaterial: Value(tank.material?.name),
               tankName: Value(tank.name),
               presetName: Value(tank.presetName),
+              // computerId and transmitterSerial are computer-owned identity
+              // and deliberately not written here: edit flows rebuild the
+              // tank field by field, and a rebuild that forgot them must not
+              // wipe what the download recorded.
             ),
           );
           // Log as pending update (assuming sync handles updates)
@@ -1680,6 +1685,7 @@ class DiveRepository {
                   tankName: Value(tank.name),
                   presetName: Value(tank.presetName),
                   computerId: Value(tank.computerId),
+                  transmitterSerial: Value(tank.transmitterSerial),
                 ),
               );
           await _syncRepository.markRecordPending(
@@ -3545,6 +3551,7 @@ class DiveRepository {
               order: t.tankOrder,
               presetName: t.presetName,
               computerId: t.computerId,
+              transmitterSerial: t.transmitterSerial,
             ),
           )
           .toList(),
@@ -3939,6 +3946,7 @@ class DiveRepository {
           order: t.tankOrder,
           presetName: t.presetName,
           computerId: t.computerId,
+          transmitterSerial: t.transmitterSerial,
         );
       }).toList(),
       profile: seriesProfile,
@@ -5796,6 +5804,7 @@ class DiveRepository {
     tankName: Value(t.name),
     presetName: Value(t.presetName),
     computerId: Value(t.computerId),
+    transmitterSerial: Value(t.transmitterSerial),
   );
 
   /// Append [tanks] to each dive (fresh ids, appended after existing tanks).

--- a/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
+++ b/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
@@ -360,6 +360,8 @@ class BulkDiveEditService {
                 orElse: () => en.TankMaterial.aluminum,
               ),
         presetName: r.presetName,
+        computerId: r.computerId,
+        transmitterSerial: r.transmitterSerial,
       ),
   ];
 

--- a/lib/features/dive_log/domain/entities/dive.dart
+++ b/lib/features/dive_log/domain/entities/dive.dart
@@ -1059,6 +1059,15 @@ class DiveTank extends Equatable {
   /// entered/edited tank not tied to a specific computer).
   final String? computerId;
 
+  /// Serial number of the air-integration transmitter that reported this
+  /// tank's pressures, as the dive computer logged it. Null for manually
+  /// entered tanks and for computers that do not report one.
+  ///
+  /// This is the cylinder's physical identity across computers: two logs of
+  /// the same dive whose tanks carry the same serial were read from the same
+  /// transmitter, whatever gas mix each computer had programmed.
+  final String? transmitterSerial;
+
   /// Deco gas-switch depth override in meters (planning only); null = auto
   /// (MOD at the deco pO2). Subsurface per-cylinder "Deco switch at", v120.
   /// Unused for logged-dive tanks.
@@ -1085,6 +1094,7 @@ class DiveTank extends Equatable {
     this.order = 0,
     this.presetName,
     this.computerId,
+    this.transmitterSerial,
     this.decoSwitchDepth,
     this.isTravelGas = false,
   });
@@ -1111,6 +1121,8 @@ class DiveTank extends Equatable {
     String? presetName,
     bool clearPresetName = false,
     String? computerId,
+    String? transmitterSerial,
+    bool clearTransmitterSerial = false,
     double? decoSwitchDepth,
     bool clearDecoSwitchDepth = false,
     bool? isTravelGas,
@@ -1128,6 +1140,9 @@ class DiveTank extends Equatable {
       order: order ?? this.order,
       presetName: clearPresetName ? null : (presetName ?? this.presetName),
       computerId: computerId ?? this.computerId,
+      transmitterSerial: clearTransmitterSerial
+          ? null
+          : (transmitterSerial ?? this.transmitterSerial),
       decoSwitchDepth: clearDecoSwitchDepth
           ? null
           : (decoSwitchDepth ?? this.decoSwitchDepth),
@@ -1149,6 +1164,7 @@ class DiveTank extends Equatable {
     order,
     presetName,
     computerId,
+    transmitterSerial,
     decoSwitchDepth,
     isTravelGas,
   ];

--- a/lib/features/dive_log/domain/services/dive_consolidation_builder.dart
+++ b/lib/features/dive_log/domain/services/dive_consolidation_builder.dart
@@ -126,7 +126,26 @@ class DiveConsolidationBuilder {
     return ConsolidationReady(primary: primary, secondaries: secondaries);
   }
 
+  /// Whether two tanks are the same physical cylinder, judged by their
+  /// air-integration transmitter serials.
+  ///
+  /// Returns true when both carry the same serial, false when both carry a
+  /// serial and they differ, and null when either side lacks one so the
+  /// caller must fall back to the gas-mix heuristic. The serial is read from
+  /// the transmitter itself, so it identifies the cylinder regardless of
+  /// which gas each computer had programmed for it: two computers paired to
+  /// one transmitter with 31% on one and 32% on the other still logged the
+  /// same tank.
+  bool? _serialIdentity(DiveTank primary, DiveTank secondary) {
+    final a = primary.transmitterSerial;
+    final b = secondary.transmitterSerial;
+    if (a == null || a.isEmpty || b == null || b.isEmpty) return null;
+    return a == b;
+  }
+
   bool _tankMatches(DiveTank primary, DiveTank secondary) {
+    final bySerial = _serialIdentity(primary, secondary);
+    if (bySerial != null) return bySerial;
     final o2Close =
         (primary.gasMix.o2 - secondary.gasMix.o2).abs() <= _gasTolerancePct;
     final heClose =
@@ -178,10 +197,27 @@ class DiveConsolidationBuilder {
             .inSeconds,
     };
 
+    // Two passes: transmitter serials first, so a tank whose serial names a
+    // specific primary tank claims that one before a serial-less primary
+    // tank on the same mix can take it; then the gas-mix heuristic for what
+    // is left.
     final tankMerges = <String, String>{};
     final claimedPrimaryTanks = <String>{};
     for (final s in secondaries) {
       for (final tank in s.tanks) {
+        for (final pTank in primary.tanks) {
+          if (claimedPrimaryTanks.contains(pTank.id)) continue;
+          if (_serialIdentity(pTank, tank) == true) {
+            tankMerges[tank.id] = pTank.id;
+            claimedPrimaryTanks.add(pTank.id);
+            break;
+          }
+        }
+      }
+    }
+    for (final s in secondaries) {
+      for (final tank in s.tanks) {
+        if (tankMerges.containsKey(tank.id)) continue;
         for (final pTank in primary.tanks) {
           if (claimedPrimaryTanks.contains(pTank.id)) continue;
           if (_tankMatches(pTank, tank)) {

--- a/lib/features/dive_log/domain/services/dive_consolidation_builder.dart
+++ b/lib/features/dive_log/domain/services/dive_consolidation_builder.dart
@@ -198,13 +198,18 @@ class DiveConsolidationBuilder {
             .inSeconds,
     };
 
-    // Two passes: transmitter serials first, so a tank whose serial names a
-    // specific primary tank claims that one before a serial-less primary
-    // tank on the same mix can take it; then the gas-mix heuristic for what
-    // is left.
+    // Each secondary claims primary tanks independently: three computers on
+    // one transmitter all merge into the same primary tank. Within a single
+    // secondary a claim is exclusive, so two of its tanks on the same mix
+    // stay two cylinders.
+    //
+    // Two passes per secondary: transmitter serials first, so a tank whose
+    // serial names a specific primary tank claims that one before a
+    // serial-less primary tank on the same mix can take it; then the gas-mix
+    // heuristic for what is left.
     final tankMerges = <String, String>{};
-    final claimedPrimaryTanks = <String>{};
     for (final s in secondaries) {
+      final claimedPrimaryTanks = <String>{};
       for (final tank in s.tanks) {
         for (final pTank in primary.tanks) {
           if (claimedPrimaryTanks.contains(pTank.id)) continue;
@@ -215,8 +220,6 @@ class DiveConsolidationBuilder {
           }
         }
       }
-    }
-    for (final s in secondaries) {
       for (final tank in s.tanks) {
         if (tankMerges.containsKey(tank.id)) continue;
         for (final pTank in primary.tanks) {

--- a/lib/features/dive_log/domain/services/dive_consolidation_builder.dart
+++ b/lib/features/dive_log/domain/services/dive_consolidation_builder.dart
@@ -1,4 +1,5 @@
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/services/transmitter_serial.dart';
 
 /// Why a consolidation was rejected outright.
 enum ConsolidationInvalidReason {
@@ -137,9 +138,9 @@ class DiveConsolidationBuilder {
   /// one transmitter with 31% on one and 32% on the other still logged the
   /// same tank.
   bool? _serialIdentity(DiveTank primary, DiveTank secondary) {
-    final a = primary.transmitterSerial;
-    final b = secondary.transmitterSerial;
-    if (a == null || a.isEmpty || b == null || b.isEmpty) return null;
+    final a = normalizeTransmitterSerial(primary.transmitterSerial);
+    final b = normalizeTransmitterSerial(secondary.transmitterSerial);
+    if (a == null || b == null) return null;
     return a == b;
   }
 

--- a/lib/features/dive_log/domain/services/transmitter_serial.dart
+++ b/lib/features/dive_log/domain/services/transmitter_serial.dart
@@ -1,0 +1,19 @@
+/// Canonical form of an air-integration transmitter serial.
+///
+/// The serial identifies a physical cylinder across dive computers, so
+/// anything that is not a real serial must read as "no transmitter" rather
+/// than as an identity two unrelated tanks could share. libdivecomputer
+/// reports zero for "none"; a file or peer that stringifies that, or pads it,
+/// must not smuggle it back in as `"0"`.
+///
+/// Returns the trimmed serial, or null for null, blank, whitespace, or a
+/// value that is only zeros.
+String? normalizeTransmitterSerial(String? raw) {
+  if (raw == null) return null;
+  final trimmed = raw.trim();
+  if (trimmed.isEmpty) return null;
+  if (_zeros.hasMatch(trimmed)) return null;
+  return trimmed;
+}
+
+final RegExp _zeros = RegExp(r'^0+$');

--- a/lib/features/dive_log/presentation/widgets/tank_editor.dart
+++ b/lib/features/dive_log/presentation/widgets/tank_editor.dart
@@ -303,9 +303,10 @@ class _TankEditorState extends ConsumerState<TankEditor> {
         material: _material,
         order: widget.tank.order,
         presetName: _selectedPreset?.name,
-        // Preserve source-computer attribution through edits; only
-        // consolidation/unlink flows may change it.
+        // Preserve source-computer attribution and transmitter identity
+        // through edits; only consolidation/unlink flows may change them.
         computerId: widget.tank.computerId,
+        transmitterSerial: widget.tank.transmitterSerial,
       ),
     );
   }

--- a/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
+++ b/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
@@ -1089,17 +1089,19 @@ Java_com_submersion_libdivecomputer_LibdcWrapper_nativeGetDiveTank(
     if (index < 0 || static_cast<unsigned int>(index) >= dive->tank_count) return nullptr;
 
     const libdc_tank_t *tk = &dive->tanks[index];
-    // Return [gasmix, volume, workpressure, beginpressure, endpressure, usage]
-    jdouble values[6] = {
+    // Return [gasmix, volume, workpressure, beginpressure, endpressure, usage,
+    //         transmitter serial]. Positional: the Kotlin readers index it.
+    jdouble values[7] = {
         static_cast<jdouble>(tk->gasmix),
         tk->volume,
         tk->workpressure,
         tk->beginpressure,
         tk->endpressure,
-        static_cast<jdouble>(tk->usage)
+        static_cast<jdouble>(tk->usage),
+        static_cast<jdouble>(tk->serial)
     };
-    jdoubleArray result = env->NewDoubleArray(6);
-    env->SetDoubleArrayRegion(result, 0, 6, values);
+    jdoubleArray result = env->NewDoubleArray(7);
+    env->SetDoubleArrayRegion(result, 0, 7, values);
     return result;
 }
 

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerApi.g.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerApi.g.kt
@@ -286,7 +286,14 @@ data class TankInfo (
    * Tank usage from libdivecomputer's `dc_usage_t` (1=oxygen, 2=diluent,
    * 3=sidemount); null when the computer reported no usage (DC_USAGE_NONE).
    */
-  val usage: Long? = null
+  val usage: Long? = null,
+  /**
+   * Serial number of the air-integration transmitter that reported this
+   * tank's pressures (`dc_tank_t.serial`, a fork extension); null when the
+   * computer reported none. Identifies the physical cylinder across
+   * computers paired to the same transmitter.
+   */
+  val transmitterSerial: Long? = null
 )
  {
   companion object {
@@ -297,7 +304,8 @@ data class TankInfo (
       val startPressureBar = pigeonVar_list[3] as Double?
       val endPressureBar = pigeonVar_list[4] as Double?
       val usage = pigeonVar_list[5] as Long?
-      return TankInfo(index, gasMixIndex, volumeLiters, startPressureBar, endPressureBar, usage)
+      val transmitterSerial = pigeonVar_list[6] as Long?
+      return TankInfo(index, gasMixIndex, volumeLiters, startPressureBar, endPressureBar, usage, transmitterSerial)
     }
   }
   fun toList(): List<Any?> {
@@ -308,6 +316,7 @@ data class TankInfo (
       startPressureBar,
       endPressureBar,
       usage,
+      transmitterSerial,
     )
   }
 }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -683,6 +683,7 @@ class DiveComputerHostApiImpl(
                 startPressureBar = if (tk[3] > 0) tk[3] else null,
                 endPressureBar = if (tk[4] > 0) tk[4] else null,
                 usage = if (tk[5].toLong() == 0L) null else tk[5].toLong(),
+                transmitterSerial = tk.getOrNull(6)?.toLong()?.takeIf { it != 0L },
             )
         }
 

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/SerialDownloadRunner.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/SerialDownloadRunner.kt
@@ -188,7 +188,9 @@ class SerialDownloadRunner(private val context: Context) {
                 gasMixIndex = tk[0].toLong(),
                 volumeLiters = if (tk[1] > 0) tk[1] else null,
                 startPressureBar = if (tk[3] > 0) tk[3] else null,
-                endPressureBar = if (tk[4] > 0) tk[4] else null
+                endPressureBar = if (tk[4] > 0) tk[4] else null,
+                usage = if (tk[5].toLong() == 0L) null else tk[5].toLong(),
+                transmitterSerial = tk.getOrNull(6)?.toLong()?.takeIf { it != 0L },
             )
         }
 

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
@@ -864,7 +864,8 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
                     volumeLiters: tk.volume > 0 ? tk.volume : nil,
                     startPressureBar: tk.beginpressure > 0 ? tk.beginpressure : nil,
                     endPressureBar: tk.endpressure > 0 ? tk.endpressure : nil,
-                    usage: tk.usage == 0 ? nil : Int64(tk.usage)
+                    usage: tk.usage == 0 ? nil : Int64(tk.usage),
+                    transmitterSerial: tk.serial == 0 ? nil : Int64(tk.serial)
                 ))
             }
         }

--- a/packages/libdivecomputer_plugin/ios/Classes/DiveComputerApi.g.swift
+++ b/packages/libdivecomputer_plugin/ios/Classes/DiveComputerApi.g.swift
@@ -334,6 +334,11 @@ struct TankInfo {
   /// Tank usage from libdivecomputer's `dc_usage_t` (1=oxygen, 2=diluent,
   /// 3=sidemount); null when the computer reported no usage (DC_USAGE_NONE).
   var usage: Int64? = nil
+  /// Serial number of the air-integration transmitter that reported this
+  /// tank's pressures (`dc_tank_t.serial`, a fork extension); null when the
+  /// computer reported none. Identifies the physical cylinder across
+  /// computers paired to the same transmitter.
+  var transmitterSerial: Int64? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -344,6 +349,7 @@ struct TankInfo {
     let startPressureBar: Double? = nilOrValue(pigeonVar_list[3])
     let endPressureBar: Double? = nilOrValue(pigeonVar_list[4])
     let usage: Int64? = nilOrValue(pigeonVar_list[5])
+    let transmitterSerial: Int64? = nilOrValue(pigeonVar_list[6])
 
     return TankInfo(
       index: index,
@@ -351,7 +357,8 @@ struct TankInfo {
       volumeLiters: volumeLiters,
       startPressureBar: startPressureBar,
       endPressureBar: endPressureBar,
-      usage: usage
+      usage: usage,
+      transmitterSerial: transmitterSerial
     )
   }
   func toList() -> [Any?] {
@@ -362,6 +369,7 @@ struct TankInfo {
       startPressureBar,
       endPressureBar,
       usage,
+      transmitterSerial,
     ]
   }
 }

--- a/packages/libdivecomputer_plugin/lib/src/generated/dive_computer_api.g.dart
+++ b/packages/libdivecomputer_plugin/lib/src/generated/dive_computer_api.g.dart
@@ -314,6 +314,7 @@ class TankInfo {
     this.startPressureBar,
     this.endPressureBar,
     this.usage,
+    this.transmitterSerial,
   });
 
   int index;
@@ -330,6 +331,12 @@ class TankInfo {
   /// 3=sidemount); null when the computer reported no usage (DC_USAGE_NONE).
   int? usage;
 
+  /// Serial number of the air-integration transmitter that reported this
+  /// tank's pressures (`dc_tank_t.serial`, a fork extension); null when the
+  /// computer reported none. Identifies the physical cylinder across
+  /// computers paired to the same transmitter.
+  int? transmitterSerial;
+
   Object encode() {
     return <Object?>[
       index,
@@ -338,6 +345,7 @@ class TankInfo {
       startPressureBar,
       endPressureBar,
       usage,
+      transmitterSerial,
     ];
   }
 
@@ -350,6 +358,7 @@ class TankInfo {
       startPressureBar: result[3] as double?,
       endPressureBar: result[4] as double?,
       usage: result[5] as int?,
+      transmitterSerial: result[6] as int?,
     );
   }
 }

--- a/packages/libdivecomputer_plugin/linux/dive_computer_api.g.cc
+++ b/packages/libdivecomputer_plugin/linux/dive_computer_api.g.cc
@@ -899,6 +899,7 @@ struct _LibdivecomputerPluginTankInfo {
   double* start_pressure_bar;
   double* end_pressure_bar;
   int64_t* usage;
+  int64_t* transmitter_serial;
 };
 
 G_DEFINE_TYPE(LibdivecomputerPluginTankInfo, libdivecomputer_plugin_tank_info, G_TYPE_OBJECT)
@@ -909,6 +910,7 @@ static void libdivecomputer_plugin_tank_info_dispose(GObject* object) {
   g_clear_pointer(&self->start_pressure_bar, g_free);
   g_clear_pointer(&self->end_pressure_bar, g_free);
   g_clear_pointer(&self->usage, g_free);
+  g_clear_pointer(&self->transmitter_serial, g_free);
   G_OBJECT_CLASS(libdivecomputer_plugin_tank_info_parent_class)->dispose(object);
 }
 
@@ -919,7 +921,7 @@ static void libdivecomputer_plugin_tank_info_class_init(LibdivecomputerPluginTan
   G_OBJECT_CLASS(klass)->dispose = libdivecomputer_plugin_tank_info_dispose;
 }
 
-LibdivecomputerPluginTankInfo* libdivecomputer_plugin_tank_info_new(int64_t index, int64_t gas_mix_index, double* volume_liters, double* start_pressure_bar, double* end_pressure_bar, int64_t* usage) {
+LibdivecomputerPluginTankInfo* libdivecomputer_plugin_tank_info_new(int64_t index, int64_t gas_mix_index, double* volume_liters, double* start_pressure_bar, double* end_pressure_bar, int64_t* usage, int64_t* transmitter_serial) {
   LibdivecomputerPluginTankInfo* self = LIBDIVECOMPUTER_PLUGIN_TANK_INFO(g_object_new(libdivecomputer_plugin_tank_info_get_type(), nullptr));
   self->index = index;
   self->gas_mix_index = gas_mix_index;
@@ -950,6 +952,13 @@ LibdivecomputerPluginTankInfo* libdivecomputer_plugin_tank_info_new(int64_t inde
   }
   else {
     self->usage = nullptr;
+  }
+  if (transmitter_serial != nullptr) {
+    self->transmitter_serial = static_cast<int64_t*>(malloc(sizeof(int64_t)));
+    *self->transmitter_serial = *transmitter_serial;
+  }
+  else {
+    self->transmitter_serial = nullptr;
   }
   return self;
 }
@@ -984,6 +993,11 @@ int64_t* libdivecomputer_plugin_tank_info_get_usage(LibdivecomputerPluginTankInf
   return self->usage;
 }
 
+int64_t* libdivecomputer_plugin_tank_info_get_transmitter_serial(LibdivecomputerPluginTankInfo* self) {
+  g_return_val_if_fail(LIBDIVECOMPUTER_PLUGIN_IS_TANK_INFO(self), nullptr);
+  return self->transmitter_serial;
+}
+
 static FlValue* libdivecomputer_plugin_tank_info_to_list(LibdivecomputerPluginTankInfo* self) {
   FlValue* values = fl_value_new_list();
   fl_value_append_take(values, fl_value_new_int(self->index));
@@ -992,6 +1006,7 @@ static FlValue* libdivecomputer_plugin_tank_info_to_list(LibdivecomputerPluginTa
   fl_value_append_take(values, self->start_pressure_bar != nullptr ? fl_value_new_float(*self->start_pressure_bar) : fl_value_new_null());
   fl_value_append_take(values, self->end_pressure_bar != nullptr ? fl_value_new_float(*self->end_pressure_bar) : fl_value_new_null());
   fl_value_append_take(values, self->usage != nullptr ? fl_value_new_int(*self->usage) : fl_value_new_null());
+  fl_value_append_take(values, self->transmitter_serial != nullptr ? fl_value_new_int(*self->transmitter_serial) : fl_value_new_null());
   return values;
 }
 
@@ -1028,7 +1043,14 @@ static LibdivecomputerPluginTankInfo* libdivecomputer_plugin_tank_info_new_from_
     usage_value = fl_value_get_int(value5);
     usage = &usage_value;
   }
-  return libdivecomputer_plugin_tank_info_new(index, gas_mix_index, volume_liters, start_pressure_bar, end_pressure_bar, usage);
+  FlValue* value6 = fl_value_get_list_value(values, 6);
+  int64_t* transmitter_serial = nullptr;
+  int64_t transmitter_serial_value;
+  if (fl_value_get_type(value6) != FL_VALUE_TYPE_NULL) {
+    transmitter_serial_value = fl_value_get_int(value6);
+    transmitter_serial = &transmitter_serial_value;
+  }
+  return libdivecomputer_plugin_tank_info_new(index, gas_mix_index, volume_liters, start_pressure_bar, end_pressure_bar, usage, transmitter_serial);
 }
 
 struct _LibdivecomputerPluginDiveEvent {

--- a/packages/libdivecomputer_plugin/linux/dive_computer_api.g.h
+++ b/packages/libdivecomputer_plugin/linux/dive_computer_api.g.h
@@ -576,12 +576,13 @@ G_DECLARE_FINAL_TYPE(LibdivecomputerPluginTankInfo, libdivecomputer_plugin_tank_
  * start_pressure_bar: field in this object.
  * end_pressure_bar: field in this object.
  * usage: field in this object.
+ * transmitter_serial: field in this object.
  *
  * Creates a new #TankInfo object.
  *
  * Returns: a new #LibdivecomputerPluginTankInfo
  */
-LibdivecomputerPluginTankInfo* libdivecomputer_plugin_tank_info_new(int64_t index, int64_t gas_mix_index, double* volume_liters, double* start_pressure_bar, double* end_pressure_bar, int64_t* usage);
+LibdivecomputerPluginTankInfo* libdivecomputer_plugin_tank_info_new(int64_t index, int64_t gas_mix_index, double* volume_liters, double* start_pressure_bar, double* end_pressure_bar, int64_t* usage, int64_t* transmitter_serial);
 
 /**
  * libdivecomputer_plugin_tank_info_get_index
@@ -643,6 +644,19 @@ double* libdivecomputer_plugin_tank_info_get_end_pressure_bar(LibdivecomputerPlu
  * Returns: the field value.
  */
 int64_t* libdivecomputer_plugin_tank_info_get_usage(LibdivecomputerPluginTankInfo* object);
+
+/**
+ * libdivecomputer_plugin_tank_info_get_transmitter_serial
+ * @object: a #LibdivecomputerPluginTankInfo.
+ *
+ * Serial number of the air-integration transmitter that reported this
+ * tank's pressures (`dc_tank_t.serial`, a fork extension); null when the
+ * computer reported none. Identifies the physical cylinder across
+ * computers paired to the same transmitter.
+ *
+ * Returns: the field value.
+ */
+int64_t* libdivecomputer_plugin_tank_info_get_transmitter_serial(LibdivecomputerPluginTankInfo* object);
 
 /**
  * LibdivecomputerPluginDiveEvent:

--- a/packages/libdivecomputer_plugin/linux/dive_converter.c
+++ b/packages/libdivecomputer_plugin/linux/dive_converter.c
@@ -193,9 +193,13 @@ LibdivecomputerPluginParsedDive* convert_parsed_dive(
         int64_t usage_val = (int64_t)tk->usage;
         int64_t* usage = (tk->usage == 0) ? NULL : &usage_val;
 
+        int64_t serial_val = (int64_t)tk->serial;
+        int64_t* serial = (tk->serial == 0) ? NULL : &serial_val;
+
         LibdivecomputerPluginTankInfo* tank =
             libdivecomputer_plugin_tank_info_new(
-                (int64_t)i, (int64_t)tk->gasmix, volume, begin_p, end_p, usage);
+                (int64_t)i, (int64_t)tk->gasmix, volume, begin_p, end_p, usage,
+                serial);
         fl_value_append_take(
             tanks,
             fl_value_new_custom_object(134, G_OBJECT(tank)));

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
@@ -591,6 +591,7 @@ static int extract_dive_fields(dc_parser_t *parser, libdc_parsed_dive_t *dive) {
                 dive->tanks[i].beginpressure = tk.beginpressure;
                 dive->tanks[i].endpressure = tk.endpressure;
                 dive->tanks[i].usage = tk.usage;
+                dive->tanks[i].serial = tk.serial;
             }
         }
         dive->tank_count = tank_count;

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
@@ -224,6 +224,7 @@ typedef struct {
     double beginpressure;      // bar
     double endpressure;        // bar
     unsigned int usage;        // dc_usage_t (0=none, 1=oxygen, 2=diluent, 3=sidemount)
+    unsigned int serial;       // air-integration transmitter serial, 0 when not reported
 } libdc_tank_t;
 
 // Name of a libdivecomputer sample event type (parser_sample_event_t), in

--- a/packages/libdivecomputer_plugin/patches/0009-tank-transmitter-serial.patch
+++ b/packages/libdivecomputer_plugin/patches/0009-tank-transmitter-serial.patch
@@ -1,0 +1,41 @@
+diff --git a/include/libdivecomputer/parser.h b/include/libdivecomputer/parser.h
+index c51907a..9e1ac2a 100644
+--- a/include/libdivecomputer/parser.h
++++ b/include/libdivecomputer/parser.h
+@@ -197,6 +197,12 @@ typedef struct dc_tank_t {
+     double beginpressure; /* Begin pressure (bar) */
+     double endpressure;   /* End pressure (bar) */
+     dc_usage_t usage;
++    /* Submersion patch (tank transmitter serial): serial number of the
++     * air-integration transmitter that reported this tank's pressures, or
++     * zero when the device does not report one. Two dive computers paired to
++     * the same transmitter log the same cylinder, so this identifies the tank
++     * across computers regardless of the gas mix each had programmed. */
++    unsigned int serial;
+ } dc_tank_t;
+ 
+ typedef enum dc_decomodel_type_t {
+diff --git a/src/halcyon_symbios_parser.c b/src/halcyon_symbios_parser.c
+index f87cd89..4970e9d 100644
+--- a/src/halcyon_symbios_parser.c
++++ b/src/halcyon_symbios_parser.c
+@@ -278,6 +278,7 @@ halcyon_symbios_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, u
+ 			tank->endpressure   = parser->tank[flags].endpressure   / 10.0;
+ 			tank->gasmix        = parser->tank[flags].gasmix;
+ 			tank->usage         = parser->tank[flags].usage;
++			tank->serial        = parser->tank[flags].id;
+ 			break;
+ 		case DC_FIELD_DECOMODEL:
+ 			if (parser->gf_lo == UNDEFINED || parser->gf_hi == UNDEFINED)
+diff --git a/src/shearwater_predator_parser.c b/src/shearwater_predator_parser.c
+index ab0f6d1..458e215 100644
+--- a/src/shearwater_predator_parser.c
++++ b/src/shearwater_predator_parser.c
+@@ -819,6 +819,7 @@ shearwater_predator_parser_get_field (dc_parser_t *abstract, dc_field_type_t typ
+ 			tank->workpressure = 0.0;
+ 			tank->beginpressure = parser->tank[flags].beginpressure * 2 * PSI / BAR;
+ 			tank->endpressure   = parser->tank[flags].endpressure   * 2 * PSI / BAR;
++			tank->serial = parser->tank[flags].serial;
+ 			tank->gasmix = DC_GASMIX_UNKNOWN;
+ 			if (shearwater_predator_is_ccr (parser->divemode) && !parser->hpccr) {
+ 				switch (parser->tank[flags].name[0]) {

--- a/packages/libdivecomputer_plugin/patches/0009-tank-transmitter-serial.patch
+++ b/packages/libdivecomputer_plugin/patches/0009-tank-transmitter-serial.patch
@@ -1,3 +1,19 @@
+diff --git a/doc/man/dc_parser_get_field.3 b/doc/man/dc_parser_get_field.3
+index 0f6455d..bf1937a 100644
+--- a/doc/man/dc_parser_get_field.3
++++ b/doc/man/dc_parser_get_field.3
+@@ -159,7 +159,10 @@ and maybe zero if
+ .Va beginpressure
+ and
+ .Va endpressure
+-being the pressures at start and finish in bar.
++being the pressures at start and finish in bar;
++.Va serial ,
++the serial number of the air-integration transmitter that reported the
++pressures, or zero if the device does not report one.
+ The
+ .Fa flags
+ value is the tank index.
 diff --git a/include/libdivecomputer/parser.h b/include/libdivecomputer/parser.h
 index c51907a..9e1ac2a 100644
 --- a/include/libdivecomputer/parser.h
@@ -16,17 +32,39 @@ index c51907a..9e1ac2a 100644
  
  typedef enum dc_decomodel_type_t {
 diff --git a/src/halcyon_symbios_parser.c b/src/halcyon_symbios_parser.c
-index f87cd89..4970e9d 100644
+index f87cd89..8066e2b 100644
 --- a/src/halcyon_symbios_parser.c
 +++ b/src/halcyon_symbios_parser.c
-@@ -278,6 +278,7 @@ halcyon_symbios_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, u
+@@ -278,6 +278,11 @@ halcyon_symbios_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, u
  			tank->endpressure   = parser->tank[flags].endpressure   / 10.0;
  			tank->gasmix        = parser->tank[flags].gasmix;
  			tank->usage         = parser->tank[flags].usage;
-+			tank->serial        = parser->tank[flags].id;
++			// A tank found through an ID_TANK_TRANSMITTER record carries a
++			// one-byte slot id tagged with TRANSMITTER_ID, not a serial;
++			// only the sensor record's 16-bit serial identifies the transmitter.
++			tank->serial        = (parser->tank[flags].id & TRANSMITTER_ID)
++				? 0 : parser->tank[flags].id;
  			break;
  		case DC_FIELD_DECOMODEL:
  			if (parser->gf_lo == UNDEFINED || parser->gf_hi == UNDEFINED)
+diff --git a/src/parser.c b/src/parser.c
+index 9a114bd..dcdc9bf 100644
+--- a/src/parser.c
++++ b/src/parser.c
+@@ -381,6 +381,13 @@ dc_parser_get_field (dc_parser_t *parser, dc_field_type_t type, unsigned int fla
+ 	if (parser->vtable->field == NULL)
+ 		return DC_STATUS_UNSUPPORTED;
+ 
++	// Submersion patch (tank transmitter serial): only the parsers that know
++	// a transmitter serial assign dc_tank_t.serial, so define it here for
++	// every other backend rather than leaving it to the caller's
++	// initialisation.
++	if (type == DC_FIELD_TANK && value != NULL)
++		((dc_tank_t *) value)->serial = 0;
++
+ 	return parser->vtable->field (parser, type, flags, value);
+ }
+ 
 diff --git a/src/shearwater_predator_parser.c b/src/shearwater_predator_parser.c
 index ab0f6d1..458e215 100644
 --- a/src/shearwater_predator_parser.c

--- a/packages/libdivecomputer_plugin/pigeons/dive_computer_api.dart
+++ b/packages/libdivecomputer_plugin/pigeons/dive_computer_api.dart
@@ -154,6 +154,7 @@ class TankInfo {
     this.startPressureBar,
     this.endPressureBar,
     this.usage,
+    this.transmitterSerial,
   });
   final int index;
   final int gasMixIndex;
@@ -164,6 +165,12 @@ class TankInfo {
   /// Tank usage from libdivecomputer's `dc_usage_t` (1=oxygen, 2=diluent,
   /// 3=sidemount); null when the computer reported no usage (DC_USAGE_NONE).
   final int? usage;
+
+  /// Serial number of the air-integration transmitter that reported this
+  /// tank's pressures (`dc_tank_t.serial`, a fork extension); null when the
+  /// computer reported none. Identifies the physical cylinder across
+  /// computers paired to the same transmitter.
+  final int? transmitterSerial;
 }
 
 class DiveEvent {

--- a/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
@@ -276,6 +276,27 @@ if(WIN32)
     target_link_libraries(test_multi_transmitter_pressure PRIVATE SetupAPI.lib ws2_32.lib)
 endif()
 
+# The transmitter serial libdivecomputer's Shearwater parser decodes from the
+# opening records must reach the wrapper's tank summary, so the app can tell
+# two computers paired to one transmitter apart from two cylinders.
+add_executable(test_tank_transmitter_serial
+    test_tank_transmitter_serial.c
+    ${WRAPPER_DIR}/libdc_wrapper.c
+    ${WRAPPER_DIR}/libdc_download.c
+    ${LIBDC_ALL_SOURCES}
+)
+target_include_directories(test_tank_transmitter_serial PRIVATE
+    ${WRAPPER_DIR}
+    ${LIBDC_DIR}/include
+    ${LIBDC_DIR}/src
+    ${PLATFORM_CONFIG_DIR}
+)
+target_compile_definitions(test_tank_transmitter_serial PRIVATE HAVE_CONFIG_H)
+if(WIN32)
+    target_compile_definitions(test_tank_transmitter_serial PRIVATE _CRT_SECURE_NO_WARNINGS)
+    target_link_libraries(test_tank_transmitter_serial PRIVATE SetupAPI.lib ws2_32.lib)
+endif()
+
 # Regression test for issue #1481: since APOS5 firmware 5.2.11 the Ratio iX3M 2
 # packs tank data into the high bits of the sample record type, and the parser
 # skipped every record whose type was not literally 0, so dives imported as
@@ -338,6 +359,9 @@ add_test(NAME test_multi_transmitter_pressure COMMAND test_multi_transmitter_pre
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 add_test(NAME test_shearwater_o2_millivolt COMMAND test_shearwater_o2_millivolt
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+add_test(NAME test_tank_transmitter_serial COMMAND test_tank_transmitter_serial
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 add_test(NAME test_ratio_ix3m2_record_type COMMAND test_ratio_ix3m2_record_type)

--- a/packages/libdivecomputer_plugin/test/native/test_dive_converter.c
+++ b/packages/libdivecomputer_plugin/test/native/test_dive_converter.c
@@ -186,8 +186,10 @@ static void test_tank_fields(void) {
     tank.volume = 12.0;
     tank.beginpressure = 200.0;
     tank.endpressure = 50.0;
+    tank.serial = 180777;
 
     assert(tank.gasmix == 0);
+    assert(tank.serial == 180777);
     assert(tank.volume == 12.0);
     assert(tank.beginpressure == 200.0);
     assert(tank.endpressure == 50.0);

--- a/packages/libdivecomputer_plugin/test/native/test_tank_transmitter_serial.c
+++ b/packages/libdivecomputer_plugin/test/native/test_tank_transmitter_serial.c
@@ -1,0 +1,98 @@
+/* Two dive computers paired to the same air-integration transmitter log the
+   same cylinder, whatever gas mix each had programmed for it. The transmitter
+   serial is therefore the cylinder's identity across computers, and the
+   consolidation code needs it on every downloaded tank.
+
+   libdivecomputer's Shearwater parser already decodes the serial from opening
+   record 5 (and 6/7 for tanks 3 and 4) but never exposed it through
+   DC_FIELD_TANK. The fork adds `dc_tank_t.serial`; this test pins the value
+   the wrapper carries out of it.
+
+   Fixture: the Petrel 3 CCR dive shared with test_multi_transmitter_pressure.
+   Its opening record 5 holds the BCD serials 12 30 86 and 10 96 23, decoded
+   by hand from the raw bytes, not from the code under test. The Petrel 3 is
+   not a Teric, so the Teric digit-pair swap does not apply. */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libdc_wrapper.h"
+
+#define EXPECTED_TANK0_SERIAL 123086u
+#define EXPECTED_TANK1_SERIAL 109623u
+
+static unsigned int load_fixture(const char *path, unsigned char **out) {
+    *out = NULL;
+    FILE *f = fopen(path, "rb");
+    if (!f) return 0;
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (len <= 0) { fclose(f); return 0; }
+    unsigned char *buf = (unsigned char *)malloc((size_t)len);
+    if (!buf) { fclose(f); return 0; }
+    size_t read = fread(buf, 1, (size_t)len, f);
+    fclose(f);
+    if (read != (size_t)len) { free(buf); return 0; }
+    *out = buf;
+    return (unsigned int)read;
+}
+
+static void parse_fixture(libdc_parsed_dive_t *dive) {
+    unsigned char *data = NULL;
+    unsigned int size = load_fixture("fixtures/petrel3_ccr_o2_cells.bin", &data);
+    assert(size == 22400);
+    assert(data != NULL);
+
+    char err[256] = {0};
+    int rc = libdc_parse_raw_dive("Shearwater", "Petrel 3", 10, data, size, dive,
+                                  err, sizeof(err));
+    if (rc != 0) {
+        printf("FAIL: libdc_parse_raw_dive returned %d (%s)\n", rc, err);
+    }
+    assert(rc == 0);
+    free(data);
+}
+
+/* Each active transmitter's serial must ride along with its tank. */
+static void test_tanks_carry_transmitter_serials(void) {
+    libdc_parsed_dive_t dive;
+    parse_fixture(&dive);
+
+    assert(dive.tank_count == 2);
+    printf("  tank 0 serial %u, tank 1 serial %u\n",
+           dive.tanks[0].serial, dive.tanks[1].serial);
+    assert(dive.tanks[0].serial == EXPECTED_TANK0_SERIAL);
+    assert(dive.tanks[1].serial == EXPECTED_TANK1_SERIAL);
+
+    /* libdc_parse_raw_dive fills a caller-owned struct: free its arrays, not it. */
+    free(dive.samples);
+    free(dive.events);
+    printf("PASS: test_tanks_carry_transmitter_serials\n");
+}
+
+/* Slots beyond tank_count are untouched by the parser and must read as
+   "no transmitter", so a binding that walks the whole array cannot invent a
+   serial for a tank that does not exist. */
+static void test_unused_tank_slots_have_no_serial(void) {
+    libdc_parsed_dive_t dive;
+    parse_fixture(&dive);
+
+    for (unsigned int t = dive.tank_count; t < LIBDC_MAX_TANKS; t++) {
+        assert(dive.tanks[t].serial == 0);
+    }
+
+    free(dive.samples);
+    free(dive.events);
+    printf("PASS: test_unused_tank_slots_have_no_serial\n");
+}
+
+int main(void) {
+    printf("Running tank transmitter serial tests...\n");
+    test_tanks_carry_transmitter_serials();
+    test_unused_tank_slots_have_no_serial();
+    printf("All tank transmitter serial tests passed\n");
+    return 0;
+}

--- a/packages/libdivecomputer_plugin/windows/dive_computer_api.g.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_computer_api.g.cc
@@ -862,13 +862,15 @@ TankInfo::TankInfo(
   const double* volume_liters,
   const double* start_pressure_bar,
   const double* end_pressure_bar,
-  const int64_t* usage)
+  const int64_t* usage,
+  const int64_t* transmitter_serial)
  : index_(index),
     gas_mix_index_(gas_mix_index),
     volume_liters_(volume_liters ? std::optional<double>(*volume_liters) : std::nullopt),
     start_pressure_bar_(start_pressure_bar ? std::optional<double>(*start_pressure_bar) : std::nullopt),
     end_pressure_bar_(end_pressure_bar ? std::optional<double>(*end_pressure_bar) : std::nullopt),
-    usage_(usage ? std::optional<int64_t>(*usage) : std::nullopt) {}
+    usage_(usage ? std::optional<int64_t>(*usage) : std::nullopt),
+    transmitter_serial_(transmitter_serial ? std::optional<int64_t>(*transmitter_serial) : std::nullopt) {}
 
 int64_t TankInfo::index() const {
   return index_;
@@ -940,15 +942,29 @@ void TankInfo::set_usage(int64_t value_arg) {
 }
 
 
+const int64_t* TankInfo::transmitter_serial() const {
+  return transmitter_serial_ ? &(*transmitter_serial_) : nullptr;
+}
+
+void TankInfo::set_transmitter_serial(const int64_t* value_arg) {
+  transmitter_serial_ = value_arg ? std::optional<int64_t>(*value_arg) : std::nullopt;
+}
+
+void TankInfo::set_transmitter_serial(int64_t value_arg) {
+  transmitter_serial_ = value_arg;
+}
+
+
 EncodableList TankInfo::ToEncodableList() const {
   EncodableList list;
-  list.reserve(6);
+  list.reserve(7);
   list.push_back(EncodableValue(index_));
   list.push_back(EncodableValue(gas_mix_index_));
   list.push_back(volume_liters_ ? EncodableValue(*volume_liters_) : EncodableValue());
   list.push_back(start_pressure_bar_ ? EncodableValue(*start_pressure_bar_) : EncodableValue());
   list.push_back(end_pressure_bar_ ? EncodableValue(*end_pressure_bar_) : EncodableValue());
   list.push_back(usage_ ? EncodableValue(*usage_) : EncodableValue());
+  list.push_back(transmitter_serial_ ? EncodableValue(*transmitter_serial_) : EncodableValue());
   return list;
 }
 
@@ -971,6 +987,10 @@ TankInfo TankInfo::FromEncodableList(const EncodableList& list) {
   auto& encodable_usage = list[5];
   if (!encodable_usage.IsNull()) {
     decoded.set_usage(std::get<int64_t>(encodable_usage));
+  }
+  auto& encodable_transmitter_serial = list[6];
+  if (!encodable_transmitter_serial.IsNull()) {
+    decoded.set_transmitter_serial(std::get<int64_t>(encodable_transmitter_serial));
   }
   return decoded;
 }

--- a/packages/libdivecomputer_plugin/windows/dive_computer_api.g.h
+++ b/packages/libdivecomputer_plugin/windows/dive_computer_api.g.h
@@ -416,7 +416,8 @@ class TankInfo {
     const double* volume_liters,
     const double* start_pressure_bar,
     const double* end_pressure_bar,
-    const int64_t* usage);
+    const int64_t* usage,
+    const int64_t* transmitter_serial);
 
   int64_t index() const;
   void set_index(int64_t value_arg);
@@ -442,6 +443,14 @@ class TankInfo {
   void set_usage(const int64_t* value_arg);
   void set_usage(int64_t value_arg);
 
+  // Serial number of the air-integration transmitter that reported this
+  // tank's pressures (`dc_tank_t.serial`, a fork extension); null when the
+  // computer reported none. Identifies the physical cylinder across
+  // computers paired to the same transmitter.
+  const int64_t* transmitter_serial() const;
+  void set_transmitter_serial(const int64_t* value_arg);
+  void set_transmitter_serial(int64_t value_arg);
+
 
  private:
   static TankInfo FromEncodableList(const flutter::EncodableList& list);
@@ -455,6 +464,7 @@ class TankInfo {
   std::optional<double> start_pressure_bar_;
   std::optional<double> end_pressure_bar_;
   std::optional<int64_t> usage_;
+  std::optional<int64_t> transmitter_serial_;
 
 };
 

--- a/packages/libdivecomputer_plugin/windows/dive_converter.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_converter.cc
@@ -200,6 +200,9 @@ ParsedDive ConvertParsedDive(const libdc_parsed_dive_t& dive) {
         std::optional<int64_t> opt_usage =
             (tk.usage == 0) ? std::nullopt
                             : std::optional<int64_t>(static_cast<int64_t>(tk.usage));
+        std::optional<int64_t> opt_serial =
+            (tk.serial == 0) ? std::nullopt
+                             : std::optional<int64_t>(static_cast<int64_t>(tk.serial));
 
         tanks.push_back(flutter::CustomEncodableValue(TankInfo(
             static_cast<int64_t>(i),
@@ -207,7 +210,8 @@ ParsedDive ConvertParsedDive(const libdc_parsed_dive_t& dive) {
             opt_vol ? &*opt_vol : nullptr,
             opt_begin ? &*opt_begin : nullptr,
             opt_end ? &*opt_end : nullptr,
-            opt_usage ? &*opt_usage : nullptr)));
+            opt_usage ? &*opt_usage : nullptr,
+            opt_serial ? &*opt_serial : nullptr)));
     }
 
     // Convert events.

--- a/test/core/database/migration_v191_plan_ascent_rates_test.dart
+++ b/test/core/database/migration_v191_plan_ascent_rates_test.dart
@@ -33,7 +33,9 @@ void main() {
     // Renumbered from v188 (itself renumbered from v185 and v184): main
     // landed the insurance-phone, media-equipment-link and raw-data
     // recompression rungs at 188-190 while this branch was open.
-    expect(AppDatabase.currentSchemaVersion, 191);
+    // Relaxed from an exact match when v194 landed: the exact assertion is
+    // the newest rung's job, and it moves with it.
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(191));
     expect(AppDatabase.migrationVersions, contains(191));
   });
 

--- a/test/core/database/migration_v194_tank_transmitter_serial_test.dart
+++ b/test/core/database/migration_v194_tank_transmitter_serial_test.dart
@@ -1,0 +1,125 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// Pre-v194 dive_tanks shape: no transmitter serial. Only the columns the
+/// rung and its assertions touch, mirroring the other migration fixtures.
+const _preV194DiveTanks = '''
+  CREATE TABLE dive_tanks (
+    id TEXT NOT NULL PRIMARY KEY,
+    dive_id TEXT NOT NULL,
+    o2_percent REAL NOT NULL DEFAULT 21.0,
+    he_percent REAL NOT NULL DEFAULT 0.0,
+    tank_order INTEGER NOT NULL DEFAULT 0,
+    computer_id TEXT
+  )
+''';
+
+void main() {
+  test('v194 adds dive_tanks.transmitter_serial, preserving rows', () async {
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 193');
+        rawDb.execute(_preV194DiveTanks);
+        rawDb.execute(
+          "INSERT INTO dive_tanks (id, dive_id, o2_percent, computer_id) "
+          "VALUES ('t1', 'd1', 32.0, 'dc1')",
+        );
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    final cols = await db.customSelect("PRAGMA table_info('dive_tanks')").get();
+    expect(
+      cols.map((c) => c.read<String>('name')),
+      contains('transmitter_serial'),
+    );
+
+    // The rung is column-only: an existing tank keeps its attribution and
+    // reads back with no transmitter, never an invented one.
+    final row = await db
+        .customSelect(
+          "SELECT computer_id, transmitter_serial FROM dive_tanks "
+          "WHERE id = 't1'",
+        )
+        .getSingle();
+    expect(row.data['computer_id'], 'dc1');
+    expect(row.data['transmitter_serial'], isNull);
+  });
+
+  test('migration list includes v194 and schema is exactly 194', () {
+    // The newest rung owns the exact assertion; relax to
+    // greaterThanOrEqualTo when the next rung lands.
+    expect(AppDatabase.currentSchemaVersion, 194);
+    expect(AppDatabase.migrationVersions, contains(194));
+  });
+
+  test('v194 is idempotent when transmitter_serial already exists', () async {
+    // An interrupted upgrade, or a database that reached this version from a
+    // parallel branch, leaves the column already added. The PRAGMA guard
+    // must skip the ALTER rather than fail on a duplicate column.
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 193');
+        rawDb.execute(_preV194DiveTanks);
+        rawDb.execute(
+          'ALTER TABLE dive_tanks ADD COLUMN transmitter_serial TEXT',
+        );
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    final cols = await db.customSelect("PRAGMA table_info('dive_tanks')").get();
+    final names = cols.map((c) => c.read<String>('name')).toList();
+    expect(names.where((n) => n == 'transmitter_serial'), hasLength(1));
+  });
+
+  test('v194 is a no-op when the dive_tanks table is absent', () async {
+    // Minimal migration fixtures build only the tables their rung touches,
+    // so the helper must self-guard rather than throw on a missing table.
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) => rawDb.execute('PRAGMA user_version = 193'),
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    // Reaching a query at all means the upgrade ran to completion.
+    final tables = await db
+        .customSelect(
+          "SELECT name FROM sqlite_master WHERE type = 'table' "
+          "AND name = 'dive_tanks'",
+        )
+        .get();
+    expect(tables, isEmpty);
+  });
+
+  test(
+    'beforeOpen backstop adds the column to a v194 database that lacks it',
+    () async {
+      // A database that arrives by restore or sync-adopt already stamped 194
+      // never runs onUpgrade; the backstop must still add the column.
+      final nativeDb = NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute('PRAGMA user_version = 194');
+          rawDb.execute(_preV194DiveTanks);
+        },
+      );
+
+      final db = AppDatabase(nativeDb);
+      addTearDown(() => db.close());
+
+      final cols = await db
+          .customSelect("PRAGMA table_info('dive_tanks')")
+          .get();
+      expect(
+        cols.map((c) => c.read<String>('name')),
+        contains('transmitter_serial'),
+      );
+    },
+  );
+}

--- a/test/core/services/export/uddf/uddf_export_builders_test.dart
+++ b/test/core/services/export/uddf/uddf_export_builders_test.dart
@@ -422,6 +422,43 @@ void main() {
         },
       );
 
+      test('does not write a blank or zero transmitter serial', () {
+        final dive = Dive(
+          id: 'dive-serial-0',
+          diveNumber: 1,
+          dateTime: DateTime(2026, 3, 28, 10, 0),
+          bottomTime: const Duration(minutes: 30),
+          maxDepth: 20.0,
+          tanks: const [
+            DiveTank(id: 'tank-1', transmitterSerial: '0'),
+            DiveTank(id: 'tank-2', transmitterSerial: '  '),
+          ],
+        );
+
+        final builder = XmlBuilder();
+        builder.element(
+          'root',
+          nest: () {
+            UddfExportBuilders.buildDiveElement(
+              builder,
+              dive,
+              null,
+              const [],
+              const [],
+              const [],
+              const [],
+              null,
+              const [],
+            );
+          },
+        );
+
+        expect(
+          builder.buildDocument().toXmlString(),
+          isNot(contains('transmitterserial')),
+        );
+      });
+
       test('no tankpressure elements when tankPressures is null', () {
         final dive = Dive(
           id: 'dive-tp-null',

--- a/test/core/services/export/uddf/uddf_export_builders_test.dart
+++ b/test/core/services/export/uddf/uddf_export_builders_test.dart
@@ -376,6 +376,52 @@ void main() {
         expect(xml, contains('15000000.0'));
       });
 
+      test(
+        'writes the transmitter serial as an app-specific tankdata child',
+        () {
+          // UDDF 3.2 has no element for an AI transmitter serial; it rides in
+          // the same app-specific slot as tankrole/tankorder so a round trip
+          // through our own export keeps the cylinder identity.
+          final dive = Dive(
+            id: 'dive-serial',
+            diveNumber: 1,
+            dateTime: DateTime(2026, 3, 28, 10, 0),
+            bottomTime: const Duration(minutes: 30),
+            maxDepth: 20.0,
+            tanks: const [
+              DiveTank(id: 'tank-1', transmitterSerial: '180777'),
+              DiveTank(id: 'tank-2'),
+            ],
+          );
+
+          final builder = XmlBuilder();
+          builder.element(
+            'root',
+            nest: () {
+              UddfExportBuilders.buildDiveElement(
+                builder,
+                dive,
+                null,
+                const [],
+                const [],
+                const [],
+                const [],
+                null,
+                const [],
+              );
+            },
+          );
+
+          final xml = builder.buildDocument().toXmlString();
+
+          expect(
+            xml,
+            contains('<transmitterserial>180777</transmitterserial>'),
+          );
+          expect('transmitterserial'.allMatches(xml), hasLength(2));
+        },
+      );
+
       test('no tankpressure elements when tankPressures is null', () {
         final dive = Dive(
           id: 'dive-tp-null',

--- a/test/core/services/export/uddf/uddf_full_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_full_import_service_test.dart
@@ -66,6 +66,19 @@ void main() {
       expect(tanks.single['transmitterSerial'], '180777');
     });
 
+    test('treats a zero transmitterserial as absent', () async {
+      final uddf = _uddfEan29.replaceFirst(
+        '<tankvolume>24.0</tankvolume>',
+        '<tankvolume>24.0</tankvolume>\n'
+            '          <transmitterserial> 0 </transmitterserial>',
+      );
+
+      final result = await service.importAllDataFromUddf(uddf);
+      final tanks = result.dives.first['tanks'] as List<Map<String, dynamic>>;
+
+      expect(tanks.single.containsKey('transmitterSerial'), isFalse);
+    });
+
     test('keeps a 0.29 UDDF mix labeled as EAN29', () async {
       final result = await service.importAllDataFromUddf(_uddfEan29);
       final dive = result.dives.first;

--- a/test/core/services/export/uddf/uddf_full_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_full_import_service_test.dart
@@ -53,6 +53,19 @@ void main() {
       service = UddfFullImportService();
     });
 
+    test('reads the app-specific transmitterserial tankdata child', () async {
+      final uddf = _uddfEan29.replaceFirst(
+        '<tankvolume>24.0</tankvolume>',
+        '<tankvolume>24.0</tankvolume>\n'
+            '          <transmitterserial>180777</transmitterserial>',
+      );
+
+      final result = await service.importAllDataFromUddf(uddf);
+      final tanks = result.dives.first['tanks'] as List<Map<String, dynamic>>;
+
+      expect(tanks.single['transmitterSerial'], '180777');
+    });
+
     test('keeps a 0.29 UDDF mix labeled as EAN29', () async {
       final result = await service.importAllDataFromUddf(_uddfEan29);
       final dive = result.dives.first;

--- a/test/core/services/export/uddf/uddf_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_import_service_test.dart
@@ -21,6 +21,7 @@ void main() {
         <tankdata>
           <tankpressurebegin>21952916</tankpressurebegin>
           <tankpressureend>14244574</tankpressureend>
+          <transmitterserial>0</transmitterserial>
         </tankdata>
         <samples>
           <waypoint>
@@ -39,6 +40,7 @@ void main() {
           result['dives']!.single['tanks'] as List<Map<String, dynamic>>;
 
       expect(tanks[0]['transmitterSerial'], '180777');
+      // "0" is the no-transmitter sentinel, never an identity.
       expect(tanks[1].containsKey('transmitterSerial'), isFalse);
     });
 

--- a/test/core/services/export/uddf/uddf_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_import_service_test.dart
@@ -4,6 +4,44 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 
 void main() {
   group('UddfImportService', () {
+    test('reads the app-specific transmitterserial tankdata child', () async {
+      const uddfContent = '''
+<uddf version="3.2.3">
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2025-09-01T14:18:24Z</datetime>
+        </informationbeforedive>
+        <tankdata>
+          <tankpressurebegin>20049962</tankpressurebegin>
+          <tankpressureend>12879411</tankpressureend>
+          <transmitterserial>180777</transmitterserial>
+        </tankdata>
+        <tankdata>
+          <tankpressurebegin>21952916</tankpressurebegin>
+          <tankpressureend>14244574</tankpressureend>
+        </tankdata>
+        <samples>
+          <waypoint>
+            <depth>1</depth>
+            <divetime>0</divetime>
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+
+      final result = await UddfImportService().importDivesFromUddf(uddfContent);
+      final tanks =
+          result['dives']!.single['tanks'] as List<Map<String, dynamic>>;
+
+      expect(tanks[0]['transmitterSerial'], '180777');
+      expect(tanks[1].containsKey('transmitterSerial'), isFalse);
+    });
+
     test(
       'maps T1/T2 refs to tanks by order when tankdata entries omit ids',
       () async {

--- a/test/core/services/sync/sync_serializer_upsert_test.dart
+++ b/test/core/services/sync/sync_serializer_upsert_test.dart
@@ -193,6 +193,35 @@ void main() {
     },
   );
 
+  test('a dive tank transmitter serial survives fetch and upsert', () async {
+    // Sync ships whole dive_tanks rows through the generated toJson/fromJson,
+    // so the v194 column needs no serializer change; this pins that a peer
+    // receives and stores the serial rather than silently dropping it.
+    await db.customStatement('PRAGMA foreign_keys = OFF');
+    await db
+        .into(db.diveTanks)
+        .insert(
+          const DiveTanksCompanion(
+            id: Value('tank-serial'),
+            diveId: Value('d1'),
+            transmitterSerial: Value('180777'),
+          ),
+        );
+
+    final row = await serializer.fetchRecord('diveTanks', 'tank-serial');
+    expect(row!['transmitterSerial'], '180777');
+
+    await (db.delete(
+      db.diveTanks,
+    )..where((t) => t.id.equals('tank-serial'))).go();
+    await serializer.upsertRecord('diveTanks', row);
+
+    final restored = await (db.select(
+      db.diveTanks,
+    )..where((t) => t.id.equals('tank-serial'))).getSingle();
+    expect(restored.transmitterSerial, '180777');
+  });
+
   test('upsertRecords composite-key junctions apply without a PK id', () async {
     await db.customStatement('PRAGMA foreign_keys = OFF');
     // diveEquipment / equipmentSetItems are keyed by (a, b), not a surrogate id.

--- a/test/features/data_quality/domain/detectors/gas_tank_source_detectors_test.dart
+++ b/test/features/data_quality/domain/detectors/gas_tank_source_detectors_test.dart
@@ -275,6 +275,28 @@ void main() {
       expect(det.detect(ctx), isEmpty);
     });
 
+    test('twin series are matched even when a series arrives out of order', () {
+      // Sorting is skipped for already-ordered input; this pins that an
+      // unordered series is still put in time order before the walk.
+      final a = [
+        for (var t = 0; t <= 1200; t += 60)
+          QualityPressureSample(t: t, bar: 200 - t * 0.05),
+      ];
+      final b = a.reversed.toList();
+      final ctx = makeContext(
+        dive: makeTestDive(
+          tanks: [
+            tank(id: 'a'),
+            tank(id: 'b', order: 1),
+          ],
+        ),
+        pressures: {'a': a, 'b': b},
+      );
+      final out = det.detect(ctx);
+      expect(out, hasLength(1));
+      expect(out.single.params['meanDiffBar'], 0.0);
+    });
+
     test('single-tank dives are skipped', () {
       final ctx = makeContext(
         dive: makeTestDive(tanks: [tank()]),

--- a/test/features/data_quality/domain/detectors/gas_tank_source_detectors_test.dart
+++ b/test/features/data_quality/domain/detectors/gas_tank_source_detectors_test.dart
@@ -17,11 +17,13 @@ domain.DiveTank tank({
   double o2 = 21.0,
   int order = 0,
   double? volume = 12,
+  String? transmitterSerial,
 }) => domain.DiveTank(
   id: id,
   volume: volume,
   gasMix: domain.GasMix(o2: o2, he: 0),
   order: order,
+  transmitterSerial: transmitterSerial,
 );
 
 GasSwitch sw({
@@ -193,6 +195,72 @@ void main() {
       final out = det.detect(ctx);
       expect(out, hasLength(1));
       expect(out.single.params['meanDiffBar'], 0.0);
+    });
+
+    test('two tanks on the same transmitter serial are twins, no series '
+        'needed', () {
+      // Two computers paired to one transmitter, consolidated before the
+      // serial gate existed: the same cylinder sits on the dive twice. The
+      // serial alone is proof, whatever the pressure series look like.
+      final ctx = makeContext(
+        dive: makeTestDive(
+          tanks: [
+            tank(id: 'a', o2: 31, transmitterSerial: '180777'),
+            tank(id: 'b', o2: 32, order: 1, transmitterSerial: '180777'),
+          ],
+        ),
+      );
+      final out = det.detect(ctx);
+      expect(out, hasLength(1));
+      expect(out.single.params['tankIdA'], 'a');
+      expect(out.single.params['tankIdB'], 'b');
+      expect(out.single.params['sameTransmitter'], isTrue);
+    });
+
+    test('tanks on different transmitter serials are never twins, even with '
+        'identical series', () {
+      // Twin cylinders on the same mix each carry their own transmitter;
+      // matching curves are a coincidence, not a double assignment.
+      final series = [
+        for (var t = 0; t <= 1200; t += 60)
+          QualityPressureSample(t: t, bar: 200 - t * 0.05),
+      ];
+      final ctx = makeContext(
+        dive: makeTestDive(
+          tanks: [
+            tank(id: 'a', transmitterSerial: '180777'),
+            tank(id: 'b', order: 1, transmitterSerial: '180778'),
+          ],
+        ),
+        pressures: {'a': series, 'b': series},
+      );
+      expect(det.detect(ctx), isEmpty);
+    });
+
+    test('twin series logged on offset cadences are still matched', () {
+      // Two computers at 10 s cadence, consolidated with a 3 s offset: no
+      // two samples share a timestamp, but the curves are the same. Nearest
+      // samples within the gap tolerance must be compared.
+      final a = [
+        for (var t = 0; t <= 1200; t += 10)
+          QualityPressureSample(t: t, bar: 200 - t * 0.05),
+      ];
+      final b = [
+        for (var t = 3; t <= 1200; t += 10)
+          QualityPressureSample(t: t, bar: 200 - t * 0.05),
+      ];
+      final ctx = makeContext(
+        dive: makeTestDive(
+          tanks: [
+            tank(id: 'a'),
+            tank(id: 'b', order: 1),
+          ],
+        ),
+        pressures: {'a': a, 'b': b},
+      );
+      final out = det.detect(ctx);
+      expect(out, hasLength(1));
+      expect(out.single.params['meanDiffBar'], lessThan(1.0));
     });
 
     test('single-tank dives are skipped', () {

--- a/test/features/data_quality/domain/detectors/gas_tank_source_detectors_test.dart
+++ b/test/features/data_quality/domain/detectors/gas_tank_source_detectors_test.dart
@@ -263,6 +263,18 @@ void main() {
       expect(out.single.params['meanDiffBar'], lessThan(1.0));
     });
 
+    test('a zero sentinel serial on two tanks is not a shared transmitter', () {
+      final ctx = makeContext(
+        dive: makeTestDive(
+          tanks: [
+            tank(id: 'a', transmitterSerial: '0'),
+            tank(id: 'b', order: 1, transmitterSerial: ' 0 '),
+          ],
+        ),
+      );
+      expect(det.detect(ctx), isEmpty);
+    });
+
     test('single-tank dives are skipped', () {
       final ctx = makeContext(
         dive: makeTestDive(tanks: [tank()]),

--- a/test/features/dive_computer/data/services/dive_parser_test.dart
+++ b/test/features/dive_computer/data/services/dive_parser_test.dart
@@ -162,6 +162,24 @@ void main() {
       expect(tanks[1].hePercent, 35.0);
     });
 
+    test('carries the transmitter serial into TankData', () {
+      final dive = diveWith(
+        tanks: const [
+          DownloadedTank(
+            index: 0,
+            o2Percent: 32.0,
+            transmitterSerial: '180777',
+          ),
+          DownloadedTank(index: 1, o2Percent: 21.0),
+        ],
+      );
+
+      final tanks = parser.parseTanks(dive);
+
+      expect(tanks[0].transmitterSerial, '180777');
+      expect(tanks[1].transmitterSerial, isNull);
+    });
+
     test('returns an empty list for a dive without tanks', () {
       expect(parser.parseTanks(diveWith()), isEmpty);
     });

--- a/test/features/dive_computer/data/services/downloaded_tank_defaults_test.dart
+++ b/test/features/dive_computer/data/services/downloaded_tank_defaults_test.dart
@@ -29,6 +29,18 @@ void main() {
     expect(result.first.presetName, 'al80');
   });
 
+  test('keeps the transmitter serial the computer reported', () {
+    const tank = TankData(
+      index: 0,
+      o2Percent: 21.0,
+      transmitterSerial: '180777',
+    );
+
+    final result = applyDefaultPresetToTanks([tank], al80);
+
+    expect(result.first.transmitterSerial, '180777');
+  });
+
   test('keeps a volume the computer reported', () {
     const tank = TankData(index: 0, o2Percent: 21.0, volumeLiters: 12.0);
 

--- a/test/features/dive_computer/data/services/parsed_tank_resolver_test.dart
+++ b/test/features/dive_computer/data/services/parsed_tank_resolver_test.dart
@@ -42,6 +42,41 @@ void main() {
           gasMixIndex: gasMixIndex,
         );
 
+    test('carries the transmitter serial the computer reported', () {
+      // Two computers paired to one transmitter log the same cylinder; the
+      // serial is what lets consolidation tell that apart from two tanks.
+      final parsed = makeParsedDive(
+        gasMixes: [pigeon.GasMix(index: 0, o2Percent: 32.0, hePercent: 0.0)],
+        tanks: [
+          pigeon.TankInfo(
+            index: 0,
+            gasMixIndex: unknownGasMixIndex,
+            startPressureBar: 200.0,
+            endPressureBar: 60.0,
+            transmitterSerial: 180777,
+          ),
+        ],
+      );
+      final tanks = resolveParsedTanks(parsed);
+      expect(tanks, hasLength(1));
+      expect(tanks.single.transmitterSerial, '180777');
+    });
+
+    test('a tank without a transmitter serial resolves to null, not "0"', () {
+      final parsed = makeParsedDive(
+        gasMixes: [pigeon.GasMix(index: 0, o2Percent: 32.0, hePercent: 0.0)],
+        tanks: [
+          pigeon.TankInfo(
+            index: 0,
+            gasMixIndex: unknownGasMixIndex,
+            startPressureBar: 200.0,
+            endPressureBar: 60.0,
+          ),
+        ],
+      );
+      expect(resolveParsedTanks(parsed).single.transmitterSerial, isNull);
+    });
+
     test('gauge-mode parsed dive yields no synthesized tanks or switches', () {
       // Gauge dives log depth+time only. Even when the computer reports a gas
       // mix (which would otherwise synthesize a pressureless air cylinder),

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -1462,6 +1462,77 @@ void main() {
       expect(await service.hasRawData('dive-nonexistent'), isFalse);
     });
 
+    test('DiveTanks carry-over: writes the transmitter serial on both an '
+        'existing tank and a new one', () async {
+      // Tanks downloaded before v194 have no serial; a re-parse of the stored
+      // raw data is how they gain one, so the existing-tank branch must write
+      // it alongside the other computer-owned fields.
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+      await db
+          .into(db.diveTanks)
+          .insert(
+            const DiveTanksCompanion(
+              id: Value('tank-0'),
+              diveId: Value('dive-1'),
+              startPressure: Value(200.0),
+              endPressure: Value(50.0),
+              o2Percent: Value(32.0),
+              hePercent: Value(0.0),
+              tankOrder: Value(0),
+              tankName: Value('My Primary AL80'),
+            ),
+          );
+
+      final parsed = makeParsedDive(
+        tanks: [
+          pigeon.TankInfo(
+            index: 0,
+            gasMixIndex: 0,
+            startPressureBar: 210.0,
+            endPressureBar: 40.0,
+            transmitterSerial: 180777,
+          ),
+          pigeon.TankInfo(
+            index: 1,
+            gasMixIndex: 1,
+            startPressureBar: 200.0,
+            endPressureBar: 100.0,
+            transmitterSerial: 109623,
+          ),
+        ],
+        gasMixes: [
+          pigeon.GasMix(index: 0, o2Percent: 32.0, hePercent: 0.0),
+          pigeon.GasMix(index: 1, o2Percent: 100.0, hePercent: 0.0),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final tanks =
+          await (db.select(db.diveTanks)
+                ..where((t) => t.diveId.equals('dive-1'))
+                ..orderBy([(t) => OrderingTerm.asc(t.tankOrder)]))
+              .get();
+      expect(tanks.map((t) => t.transmitterSerial), ['180777', '109623']);
+      // The user-authored name survives the update as before.
+      expect(tanks.first.tankName, 'My Primary AL80');
+    });
+
     test('DiveTanks carry-over: overwrites computer fields, preserves user '
         'fields, handles new/removed tanks', () async {
       await insertDive('dive-1');

--- a/test/features/dive_import/uddf_import_source_uuid_test.dart
+++ b/test/features/dive_import/uddf_import_source_uuid_test.dart
@@ -163,6 +163,26 @@ void main() {
       );
     });
 
+    test('persists the tankdata transmitterserial to dive_tanks', () async {
+      final diverId = await createTestDiver();
+      final uddf = buildMinimalUddf().replaceFirst(
+        '<tankvolume>12.0</tankvolume>',
+        '<tankvolume>12.0</tankvolume>\n'
+            '          <transmitterserial>180777</transmitterserial>',
+      );
+
+      final parsed = await exportService.importAllDataFromUddf(uddf);
+      await importer.import(
+        data: parsed,
+        selections: const UddfImportSelections(dives: {0}),
+        repositories: buildRepositories(),
+        diverId: diverId,
+      );
+
+      final tanks = await db.select(db.diveTanks).get();
+      expect(tanks.single.transmitterSerial, '180777');
+    });
+
     test(
       'writes null source_uuid when UDDF <dive> has no id attribute',
       () async {

--- a/test/features/dive_log/data/repositories/dive_computer_repository_import_attribution_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_repository_import_attribution_test.dart
@@ -47,6 +47,34 @@ void main() {
     return id;
   }
 
+  test('importProfile stores the transmitter serial on the tank row', () async {
+    // The serial is the cylinder's identity across computers; a download
+    // that drops it leaves consolidation with only the gas-mix heuristic.
+    final computerId = await insertComputer();
+
+    final diveId = await repository.importProfile(
+      computerId: computerId,
+      profileStartTime: DateTime(2026, 6, 1, 9, 0),
+      points: const [
+        ProfilePointData(timestamp: 0, depth: 0.0, pressure: 200.0),
+        ProfilePointData(timestamp: 600, depth: 20.0, pressure: 150.0),
+      ],
+      durationSeconds: 1800,
+      maxDepth: 25.0,
+      tanks: const [
+        TankData(index: 0, o2Percent: 32.0, transmitterSerial: '180777'),
+        TankData(index: 1, o2Percent: 50.0),
+      ],
+    );
+
+    final tanks =
+        await (db.select(db.diveTanks)
+              ..where((t) => t.diveId.equals(diveId))
+              ..orderBy([(t) => OrderingTerm.asc(t.tankOrder)]))
+            .get();
+    expect(tanks.map((t) => t.transmitterSerial), ['180777', null]);
+  });
+
   test(
     'importProfile stamps computerId on tanks, pressures, and events',
     () async {

--- a/test/features/dive_log/data/repositories/dive_repository_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_test.dart
@@ -179,6 +179,27 @@ void main() {
         expect(fetchedDive.tanks[0].gasMix.o2, equals(32.0));
       });
 
+      test(
+        'should keep a tank transmitter serial through create and read',
+        () async {
+          final dive = createTestDive(
+            tanks: [
+              const DiveTank(
+                id: '',
+                gasMix: GasMix(o2: 32.0),
+                order: 0,
+                transmitterSerial: '180777',
+              ),
+            ],
+          );
+
+          final createdDive = await repository.createDive(dive);
+          final fetchedDive = await repository.getDiveById(createdDive.id);
+
+          expect(fetchedDive!.tanks.single.transmitterSerial, '180777');
+        },
+      );
+
       test('should create a dive with site', () async {
         final site = await siteRepository.createSite(
           const DiveSite(id: '', name: 'Test Site'),
@@ -331,6 +352,65 @@ void main() {
     });
 
     group('updateDive', () {
+      test(
+        'keeps a stored transmitter serial when the edited tank omits it',
+        () async {
+          // The serial is computer-owned, like computerId: an edit flow that
+          // rebuilds the tank without it must not wipe what the download wrote.
+          final created = await repository.createDive(
+            createTestDive(
+              tanks: [
+                const DiveTank(
+                  id: '',
+                  gasMix: GasMix(o2: 32.0),
+                  order: 0,
+                  transmitterSerial: '180777',
+                ),
+              ],
+            ),
+          );
+          final loaded = (await repository.getDiveById(created.id))!;
+          final edited = loaded.copyWith(
+            tanks: [
+              loaded.tanks.single.copyWith(
+                startPressure: 210.0,
+                clearTransmitterSerial: true,
+              ),
+            ],
+          );
+
+          await repository.updateDive(edited);
+          final result = (await repository.getDiveById(created.id))!;
+
+          expect(result.tanks.single.startPressure, 210.0);
+          expect(result.tanks.single.transmitterSerial, '180777');
+        },
+      );
+
+      test(
+        'stores the transmitter serial on a tank added by an update',
+        () async {
+          final created = await repository.createDive(createTestDive());
+          final loaded = (await repository.getDiveById(created.id))!;
+
+          await repository.updateDive(
+            loaded.copyWith(
+              tanks: [
+                const DiveTank(
+                  id: 'added-tank',
+                  gasMix: GasMix(o2: 32.0),
+                  order: 0,
+                  transmitterSerial: '180777',
+                ),
+              ],
+            ),
+          );
+          final result = (await repository.getDiveById(created.id))!;
+
+          expect(result.tanks.single.transmitterSerial, '180777');
+        },
+      );
+
       test('should update dive fields', () async {
         final dive = await repository.createDive(
           createTestDive(

--- a/test/features/dive_log/domain/services/dive_consolidation_builder_test.dart
+++ b/test/features/dive_log/domain/services/dive_consolidation_builder_test.dart
@@ -170,6 +170,178 @@ void main() {
       },
     );
 
+    test(
+      'matching transmitter serials merge even when the programmed mix differs',
+      () {
+        // Two Terics paired to the same transmitter: one programmed 31%,
+        // the other 32%. Same physical cylinder, so the gas gate must yield.
+        const primaryTank = DiveTank(
+          id: 'p1',
+          gasMix: GasMix(o2: 31.0, he: 0.0),
+          startPressure: 207,
+          endPressure: 63,
+          transmitterSerial: '180777',
+        );
+        const secondaryTank = DiveTank(
+          id: 's1',
+          gasMix: GasMix(o2: 32.0, he: 0.0),
+          startPressure: 208,
+          endPressure: 64,
+          transmitterSerial: '180777',
+        );
+        final primary = makeDive(
+          'p',
+          entry: t,
+          runtimeMin: 40,
+          tanks: [primaryTank],
+        );
+        final secondary = makeDive(
+          's',
+          entry: t.add(const Duration(minutes: 10)),
+          runtimeMin: 30,
+          tanks: [secondaryTank],
+        );
+        final plan = builder.build([primary, secondary]);
+        expect(plan.tankMerges, {'s1': 'p1'});
+      },
+    );
+
+    test('matching transmitter serials merge even when pressures disagree', () {
+      // The transmitter is the cylinder's identity; a pressure gap only
+      // says the two computers logged it at different moments.
+      const primaryTank = DiveTank(
+        id: 'p1',
+        gasMix: GasMix(o2: 32.0, he: 0.0),
+        startPressure: 207,
+        endPressure: 63,
+        transmitterSerial: '180777',
+      );
+      const secondaryTank = DiveTank(
+        id: 's1',
+        gasMix: GasMix(o2: 32.0, he: 0.0),
+        startPressure: 190,
+        endPressure: 80,
+        transmitterSerial: '180777',
+      );
+      final primary = makeDive(
+        'p',
+        entry: t,
+        runtimeMin: 40,
+        tanks: [primaryTank],
+      );
+      final secondary = makeDive(
+        's',
+        entry: t.add(const Duration(minutes: 10)),
+        runtimeMin: 30,
+        tanks: [secondaryTank],
+      );
+      final plan = builder.build([primary, secondary]);
+      expect(plan.tankMerges, {'s1': 'p1'});
+    });
+
+    test(
+      'differing transmitter serials never merge, even on identical data',
+      () {
+        // Twin cylinders on the same mix with their own transmitters are two
+        // tanks, however closely their readings agree.
+        const primaryTank = DiveTank(
+          id: 'p1',
+          gasMix: GasMix(o2: 32.0, he: 0.0),
+          startPressure: 207,
+          endPressure: 63,
+          transmitterSerial: '180777',
+        );
+        const secondaryTank = DiveTank(
+          id: 's1',
+          gasMix: GasMix(o2: 32.0, he: 0.0),
+          startPressure: 207,
+          endPressure: 63,
+          transmitterSerial: '180778',
+        );
+        final primary = makeDive(
+          'p',
+          entry: t,
+          runtimeMin: 40,
+          tanks: [primaryTank],
+        );
+        final secondary = makeDive(
+          's',
+          entry: t.add(const Duration(minutes: 10)),
+          runtimeMin: 30,
+          tanks: [secondaryTank],
+        );
+        final plan = builder.build([primary, secondary]);
+        expect(plan.tankMerges, isEmpty);
+      },
+    );
+
+    test('a serial on only one side falls back to the gas-mix rule', () {
+      const primaryTank = DiveTank(
+        id: 'p1',
+        gasMix: GasMix(o2: 32.0, he: 0.0),
+        startPressure: 207,
+        endPressure: 63,
+        transmitterSerial: '180777',
+      );
+      const secondaryTank = DiveTank(
+        id: 's1',
+        gasMix: GasMix(o2: 32.0, he: 0.0),
+        startPressure: 208,
+        endPressure: 64,
+      );
+      final primary = makeDive(
+        'p',
+        entry: t,
+        runtimeMin: 40,
+        tanks: [primaryTank],
+      );
+      final secondary = makeDive(
+        's',
+        entry: t.add(const Duration(minutes: 10)),
+        runtimeMin: 30,
+        tanks: [secondaryTank],
+      );
+      final plan = builder.build([primary, secondary]);
+      expect(plan.tankMerges, {'s1': 'p1'});
+    });
+
+    test('a serial match claims the primary tank that shares the serial, '
+        'not the first tank with a close mix', () {
+      // Primary: back gas (32%, serial A) then a stage (32%, no serial).
+      // Secondary: one tank with serial A. It must land on the primary tank
+      // carrying that serial rather than whichever tank is listed first.
+      const primaryStage = DiveTank(
+        id: 'p-stage',
+        gasMix: GasMix(o2: 32.0, he: 0.0),
+        order: 0,
+      );
+      const primaryBack = DiveTank(
+        id: 'p-back',
+        gasMix: GasMix(o2: 32.0, he: 0.0),
+        order: 1,
+        transmitterSerial: '180777',
+      );
+      const secondaryTank = DiveTank(
+        id: 's1',
+        gasMix: GasMix(o2: 32.0, he: 0.0),
+        transmitterSerial: '180777',
+      );
+      final primary = makeDive(
+        'p',
+        entry: t,
+        runtimeMin: 40,
+        tanks: [primaryStage, primaryBack],
+      );
+      final secondary = makeDive(
+        's',
+        entry: t.add(const Duration(minutes: 10)),
+        runtimeMin: 30,
+        tanks: [secondaryTank],
+      );
+      final plan = builder.build([primary, secondary]);
+      expect(plan.tankMerges, {'s1': 'p-back'});
+    });
+
     test('gas differing by more than 0.5% keeps tanks separate', () {
       const primaryTank = DiveTank(
         id: 'p1',

--- a/test/features/dive_log/domain/services/dive_consolidation_builder_test.dart
+++ b/test/features/dive_log/domain/services/dive_consolidation_builder_test.dart
@@ -275,6 +275,34 @@ void main() {
       },
     );
 
+    test('a zero sentinel serial on both sides is no identity at all', () {
+      // "0" is libdivecomputer's "no transmitter"; two such tanks must fall
+      // back to the gas-mix rule, which here keeps them apart.
+      const primaryTank = DiveTank(
+        id: 'p1',
+        gasMix: GasMix(o2: 31.0, he: 0.0),
+        transmitterSerial: '0',
+      );
+      const secondaryTank = DiveTank(
+        id: 's1',
+        gasMix: GasMix(o2: 32.0, he: 0.0),
+        transmitterSerial: '0',
+      );
+      final primary = makeDive(
+        'p',
+        entry: t,
+        runtimeMin: 40,
+        tanks: [primaryTank],
+      );
+      final secondary = makeDive(
+        's',
+        entry: t.add(const Duration(minutes: 10)),
+        runtimeMin: 30,
+        tanks: [secondaryTank],
+      );
+      expect(builder.build([primary, secondary]).tankMerges, isEmpty);
+    });
+
     test('a serial on only one side falls back to the gas-mix rule', () {
       const primaryTank = DiveTank(
         id: 'p1',

--- a/test/features/dive_log/domain/services/dive_consolidation_builder_test.dart
+++ b/test/features/dive_log/domain/services/dive_consolidation_builder_test.dart
@@ -303,6 +303,82 @@ void main() {
       expect(builder.build([primary, secondary]).tankMerges, isEmpty);
     });
 
+    test('every secondary on the same transmitter merges into one primary '
+        'tank', () {
+      // Three computers paired to one transmitter: the primary tank must
+      // absorb BOTH secondaries' tanks, not just the first one's.
+      const primaryTank = DiveTank(
+        id: 'p1',
+        gasMix: GasMix(o2: 32.0, he: 0.0),
+        transmitterSerial: '180777',
+      );
+      const secondaryTank1 = DiveTank(
+        id: 's1',
+        gasMix: GasMix(o2: 31.0, he: 0.0),
+        transmitterSerial: '180777',
+      );
+      const secondaryTank2 = DiveTank(
+        id: 's2',
+        gasMix: GasMix(o2: 32.0, he: 0.0),
+        transmitterSerial: '180777',
+      );
+      final primary = makeDive(
+        'p',
+        entry: t,
+        runtimeMin: 40,
+        tanks: [primaryTank],
+      );
+      final secondary1 = makeDive(
+        's-one',
+        entry: t.add(const Duration(minutes: 5)),
+        runtimeMin: 30,
+        tanks: [secondaryTank1],
+      );
+      final secondary2 = makeDive(
+        's-two',
+        entry: t.add(const Duration(minutes: 10)),
+        runtimeMin: 30,
+        tanks: [secondaryTank2],
+      );
+      final plan = builder.build([primary, secondary1, secondary2]);
+      expect(plan.tankMerges, {'s1': 'p1', 's2': 'p1'});
+    });
+
+    test(
+      'two tanks of one secondary never both claim the same primary tank',
+      () {
+        // Within a single secondary the claim is exclusive: its second tank on
+        // the same mix is a second cylinder, not a second reading of the first.
+        const primaryTank = DiveTank(
+          id: 'p1',
+          gasMix: GasMix(o2: 32.0, he: 0.0),
+        );
+        const secondaryTank1 = DiveTank(
+          id: 's1',
+          gasMix: GasMix(o2: 32.0, he: 0.0),
+        );
+        const secondaryTank2 = DiveTank(
+          id: 's2',
+          gasMix: GasMix(o2: 32.0, he: 0.0),
+          order: 1,
+        );
+        final primary = makeDive(
+          'p',
+          entry: t,
+          runtimeMin: 40,
+          tanks: [primaryTank],
+        );
+        final secondary = makeDive(
+          's',
+          entry: t.add(const Duration(minutes: 10)),
+          runtimeMin: 30,
+          tanks: [secondaryTank1, secondaryTank2],
+        );
+        final plan = builder.build([primary, secondary]);
+        expect(plan.tankMerges, {'s1': 'p1'});
+      },
+    );
+
     test('a serial on only one side falls back to the gas-mix rule', () {
       const primaryTank = DiveTank(
         id: 'p1',

--- a/test/features/dive_log/domain/services/transmitter_serial_test.dart
+++ b/test/features/dive_log/domain/services/transmitter_serial_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/services/transmitter_serial.dart';
+
+void main() {
+  group('normalizeTransmitterSerial', () {
+    test('keeps a real serial, trimmed', () {
+      expect(normalizeTransmitterSerial(' 180777 '), '180777');
+    });
+
+    test('treats null, blank and whitespace as absent', () {
+      expect(normalizeTransmitterSerial(null), isNull);
+      expect(normalizeTransmitterSerial(''), isNull);
+      expect(normalizeTransmitterSerial('   '), isNull);
+    });
+
+    test('treats the zero sentinel as absent, however it is padded', () {
+      // libdivecomputer reports 0 for "no transmitter"; a file or peer that
+      // stringifies that must not turn it into an identity two unrelated
+      // tanks could share.
+      expect(normalizeTransmitterSerial('0'), isNull);
+      expect(normalizeTransmitterSerial('000'), isNull);
+      expect(normalizeTransmitterSerial(' 0 '), isNull);
+    });
+  });
+}

--- a/test/features/dive_log/presentation/widgets/tank_editor_test.dart
+++ b/test/features/dive_log/presentation/widgets/tank_editor_test.dart
@@ -167,6 +167,8 @@ void main() {
         startPressure: 200.0,
         endPressure: 50.0,
         gasMix: GasMix(o2: 21.0, he: 0.0),
+        computerId: 'dc-1',
+        transmitterSerial: '180777',
       );
 
       DiveTank? updatedTank;
@@ -226,6 +228,11 @@ void main() {
 
       // End pressure: 725 psi -> ~50 bar
       expect(updatedTank!.endPressure, closeTo(50.0, 0.5));
+
+      // Computer-owned identity survives an edit: the editor rebuilds the
+      // tank field by field, so anything it forgets is silently wiped.
+      expect(updatedTank!.computerId, 'dc-1');
+      expect(updatedTank!.transmitterSerial, '180777');
     });
 
     testWidgets('applyPreset shows volumeCuft in imperial mode', (


### PR DESCRIPTION
## Summary

A logbook with two Shearwater Terics paired to the same transmitter (serial 180777) showed the same cylinder twice on every dive where the diver had 31% programmed on one computer and 32% on the other: consolidation only matched tanks on gas mix (within 0.5 pp) and shared pressures (within 5 bar), so the secondary kept its own `dive_tanks` row and pressure series, and gas consumption and SAC doubled.

The transmitter serial is the cylinder's physical identity across computers. This PR carries it from libdivecomputer to the database and makes it the primary tank-match key, with the gas-mix rule as the fallback.

## Changes

**libdivecomputer fork** (`patches/0009-tank-transmitter-serial.patch`, gitlink `5955815` -> `cbd536d`, fork PR submersion-app/libdivecomputer#3, merge that first with a merge commit)
- `dc_tank_t.serial`: the air-integration transmitter serial, zero when not reported. The Shearwater parser already decoded it from opening records 5 to 7 (with the Teric digit-pair fix) and the Halcyon Symbios parser tracks it as the tank id; both now expose it through `DC_FIELD_TANK`. `dc_parser_get_field` zeroes the field before dispatching, so every other parser reads as "none" whatever the caller initialised; Symbios slot ids tagged with the transmitter marker bit report zero rather than a fake serial.

**Plugin transport**
- `libdc_tank_t.serial` in the C wrapper, `TankInfo.transmitterSerial` (`int?`) in pigeon, wired through the Swift, JNI/Kotlin (both the BLE/USB and serial download paths), Windows and Linux converters.
- Native regression test `test_tank_transmitter_serial.c` pins the Petrel 3 fixture's serials 123086 and 109623, decoded by hand from the raw opening record before the test was written.

**App**
- Schema v194: nullable `dive_tanks.transmitter_serial`, rung plus `beforeOpen` backstop, migration tests. 192 and 193 are held by other open PRs.
- `DiveTank.transmitterSerial` stored on download and re-parse (both the existing-tank update and new-tank insert), through `createDive`, `updateDive` (new tanks), bulk add/replace, the bulk-edit undo mapper, the default-preset helper and the tank editor. The `updateDive` update branch deliberately omits it, like `computerId`, so an edit flow that rebuilds the tank cannot wipe it.
- `DiveConsolidationBuilder`: equal non-null serials match regardless of programmed mix or pressures; differing non-null serials never match; otherwise the existing rule. The claim loop runs a serial pass before the gas-mix pass so a serial-less tank listed first cannot take a tank whose serial names another.
- UDDF: `<transmitterserial>` as an app-specific `tankdata` child (alongside `tankrole` and `tankorder`), read by both importers and the entity importer.
- Sync carries the column through the generated whole-row `toJson`/`fromJson`; a guard test pins that.
- Data quality: `TankAssignmentDetector` v2. Two tanks on one dive with the same serial are flagged as twins without needing series (`sameTransmitter: true`), differing serials veto the series heuristic, and series are compared at the nearest samples within 5 s because consolidated computers never share timestamps (the old exact-timestamp join silently found nothing). Existing dives that already carry the duplicate surface as this finding after a re-parse populates the serials.

## Verification

- Native wrapper suite: 16/16 (`ctest`), including the new serial test.
- `flutter analyze`: no issues.
- Affected-area sweep (`test/core/database`, `sync`, `export`, `dive_log`, `dive_computer`, `data_quality`, `dive_import`) and the plugin package tests: see the CI matrix for the Windows, Linux, Android and Apple converter builds, which cannot be compiled on this machine.

## Follow-ups

- Show the serial in the cylinders card.
- A "merge duplicate tank" repair for the twin finding (only swap/reassign series are offered today).
- FIT imports already carry `FitTank.sensorId`; it could feed the same column.
