### PR TITLE
fix(google-drive): guard the APK signing cert and stop mislabelling refusals

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,34 @@
+name: Submersion CodeQL config
+
+# Query exclusions. Keep this list short, and record why each one is here:
+# an exclusion is a permanent hole in the analysis, so it needs to be as
+# defensible in a year as it is today.
+query-filters:
+  # py/weak-sensitive-data-hashing fires on scripts/check_apk_signing_cert.py
+  # and its test, which SHA-1 the APK's signing certificate.
+  #
+  # The algorithm is fixed by Google, not chosen by us. An Android app carries
+  # no OAuth client ID; Google matches it by package name plus the SHA-1
+  # fingerprint of its signing certificate, and an Android OAuth client is
+  # registered against that SHA-1. A stronger digest would produce a value
+  # that matches nothing the Google Cloud console exposes, so "fixing" the
+  # alert would silence it by destroying the check.
+  #
+  # The query's sensitive-data classification is also a name-based heuristic
+  # firing on the word "certificate". A signing certificate is public: it
+  # ships inside every copy of the APK. No integrity decision rests on the
+  # digest either, since Android verifies the signature itself and the guard
+  # only compares identifiers.
+  #
+  # Excluded by query id rather than by path so every other query still runs
+  # on those two files. As of this writing they hold the only hashlib calls in
+  # the repository, so nothing else is losing coverage; if Python that hashes
+  # a real secret is added later, narrow or remove this exclusion.
+  #
+  # Inline `# codeql[py/weak-sensitive-data-hashing]` comments were tried
+  # first and do not work: GitHub code scanning does not honour CodeQL
+  # suppression comments, and re-flagged the alert on the exact line carrying
+  # one. Dismissing the alerts in the Security tab is the alternative, but it
+  # leaves no trace in the repository for a reviewer to weigh.
+  - exclude:
+      id: py/weak-sensitive-data-hashing

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -841,6 +841,21 @@ jobs:
             build/app/outputs/flutter-apk/app-release.apk \
             build/app/outputs/bundle/release/app-release.aab
 
+      # An Android app carries no OAuth client ID: Google matches it by package
+      # name plus signing-certificate SHA-1, so the signing key IS the Google
+      # Drive credential. The APK below keeps the CI keystore's certificate
+      # while the AAB is re-signed by Play, and registering only the Play
+      # fingerprint left every GitHub Releases install unable to sign in, with
+      # a message that read as a user cancellation. Fails the release if the
+      # APK is signed by a certificate that has no registered OAuth client.
+      # Runs here rather than in ci.yaml because a PR build has no
+      # key.properties and falls back to a per-runner debug keystore whose
+      # fingerprint is generated at random.
+      - name: Verify APK signing certificate is a registered OAuth client
+        run: |
+          python3 scripts/check_apk_signing_cert.py \
+            build/app/outputs/flutter-apk/app-release.apk
+
       # Guards against issue #433: sqlite3_flutter_libs 0.6.0+eol (an empty
       # tombstone release) silently dropped libsqlite3.so from the package, so
       # the app could not open its database on launch. Fail the release before

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -514,9 +514,11 @@ jobs:
       - name: Run Python guard tests with coverage
         run: |
           mkdir -p coverage
-          guards='scripts/check_proguard_serial_keep.py,scripts/check_native_libs_present.py,scripts/check_bundled_native_assets.py,scripts/check_jni_local_refs.py,scripts/check_dc_process_isolation.py,scripts/check_ci_success_gate.py,scripts/fix_macho_symbol_order.py,scripts/release/sanitize_apple_store_notes.py'
+          guards='scripts/check_proguard_serial_keep.py,scripts/check_apk_signing_cert.py,scripts/check_native_libs_present.py,scripts/check_bundled_native_assets.py,scripts/check_jni_local_refs.py,scripts/check_dc_process_isolation.py,scripts/check_ci_success_gate.py,scripts/fix_macho_symbol_order.py,scripts/release/sanitize_apple_store_notes.py'
           python3 -m coverage run --include="$guards" \
             scripts/check_proguard_serial_keep_test.py
+          python3 -m coverage run --append --include="$guards" \
+            scripts/check_apk_signing_cert_test.py
           python3 -m coverage run --append --include="$guards" \
             scripts/check_native_libs_present_test.py
           python3 -m coverage run --append --include="$guards" \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/lib/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart
+++ b/lib/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart
@@ -121,7 +121,7 @@ class GoogleSignInAuthenticator implements GoogleDriveAuthenticator {
             // Deliberately platform-neutral about where to look: this
             // authenticator also serves iOS and macOS, so naming Android's
             // settings would misdirect users there.
-            'Google sign-in was refused by the device (${e.description}). '
+            'Google Sign-In was refused by the device (${e.description}). '
             'Check that the Google account on this device is signed in and '
             'up to date in the system settings, then try again.',
             e,

--- a/lib/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart
+++ b/lib/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart
@@ -121,29 +121,37 @@ class GoogleSignInAuthenticator implements GoogleDriveAuthenticator {
             // Deliberately platform-neutral about where to look: this
             // authenticator also serves iOS and macOS, so naming Android's
             // settings would misdirect users there.
-            'Google Sign-In was refused by the device (${e.description}). '
-            'Check that the Google account on this device is signed in and '
-            'up to date in the system settings, then try again.',
-            e,
+            'Google Sign-In was refused by the device. Check that the Google '
+            'account on this device is signed in and up to date in the system '
+            'settings, then try again.',
+            // The plain status, never the exception. displayMessage appends
+            // the cause and the Cloud Sync snackbar renders displayMessage,
+            // so passing `e` here would print its toString on screen: the
+            // word "canceled" back in front of a user who cancelled nothing,
+            // plus a second copy of the status. The exception itself is
+            // already in the log line above, which is where it belongs.
+            e.description,
             stackTrace,
           );
         }
         _log.info('Google Sign-In was cancelled by the user');
         throw CloudStorageException(
           'Google Sign-In was cancelled',
-          e,
+          // No cause: a dismissal has no detail worth showing, and the
+          // exception's toString would only leak plugin internals.
+          null,
           stackTrace,
         );
       }
       _log.error('Google Sign-In failed', error: e, stackTrace: stackTrace);
       throw CloudStorageException(
-        'Google Sign-In failed: ${e.description ?? e.code.name}',
-        e,
+        'Google Sign-In failed',
+        e.description ?? e.code.name,
         stackTrace,
       );
     } catch (e, stackTrace) {
       _log.error('Google Sign-In failed', error: e, stackTrace: stackTrace);
-      throw CloudStorageException('Google Sign-In failed: $e', e, stackTrace);
+      throw CloudStorageException('Google Sign-In failed', e, stackTrace);
     }
   }
 

--- a/lib/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart
+++ b/lib/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart
@@ -111,6 +111,23 @@ class GoogleSignInAuthenticator implements GoogleDriveAuthenticator {
       _log.info('Authenticated with Google Drive as ${account.email}');
     } on GoogleSignInException catch (e, stackTrace) {
       if (e.code == GoogleSignInExceptionCode.canceled) {
+        if (_isPlatformRefusal(e.description)) {
+          _log.error(
+            'Google Play services refused to authorize the account',
+            error: e,
+            stackTrace: stackTrace,
+          );
+          throw CloudStorageException(
+            // Deliberately platform-neutral about where to look: this
+            // authenticator also serves iOS and macOS, so naming Android's
+            // settings would misdirect users there.
+            'Google sign-in was refused by the device (${e.description}). '
+            'Check that the Google account on this device is signed in and '
+            'up to date in the system settings, then try again.',
+            e,
+            stackTrace,
+          );
+        }
         _log.info('Google Sign-In was cancelled by the user');
         throw CloudStorageException(
           'Google Sign-In was cancelled',
@@ -129,6 +146,27 @@ class GoogleSignInAuthenticator implements GoogleDriveAuthenticator {
       throw CloudStorageException('Google Sign-In failed: $e', e, stackTrace);
     }
   }
+
+  /// Whether a `canceled` code actually describes a refusal by Google Play
+  /// services rather than a dialog the user dismissed.
+  ///
+  /// Android routes both through `GetCredentialCancellationException`, so the
+  /// SDK reports them under one code. Play services prefixes its own
+  /// refusals with the numeric status it failed on, as in
+  /// `[16] Account reauth failed.`; a dismissal carries prose with no such
+  /// prefix. Matching the bracketed status rather than the wording keeps this
+  /// working when Google rewords a message, and it is the only structure the
+  /// two cases do not share.
+  ///
+  /// The distinction matters because the two need opposite responses: a
+  /// dismissal is a decision to leave alone, while a refusal is a fault the
+  /// user cannot act on without being told what it was. Reporting a refusal
+  /// as "cancelled" is what left Google Drive users on an unregistered build
+  /// retrying a dialog they had never dismissed.
+  static bool _isPlatformRefusal(String? description) =>
+      description != null && _platformStatusPrefix.hasMatch(description);
+
+  static final _platformStatusPrefix = RegExp(r'^\s*\[\d+\]');
 
   void _installClient(
     GoogleSignInAccount account,

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType;
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/dropbox/dropbox_auth_store.dart';
 import 'package:submersion/core/services/cloud_storage/icloud_native_service.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
@@ -59,6 +60,18 @@ String connectionErrorMessage(
   }
   return l10n.settings_cloudSync_provider_connectionFailed(providerName, error);
 }
+
+/// Snackbar-safe text for a connection failure.
+///
+/// [CloudStorageException.displayMessage] exists for this: its `toString`
+/// prefixes the class name, which reached users as "Google Drive connection
+/// failed: CloudStorageException: ...". The cause is kept either way, since
+/// that is where the actionable detail lives.
+///
+/// Pure (no `BuildContext`/`ref`) so it is unit-testable on any host.
+@visibleForTesting
+String errorDisplayText(Object error) =>
+    error is CloudStorageException ? error.displayMessage : error.toString();
 
 class CloudSyncPage extends ConsumerStatefulWidget {
   const CloudSyncPage({super.key});
@@ -920,7 +933,7 @@ class _CloudSyncPageState extends ConsumerState<CloudSyncPage> {
       provider,
       iCloudAvailability,
       providerName,
-      error.toString(),
+      errorDisplayText(error),
     );
   }
 

--- a/scripts/check_apk_signing_cert.py
+++ b/scripts/check_apk_signing_cert.py
@@ -114,7 +114,12 @@ def _signing_block_pairs(data):
     end = magic_start - 8
     while offset < end:
         pair_length = _read_u64(data, offset)
-        if pair_length < 4 or offset + 8 + pair_length > end + 8:
+        # A pair spans [offset, offset + 8 + pair_length) and must stay inside
+        # the pairs section, which ends where the trailing size field begins.
+        # Allowing it to reach into that field would feed eight bytes of
+        # framing to the scheme-block parser as though they were signature
+        # data.
+        if pair_length < 4 or offset + 8 + pair_length > end:
             raise SigningBlockError("APK Signing Block is truncated")
         block_id = _read_u32(data, offset + 8)
         pairs[block_id] = data[offset + 12 : offset + 8 + pair_length]

--- a/scripts/check_apk_signing_cert.py
+++ b/scripts/check_apk_signing_cert.py
@@ -175,11 +175,12 @@ def sha1_fingerprint(certificate):
     identifiers. Hence the `usedforsecurity=False` declaration, and the
     suppression of CodeQL's name-based "sensitive data" heuristic, which fires
     on the word "certificate" rather than on how the digest is used.
+
+    The call is kept on one line deliberately: CodeQL anchors this alert to
+    the argument rather than to the call, so a suppression comment on a split
+    call sits one line above the alert and does not apply.
     """
-    digest = hashlib.sha1(  # codeql[py/weak-sensitive-data-hashing]
-        certificate, usedforsecurity=False
-    )
-    return digest.hexdigest()
+    return hashlib.sha1(certificate, usedforsecurity=False).hexdigest()  # codeql[py/weak-sensitive-data-hashing]
 
 
 def signer_sha1(path):

--- a/scripts/check_apk_signing_cert.py
+++ b/scripts/check_apk_signing_cert.py
@@ -96,6 +96,18 @@ def _signing_block_pairs(data):
     The block sits immediately before the central directory, and is framed by
     a size field at each end plus a trailing magic string.
     """
+    try:
+        return _unchecked_signing_block_pairs(data)
+    except struct.error as error:
+        # Every _read_u32/_read_u64 below walks offsets taken from the file
+        # itself, so a truncated or hostile APK can point past the end. Report
+        # that as a guard failure; an escaping struct.error would crash the
+        # release build rather than failing it.
+        raise SigningBlockError(f"malformed APK Signing Block: {error}") from error
+
+
+def _unchecked_signing_block_pairs(data):
+    """Body of [_signing_block_pairs], minus the struct.error translation."""
     eocd = _find_eocd(data)
     cd_offset = _read_u32(data, eocd + 16)
     if cd_offset < len(APK_SIG_BLOCK_MAGIC) + 8:
@@ -125,6 +137,12 @@ def _signing_block_pairs(data):
         block_id = _read_u32(data, offset + 8)
         pairs[block_id] = data[offset + 12 : offset + 8 + pair_length]
         offset += 8 + pair_length
+
+    # Redundant while the per-pair bound above is correct, and kept precisely
+    # because that bound was once wrong: it allowed a pair to finish 8 bytes
+    # past `end`, which this check would have caught independently.
+    if offset != end:
+        raise SigningBlockError("APK Signing Block pairs do not fill the block")
     return pairs
 
 

--- a/scripts/check_apk_signing_cert.py
+++ b/scripts/check_apk_signing_cert.py
@@ -35,6 +35,7 @@ Usage:
 """
 
 import hashlib
+import mmap
 import struct
 import sys
 
@@ -186,12 +187,21 @@ def sha1_fingerprint(certificate):
 def signer_sha1(path):
     """Return the lowercase SHA-1 hex digest of the APK's signer certificate."""
     with open(path, "rb") as apk:
-        data = apk.read()
-
-    pairs = _signing_block_pairs(data)
-    for block_id in SCHEME_BLOCK_IDS:
-        if block_id in pairs:
-            return sha1_fingerprint(_first_certificate(pairs[block_id]))
+        # Mapped rather than read: a release APK runs to hundreds of MB and
+        # this parser only ever seeks, slices and unpacks, so a full in-memory
+        # copy buys nothing. The slices handed back are ordinary bytes, so
+        # they outlive the mapping.
+        try:
+            mapped = mmap.mmap(apk.fileno(), 0, access=mmap.ACCESS_READ)
+        except ValueError as error:
+            # mmap rejects a zero-length file; report it like any other
+            # unparseable input rather than escaping as a ValueError.
+            raise SigningBlockError(f"cannot read APK: {error}") from error
+        with mapped as data:
+            pairs = _signing_block_pairs(data)
+            for block_id in SCHEME_BLOCK_IDS:
+                if block_id in pairs:
+                    return sha1_fingerprint(_first_certificate(pairs[block_id]))
     raise SigningBlockError(
         "APK Signing Block holds no v2, v3 or v3.1 signature scheme block"
     )

--- a/scripts/check_apk_signing_cert.py
+++ b/scripts/check_apk_signing_cert.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Verify that a release APK is signed by a certificate Google will accept.
+
+Android apps hold no OAuth client ID. Google identifies them by package name
+plus the SHA-1 of the signing certificate, so on Android the signing key *is*
+the OAuth credential. A build signed by a certificate that has no matching
+Android OAuth client cannot obtain a Google credential at all: Google Play
+services refuses, and google_sign_in surfaces the refusal as
+``GoogleSignInException(canceled, "[16] Account reauth failed.")``, which reads
+like the user dismissed the dialog.
+
+This repository publishes two differently signed Android binaries from one
+workflow. The ``.aab`` goes to Play, which re-signs it with the Play App
+Signing key; the ``.apk`` attached to GitHub Releases keeps the CI keystore's
+own certificate. Registering only the former is what broke Google Drive sync
+for every user who installed the APK from GitHub Releases (the channel
+README.md points stable Android users at), while Play open-test users were
+unaffected. Upgrading could never fix it, because that APK carries
+``UPDATE_CHANNEL=github`` and so self-updates within the same broken channel.
+
+The guard fails (exit code 1) when the APK's signer certificate is not one of
+[REGISTERED_SIGNING_CERTS]. Adding a fingerprint there is a claim that an
+Android OAuth client for package ``app.submersion`` with that fingerprint
+exists in Google Cloud project 433819313354; the claim cannot be verified from
+CI, so the entry and the console registration have to be made together.
+
+Only the APK is checked. The AAB's shipped signature is applied by Play after
+upload, so its certificate does not exist at build time.
+
+The signing block is parsed with the standard library alone so the check runs
+identically in CI (Linux) and locally (macOS) without an Android SDK on PATH.
+
+Usage:
+    check_apk_signing_cert.py <app.apk> [more.apk ...]
+"""
+
+import hashlib
+import struct
+import sys
+
+APK_SIG_BLOCK_MAGIC = b"APK Sig Block 42"
+
+# Signature scheme block IDs, from the APK signing block specification.
+V2_BLOCK_ID = 0x7109871A
+V3_BLOCK_ID = 0xF05368C0
+V31_BLOCK_ID = 0x1B93AD61
+
+# Highest scheme first: a v3 block supersedes v2 and is what a current device
+# uses to decide the app's signing identity.
+SCHEME_BLOCK_IDS = (V31_BLOCK_ID, V3_BLOCK_ID, V2_BLOCK_ID)
+
+EOCD_MAGIC = b"PK\x05\x06"
+EOCD_MIN_SIZE = 22
+MAX_COMMENT_SIZE = 0xFFFF
+
+# SHA-1 fingerprints registered as Android OAuth clients for app.submersion.
+# See the module docstring: an entry here without the matching console client
+# breaks Google Drive sign-in for everyone running that build.
+REGISTERED_SIGNING_CERTS = {
+    "61b92267316a4b8ac71663c3b2490c7941cc4b89": (
+        "CI release keystore, signs the APK attached to GitHub Releases"
+    ),
+}
+
+
+class SigningBlockError(Exception):
+    """Raised when an APK has no parseable v2/v3 signing block."""
+
+
+def normalise(fingerprint):
+    """Reduce a fingerprint to lowercase hex, ignoring colons and whitespace."""
+    return "".join(fingerprint.split()).replace(":", "").lower()
+
+
+def _read_u32(data, offset):
+    return struct.unpack_from("<I", data, offset)[0]
+
+
+def _read_u64(data, offset):
+    return struct.unpack_from("<Q", data, offset)[0]
+
+
+def _find_eocd(data):
+    """Return the offset of the End Of Central Directory record."""
+    search_start = max(0, len(data) - (EOCD_MIN_SIZE + MAX_COMMENT_SIZE))
+    offset = data.rfind(EOCD_MAGIC, search_start)
+    if offset < 0:
+        raise SigningBlockError("not a ZIP archive: no end-of-central-directory record")
+    return offset
+
+
+def _signing_block_pairs(data):
+    """Return the ``{id: value}`` pairs of the APK Signing Block.
+
+    The block sits immediately before the central directory, and is framed by
+    a size field at each end plus a trailing magic string.
+    """
+    eocd = _find_eocd(data)
+    cd_offset = _read_u32(data, eocd + 16)
+    if cd_offset < len(APK_SIG_BLOCK_MAGIC) + 8:
+        raise SigningBlockError("no APK Signing Block: the APK is not v2/v3 signed")
+
+    magic_start = cd_offset - len(APK_SIG_BLOCK_MAGIC)
+    if data[magic_start:cd_offset] != APK_SIG_BLOCK_MAGIC:
+        raise SigningBlockError("no APK Signing Block: the APK is not v2/v3 signed")
+
+    size = _read_u64(data, magic_start - 8)
+    block_start = cd_offset - size
+    if block_start < 8 or _read_u64(data, block_start - 8) != size:
+        raise SigningBlockError("APK Signing Block size fields disagree")
+
+    pairs = {}
+    offset = block_start
+    end = magic_start - 8
+    while offset < end:
+        pair_length = _read_u64(data, offset)
+        if pair_length < 4 or offset + 8 + pair_length > end + 8:
+            raise SigningBlockError("APK Signing Block is truncated")
+        block_id = _read_u32(data, offset + 8)
+        pairs[block_id] = data[offset + 12 : offset + 8 + pair_length]
+        offset += 8 + pair_length
+    return pairs
+
+
+def _first_certificate(scheme_block):
+    """Extract the first signer's DER certificate from a v2/v3 scheme block.
+
+    Layout, every field length-prefixed with a u32: signers -> signer ->
+    signed data -> (digests, certificates) -> certificate. Only the first
+    signer is read; Submersion signs with a single key, and the first entry is
+    the one whose identity Google matches.
+    """
+    try:
+        # Step into signers, then the first signer, then its signed data.
+        offset = 4  # length of the signers sequence
+        offset += 4  # length of the first signer
+        signed_data_length = _read_u32(scheme_block, offset)
+        offset += 4
+        signed_data = scheme_block[offset : offset + signed_data_length]
+
+        digests_length = _read_u32(signed_data, 0)
+        certificates_start = 4 + digests_length
+        certificates_length = _read_u32(signed_data, certificates_start)
+        certificates = signed_data[
+            certificates_start + 4 : certificates_start + 4 + certificates_length
+        ]
+
+        first_length = _read_u32(certificates, 0)
+        certificate = certificates[4 : 4 + first_length]
+    except struct.error as error:
+        raise SigningBlockError(f"malformed signature scheme block: {error}") from error
+
+    if not certificate:
+        raise SigningBlockError("signature scheme block carries no certificate")
+    return certificate
+
+
+def signer_sha1(path):
+    """Return the lowercase SHA-1 hex digest of the APK's signer certificate."""
+    with open(path, "rb") as apk:
+        data = apk.read()
+
+    pairs = _signing_block_pairs(data)
+    for block_id in SCHEME_BLOCK_IDS:
+        if block_id in pairs:
+            certificate = _first_certificate(pairs[block_id])
+            return hashlib.sha1(certificate).hexdigest()
+    raise SigningBlockError(
+        "APK Signing Block holds no v2, v3 or v3.1 signature scheme block"
+    )
+
+
+def main(argv, registered=None):
+    if not argv:
+        print(f"Usage: {sys.argv[0]} <app.apk> [more.apk ...]", file=sys.stderr)
+        return 2
+
+    registered = REGISTERED_SIGNING_CERTS if registered is None else registered
+    expected = {normalise(key): value for key, value in registered.items()}
+
+    failed = False
+    for path in argv:
+        try:
+            fingerprint = signer_sha1(path)
+        except (SigningBlockError, OSError) as error:
+            print(f"FAIL {path}: {error}", file=sys.stderr)
+            failed = True
+            continue
+
+        if fingerprint in expected:
+            print(f"OK   {path}: signed by {expected[fingerprint]} ({fingerprint})")
+            continue
+
+        failed = True
+        print(
+            f"FAIL {path}: signer certificate SHA-1 {fingerprint} is not registered\n"
+            "     as an Android OAuth client, so Google Sign-In cannot work in this\n"
+            "     build. Users would see 'Google Sign-In was cancelled' with\n"
+            "     '[16] Account reauth failed.' and have no way to recover.\n"
+            "     Either register package app.submersion with this SHA-1 in Google\n"
+            "     Cloud project 433819313354 and add it to REGISTERED_SIGNING_CERTS,\n"
+            "     or sign with a keystore that is already registered.\n"
+            "     Registered: " + ", ".join(sorted(expected)),
+            file=sys.stderr,
+        )
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_apk_signing_cert.py
+++ b/scripts/check_apk_signing_cert.py
@@ -173,15 +173,14 @@ def sha1_fingerprint(certificate):
     Nothing secret is hashed: a signing certificate is public and ships inside
     every copy of the APK. No integrity decision rests on the digest either.
     Android verifies the signature itself, and this guard only compares
-    identifiers. Hence the `usedforsecurity=False` declaration, and the
-    suppression of CodeQL's name-based "sensitive data" heuristic, which fires
-    on the word "certificate" rather than on how the digest is used.
+    identifiers. Hence the `usedforsecurity=False` declaration.
 
-    The call is kept on one line deliberately: CodeQL anchors this alert to
-    the argument rather than to the call, so a suppression comment on a split
-    call sits one line above the alert and does not apply.
+    CodeQL's py/weak-sensitive-data-hashing fires here on a name-based
+    heuristic, and is excluded in .github/codeql/codeql-config.yml, which
+    carries the full reasoning. Inline suppression comments do not work:
+    GitHub code scanning does not honour them.
     """
-    return hashlib.sha1(certificate, usedforsecurity=False).hexdigest()  # codeql[py/weak-sensitive-data-hashing]
+    return hashlib.sha1(certificate, usedforsecurity=False).hexdigest()
 
 
 def signer_sha1(path):

--- a/scripts/check_apk_signing_cert.py
+++ b/scripts/check_apk_signing_cert.py
@@ -141,7 +141,7 @@ def _unchecked_signing_block_pairs(data):
     # Redundant while the per-pair bound above is correct, and kept precisely
     # because that bound was once wrong: it allowed a pair to finish 8 bytes
     # past `end`, which this check would have caught independently.
-    if offset != end:
+    if offset != end:  # pragma: no cover - unreachable while the bound holds
         raise SigningBlockError("APK Signing Block pairs do not fill the block")
     return pairs
 
@@ -261,5 +261,5 @@ def main(argv, registered=None):
     return 1 if failed else 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main(sys.argv[1:]))

--- a/scripts/check_apk_signing_cert.py
+++ b/scripts/check_apk_signing_cert.py
@@ -155,6 +155,28 @@ def _first_certificate(scheme_block):
     return certificate
 
 
+def sha1_fingerprint(certificate):
+    """Return a DER certificate's SHA-1 digest, as Google's console shows it.
+
+    SHA-1 is not a security choice here and cannot be exchanged for a stronger
+    digest. An Android OAuth client is registered against the SHA-1
+    fingerprint of the signing certificate, so this value is only meaningful
+    when computed the way Google computes it; a SHA-256 digest would match
+    nothing the console exposes.
+
+    Nothing secret is hashed: a signing certificate is public and ships inside
+    every copy of the APK. No integrity decision rests on the digest either.
+    Android verifies the signature itself, and this guard only compares
+    identifiers. Hence the `usedforsecurity=False` declaration, and the
+    suppression of CodeQL's name-based "sensitive data" heuristic, which fires
+    on the word "certificate" rather than on how the digest is used.
+    """
+    digest = hashlib.sha1(  # codeql[py/weak-sensitive-data-hashing]
+        certificate, usedforsecurity=False
+    )
+    return digest.hexdigest()
+
+
 def signer_sha1(path):
     """Return the lowercase SHA-1 hex digest of the APK's signer certificate."""
     with open(path, "rb") as apk:
@@ -163,8 +185,7 @@ def signer_sha1(path):
     pairs = _signing_block_pairs(data)
     for block_id in SCHEME_BLOCK_IDS:
         if block_id in pairs:
-            certificate = _first_certificate(pairs[block_id])
-            return hashlib.sha1(certificate).hexdigest()
+            return sha1_fingerprint(_first_certificate(pairs[block_id]))
     raise SigningBlockError(
         "APK Signing Block holds no v2, v3 or v3.1 signature scheme block"
     )

--- a/scripts/check_apk_signing_cert_test.py
+++ b/scripts/check_apk_signing_cert_test.py
@@ -15,6 +15,18 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import check_apk_signing_cert as guard  # noqa: E402
 
 
+def _sha1(data):
+    """SHA-1 of test bytes, matching the guard's own fingerprint helper.
+
+    See check_apk_signing_cert.sha1_fingerprint for why SHA-1 is fixed here
+    and why the CodeQL sensitive-data heuristic does not apply.
+    """
+    digest = hashlib.sha1(  # codeql[py/weak-sensitive-data-hashing]
+        data, usedforsecurity=False
+    )
+    return digest.hexdigest()
+
+
 def _length_prefixed(payload):
     """u32 length prefix, the encoding used throughout the v2/v3 schemes."""
     return struct.pack("<I", len(payload)) + payload
@@ -77,7 +89,7 @@ def _write_temp(data, suffix=".apk"):
 class SignerCertificateTest(unittest.TestCase):
     def setUp(self):
         self.cert = b"pretend-x509-der-bytes"
-        self.fingerprint = hashlib.sha1(self.cert).hexdigest()
+        self.fingerprint = _sha1(self.cert)
         self._paths = []
 
     def tearDown(self):
@@ -107,7 +119,7 @@ class SignerCertificateTest(unittest.TestCase):
                 guard.V3_BLOCK_ID: _length_prefixed(_signer_block(v3_cert)),
             },
         )
-        self.assertEqual(guard.signer_sha1(path), hashlib.sha1(v3_cert).hexdigest())
+        self.assertEqual(guard.signer_sha1(path), _sha1(v3_cert))
 
     def test_unsigned_apk_raises(self):
         raw = io.BytesIO()
@@ -163,12 +175,12 @@ class MainTest(unittest.TestCase):
 
     def test_accepts_a_registered_certificate(self):
         cert = b"registered-cert"
-        registered = {hashlib.sha1(cert).hexdigest(): "test keystore"}
+        registered = {_sha1(cert): "test keystore"}
         self.assertEqual(guard.main([self._apk(cert)], registered=registered), 0)
 
     def test_rejects_an_unregistered_certificate(self):
         cert = b"some-other-cert"
-        registered = {hashlib.sha1(b"registered-cert").hexdigest(): "test keystore"}
+        registered = {_sha1(b"registered-cert"): "test keystore"}
         self.assertEqual(guard.main([self._apk(cert)], registered=registered), 1)
 
     def test_rejects_an_unparseable_apk(self):

--- a/scripts/check_apk_signing_cert_test.py
+++ b/scripts/check_apk_signing_cert_test.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Tests for check_apk_signing_cert."""
+
+import hashlib
+import io
+import os
+import struct
+import sys
+import tempfile
+import unittest
+import zipfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import check_apk_signing_cert as guard  # noqa: E402
+
+
+def _length_prefixed(payload):
+    """u32 length prefix, the encoding used throughout the v2/v3 schemes."""
+    return struct.pack("<I", len(payload)) + payload
+
+
+def _signer_block(cert_der, extra_signed_data=b""):
+    """Build one signer entry holding ``cert_der``.
+
+    Mirrors the real layout: signed data is a length-prefixed record whose
+    first field is the digest sequence and whose second is the certificate
+    sequence.
+    """
+    digests = _length_prefixed(b"\x00" * 12)  # opaque to this guard
+    certificates = _length_prefixed(_length_prefixed(cert_der))
+    signed_data = _length_prefixed(digests + certificates + extra_signed_data)
+    return _length_prefixed(signed_data + b"\x00" * 8)
+
+
+def _signing_block(pairs):
+    """Assemble an APK Signing Block from ``{id: value}`` pairs."""
+    body = b""
+    for block_id, value in pairs.items():
+        body += struct.pack("<QI", len(value) + 4, block_id) + value
+    size = len(body) + 8 + 16
+    return (
+        struct.pack("<Q", size) + body + struct.pack("<Q", size) + guard.APK_SIG_BLOCK_MAGIC
+    )
+
+
+def _apk_with_signing_block(cert_der, block_id=guard.V2_BLOCK_ID, pairs=None):
+    """Write a ZIP and splice a signing block in ahead of its central directory.
+
+    The signing block sits between the last local file entry and the central
+    directory, so every central-directory offset shifts by its length.
+    """
+    raw = io.BytesIO()
+    with zipfile.ZipFile(raw, "w") as zf:
+        zf.writestr("AndroidManifest.xml", "placeholder")
+    data = raw.getvalue()
+
+    eocd = data.rindex(b"PK\x05\x06")
+    cd_offset = struct.unpack_from("<I", data, eocd + 16)[0]
+
+    if pairs is None:
+        pairs = {block_id: _length_prefixed(_signer_block(cert_der))}
+    block = _signing_block(pairs)
+
+    patched = bytearray(data[:cd_offset] + block + data[cd_offset:])
+    struct.pack_into("<I", patched, eocd + len(block) + 16, cd_offset + len(block))
+    return bytes(patched)
+
+
+def _write_temp(data, suffix=".apk"):
+    handle, path = tempfile.mkstemp(suffix=suffix)
+    with os.fdopen(handle, "wb") as f:
+        f.write(data)
+    return path
+
+
+class SignerCertificateTest(unittest.TestCase):
+    def setUp(self):
+        self.cert = b"pretend-x509-der-bytes"
+        self.fingerprint = hashlib.sha1(self.cert).hexdigest()
+        self._paths = []
+
+    def tearDown(self):
+        for path in self._paths:
+            os.unlink(path)
+
+    def _apk(self, *args, **kwargs):
+        path = _write_temp(_apk_with_signing_block(*args, **kwargs))
+        self._paths.append(path)
+        return path
+
+    def test_reads_fingerprint_from_v2_block(self):
+        path = self._apk(self.cert, block_id=guard.V2_BLOCK_ID)
+        self.assertEqual(guard.signer_sha1(path), self.fingerprint)
+
+    def test_reads_fingerprint_from_v3_block(self):
+        path = self._apk(self.cert, block_id=guard.V3_BLOCK_ID)
+        self.assertEqual(guard.signer_sha1(path), self.fingerprint)
+
+    def test_prefers_v3_over_v2_when_both_present(self):
+        """A v3 rotation block supersedes v2, so it decides the identity."""
+        v3_cert = b"the-v3-certificate"
+        path = self._apk(
+            self.cert,
+            pairs={
+                guard.V2_BLOCK_ID: _length_prefixed(_signer_block(self.cert)),
+                guard.V3_BLOCK_ID: _length_prefixed(_signer_block(v3_cert)),
+            },
+        )
+        self.assertEqual(guard.signer_sha1(path), hashlib.sha1(v3_cert).hexdigest())
+
+    def test_unsigned_apk_raises(self):
+        raw = io.BytesIO()
+        with zipfile.ZipFile(raw, "w") as zf:
+            zf.writestr("AndroidManifest.xml", "placeholder")
+        path = _write_temp(raw.getvalue())
+        self._paths.append(path)
+        with self.assertRaises(guard.SigningBlockError):
+            guard.signer_sha1(path)
+
+    def test_signing_block_without_a_known_scheme_raises(self):
+        path = self._apk(self.cert, pairs={0x12345678: b"\x00" * 8})
+        with self.assertRaises(guard.SigningBlockError):
+            guard.signer_sha1(path)
+
+
+class FingerprintNormalisationTest(unittest.TestCase):
+    def test_accepts_colon_separated_uppercase(self):
+        self.assertEqual(
+            guard.normalise("B3:25:29:FF"),
+            guard.normalise("b32529ff"),
+        )
+
+    def test_strips_whitespace(self):
+        self.assertEqual(guard.normalise("  ab cd  "), "abcd")
+
+
+class RegisteredCertsTest(unittest.TestCase):
+    def test_every_registered_fingerprint_is_a_sha1_hex_digest(self):
+        self.assertTrue(guard.REGISTERED_SIGNING_CERTS)
+        for fingerprint in guard.REGISTERED_SIGNING_CERTS:
+            self.assertEqual(len(fingerprint), 40, fingerprint)
+            self.assertEqual(fingerprint, fingerprint.lower(), fingerprint)
+            int(fingerprint, 16)  # raises if not hex
+
+    def test_every_registered_fingerprint_names_where_it_is_registered(self):
+        for description in guard.REGISTERED_SIGNING_CERTS.values():
+            self.assertTrue(description.strip())
+
+
+class MainTest(unittest.TestCase):
+    def setUp(self):
+        self._paths = []
+
+    def tearDown(self):
+        for path in self._paths:
+            os.unlink(path)
+
+    def _apk(self, cert):
+        path = _write_temp(_apk_with_signing_block(cert))
+        self._paths.append(path)
+        return path
+
+    def test_accepts_a_registered_certificate(self):
+        cert = b"registered-cert"
+        registered = {hashlib.sha1(cert).hexdigest(): "test keystore"}
+        self.assertEqual(guard.main([self._apk(cert)], registered=registered), 0)
+
+    def test_rejects_an_unregistered_certificate(self):
+        cert = b"some-other-cert"
+        registered = {hashlib.sha1(b"registered-cert").hexdigest(): "test keystore"}
+        self.assertEqual(guard.main([self._apk(cert)], registered=registered), 1)
+
+    def test_rejects_an_unparseable_apk(self):
+        path = _write_temp(b"not a zip at all")
+        self._paths.append(path)
+        self.assertEqual(guard.main([path], registered={"ab" * 20: "test"}), 1)
+
+    def test_requires_at_least_one_apk(self):
+        self.assertEqual(guard.main([]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check_apk_signing_cert_test.py
+++ b/scripts/check_apk_signing_cert_test.py
@@ -18,11 +18,10 @@ import check_apk_signing_cert as guard  # noqa: E402
 def _sha1(data):
     """SHA-1 of test bytes, matching the guard's own fingerprint helper.
 
-    See check_apk_signing_cert.sha1_fingerprint for why SHA-1 is fixed here,
-    why the CodeQL sensitive-data heuristic does not apply, and why the call
-    stays on one line.
+    See check_apk_signing_cert.sha1_fingerprint for why SHA-1 is fixed here
+    and why the CodeQL sensitive-data heuristic does not apply.
     """
-    return hashlib.sha1(data, usedforsecurity=False).hexdigest()  # codeql[py/weak-sensitive-data-hashing]
+    return hashlib.sha1(data, usedforsecurity=False).hexdigest()
 
 
 def _length_prefixed(payload):

--- a/scripts/check_apk_signing_cert_test.py
+++ b/scripts/check_apk_signing_cert_test.py
@@ -130,6 +130,27 @@ class SignerCertificateTest(unittest.TestCase):
         with self.assertRaises(guard.SigningBlockError):
             guard.signer_sha1(path)
 
+    def test_pair_running_into_the_trailing_size_field_raises(self):
+        """Pairs must fit inside [block_start, end), not overlap the framing.
+
+        The pairs section ends where the trailing size field begins. A pair
+        whose declared length reaches into that field is malformed, and
+        accepting it would hand the scheme-block parser eight bytes of framing
+        as though they were signature data.
+        """
+        data = bytearray(_apk_with_signing_block(self.cert))
+        magic_start = data.index(guard.APK_SIG_BLOCK_MAGIC)
+        size = struct.unpack_from("<Q", data, magic_start - 8)[0]
+        block_start = (magic_start + 16) - size
+
+        pair_length = struct.unpack_from("<Q", data, block_start)[0]
+        struct.pack_into("<Q", data, block_start, pair_length + 8)
+
+        path = _write_temp(bytes(data))
+        self._paths.append(path)
+        with self.assertRaises(guard.SigningBlockError):
+            guard.signer_sha1(path)
+
     def test_signing_block_without_a_known_scheme_raises(self):
         path = self._apk(self.cert, pairs={0x12345678: b"\x00" * 8})
         with self.assertRaises(guard.SigningBlockError):

--- a/scripts/check_apk_signing_cert_test.py
+++ b/scripts/check_apk_signing_cert_test.py
@@ -148,6 +148,54 @@ class SignerCertificateTest(unittest.TestCase):
         with self.assertRaises(guard.SigningBlockError):
             guard.signer_sha1(path)
 
+    def test_zip_with_no_signing_block_raises(self):
+        """An empty ZIP puts the central directory at offset 0.
+
+        That is the shape of an APK signed with v1 only, or not at all: there
+        is no room before the central directory for a signing block.
+        """
+        raw = io.BytesIO()
+        with zipfile.ZipFile(raw, "w"):
+            pass
+        path = _write_temp(raw.getvalue())
+        self._paths.append(path)
+        with self.assertRaises(guard.SigningBlockError):
+            guard.signer_sha1(path)
+
+    def test_disagreeing_size_fields_raise(self):
+        """The block is framed by a size field at each end; they must match."""
+        data = bytearray(_apk_with_signing_block(self.cert))
+        magic_start = data.index(guard.APK_SIG_BLOCK_MAGIC)
+        size = struct.unpack_from("<Q", data, magic_start - 8)[0]
+        block_start = (magic_start + 16) - size
+
+        # Corrupt the leading size only, so the two disagree.
+        struct.pack_into("<Q", data, block_start - 8, size + 8)
+
+        path = _write_temp(bytes(data))
+        self._paths.append(path)
+        with self.assertRaises(guard.SigningBlockError):
+            guard.signer_sha1(path)
+
+    def test_truncated_scheme_block_raises(self):
+        """A scheme block too short for its nested lengths must not crash.
+
+        struct.error escaping _first_certificate would surface as a traceback
+        rather than a guard failure.
+        """
+        path = self._apk(self.cert, pairs={guard.V2_BLOCK_ID: b"\x00" * 8})
+        with self.assertRaises(guard.SigningBlockError):
+            guard.signer_sha1(path)
+
+    def test_scheme_block_with_an_empty_certificate_raises(self):
+        """A zero-length certificate would otherwise hash to a real digest."""
+        path = self._apk(
+            self.cert,
+            pairs={guard.V2_BLOCK_ID: _length_prefixed(_signer_block(b""))},
+        )
+        with self.assertRaises(guard.SigningBlockError):
+            guard.signer_sha1(path)
+
     def test_signing_block_without_a_known_scheme_raises(self):
         path = self._apk(self.cert, pairs={0x12345678: b"\x00" * 8})
         with self.assertRaises(guard.SigningBlockError):

--- a/scripts/check_apk_signing_cert_test.py
+++ b/scripts/check_apk_signing_cert_test.py
@@ -18,13 +18,11 @@ import check_apk_signing_cert as guard  # noqa: E402
 def _sha1(data):
     """SHA-1 of test bytes, matching the guard's own fingerprint helper.
 
-    See check_apk_signing_cert.sha1_fingerprint for why SHA-1 is fixed here
-    and why the CodeQL sensitive-data heuristic does not apply.
+    See check_apk_signing_cert.sha1_fingerprint for why SHA-1 is fixed here,
+    why the CodeQL sensitive-data heuristic does not apply, and why the call
+    stays on one line.
     """
-    digest = hashlib.sha1(  # codeql[py/weak-sensitive-data-hashing]
-        data, usedforsecurity=False
-    )
-    return digest.hexdigest()
+    return hashlib.sha1(data, usedforsecurity=False).hexdigest()  # codeql[py/weak-sensitive-data-hashing]
 
 
 def _length_prefixed(payload):

--- a/scripts/check_apk_signing_cert_test.py
+++ b/scripts/check_apk_signing_cert_test.py
@@ -207,6 +207,12 @@ class MainTest(unittest.TestCase):
         self._paths.append(path)
         self.assertEqual(guard.main([path], registered={"ab" * 20: "test"}), 1)
 
+    def test_rejects_an_empty_file(self):
+        """A zero-length file must fail as a guard error, not crash it."""
+        path = _write_temp(b"")
+        self._paths.append(path)
+        self.assertEqual(guard.main([path], registered={"ab" * 20: "test"}), 1)
+
     def test_requires_at_least_one_apk(self):
         self.assertEqual(guard.main([]), 2)
 

--- a/scripts/check_apk_signing_cert_test.py
+++ b/scripts/check_apk_signing_cert_test.py
@@ -212,6 +212,17 @@ class MainTest(unittest.TestCase):
         self._paths.append(path)
         self.assertEqual(guard.main([path], registered={"ab" * 20: "test"}), 1)
 
+    def test_rejects_a_truncated_end_of_central_directory(self):
+        """Unpacking past the end must fail as a guard error, not a traceback.
+
+        The EOCD magic is present but the record is cut short, so reading the
+        central-directory offset runs off the end of the file. struct.error
+        escaping here would crash the release build instead of failing it.
+        """
+        path = _write_temp(b"PK\x05\x06" + b"\x00" * 5)
+        self._paths.append(path)
+        self.assertEqual(guard.main([path], registered={"ab" * 20: "test"}), 1)
+
     def test_requires_at_least_one_apk(self):
         self.assertEqual(guard.main([]), 2)
 

--- a/test/core/services/cloud_storage/google_drive/google_sign_in_authenticator_test.dart
+++ b/test/core/services/cloud_storage/google_drive/google_sign_in_authenticator_test.dart
@@ -217,6 +217,49 @@ void main() {
       );
     });
 
+    test('does not call a Play services refusal a user cancellation', () async {
+      // google_sign_in reports a Google Play services refusal under the
+      // same `canceled` code as a real dismissal. Users on a build whose
+      // signing certificate has no registered Android OAuth client hit this
+      // on every attempt, and the old wording told them they had cancelled
+      // a dialog they never saw. See scripts/check_apk_signing_cert.py.
+      platform.authenticateError = const GoogleSignInException(
+        code: GoogleSignInExceptionCode.canceled,
+        description: '[16] Account reauth failed.',
+      );
+
+      await expectLater(
+        auth.authenticate(),
+        throwsA(
+          isA<CloudStorageException>()
+              .having((e) => e.message, 'message', isNot(contains('cancelled')))
+              .having(
+                (e) => e.message,
+                'message',
+                contains('Account reauth failed'),
+              ),
+        ),
+      );
+    });
+
+    test('still treats a dismissed sign-in dialog as a cancellation', () async {
+      platform.authenticateError = const GoogleSignInException(
+        code: GoogleSignInExceptionCode.canceled,
+        description: 'activity is cancelled by the user.',
+      );
+
+      await expectLater(
+        auth.authenticate(),
+        throwsA(
+          isA<CloudStorageException>().having(
+            (e) => e.message,
+            'message',
+            contains('cancelled'),
+          ),
+        ),
+      );
+    });
+
     test('maps other sign-in failures with their description', () async {
       platform.authenticateError = const GoogleSignInException(
         code: GoogleSignInExceptionCode.unknownError,

--- a/test/core/services/cloud_storage/google_drive/google_sign_in_authenticator_test.dart
+++ b/test/core/services/cloud_storage/google_drive/google_sign_in_authenticator_test.dart
@@ -234,10 +234,61 @@ void main() {
           isA<CloudStorageException>()
               .having((e) => e.message, 'message', isNot(contains('cancelled')))
               .having(
-                (e) => e.message,
-                'message',
+                (e) => e.displayMessage,
+                'displayMessage',
                 contains('Account reauth failed'),
               ),
+        ),
+      );
+    });
+
+    test('a refusal shows the status once, with no plugin internals', () async {
+      // displayMessage appends the cause, and the Cloud Sync snackbar renders
+      // displayMessage. Passing the GoogleSignInException itself as the cause
+      // therefore put its toString -- including the word "canceled" -- back on
+      // screen, and repeated the status the message already carried.
+      platform.authenticateError = const GoogleSignInException(
+        code: GoogleSignInExceptionCode.canceled,
+        description: '[16] Account reauth failed.',
+      );
+
+      await expectLater(
+        auth.authenticate(),
+        throwsA(
+          isA<CloudStorageException>()
+              .having(
+                (e) => e.displayMessage,
+                'displayMessage',
+                isNot(contains('GoogleSignInException')),
+              )
+              .having(
+                (e) => e.displayMessage.toLowerCase(),
+                'displayMessage',
+                isNot(contains('cancel')),
+              )
+              .having(
+                (e) => '[16]'.allMatches(e.displayMessage).length,
+                'occurrences of the status',
+                1,
+              ),
+        ),
+      );
+    });
+
+    test('a dismissal shows no plugin internals either', () async {
+      platform.authenticateError = const GoogleSignInException(
+        code: GoogleSignInExceptionCode.canceled,
+        description: 'activity is cancelled by the user.',
+      );
+
+      await expectLater(
+        auth.authenticate(),
+        throwsA(
+          isA<CloudStorageException>().having(
+            (e) => e.displayMessage,
+            'displayMessage',
+            isNot(contains('GoogleSignInException')),
+          ),
         ),
       );
     });
@@ -269,11 +320,17 @@ void main() {
       await expectLater(
         auth.authenticate(),
         throwsA(
-          isA<CloudStorageException>().having(
-            (e) => e.message,
-            'message',
-            contains('network unreachable'),
-          ),
+          isA<CloudStorageException>()
+              .having(
+                (e) => e.displayMessage,
+                'displayMessage',
+                contains('network unreachable'),
+              )
+              .having(
+                (e) => e.displayMessage,
+                'displayMessage',
+                isNot(contains('GoogleSignInException')),
+              ),
         ),
       );
     });

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -574,6 +574,31 @@ void main() {
     });
   });
 
+  group('errorDisplayText', () {
+    test('drops the class-name prefix from a CloudStorageException', () {
+      // The banner in the reported screenshots read "CloudStorageException:
+      // Google Sign-In was cancelled (...)". CloudStorageException documents
+      // displayMessage as the snackbar-safe form for exactly this reason.
+      const error = CloudStorageException('Sign-in was refused');
+
+      expect(errorDisplayText(error), 'Sign-in was refused');
+      expect(errorDisplayText(error), isNot(contains('CloudStorageException')));
+    });
+
+    test('keeps the underlying cause, which carries the detail', () {
+      const error = CloudStorageException(
+        'Sign-in was refused',
+        '[16] Account reauth failed.',
+      );
+
+      expect(errorDisplayText(error), contains('Account reauth failed'));
+    });
+
+    test('falls back to toString for any other error', () {
+      expect(errorDisplayText(StateError('boom')), contains('boom'));
+    });
+  });
+
   group('connectionErrorMessage', () {
     final l10n = AppLocalizationsEn();
 


### PR DESCRIPTION
## Why

Reported on Reddit: Android users saw this on every Google Drive connect attempt, while another user on the same 1.7.7.8077 synced fine.

```
Google Drive connection failed: CloudStorageException: Google Sign-In was
cancelled (GoogleSignInException(code GoogleSignInExceptionCode.canceled,
[16] Account reauth failed., null))
```

An Android app carries no OAuth client ID. Google matches it by **package name plus signing-certificate SHA-1**, so the signing key *is* the Google credential, which quietly makes the distribution channel part of the auth configuration.

`build-all.yml` publishes two differently signed Android binaries:

| Binary | Signed by | SHA-1 | Registered as an OAuth client |
| --- | --- | --- | --- |
| `.aab` to Play | Play App Signing | `B3:25:29:FF:6F:B3:EE:3D...` | yes |
| `.apk` to GitHub Releases | CI keystore | `61:B9:22:67:31:6A:4B:8A:...` | **no** |

Measured with `apksigner verify --print-certs` on the published `Submersion-v1.7.7.8077-Android.apk`.

`README.md` sends stable Android users to GitHub Releases and beta users to the Play open test, so the split was exactly "Play works, GitHub APK cannot". Upgrading never helped either: that APK carries `UPDATE_CHANNEL=github` and self-updates inside the same channel.

## Required companion step

The actual repair is console-only and is **not** in this PR: add a third Android OAuth client in Google Cloud project `433819313354`, package `app.submersion`, with the `61:B9:22:...` fingerprint. Existing installs recover as soon as it exists. The allowlist entry added here is a claim that this client exists, which CI cannot verify.

## What this changes

**A release guard.** `scripts/check_apk_signing_cert.py` fails the release when the APK's signer certificate is not a registered fingerprint, in the same family as the existing `check_16kb_alignment.py` (#318) and `check_native_libs_present.py` (#433) guards. It parses the APK Signing Block with the standard library alone, verified byte-identical to `apksigner` on the real published APK, so no Android SDK is needed on PATH.

It runs in `build-all.yml` only. A `ci.yaml` PR build has no `key.properties` and falls back to a per-runner debug keystore whose fingerprint is generated at random, which would make the assertion meaningless.

**Refusals stop being reported as cancellations.** Android funnels both a dismissed dialog and a Play services refusal through `GetCredentialCancellationException`, so google_sign_in reports one `canceled` code for both. Play services prefixes its own refusals with the numeric status it failed on (`[16] ...`) and a dismissal does not, so the split is on that structure rather than on wording Google may reword.

**The snackbar stops leaking the class name.** `cloud_sync_page` used `error.toString()`; `CloudStorageException.displayMessage` is documented as the snackbar-safe form and is now used.

## Verification

- 13 new Python guard tests, passing on 3.9 and 3.14, wired into the CI guard-coverage step
- parser output confirmed identical to `apksigner` on the real 266 MB published APK
- 666 Dart tests across cloud-storage, settings, setup-wizard and accounts pass
- `flutter analyze` clean project-wide, `dart format` clean, `actionlint` reports nothing at the new workflow steps

## Note

I proved the GitHub APK *cannot* authenticate. I did not prove the two specific reporters installed it, so it is worth asking them whether they installed from GitHub Releases or the Play open test before closing the loop on the thread.
