### PR TITLE
fix(safety-review): recompute the review when the profile changes und…

### DIFF
--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/dive_computer/data/services/libdc_dive_mode.dart';
 import 'package:submersion/features/dive_log/data/repositories/profile_series_repository.dart';
+import 'package:submersion/features/dive_log/data/repositories/safety_findings_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_series_repository.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart'
     as codec;
@@ -369,6 +370,7 @@ class ReparseService {
     final sources = await getSourcesForDiveReparse(diveId);
     final errors = <String>[];
     var profilesPreserved = 0;
+    var appliedAny = false;
 
     for (final source in sources) {
       if (source.descriptorVendor == null ||
@@ -392,10 +394,25 @@ class ReparseService {
           descriptorModel: source.descriptorModel,
           libdivecomputerVersion: source.libdivecomputerVersion,
         );
+        appliedAny = true;
         if (outcome.profilePreserved) profilesPreserved++;
       } catch (e) {
         errors.add(e.toString());
       }
+    }
+
+    // A re-parse that landed rewrites the profile and/or the dive's
+    // computer-authored fields (gradient factors, ppO2, deco algorithm) the
+    // stored safety review was computed against, but never touched the review
+    // itself -- so it kept showing findings from the old data. Drop it here,
+    // once, the same as editProfile and the live-download path do (#1641).
+    // Left alone when every source failed: nothing changed, nothing to redo.
+    if (appliedAny) {
+      await SafetyFindingsRepository.clearReviewForDive(
+        db,
+        SyncRepository(database: db),
+        diveId,
+      );
     }
 
     return (errors: errors, profilesPreserved: profilesPreserved);

--- a/lib/features/dive_log/data/repositories/safety_findings_repository.dart
+++ b/lib/features/dive_log/data/repositories/safety_findings_repository.dart
@@ -263,6 +263,14 @@ class SafetyFindingsRepository {
     }
   }
 
+  /// Instance wrapper over [clearReviewForDive], for a caller that holds a
+  /// repository rather than a `(db, sync)` pair -- the "Analyze all dives"
+  /// sweep, which drops each stored review so the recompute actually runs
+  /// instead of the compute-through-cache handing back the current one
+  /// unchanged (#1643).
+  Future<void> clearReview(String diveId) =>
+      clearReviewForDive(_db, _syncRepository, diveId);
+
   /// Maps a stored finding row to its domain entity, or null when the row's
   /// rule_id does not correspond to a known [SafetyRuleId]. Callers drop null
   /// rows rather than surface a coerced (misleading) rule.

--- a/lib/features/dive_log/presentation/providers/safety_review_sweep.dart
+++ b/lib/features/dive_log/presentation/providers/safety_review_sweep.dart
@@ -93,7 +93,15 @@ class SafetyReviewSweep {
         );
       }
       try {
-        // Invalidate first. safetyReviewProvider is not autoDispose, so any
+        // Drop the stored review first. safetyReviewProvider hands a
+        // still-current-engine-version review straight back from the DB
+        // without recomputing, so after the first sweep every dive would
+        // short-circuit and "Analyze all dives" would refresh nothing --
+        // exactly the bulk recompute the user reached for after fixing input
+        // data (a corrected re-parse, an edited profile) (#1643). With the
+        // marker gone the provider's compute branch runs.
+        await _ref.read(safetyFindingsRepositoryProvider).clearReview(diveId);
+        // Then invalidate. safetyReviewProvider is not autoDispose, so any
         // dive whose detail page was opened this session holds a cached
         // AsyncValue -- including a cached null from a dive opened mid-sync
         // before its profile arrived. A bare read would return that cached

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -523,6 +523,122 @@ void main() {
       },
     );
 
+    /// Seeds a stored safety review (marker + one finding) at the current
+    /// engine version for [diveId], so a stale review is distinguishable
+    /// from a missing one.
+    Future<void> seedStoredReview(String diveId) async {
+      await db
+          .into(db.diveSafetyReviews)
+          .insert(
+            DiveSafetyReviewsCompanion.insert(
+              diveId: diveId,
+              engineVersion: 999,
+              reviewedAt: nowMs,
+            ),
+          );
+      await db
+          .into(db.diveSafetyFindings)
+          .insert(
+            DiveSafetyFindingsCompanion.insert(
+              id: 'finding-$diveId',
+              diveId: diveId,
+              ruleId: 'ascent_rate',
+              severity: 'warning',
+              engineVersion: 999,
+              createdAt: nowMs,
+            ),
+          );
+    }
+
+    Future<bool> hasStoredReview(String diveId) async {
+      final marker = await (db.select(
+        db.diveSafetyReviews,
+      )..where((t) => t.diveId.equals(diveId))).getSingleOrNull();
+      return marker != null;
+    }
+
+    test('reparseDive drops the stale safety review (#1641)', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-1'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('comp-1'),
+              isPrimary: const Value(true),
+              sourceFormat: const Value('dive_computer'),
+              rawData: Value(Uint8List.fromList(List.filled(64, 0xAB))),
+              descriptorVendor: const Value('Shearwater'),
+              descriptorProduct: const Value('Perdix'),
+              descriptorModel: const Value(5),
+              libdivecomputerVersion: const Value('0.9.0'),
+              importedAt: Value(now),
+              createdAt: Value(now),
+            ),
+          );
+      await seedStoredReview('dive-1');
+      expect(await hasStoredReview('dive-1'), isTrue);
+
+      final errors = (await service.reparseDive(
+        'dive-1',
+        parseFn: (v, p, m, raw) async => makeParsedDive(maxDepthMeters: 30.0),
+      )).errors;
+
+      expect(errors, isEmpty);
+      expect(
+        await hasStoredReview('dive-1'),
+        isFalse,
+        reason: 'a landed re-parse must invalidate the stored review',
+      );
+      final findings = await (db.select(
+        db.diveSafetyFindings,
+      )..where((t) => t.diveId.equals('dive-1'))).get();
+      expect(findings, isEmpty);
+    });
+
+    test(
+      'reparseDive leaves the review alone when every source fails (#1641)',
+      () async {
+        await insertDive('dive-1');
+        await insertComputer('comp-1');
+        final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+        await db
+            .into(db.diveDataSources)
+            .insert(
+              DiveDataSourcesCompanion(
+                id: const Value('src-1'),
+                diveId: const Value('dive-1'),
+                computerId: const Value('comp-1'),
+                isPrimary: const Value(true),
+                sourceFormat: const Value('dive_computer'),
+                rawData: Value(Uint8List.fromList(List.filled(64, 0xAB))),
+                descriptorVendor: const Value('Shearwater'),
+                descriptorProduct: const Value('Perdix'),
+                descriptorModel: const Value(5),
+                libdivecomputerVersion: const Value('0.9.0'),
+                importedAt: Value(now),
+                createdAt: Value(now),
+              ),
+            );
+        await seedStoredReview('dive-1');
+
+        final result = await service.reparseDive(
+          'dive-1',
+          parseFn: (v, p, m, raw) async => throw StateError('parser blew up'),
+        );
+
+        expect(result.errors, isNotEmpty);
+        expect(
+          await hasStoredReview('dive-1'),
+          isTrue,
+          reason: 'nothing changed, so the review must not be dropped',
+        );
+      },
+    );
+
     test(
       'reparseDive silently skips sources missing descriptor info',
       () async {

--- a/test/features/dive_log/presentation/providers/safety_review_sweep_test.dart
+++ b/test/features/dive_log/presentation/providers/safety_review_sweep_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/dive_log/data/repositories/safety_findings_repository.dart';
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/dive_log/domain/services/safety_review_service.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_sweep.dart';
@@ -20,6 +21,32 @@ class _RecordingRepo extends SafetyFindingsRepository {
 
   @override
   Future<SafetyReview?> getReview(String diveId) async => null;
+
+  @override
+  Future<void> saveReview(SafetyReview review) async =>
+      saved.add(review.diveId);
+}
+
+/// Serves a stored review at the CURRENT engine version for every dive --
+/// exactly the state after one sweep -- so `safetyReviewProvider` would
+/// short-circuit and recompute nothing. `clearReview` flips that per dive.
+class _StaleReviewRepo extends SafetyFindingsRepository {
+  final Set<String> cleared = {};
+  final saved = <String>[];
+
+  @override
+  Future<SafetyReview?> getReview(String diveId) async {
+    if (cleared.contains(diveId)) return null;
+    return SafetyReview(
+      diveId: diveId,
+      engineVersion: SafetyReviewService.engineVersion,
+      reviewedAt: DateTime.utc(2026),
+      findings: const [],
+    );
+  }
+
+  @override
+  Future<void> clearReview(String diveId) async => cleared.add(diveId);
 
   @override
   Future<void> saveReview(SafetyReview review) async =>
@@ -76,7 +103,7 @@ void main() {
 
   /// A container whose analysis always yields a rapid-ascent fixture, so every
   /// dive produces a persistable review.
-  ProviderContainer makeContainer(_RecordingRepo repo) {
+  ProviderContainer makeContainer(SafetyFindingsRepository repo) {
     final profile = rapidAscentProfile();
     final analysis = analyzeFixture(
       depths: profile.depths,
@@ -96,6 +123,29 @@ void main() {
     addTearDown(container.dispose);
     return container;
   }
+
+  test('forces a recompute even when every dive already has a current review '
+      '(#1643)', () async {
+    final repo = _StaleReviewRepo();
+    final result = await makeContainer(
+      repo,
+    ).read(safetyReviewSweepProvider).run();
+
+    // Without the clearReview call the provider's compute-through-cache
+    // hands each current review straight back and saveReview never fires.
+    expect(
+      repo.cleared,
+      containsAll(<String>['d1', 'd2']),
+      reason: 'the sweep drops each stored review before re-reading',
+    );
+    expect(
+      repo.saved,
+      containsAll(<String>['d1', 'd2']),
+      reason: 'so every dive is genuinely recomputed and re-saved',
+    );
+    expect(result.swept, 2);
+    expect(result.failed, 0);
+  });
 
   test('sweeps every diver when diverId is null', () async {
     final repo = _RecordingRepo();


### PR DESCRIPTION
## Summary

Two paths leave a dive's stored safety review in place after the data it was computed against changes, so it keeps showing findings from the old profile -- wrong ppO2, gradient-factor and missed-stop observations -- with nothing in the UI marking it stale.

Diagnosed by @trustthegoose (#1641, #1643). Both bite hardest right after a corrected re-parse: re-parse a dive whose profile had a bad depth spike, and the stale review still carries the impossible ppO2 / GF findings that spike produced.

Fixes #1641, fixes #1643.

## Changes

- **`ReparseService.reparseDive()`** rewrites the profile and the dive's computer-authored fields (gradient factors, ppO2, deco algorithm) but never touched the review. It now calls `SafetyFindingsRepository.clearReviewForDive()` once, after the loop, when at least one source's re-parse landed -- the same invalidation `editProfile` and the live-download path already do. A re-parse where every source fails changes nothing and leaves the review alone.
- **`SafetyReviewSweep`** ("Analyze all dives") only `invalidate`d the Riverpod provider. `safetyReviewProvider` still served each already-current-engine-version review straight from the DB, so after the first sweep the action recomputed nothing. It now drops each stored review first, via a new `SafetyFindingsRepository.clearReview()` instance wrapper over the existing static, so the provider's compute branch runs.

## Test Plan

- `reparse_service_test.dart`: a landed re-parse drops a seeded stale review (marker + findings); a re-parse where every source throws leaves it in place.
- `safety_review_sweep_test.dart`: with a repo that serves a current-engine-version review for every dive, the sweep still calls `clearReview` and re-`saveReview`s each one (before the fix it saved nothing).
- `flutter test test/features/dive_computer/ test/features/dive_log/` green; `flutter analyze` clean; `dart format` clean. (`deco_filter_providers_test` fails on `main` too, unrelated.)