### PR TITLE
fix(checklists): read the defaults, finish GUE EDGE, and stamp completion

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -2327,18 +2327,27 @@ const String kSeedBuiltInPreDiveTemplateItemsSql = '''
     ('builtin-predive-bwraf-4', 'builtin-predive-bwraf', NULL,
      'Final OK: mask, fins, computer set, buddy signal', '', 4, 'check',
      NULL, NULL, NULL, NULL, 1, 0, 0),
-    ('builtin-predive-gue-0', 'builtin-predive-gue-edge', NULL,
-     'Equipment: full gear check head to toe', '', 0, 'check',
+    ('builtin-predive-gue-edge-0', 'builtin-predive-gue-edge', NULL,
+     'Goal: agree the objective and what turns the dive', '', 0, 'check',
      NULL, NULL, NULL, NULL, 1, 0, 0),
-    ('builtin-predive-gue-1', 'builtin-predive-gue-edge', NULL,
-     'Descent: agree on descent method and reference', '', 1, 'check',
+    ('builtin-predive-gue-edge-1', 'builtin-predive-gue-edge', NULL,
+     'Unified team: roles, order, communication, lost-buddy plan', '',
+     1, 'check', NULL, NULL, NULL, NULL, 1, 0, 0),
+    ('builtin-predive-gue-edge-2', 'builtin-predive-gue-edge', NULL,
+     'Equipment: match and check the team head to toe', '', 2, 'check',
      NULL, NULL, NULL, NULL, 1, 0, 0),
-    ('builtin-predive-gue-2', 'builtin-predive-gue-edge', NULL,
-     'Gas: analyze, label, confirm MOD and turn pressure', '', 2, 'check',
+    ('builtin-predive-gue-edge-3', 'builtin-predive-gue-edge', NULL,
+     'Exposure: suit, thermal protection, planned time in the water', '',
+     3, 'check', NULL, NULL, NULL, NULL, 1, 0, 0),
+    ('builtin-predive-gue-edge-4', 'builtin-predive-gue-edge', NULL,
+     'Decompression: agree the ascent schedule and deco gases', '',
+     4, 'check', NULL, NULL, NULL, NULL, 1, 0, 0),
+    ('builtin-predive-gue-edge-5', 'builtin-predive-gue-edge', NULL,
+     'Gas: analyze, label, confirm MOD and turn pressure', '', 5, 'check',
      NULL, NULL, NULL, NULL, 1, 0, 0),
-    ('builtin-predive-gue-3', 'builtin-predive-gue-edge', NULL,
-     'Environment: conditions, entry/exit, hazards', '', 3, 'check',
-     NULL, NULL, NULL, NULL, 1, 0, 0),
+    ('builtin-predive-gue-edge-6', 'builtin-predive-gue-edge', NULL,
+     'Environment: conditions, entry/exit, descent reference, hazards', '',
+     6, 'check', NULL, NULL, NULL, NULL, 1, 0, 0),
     ('builtin-predive-ccr-0', 'builtin-predive-ccr-build', 'Assembly',
      'Scrubber packed and within duration limits', '', 0, 'check',
      NULL, NULL, NULL, NULL, 1, 0, 0),
@@ -2381,6 +2390,27 @@ const String kSeedBuiltInPreDiveTemplateItemsSql = '''
     ('builtin-predive-pack-3', 'builtin-predive-gear-packing', NULL,
      'Water, sun protection, logbook', '', 3, 'check',
      NULL, NULL, NULL, NULL, 0, 0, 0)
+''';
+
+/// Retires the original four-item GUE EDGE list (ids `builtin-predive-gue-0`
+/// through `-3`), which implemented only the "EDGE" half of the mnemonic and
+/// read its D as "Descent". [kSeedBuiltInPreDiveTemplateItemsSql] seeds the
+/// canonical seven-point sequence under `builtin-predive-gue-edge-*` ids, so
+/// this DELETE is what lets a database seeded before the fix pick the new rows
+/// up: INSERT OR IGNORE adds the missing checks but can never rewrite or
+/// renumber the stale ones.
+///
+/// Safe to run on every open, and unconditionally: built-in items are
+/// read-only in the UI, excluded from sync export, and session items are
+/// independent snapshots taken at start time, so no diver-owned data hangs off
+/// these rows. Idempotent -- a no-op once the legacy ids are gone.
+const String kRetireLegacyGueEdgeItemsSql = '''
+  DELETE FROM pre_dive_checklist_template_items
+  WHERE template_id = 'builtin-predive-gue-edge'
+    AND id IN (
+      'builtin-predive-gue-0', 'builtin-predive-gue-1',
+      'builtin-predive-gue-2', 'builtin-predive-gue-3'
+    )
 ''';
 
 /// Seeds the nine built-in dive roles. Mirrors [kSeedBuiltInDiveTypesSql]:
@@ -4762,6 +4792,7 @@ class AppDatabase extends _$AppDatabase {
     ).get();
     if (diversTable.isEmpty) return;
     await customStatement(kSeedBuiltInPreDiveTemplatesSql);
+    await customStatement(kRetireLegacyGueEdgeItemsSql);
     await customStatement(kSeedBuiltInPreDiveTemplateItemsSql);
   }
 

--- a/lib/features/checklists/data/repositories/trip_checklist_repository.dart
+++ b/lib/features/checklists/data/repositories/trip_checklist_repository.dart
@@ -363,6 +363,51 @@ class TripChecklistRepository {
     }
   }
 
+  /// Done/total for several trips in one query, keyed by trip id.
+  ///
+  /// A trip with no items is absent from the result rather than present with
+  /// zeroes: GROUP BY only yields rows that exist. Callers ranking trips read
+  /// that absence as "nothing to show for this one".
+  ///
+  /// Batched deliberately. The caller (home screen) needs to look past a trip
+  /// whose list is empty, and doing that one `getProgress` at a time would
+  /// fan a per-trip query -- and, through the provider family, a per-trip
+  /// table subscription -- out of a widget that rebuilds on every dashboard
+  /// paint. Mirrors PreDiveSessionRepository.getItemsForSessions.
+  Future<Map<String, ({int done, int total})>> getProgressForTrips(
+    List<String> tripIds,
+  ) async {
+    if (tripIds.isEmpty) return {};
+    try {
+      // Only the placeholder count is interpolated; every id is bound.
+      final placeholders = List.filled(tripIds.length, '?').join(', ');
+      final rows = await _db
+          .customSelect(
+            'SELECT trip_id, COUNT(*) AS total, '
+            'SUM(CASE WHEN is_done THEN 1 ELSE 0 END) AS done '
+            'FROM trip_checklist_items WHERE trip_id IN ($placeholders) '
+            'GROUP BY trip_id',
+            variables: [for (final id in tripIds) Variable.withString(id)],
+            readsFrom: {_db.tripChecklistItems},
+          )
+          .get();
+      return {
+        for (final row in rows)
+          row.read<String>('trip_id'): (
+            done: row.read<int?>('done') ?? 0,
+            total: row.read<int>('total'),
+          ),
+      };
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to get checklist progress in bulk',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   Future<int> _nextSortOrder(String tripId) async {
     final row = await _db
         .customSelect(

--- a/lib/features/checklists/presentation/providers/checklist_providers.dart
+++ b/lib/features/checklists/presentation/providers/checklist_providers.dart
@@ -75,11 +75,14 @@ final tripChecklistProgressProvider =
 /// home button landed on a page headed "Pre-Dive Checklists" instead. This
 /// gives the trip list its own home surface, under its own label.
 ///
-/// A trip already under way wins over one still ahead, since that is the
-/// checklist being worked through today. Trips with nothing on their list are
-/// skipped: an empty row would be a permanent no-op on the home screen.
+/// Trips are ranked by how present they are -- one already under way first,
+/// then the rest by how soon they start -- and the first with anything on its
+/// list wins. Ranking and emptiness are separate filters on purpose: picking
+/// the date-best trip and only then checking it for items would return null
+/// whenever the nearest trip happened to be empty, hiding a perfectly good
+/// checklist one trip along.
 ///
-/// Both tests read the one captured [now] through the entity's own date-only
+/// Both date tests read the one captured `now` through the entity's date-only
 /// helpers. `Trip.isInProgress` would re-read `DateTime.now()` per trip, and
 /// pairing it with an instant comparison on `startDate` mixed two clocks and
 /// two granularities in a single pass: a trip starting today read as under
@@ -88,22 +91,30 @@ final tripChecklistProgressProvider =
 final homeTripChecklistProvider =
     FutureProvider<({Trip trip, int done, int total})?>((ref) async {
       final trips = await ref.watch(allTripsProvider.future);
+      final repository = ref.watch(tripChecklistRepositoryProvider);
+      ref.invalidateSelfWhen(repository.watchTripChecklistChanges());
+
       final now = DateTime.now();
-      Trip? candidate;
-      for (final trip in trips) {
-        if (trip.containsDate(now)) {
-          candidate = trip;
-          break;
-        }
-        if (!trip.startsAfter(now)) continue;
-        if (candidate == null || trip.startDate.isBefore(candidate.startDate)) {
-          candidate = trip;
-        }
+      final ranked =
+          [
+            for (final trip in trips)
+              if (trip.containsDate(now) || trip.startsAfter(now)) trip,
+          ]..sort((a, b) {
+            final aRunning = a.containsDate(now);
+            if (aRunning != b.containsDate(now)) return aRunning ? -1 : 1;
+            return a.startDate.compareTo(b.startDate);
+          });
+      if (ranked.isEmpty) return null;
+
+      // One query for the whole shortlist: the answer may be any of them, and
+      // asking per trip would fan out a query and a table subscription each.
+      final progress = await repository.getProgressForTrips([
+        for (final trip in ranked) trip.id,
+      ]);
+      for (final trip in ranked) {
+        final counts = progress[trip.id];
+        if (counts == null || counts.total == 0) continue;
+        return (trip: trip, done: counts.done, total: counts.total);
       }
-      if (candidate == null) return null;
-      final progress = await ref.watch(
-        tripChecklistProgressProvider(candidate.id).future,
-      );
-      if (progress.total == 0) return null;
-      return (trip: candidate, done: progress.done, total: progress.total);
+      return null;
     });

--- a/lib/features/checklists/presentation/providers/checklist_providers.dart
+++ b/lib/features/checklists/presentation/providers/checklist_providers.dart
@@ -78,17 +78,24 @@ final tripChecklistProgressProvider =
 /// A trip already under way wins over one still ahead, since that is the
 /// checklist being worked through today. Trips with nothing on their list are
 /// skipped: an empty row would be a permanent no-op on the home screen.
+///
+/// Both tests read the one captured [now] through the entity's own date-only
+/// helpers. `Trip.isInProgress` would re-read `DateTime.now()` per trip, and
+/// pairing it with an instant comparison on `startDate` mixed two clocks and
+/// two granularities in a single pass: a trip starting today read as under
+/// way to one branch and already past to the other, and a pass spanning
+/// midnight could classify two trips against different days.
 final homeTripChecklistProvider =
     FutureProvider<({Trip trip, int done, int total})?>((ref) async {
       final trips = await ref.watch(allTripsProvider.future);
       final now = DateTime.now();
       Trip? candidate;
       for (final trip in trips) {
-        if (trip.isInProgress) {
+        if (trip.containsDate(now)) {
           candidate = trip;
           break;
         }
-        if (!trip.startDate.isAfter(now)) continue;
+        if (!trip.startsAfter(now)) continue;
         if (candidate == null || trip.startDate.isBefore(candidate.startDate)) {
           candidate = trip;
         }

--- a/lib/features/checklists/presentation/providers/checklist_providers.dart
+++ b/lib/features/checklists/presentation/providers/checklist_providers.dart
@@ -6,6 +6,8 @@ import 'package:submersion/features/checklists/domain/entities/checklist_templat
 import 'package:submersion/features/checklists/domain/entities/trip_checklist_item.dart'
     as domain;
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/trips/domain/entities/trip.dart';
+import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
 
 /// Repository singletons
 final checklistTemplateRepositoryProvider =
@@ -63,4 +65,38 @@ final tripChecklistProgressProvider =
       final repository = ref.watch(tripChecklistRepositoryProvider);
       ref.invalidateSelfWhen(repository.watchTripChecklistChanges());
       return repository.getProgress(tripId);
+    });
+
+/// The one trip checklist worth surfacing on the home screen, or null.
+///
+/// Home used to offer a single checklist button and it went to the pre-dive
+/// runs, so a trip's to-do list -- a different feature, a different table --
+/// was only ever reachable by opening the trip, and a diver following the
+/// home button landed on a page headed "Pre-Dive Checklists" instead. This
+/// gives the trip list its own home surface, under its own label.
+///
+/// A trip already under way wins over one still ahead, since that is the
+/// checklist being worked through today. Trips with nothing on their list are
+/// skipped: an empty row would be a permanent no-op on the home screen.
+final homeTripChecklistProvider =
+    FutureProvider<({Trip trip, int done, int total})?>((ref) async {
+      final trips = await ref.watch(allTripsProvider.future);
+      final now = DateTime.now();
+      Trip? candidate;
+      for (final trip in trips) {
+        if (trip.isInProgress) {
+          candidate = trip;
+          break;
+        }
+        if (!trip.startDate.isAfter(now)) continue;
+        if (candidate == null || trip.startDate.isBefore(candidate.startDate)) {
+          candidate = trip;
+        }
+      }
+      if (candidate == null) return null;
+      final progress = await ref.watch(
+        tripChecklistProgressProvider(candidate.id).future,
+      );
+      if (progress.total == 0) return null;
+      return (trip: candidate, done: progress.done, total: progress.total);
     });

--- a/lib/features/pre_dive/data/services/checklist_dive_linker.dart
+++ b/lib/features/pre_dive/data/services/checklist_dive_linker.dart
@@ -30,10 +30,17 @@ class ChecklistDiveLinker {
   /// a CCR build or a gear-packing list worked through over an hour would
   /// fall out of the window even when it ended minutes before the dive.
   ///
-  /// A run still in progress has no completion stamp, so it falls back to its
-  /// start.
+  /// A run still in progress anchors on its start. The status decides that,
+  /// not the presence of the stamp: `completedAt` is only written alongside a
+  /// terminal status, so a running row carrying one is contradictory data,
+  /// and trusting it would anchor the run on a time it never finished at and
+  /// hand it to the wrong dive -- or, if that time falls outside the window,
+  /// to none at all. Mirrors the same defence in the sessions list's
+  /// `_whenLabel`.
   static DateTime anchorOf(domain.PreDiveSession session) =>
-      session.completedAt ?? session.startedAt;
+      session.status == domain.PreDiveSessionStatus.inProgress
+      ? session.startedAt
+      : session.completedAt ?? session.startedAt;
 
   Future<bool> autoLinkForDive({
     required String diveId,

--- a/lib/features/pre_dive/data/services/checklist_dive_linker.dart
+++ b/lib/features/pre_dive/data/services/checklist_dive_linker.dart
@@ -14,12 +14,26 @@ class ChecklistDiveLinker {
     : _sessions = sessions ?? PreDiveSessionRepository();
 
   /// A checklist run belongs to the dive that splashed within this window
-  /// after it started.
+  /// after the run finished.
   static const linkWindow = Duration(hours: 3);
 
   /// Absorbs dive-computer wall-clock skew relative to the phone: a session
-  /// "started" slightly after the recorded dive start still links.
+  /// timestamped slightly after the recorded dive start still links.
   static const forwardGrace = Duration(minutes: 15);
+
+  /// When a run counts as "done" for the purpose of matching it to a dive.
+  ///
+  /// Completion, not start, is the anchor: the diver finishes the checklist
+  /// and gets in the water, so the gap that matters is the one between the
+  /// last item ticked and the splash. Anchoring on [startedAt] instead
+  /// measured from the wrong end and dropped every run that took a while --
+  /// a CCR build or a gear-packing list worked through over an hour would
+  /// fall out of the window even when it ended minutes before the dive.
+  ///
+  /// A run still in progress has no completion stamp, so it falls back to its
+  /// start.
+  static DateTime anchorOf(domain.PreDiveSession session) =>
+      session.completedAt ?? session.startedAt;
 
   Future<bool> autoLinkForDive({
     required String diveId,
@@ -37,7 +51,7 @@ class ChecklistDiveLinker {
       for (final s in candidates) {
         // getUnlinkedSessions filters exactly; belt-and-braces re-check.
         if (s.diverId != diverId) continue;
-        final delta = diveStart.difference(s.startedAt);
+        final delta = diveStart.difference(anchorOf(s));
         final inWindow = delta <= linkWindow && delta >= -forwardGrace;
         if (!inWindow) continue;
         final distance = delta.abs();

--- a/lib/features/pre_dive/presentation/pages/pre_dive_session_runner_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_session_runner_page.dart
@@ -299,8 +299,10 @@ class PreDiveSessionRunnerPage extends ConsumerWidget {
                 '${_statusLabel(context, session.status)}'
                 // Time of day, not just the date: the gap between finishing
                 // the checklist and splashing is what the run is evidence of,
-                // and it is what auto-links this run to a dive.
-                '${session.completedAt == null ? '' : ' - ${UnitFormatter(ref.watch(settingsProvider)).formatDateTime(session.completedAt)}'}',
+                // and it is what auto-links this run to a dive. l10n is
+                // threaded through so the date/time connector is translated
+                // rather than falling back to a hardcoded English "at".
+                '${session.completedAt == null ? '' : ' - ${UnitFormatter(ref.watch(settingsProvider)).formatDateTime(session.completedAt, l10n: l10n)}'}',
                 style: theme.textTheme.bodyMedium,
               ),
             ),

--- a/lib/features/pre_dive/presentation/pages/pre_dive_session_runner_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_session_runner_page.dart
@@ -297,7 +297,10 @@ class PreDiveSessionRunnerPage extends ConsumerWidget {
               child: Text(
                 '${l10n.preDive_runner_locked} - '
                 '${_statusLabel(context, session.status)}'
-                '${session.completedAt == null ? '' : ' - ${UnitFormatter(ref.watch(settingsProvider)).formatDate(session.completedAt)}'}',
+                // Time of day, not just the date: the gap between finishing
+                // the checklist and splashing is what the run is evidence of,
+                // and it is what auto-links this run to a dive.
+                '${session.completedAt == null ? '' : ' - ${UnitFormatter(ref.watch(settingsProvider)).formatDateTime(session.completedAt)}'}',
                 style: theme.textTheme.bodyMedium,
               ),
             ),

--- a/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
@@ -344,39 +344,52 @@ class _SessionTile extends ConsumerWidget {
 
   const _SessionTile({required this.session});
 
-  /// Status and its timestamp in one phrase.
+  /// Status and its timestamp.
   ///
   /// A finished run is stamped the moment it is completed or aborted, and
   /// that stamp is what decides which dive the run auto-links to, so it is
-  /// the timestamp worth showing -- with the time of day, not just the date.
+  /// the timestamp worth showing, with the time of day rather than just the
+  /// date. When it is there, status and time fold into one phrase.
   ///
-  /// The stamp is only meaningful once the run is over, so the status picks
-  /// the timestamp as well as the wording. A row that is still in progress
-  /// reports its start whatever `completedAt` holds: that pairing is
-  /// contradictory data, and reading the finish time out of it to print under
-  /// a "Started" label would quietly misreport the run rather than expose the
-  /// contradiction. A finished row missing its stamp can likewise only report
-  /// its start honestly.
+  /// The stamp is only meaningful once the run is over, so the status, not
+  /// the presence of the stamp, decides which time is shown. A row still in
+  /// progress reports its start whatever `completedAt` holds: that pairing is
+  /// contradictory data, and reading a finish time out of it would quietly
+  /// misreport the run rather than expose the contradiction.
+  ///
+  /// A terminal row with no usable stamp (legacy or sync-applied data) falls
+  /// back to two parts rather than one: the start, which is the only time
+  /// certainly true of it, followed by the status. Folding the two facts into
+  /// a single phrase must never cost one of them, and "Started ..." alone on
+  /// a completed run hides what actually happened. Nothing is appended for a
+  /// run still going, where the phrase already says it.
   ///
   /// [l10n] reaches [UnitFormatter.formatDateTime] so the connector between
   /// date and time is translated; without it the formatter falls back to a
   /// hardcoded English "at" and a German tile reads "14.11.2023 at 09:12".
   String _whenLabel(BuildContext context, UnitFormatter units) {
     final l10n = context.l10n;
-    final finishedAt = session.status == PreDiveSessionStatus.inProgress
-        ? null
-        : session.completedAt;
-    if (finishedAt == null) {
-      return l10n.preDive_sessions_startedAt(
-        units.formatDateTime(session.startedAt, l10n: l10n),
-      );
+    final running = session.status == PreDiveSessionStatus.inProgress;
+    final finishedAt = running ? null : session.completedAt;
+    if (finishedAt != null) {
+      final when = units.formatDateTime(finishedAt, l10n: l10n);
+      return session.status == PreDiveSessionStatus.aborted
+          ? l10n.preDive_sessions_abortedAt(when)
+          : l10n.preDive_sessions_completedAt(when);
     }
-    final when = units.formatDateTime(finishedAt, l10n: l10n);
-    // inProgress is handled above, so only the two finished states remain.
-    return session.status == PreDiveSessionStatus.aborted
-        ? l10n.preDive_sessions_abortedAt(when)
-        : l10n.preDive_sessions_completedAt(when);
+    final started = l10n.preDive_sessions_startedAt(
+      units.formatDateTime(session.startedAt, l10n: l10n),
+    );
+    return running ? started : '$started - ${_statusLabel(context)}';
   }
+
+  String _statusLabel(BuildContext context) => switch (session.status) {
+    PreDiveSessionStatus.inProgress =>
+      context.l10n.preDive_sessions_statusInProgress,
+    PreDiveSessionStatus.completed =>
+      context.l10n.preDive_sessions_statusCompleted,
+    PreDiveSessionStatus.aborted => context.l10n.preDive_sessions_statusAborted,
+  };
 
   /// Attaches this run to a dive the diver picks (#1066). The automatic
   /// linker only reaches back three hours from the dive, so a build check run

--- a/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
@@ -349,21 +349,33 @@ class _SessionTile extends ConsumerWidget {
   /// A finished run is stamped the moment it is completed or aborted, and
   /// that stamp is what decides which dive the run auto-links to, so it is
   /// the timestamp worth showing -- with the time of day, not just the date.
-  /// Only a run still going has nothing to report but its start.
+  ///
+  /// The stamp is only meaningful once the run is over, so the status picks
+  /// the timestamp as well as the wording. A row that is still in progress
+  /// reports its start whatever `completedAt` holds: that pairing is
+  /// contradictory data, and reading the finish time out of it to print under
+  /// a "Started" label would quietly misreport the run rather than expose the
+  /// contradiction. A finished row missing its stamp can likewise only report
+  /// its start honestly.
+  ///
+  /// [l10n] reaches [UnitFormatter.formatDateTime] so the connector between
+  /// date and time is translated; without it the formatter falls back to a
+  /// hardcoded English "at" and a German tile reads "14.11.2023 at 09:12".
   String _whenLabel(BuildContext context, UnitFormatter units) {
     final l10n = context.l10n;
-    final finishedAt = session.completedAt;
+    final finishedAt = session.status == PreDiveSessionStatus.inProgress
+        ? null
+        : session.completedAt;
     if (finishedAt == null) {
       return l10n.preDive_sessions_startedAt(
-        units.formatDateTime(session.startedAt),
+        units.formatDateTime(session.startedAt, l10n: l10n),
       );
     }
-    final when = units.formatDateTime(finishedAt);
-    return switch (session.status) {
-      PreDiveSessionStatus.inProgress => l10n.preDive_sessions_startedAt(when),
-      PreDiveSessionStatus.completed => l10n.preDive_sessions_completedAt(when),
-      PreDiveSessionStatus.aborted => l10n.preDive_sessions_abortedAt(when),
-    };
+    final when = units.formatDateTime(finishedAt, l10n: l10n);
+    // inProgress is handled above, so only the two finished states remain.
+    return session.status == PreDiveSessionStatus.aborted
+        ? l10n.preDive_sessions_abortedAt(when)
+        : l10n.preDive_sessions_completedAt(when);
   }
 
   /// Attaches this run to a dive the diver picks (#1066). The automatic

--- a/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
@@ -344,14 +344,25 @@ class _SessionTile extends ConsumerWidget {
 
   const _SessionTile({required this.session});
 
-  String _statusLabel(BuildContext context) {
+  /// Status and its timestamp in one phrase.
+  ///
+  /// A finished run is stamped the moment it is completed or aborted, and
+  /// that stamp is what decides which dive the run auto-links to, so it is
+  /// the timestamp worth showing -- with the time of day, not just the date.
+  /// Only a run still going has nothing to report but its start.
+  String _whenLabel(BuildContext context, UnitFormatter units) {
+    final l10n = context.l10n;
+    final finishedAt = session.completedAt;
+    if (finishedAt == null) {
+      return l10n.preDive_sessions_startedAt(
+        units.formatDateTime(session.startedAt),
+      );
+    }
+    final when = units.formatDateTime(finishedAt);
     return switch (session.status) {
-      PreDiveSessionStatus.inProgress =>
-        context.l10n.preDive_sessions_statusInProgress,
-      PreDiveSessionStatus.completed =>
-        context.l10n.preDive_sessions_statusCompleted,
-      PreDiveSessionStatus.aborted =>
-        context.l10n.preDive_sessions_statusAborted,
+      PreDiveSessionStatus.inProgress => l10n.preDive_sessions_startedAt(when),
+      PreDiveSessionStatus.completed => l10n.preDive_sessions_completedAt(when),
+      PreDiveSessionStatus.aborted => l10n.preDive_sessions_abortedAt(when),
     };
   }
 
@@ -401,9 +412,7 @@ class _SessionTile extends ConsumerWidget {
     final theme = Theme.of(context);
     final flagged =
         ref.watch(preDiveSessionStatsProvider).value?[session.id]?.flagged ?? 0;
-    final startedDate = UnitFormatter(
-      ref.watch(settingsProvider),
-    ).formatDate(session.startedAt);
+    final units = UnitFormatter(ref.watch(settingsProvider));
 
     final hasLinkedDive = session.diveId != null;
 
@@ -429,8 +438,7 @@ class _SessionTile extends ConsumerWidget {
         children: [
           Text(
             [
-              startedDate,
-              _statusLabel(context),
+              _whenLabel(context, units),
               if (flagged > 0) l10n.preDive_runner_flaggedBadge(flagged),
             ].join(' - '),
           ),

--- a/lib/features/pre_dive/presentation/pages/pre_dive_template_edit_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_template_edit_page.dart
@@ -36,7 +36,21 @@ class _PreDiveTemplateEditPageState
   /// can read what a default checks before cloning it. Everything that would
   /// mutate the template is withheld rather than merely disabled, so the page
   /// reads as a viewer instead of a broken editor.
+  ///
+  /// False until [_load] lands, so read [_editable] rather than `!_readOnly`
+  /// for anything that offers editing.
   bool get _readOnly => _existing?.isBuiltIn ?? false;
+
+  /// Whether the editing chrome may be shown yet.
+  ///
+  /// The built-in flag lives on the fetched row, so while a template is in
+  /// flight this page does not know which mode it is in. Treating "not known
+  /// to be read-only" as editable put the edit title and a Save button on the
+  /// first frame and then withdrew them the instant a built-in resolved.
+  /// Waiting is the claim that can only be upgraded, never retracted.
+  ///
+  /// A brand new template has nothing to fetch, so it is editable at once.
+  bool get _editable => !_loading && !_readOnly;
 
   @override
   void initState() {
@@ -147,18 +161,15 @@ class _PreDiveTemplateEditPageState
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          _readOnly
-              ? l10n.preDive_edit_titleView
-              : widget.isEditing
+          !widget.isEditing
+              ? l10n.preDive_edit_titleNew
+              : _editable
               ? l10n.preDive_edit_titleEdit
-              : l10n.preDive_edit_titleNew,
+              : l10n.preDive_edit_titleView,
         ),
         actions: [
-          if (!_readOnly)
-            TextButton(
-              onPressed: _loading ? null : _save,
-              child: Text(l10n.common_action_save),
-            ),
+          if (_editable)
+            TextButton(onPressed: _save, child: Text(l10n.common_action_save)),
         ],
       ),
       body: _loading

--- a/lib/features/pre_dive/presentation/pages/pre_dive_template_edit_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_template_edit_page.dart
@@ -32,7 +32,10 @@ class _PreDiveTemplateEditPageState
   PreDiveChecklistTemplate? _existing;
   bool _loading = false;
 
-  /// Built-ins never reach this page from the list UI, but guard anyway.
+  /// Built-ins reach this page as viewers: the list opens them so a diver
+  /// can read what a default checks before cloning it. Everything that would
+  /// mutate the template is withheld rather than merely disabled, so the page
+  /// reads as a viewer instead of a broken editor.
   bool get _readOnly => _existing?.isBuiltIn ?? false;
 
   @override
@@ -144,15 +147,18 @@ class _PreDiveTemplateEditPageState
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          widget.isEditing
+          _readOnly
+              ? l10n.preDive_edit_titleView
+              : widget.isEditing
               ? l10n.preDive_edit_titleEdit
               : l10n.preDive_edit_titleNew,
         ),
         actions: [
-          TextButton(
-            onPressed: _loading || _readOnly ? null : _save,
-            child: Text(l10n.common_action_save),
-          ),
+          if (!_readOnly)
+            TextButton(
+              onPressed: _loading ? null : _save,
+              child: Text(l10n.common_action_save),
+            ),
         ],
       ),
       body: _loading
@@ -162,6 +168,16 @@ class _PreDiveTemplateEditPageState
               child: ListView(
                 padding: const EdgeInsets.all(16),
                 children: [
+                  if (_readOnly) ...[
+                    Card(
+                      margin: EdgeInsets.zero,
+                      child: ListTile(
+                        leading: const Icon(Icons.lock_outline),
+                        title: Text(l10n.preDive_edit_builtInNotice),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                  ],
                   TextFormField(
                     controller: _nameController,
                     enabled: !_readOnly,
@@ -230,25 +246,26 @@ class _PreDiveTemplateEditPageState
                                 l10n.preDive_item_required,
                             ].join(' - '),
                           ),
-                          leading: IconButton(
-                            icon: const Icon(Icons.delete_outline),
-                            onPressed: _readOnly
-                                ? null
-                                : () => setState(
+                          leading: _readOnly
+                              ? const Icon(Icons.check_box_outline_blank)
+                              : IconButton(
+                                  icon: const Icon(Icons.delete_outline),
+                                  onPressed: () => setState(
                                     () => _items = [..._items]..removeAt(i),
                                   ),
-                          ),
+                                ),
                           onTap: _readOnly
                               ? null
                               : () => _addOrEditItem(item: _items[i]),
                         ),
                     ],
                   ),
-                  TextButton.icon(
-                    icon: const Icon(Icons.add),
-                    label: Text(l10n.preDive_edit_addItem),
-                    onPressed: _readOnly ? null : () => _addOrEditItem(),
-                  ),
+                  if (!_readOnly)
+                    TextButton.icon(
+                      icon: const Icon(Icons.add),
+                      label: Text(l10n.preDive_edit_addItem),
+                      onPressed: () => _addOrEditItem(),
+                    ),
                 ],
               ),
             ),

--- a/lib/features/pre_dive/presentation/pages/pre_dive_template_edit_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_template_edit_page.dart
@@ -246,8 +246,16 @@ class _PreDiveTemplateEditPageState
                                 l10n.preDive_item_required,
                             ].join(' - '),
                           ),
+                          // No leading column at all in read-only mode. An
+                          // empty checkbox was standing in as a spacer, but
+                          // that glyph reads as "tap to toggle" on a row
+                          // whose onTap is null, and these template items
+                          // have no state to toggle. Nothing here needs
+                          // aligning either: every row in this mode lacks the
+                          // delete button, so reserving its column would hold
+                          // space for a control that never appears.
                           leading: _readOnly
-                              ? const Icon(Icons.check_box_outline_blank)
+                              ? null
                               : IconButton(
                                   icon: const Icon(Icons.delete_outline),
                                   onPressed: () => setState(

--- a/lib/features/pre_dive/presentation/pages/pre_dive_templates_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_templates_page.dart
@@ -7,8 +7,8 @@ import 'package:submersion/features/pre_dive/domain/entities/pre_dive_checklist_
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
-/// Settings page listing pre-dive checklist templates: read-only built-ins
-/// (clonable) plus fully editable user templates.
+/// Settings page listing pre-dive checklist templates: built-ins, which
+/// open read-only and can be cloned, plus fully editable user templates.
 class PreDiveTemplatesPage extends ConsumerWidget {
   const PreDiveTemplatesPage({super.key});
 
@@ -124,6 +124,8 @@ class _TemplateTile extends ConsumerWidget {
       trailing: PopupMenuButton<String>(
         onSelected: (value) {
           switch (value) {
+            case 'open':
+              context.push('/pre-dive-checklists/${template.id}/edit');
             case 'clone':
               _clone(context, ref);
             case 'delete':
@@ -131,6 +133,11 @@ class _TemplateTile extends ConsumerWidget {
           }
         },
         itemBuilder: (context) => [
+          if (template.isBuiltIn)
+            PopupMenuItem(
+              value: 'open',
+              child: Text(l10n.preDive_templates_view),
+            ),
           PopupMenuItem(
             value: 'clone',
             child: Text(l10n.preDive_templates_clone),
@@ -142,9 +149,11 @@ class _TemplateTile extends ConsumerWidget {
             ),
         ],
       ),
-      onTap: template.isBuiltIn
-          ? null
-          : () => context.push('/pre-dive-checklists/${template.id}/edit'),
+      // Built-ins open too. The destination renders read-only for them
+      // (PreDiveTemplateEditPage._readOnly), so the diver can read what a
+      // default actually checks before deciding whether to clone it -- the
+      // old null tap made the defaults unreadable until cloned.
+      onTap: () => context.push('/pre-dive-checklists/${template.id}/edit'),
     );
   }
 }

--- a/lib/features/pre_dive/presentation/widgets/pre_dive_dashboard_card.dart
+++ b/lib/features/pre_dive/presentation/widgets/pre_dive_dashboard_card.dart
@@ -2,13 +2,27 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/checklists/presentation/providers/checklist_providers.dart';
 import 'package:submersion/features/pre_dive/domain/services/checklist_session_engine.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
-/// Dashboard card for pre-dive checklists. Hidden until the feature has
-/// been used (a session exists or a user template was created) so
-/// non-users pay no UI tax; built-ins alone do not surface it.
+/// Home card for both kinds of checklist the app keeps, each under its own
+/// label and going to its own place.
+///
+/// The app has two unrelated checklist features: pre-dive runs (timed,
+/// immutable audit records) and trip checklists (dated to-dos on a trip).
+/// Home used to offer only the pre-dive button, so a diver who kept trip
+/// checklists followed the home button and arrived at a page headed
+/// "Pre-Dive Checklists" that knew nothing about their list. Naming the two
+/// rows separately is the fix: the card no longer implies that the pre-dive
+/// runner is where every checklist lives.
+///
+/// Each row is hidden until it has something to say -- pre-dive until the
+/// feature has been used (a session exists or a user template was created;
+/// built-ins alone do not surface it), the trip row until the current or next
+/// trip actually has items -- and the card itself disappears when neither
+/// does, so non-users pay no UI tax.
 class PreDiveDashboardCard extends ConsumerWidget {
   const PreDiveDashboardCard({super.key});
 
@@ -20,18 +34,21 @@ class PreDiveDashboardCard extends ConsumerWidget {
     final sessions = ref.watch(preDiveSessionsProvider).value ?? const [];
     final templates = ref.watch(preDiveTemplatesProvider).value ?? const [];
     final hasUserTemplates = templates.any((t) => !t.isBuiltIn);
+    final tripChecklist = ref.watch(homeTripChecklistProvider).value;
 
-    if (active == null && sessions.isEmpty && !hasUserTemplates) {
+    final showPreDive =
+        active != null || sessions.isNotEmpty || hasUserTemplates;
+    if (!showPreDive && tripChecklist == null) {
       return const SizedBox.shrink();
     }
 
-    final Widget action;
+    final Widget preDiveAction;
     if (active != null) {
       final items = ref.watch(preDiveSessionItemsProvider(active.id)).value;
       final resolved = items == null
           ? 0
           : ChecklistSessionEngine.resolvedCount(items);
-      action = FilledButton.icon(
+      preDiveAction = FilledButton.icon(
         icon: const Icon(Icons.play_arrow),
         label: Text(
           l10n.preDive_dashboard_resume(resolved, items?.length ?? 0),
@@ -39,7 +56,7 @@ class PreDiveDashboardCard extends ConsumerWidget {
         onPressed: () => context.push('/pre-dive-sessions/${active.id}'),
       );
     } else {
-      action = FilledButton.tonalIcon(
+      preDiveAction = FilledButton.tonalIcon(
         icon: const Icon(Icons.fact_check),
         label: Text(l10n.preDive_dashboard_start),
         onPressed: () => context.push('/pre-dive-sessions'),
@@ -56,19 +73,65 @@ class PreDiveDashboardCard extends ConsumerWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  l10n.preDive_dashboard_title,
+                  l10n.dashboard_checklists_title,
                   style: theme.textTheme.bodyMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                const SizedBox(height: 8),
-                SizedBox(width: double.infinity, child: action),
+                if (showPreDive) ...[
+                  const SizedBox(height: 8),
+                  _RowLabel(text: l10n.dashboard_checklists_preDiveLabel),
+                  const SizedBox(height: 4),
+                  SizedBox(width: double.infinity, child: preDiveAction),
+                ],
+                if (tripChecklist != null) ...[
+                  const SizedBox(height: 12),
+                  _RowLabel(
+                    text: l10n.dashboard_checklists_tripLabel(
+                      tripChecklist.trip.name,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton.icon(
+                      icon: const Icon(Icons.checklist),
+                      label: Text(
+                        l10n.checklists_progress(
+                          tripChecklist.done,
+                          tripChecklist.total,
+                        ),
+                      ),
+                      onPressed: () =>
+                          context.push('/trips/${tripChecklist.trip.id}'),
+                    ),
+                  ),
+                ],
               ],
             ),
           ),
         ),
         const SizedBox(height: 12),
       ],
+    );
+  }
+}
+
+class _RowLabel extends StatelessWidget {
+  final String text;
+
+  const _RowLabel({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      text,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: theme.textTheme.labelMedium?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
     );
   }
 }

--- a/lib/features/trips/domain/entities/trip.dart
+++ b/lib/features/trips/domain/entities/trip.dart
@@ -66,6 +66,20 @@ class Trip extends Equatable {
     return !dateOnly.isBefore(start) && !dateOnly.isAfter(end);
   }
 
+  /// Whether the trip's first day is still ahead of [date] (date-only, same
+  /// normalization as [containsDate]).
+  ///
+  /// Takes its reference date rather than reading the clock, so a caller
+  /// classifying several trips in one pass can measure every one of them
+  /// against a single captured instant. [isInProgress] and [isUpcoming] each
+  /// call `DateTime.now()` themselves, so combining them with a locally
+  /// captured "now" mixes clock reads that can straddle midnight.
+  bool startsAfter(DateTime date) {
+    final dateOnly = DateTime(date.year, date.month, date.day);
+    final start = DateTime(startDate.year, startDate.month, startDate.day);
+    return start.isAfter(dateOnly);
+  }
+
   /// Whether this trip is upcoming or currently underway (date-only
   /// comparison, same normalization as [containsDate]).
   bool get isUpcoming {

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1077,6 +1077,43 @@
     }
   },
   "preDive_dashboard_start": "بدء فحص ما قبل الغوص",
+  "preDive_templates_view": "عرض",
+  "preDive_edit_titleView": "عرض قائمة تحقق ما قبل الغوص",
+  "preDive_edit_builtInNotice": "قائمة تحقق مدمجة. استنسخها للحصول على نسخة قابلة للتعديل.",
+  "dashboard_checklists_title": "قوائم التحقق",
+  "dashboard_checklists_preDiveLabel": "ما قبل الغوص",
+  "dashboard_checklists_tripLabel": "الرحلة: {name}",
+  "@dashboard_checklists_tripLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_startedAt": "بدأت {when}",
+  "@preDive_sessions_startedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_completedAt": "اكتملت {when}",
+  "@preDive_sessions_completedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_abortedAt": "أُلغيت {when}",
+  "@preDive_sessions_abortedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
   "trips_detail_preDive_action": "قائمة تحقق ما قبل الغوص",
   "settings_manage_preDiveChecklists": "قوائم تحقق ما قبل الغوص",
   "settings_manage_preDiveChecklists_subtitle": "فحوصات رفيق الغوص، قوائم تجهيز CCR، توضيب المعدات",
@@ -6570,7 +6607,7 @@
   "settings_homeCards_resetDialog_confirm": "إعادة تعيين",
   "settings_homeCards_card_hero": "ترويسة الترحيب",
   "settings_homeCards_card_gaugeStrip": "شرائح الحالة",
-  "settings_homeCards_card_preDive": "قائمة فحص ما قبل الغوص",
+  "settings_homeCards_card_preDive": "قوائم التحقق",
   "settings_homeCards_card_recentDives": "الغوصات الأخيرة",
   "settings_homeCards_card_quickActions": "إجراءات سريعة",
   "settings_homeCards_card_milestones": "الإنجازات",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1077,6 +1077,43 @@
     }
   },
   "preDive_dashboard_start": "Check vor dem Tauchgang starten",
+  "preDive_templates_view": "Ansehen",
+  "preDive_edit_titleView": "Checkliste vor dem Tauchgang ansehen",
+  "preDive_edit_builtInNotice": "Integrierte Checkliste. Duplizieren, um eine bearbeitbare Kopie zu erhalten.",
+  "dashboard_checklists_title": "Checklisten",
+  "dashboard_checklists_preDiveLabel": "Vor dem Tauchgang",
+  "dashboard_checklists_tripLabel": "Reise: {name}",
+  "@dashboard_checklists_tripLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_startedAt": "Begonnen {when}",
+  "@preDive_sessions_startedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_completedAt": "Abgeschlossen {when}",
+  "@preDive_sessions_completedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_abortedAt": "Abgebrochen {when}",
+  "@preDive_sessions_abortedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
   "trips_detail_preDive_action": "Checkliste vor dem Tauchgang",
   "settings_manage_preDiveChecklists": "Checklisten vor dem Tauchgang",
   "settings_manage_preDiveChecklists_subtitle": "Buddy-Checks, CCR-Aufbaulisten, Ausrüstungspacken",
@@ -6570,7 +6607,7 @@
   "settings_homeCards_resetDialog_confirm": "Zurücksetzen",
   "settings_homeCards_card_hero": "Begrüßungsbereich",
   "settings_homeCards_card_gaugeStrip": "Status-Chips",
-  "settings_homeCards_card_preDive": "Pre-Dive-Checkliste",
+  "settings_homeCards_card_preDive": "Checklisten",
   "settings_homeCards_card_recentDives": "Letzte Tauchgänge",
   "settings_homeCards_card_quickActions": "Schnellaktionen",
   "settings_homeCards_card_milestones": "Meilensteine",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1636,6 +1636,43 @@
     }
   },
   "preDive_dashboard_start": "Start pre-dive check",
+  "preDive_templates_view": "View",
+  "preDive_edit_titleView": "View Pre-Dive Checklist",
+  "preDive_edit_builtInNotice": "Built-in checklist. Clone it to make an editable copy.",
+  "dashboard_checklists_title": "Checklists",
+  "dashboard_checklists_preDiveLabel": "Pre-dive",
+  "dashboard_checklists_tripLabel": "Trip: {name}",
+  "@dashboard_checklists_tripLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_startedAt": "Started {when}",
+  "@preDive_sessions_startedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_completedAt": "Completed {when}",
+  "@preDive_sessions_completedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_abortedAt": "Aborted {when}",
+  "@preDive_sessions_abortedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
   "trips_detail_preDive_action": "Pre-dive checklist",
   "settings_manage_preDiveChecklists": "Pre-Dive Checklists",
   "settings_manage_preDiveChecklists_subtitle": "Buddy checks, CCR build lists, gear packing",
@@ -2054,7 +2091,7 @@
   "settings_homeCards_resetDialog_confirm": "Reset",
   "settings_homeCards_card_hero": "Welcome header",
   "settings_homeCards_card_gaugeStrip": "Status chips",
-  "settings_homeCards_card_preDive": "Pre-dive checklist",
+  "settings_homeCards_card_preDive": "Checklists",
   "settings_homeCards_card_recentDives": "Recent dives",
   "settings_homeCards_card_quickActions": "Quick actions",
   "settings_homeCards_card_milestones": "Milestones",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1077,6 +1077,43 @@
     }
   },
   "preDive_dashboard_start": "Iniciar comprobación previa a la inmersión",
+  "preDive_templates_view": "Ver",
+  "preDive_edit_titleView": "Ver lista previa a la inmersión",
+  "preDive_edit_builtInNotice": "Lista integrada. Duplícala para obtener una copia editable.",
+  "dashboard_checklists_title": "Listas de verificación",
+  "dashboard_checklists_preDiveLabel": "Previa a la inmersión",
+  "dashboard_checklists_tripLabel": "Viaje: {name}",
+  "@dashboard_checklists_tripLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_startedAt": "Iniciada {when}",
+  "@preDive_sessions_startedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_completedAt": "Completada {when}",
+  "@preDive_sessions_completedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_abortedAt": "Cancelada {when}",
+  "@preDive_sessions_abortedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
   "trips_detail_preDive_action": "Lista previa a la inmersión",
   "settings_manage_preDiveChecklists": "Listas previas a la inmersión",
   "settings_manage_preDiveChecklists_subtitle": "Comprobaciones en pareja, listas de montaje CCR, preparación del equipo",
@@ -6570,7 +6607,7 @@
   "settings_homeCards_resetDialog_confirm": "Restablecer",
   "settings_homeCards_card_hero": "Cabecera de bienvenida",
   "settings_homeCards_card_gaugeStrip": "Chips de estado",
-  "settings_homeCards_card_preDive": "Lista previa a la inmersión",
+  "settings_homeCards_card_preDive": "Listas de verificación",
   "settings_homeCards_card_recentDives": "Inmersiones recientes",
   "settings_homeCards_card_quickActions": "Acciones rápidas",
   "settings_homeCards_card_milestones": "Hitos",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1077,6 +1077,43 @@
     }
   },
   "preDive_dashboard_start": "Démarrer la vérification pré-plongée",
+  "preDive_templates_view": "Afficher",
+  "preDive_edit_titleView": "Afficher la checklist pré-plongée",
+  "preDive_edit_builtInNotice": "Checklist intégrée. Dupliquez-la pour obtenir une copie modifiable.",
+  "dashboard_checklists_title": "Checklists",
+  "dashboard_checklists_preDiveLabel": "Pré-plongée",
+  "dashboard_checklists_tripLabel": "Voyage : {name}",
+  "@dashboard_checklists_tripLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_startedAt": "Commencée {when}",
+  "@preDive_sessions_startedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_completedAt": "Terminée {when}",
+  "@preDive_sessions_completedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_abortedAt": "Interrompue {when}",
+  "@preDive_sessions_abortedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
   "trips_detail_preDive_action": "Checklist pré-plongée",
   "settings_manage_preDiveChecklists": "Checklists pré-plongée",
   "settings_manage_preDiveChecklists_subtitle": "Vérifications entre binômes, listes de montage CCR, préparation du matériel",
@@ -6570,7 +6607,7 @@
   "settings_homeCards_resetDialog_confirm": "Réinitialiser",
   "settings_homeCards_card_hero": "En-tête de bienvenue",
   "settings_homeCards_card_gaugeStrip": "Pastilles d'état",
-  "settings_homeCards_card_preDive": "Check-list pré-plongée",
+  "settings_homeCards_card_preDive": "Checklists",
   "settings_homeCards_card_recentDives": "Plongées récentes",
   "settings_homeCards_card_quickActions": "Actions rapides",
   "settings_homeCards_card_milestones": "Jalons",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1077,6 +1077,43 @@
     }
   },
   "preDive_dashboard_start": "התחל בדיקה לפני צלילה",
+  "preDive_templates_view": "הצגה",
+  "preDive_edit_titleView": "הצגת רשימת בדיקה לפני צלילה",
+  "preDive_edit_builtInNotice": "רשימת בדיקה מובנית. שכפלו אותה כדי ליצור עותק הניתן לעריכה.",
+  "dashboard_checklists_title": "רשימות בדיקה",
+  "dashboard_checklists_preDiveLabel": "לפני צלילה",
+  "dashboard_checklists_tripLabel": "טיול: {name}",
+  "@dashboard_checklists_tripLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_startedAt": "התחילה {when}",
+  "@preDive_sessions_startedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_completedAt": "הושלמה {when}",
+  "@preDive_sessions_completedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_abortedAt": "בוטלה {when}",
+  "@preDive_sessions_abortedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
   "trips_detail_preDive_action": "רשימת בדיקה לפני צלילה",
   "settings_manage_preDiveChecklists": "רשימות בדיקה לפני צלילה",
   "settings_manage_preDiveChecklists_subtitle": "בדיקות באדי, רשימות הרכבת CCR, אריזת ציוד",
@@ -6570,7 +6607,7 @@
   "settings_homeCards_resetDialog_confirm": "איפוס",
   "settings_homeCards_card_hero": "כותרת פתיחה",
   "settings_homeCards_card_gaugeStrip": "שבבי מצב",
-  "settings_homeCards_card_preDive": "רשימת בדיקה לפני צלילה",
+  "settings_homeCards_card_preDive": "רשימות בדיקה",
   "settings_homeCards_card_recentDives": "צלילות אחרונות",
   "settings_homeCards_card_quickActions": "פעולות מהירות",
   "settings_homeCards_card_milestones": "אבני דרך",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1077,6 +1077,43 @@
     }
   },
   "preDive_dashboard_start": "Merülés előtti ellenőrzés indítása",
+  "preDive_templates_view": "Megtekintés",
+  "preDive_edit_titleView": "Merülés előtti ellenőrzőlista megtekintése",
+  "preDive_edit_builtInNotice": "Beépített ellenőrzőlista. Duplikálja szerkeszthető másolat készítéséhez.",
+  "dashboard_checklists_title": "Ellenőrzőlisták",
+  "dashboard_checklists_preDiveLabel": "Merülés előtt",
+  "dashboard_checklists_tripLabel": "Utazás: {name}",
+  "@dashboard_checklists_tripLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_startedAt": "Elkezdve: {when}",
+  "@preDive_sessions_startedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_completedAt": "Befejezve: {when}",
+  "@preDive_sessions_completedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_abortedAt": "Megszakítva: {when}",
+  "@preDive_sessions_abortedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
   "trips_detail_preDive_action": "Merülés előtti ellenőrzőlista",
   "settings_manage_preDiveChecklists": "Merülés előtti ellenőrzőlisták",
   "settings_manage_preDiveChecklists_subtitle": "Társellenőrzések, CCR összeszerelési listák, felszereléscsomagolás",
@@ -6570,7 +6607,7 @@
   "settings_homeCards_resetDialog_confirm": "Visszaállítás",
   "settings_homeCards_card_hero": "Üdvözlő fejléc",
   "settings_homeCards_card_gaugeStrip": "Állapotjelzők",
-  "settings_homeCards_card_preDive": "Merülés előtti ellenőrzőlista",
+  "settings_homeCards_card_preDive": "Ellenőrzőlisták",
   "settings_homeCards_card_recentDives": "Legutóbbi merülések",
   "settings_homeCards_card_quickActions": "Gyorsműveletek",
   "settings_homeCards_card_milestones": "Mérföldkövek",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1077,6 +1077,43 @@
     }
   },
   "preDive_dashboard_start": "Avvia controllo pre-immersione",
+  "preDive_templates_view": "Visualizza",
+  "preDive_edit_titleView": "Visualizza checklist pre-immersione",
+  "preDive_edit_builtInNotice": "Checklist predefinita. Duplicala per ottenere una copia modificabile.",
+  "dashboard_checklists_title": "Checklist",
+  "dashboard_checklists_preDiveLabel": "Pre-immersione",
+  "dashboard_checklists_tripLabel": "Viaggio: {name}",
+  "@dashboard_checklists_tripLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_startedAt": "Iniziata {when}",
+  "@preDive_sessions_startedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_completedAt": "Completata {when}",
+  "@preDive_sessions_completedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_abortedAt": "Interrotta {when}",
+  "@preDive_sessions_abortedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
   "trips_detail_preDive_action": "Checklist pre-immersione",
   "settings_manage_preDiveChecklists": "Checklist pre-immersione",
   "settings_manage_preDiveChecklists_subtitle": "Buddy check, liste di montaggio CCR, preparazione attrezzatura",
@@ -6570,7 +6607,7 @@
   "settings_homeCards_resetDialog_confirm": "Ripristina",
   "settings_homeCards_card_hero": "Intestazione di benvenuto",
   "settings_homeCards_card_gaugeStrip": "Chip di stato",
-  "settings_homeCards_card_preDive": "Checklist pre-immersione",
+  "settings_homeCards_card_preDive": "Checklist",
   "settings_homeCards_card_recentDives": "Immersioni recenti",
   "settings_homeCards_card_quickActions": "Azioni rapide",
   "settings_homeCards_card_milestones": "Traguardi",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -4457,6 +4457,60 @@ abstract class AppLocalizations {
   /// **'Start pre-dive check'**
   String get preDive_dashboard_start;
 
+  /// No description provided for @preDive_templates_view.
+  ///
+  /// In en, this message translates to:
+  /// **'View'**
+  String get preDive_templates_view;
+
+  /// No description provided for @preDive_edit_titleView.
+  ///
+  /// In en, this message translates to:
+  /// **'View Pre-Dive Checklist'**
+  String get preDive_edit_titleView;
+
+  /// No description provided for @preDive_edit_builtInNotice.
+  ///
+  /// In en, this message translates to:
+  /// **'Built-in checklist. Clone it to make an editable copy.'**
+  String get preDive_edit_builtInNotice;
+
+  /// No description provided for @dashboard_checklists_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Checklists'**
+  String get dashboard_checklists_title;
+
+  /// No description provided for @dashboard_checklists_preDiveLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Pre-dive'**
+  String get dashboard_checklists_preDiveLabel;
+
+  /// No description provided for @dashboard_checklists_tripLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Trip: {name}'**
+  String dashboard_checklists_tripLabel(String name);
+
+  /// No description provided for @preDive_sessions_startedAt.
+  ///
+  /// In en, this message translates to:
+  /// **'Started {when}'**
+  String preDive_sessions_startedAt(String when);
+
+  /// No description provided for @preDive_sessions_completedAt.
+  ///
+  /// In en, this message translates to:
+  /// **'Completed {when}'**
+  String preDive_sessions_completedAt(String when);
+
+  /// No description provided for @preDive_sessions_abortedAt.
+  ///
+  /// In en, this message translates to:
+  /// **'Aborted {when}'**
+  String preDive_sessions_abortedAt(String when);
+
   /// No description provided for @trips_detail_preDive_action.
   ///
   /// In en, this message translates to:
@@ -5666,7 +5720,7 @@ abstract class AppLocalizations {
   /// No description provided for @settings_homeCards_card_preDive.
   ///
   /// In en, this message translates to:
-  /// **'Pre-dive checklist'**
+  /// **'Checklists'**
   String get settings_homeCards_card_preDive;
 
   /// No description provided for @settings_homeCards_card_recentDives.

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -2597,6 +2597,42 @@ class AppLocalizationsAr extends AppLocalizations {
   String get preDive_dashboard_start => 'بدء فحص ما قبل الغوص';
 
   @override
+  String get preDive_templates_view => 'عرض';
+
+  @override
+  String get preDive_edit_titleView => 'عرض قائمة تحقق ما قبل الغوص';
+
+  @override
+  String get preDive_edit_builtInNotice =>
+      'قائمة تحقق مدمجة. استنسخها للحصول على نسخة قابلة للتعديل.';
+
+  @override
+  String get dashboard_checklists_title => 'قوائم التحقق';
+
+  @override
+  String get dashboard_checklists_preDiveLabel => 'ما قبل الغوص';
+
+  @override
+  String dashboard_checklists_tripLabel(String name) {
+    return 'الرحلة: $name';
+  }
+
+  @override
+  String preDive_sessions_startedAt(String when) {
+    return 'بدأت $when';
+  }
+
+  @override
+  String preDive_sessions_completedAt(String when) {
+    return 'اكتملت $when';
+  }
+
+  @override
+  String preDive_sessions_abortedAt(String when) {
+    return 'أُلغيت $when';
+  }
+
+  @override
   String get trips_detail_preDive_action => 'قائمة تحقق ما قبل الغوص';
 
   @override
@@ -3284,7 +3320,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settings_homeCards_card_gaugeStrip => 'شرائح الحالة';
 
   @override
-  String get settings_homeCards_card_preDive => 'قائمة فحص ما قبل الغوص';
+  String get settings_homeCards_card_preDive => 'قوائم التحقق';
 
   @override
   String get settings_homeCards_card_recentDives => 'الغوصات الأخيرة';

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -2656,6 +2656,42 @@ class AppLocalizationsDe extends AppLocalizations {
   String get preDive_dashboard_start => 'Check vor dem Tauchgang starten';
 
   @override
+  String get preDive_templates_view => 'Ansehen';
+
+  @override
+  String get preDive_edit_titleView => 'Checkliste vor dem Tauchgang ansehen';
+
+  @override
+  String get preDive_edit_builtInNotice =>
+      'Integrierte Checkliste. Duplizieren, um eine bearbeitbare Kopie zu erhalten.';
+
+  @override
+  String get dashboard_checklists_title => 'Checklisten';
+
+  @override
+  String get dashboard_checklists_preDiveLabel => 'Vor dem Tauchgang';
+
+  @override
+  String dashboard_checklists_tripLabel(String name) {
+    return 'Reise: $name';
+  }
+
+  @override
+  String preDive_sessions_startedAt(String when) {
+    return 'Begonnen $when';
+  }
+
+  @override
+  String preDive_sessions_completedAt(String when) {
+    return 'Abgeschlossen $when';
+  }
+
+  @override
+  String preDive_sessions_abortedAt(String when) {
+    return 'Abgebrochen $when';
+  }
+
+  @override
   String get trips_detail_preDive_action => 'Checkliste vor dem Tauchgang';
 
   @override
@@ -3361,7 +3397,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_homeCards_card_gaugeStrip => 'Status-Chips';
 
   @override
-  String get settings_homeCards_card_preDive => 'Pre-Dive-Checkliste';
+  String get settings_homeCards_card_preDive => 'Checklisten';
 
   @override
   String get settings_homeCards_card_recentDives => 'Letzte Tauchgänge';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -2599,6 +2599,42 @@ class AppLocalizationsEn extends AppLocalizations {
   String get preDive_dashboard_start => 'Start pre-dive check';
 
   @override
+  String get preDive_templates_view => 'View';
+
+  @override
+  String get preDive_edit_titleView => 'View Pre-Dive Checklist';
+
+  @override
+  String get preDive_edit_builtInNotice =>
+      'Built-in checklist. Clone it to make an editable copy.';
+
+  @override
+  String get dashboard_checklists_title => 'Checklists';
+
+  @override
+  String get dashboard_checklists_preDiveLabel => 'Pre-dive';
+
+  @override
+  String dashboard_checklists_tripLabel(String name) {
+    return 'Trip: $name';
+  }
+
+  @override
+  String preDive_sessions_startedAt(String when) {
+    return 'Started $when';
+  }
+
+  @override
+  String preDive_sessions_completedAt(String when) {
+    return 'Completed $when';
+  }
+
+  @override
+  String preDive_sessions_abortedAt(String when) {
+    return 'Aborted $when';
+  }
+
+  @override
   String get trips_detail_preDive_action => 'Pre-dive checklist';
 
   @override
@@ -3288,7 +3324,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_homeCards_card_gaugeStrip => 'Status chips';
 
   @override
-  String get settings_homeCards_card_preDive => 'Pre-dive checklist';
+  String get settings_homeCards_card_preDive => 'Checklists';
 
   @override
   String get settings_homeCards_card_recentDives => 'Recent dives';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -2653,6 +2653,42 @@ class AppLocalizationsEs extends AppLocalizations {
       'Iniciar comprobación previa a la inmersión';
 
   @override
+  String get preDive_templates_view => 'Ver';
+
+  @override
+  String get preDive_edit_titleView => 'Ver lista previa a la inmersión';
+
+  @override
+  String get preDive_edit_builtInNotice =>
+      'Lista integrada. Duplícala para obtener una copia editable.';
+
+  @override
+  String get dashboard_checklists_title => 'Listas de verificación';
+
+  @override
+  String get dashboard_checklists_preDiveLabel => 'Previa a la inmersión';
+
+  @override
+  String dashboard_checklists_tripLabel(String name) {
+    return 'Viaje: $name';
+  }
+
+  @override
+  String preDive_sessions_startedAt(String when) {
+    return 'Iniciada $when';
+  }
+
+  @override
+  String preDive_sessions_completedAt(String when) {
+    return 'Completada $when';
+  }
+
+  @override
+  String preDive_sessions_abortedAt(String when) {
+    return 'Cancelada $when';
+  }
+
+  @override
   String get trips_detail_preDive_action => 'Lista previa a la inmersión';
 
   @override
@@ -3351,7 +3387,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_homeCards_card_gaugeStrip => 'Chips de estado';
 
   @override
-  String get settings_homeCards_card_preDive => 'Lista previa a la inmersión';
+  String get settings_homeCards_card_preDive => 'Listas de verificación';
 
   @override
   String get settings_homeCards_card_recentDives => 'Inmersiones recientes';

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -2656,6 +2656,42 @@ class AppLocalizationsFr extends AppLocalizations {
   String get preDive_dashboard_start => 'Démarrer la vérification pré-plongée';
 
   @override
+  String get preDive_templates_view => 'Afficher';
+
+  @override
+  String get preDive_edit_titleView => 'Afficher la checklist pré-plongée';
+
+  @override
+  String get preDive_edit_builtInNotice =>
+      'Checklist intégrée. Dupliquez-la pour obtenir une copie modifiable.';
+
+  @override
+  String get dashboard_checklists_title => 'Checklists';
+
+  @override
+  String get dashboard_checklists_preDiveLabel => 'Pré-plongée';
+
+  @override
+  String dashboard_checklists_tripLabel(String name) {
+    return 'Voyage : $name';
+  }
+
+  @override
+  String preDive_sessions_startedAt(String when) {
+    return 'Commencée $when';
+  }
+
+  @override
+  String preDive_sessions_completedAt(String when) {
+    return 'Terminée $when';
+  }
+
+  @override
+  String preDive_sessions_abortedAt(String when) {
+    return 'Interrompue $when';
+  }
+
+  @override
   String get trips_detail_preDive_action => 'Checklist pré-plongée';
 
   @override
@@ -3361,7 +3397,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_homeCards_card_gaugeStrip => 'Pastilles d\'état';
 
   @override
-  String get settings_homeCards_card_preDive => 'Check-list pré-plongée';
+  String get settings_homeCards_card_preDive => 'Checklists';
 
   @override
   String get settings_homeCards_card_recentDives => 'Plongées récentes';

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -2575,6 +2575,42 @@ class AppLocalizationsHe extends AppLocalizations {
   String get preDive_dashboard_start => 'התחל בדיקה לפני צלילה';
 
   @override
+  String get preDive_templates_view => 'הצגה';
+
+  @override
+  String get preDive_edit_titleView => 'הצגת רשימת בדיקה לפני צלילה';
+
+  @override
+  String get preDive_edit_builtInNotice =>
+      'רשימת בדיקה מובנית. שכפלו אותה כדי ליצור עותק הניתן לעריכה.';
+
+  @override
+  String get dashboard_checklists_title => 'רשימות בדיקה';
+
+  @override
+  String get dashboard_checklists_preDiveLabel => 'לפני צלילה';
+
+  @override
+  String dashboard_checklists_tripLabel(String name) {
+    return 'טיול: $name';
+  }
+
+  @override
+  String preDive_sessions_startedAt(String when) {
+    return 'התחילה $when';
+  }
+
+  @override
+  String preDive_sessions_completedAt(String when) {
+    return 'הושלמה $when';
+  }
+
+  @override
+  String preDive_sessions_abortedAt(String when) {
+    return 'בוטלה $when';
+  }
+
+  @override
   String get trips_detail_preDive_action => 'רשימת בדיקה לפני צלילה';
 
   @override
@@ -3259,7 +3295,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settings_homeCards_card_gaugeStrip => 'שבבי מצב';
 
   @override
-  String get settings_homeCards_card_preDive => 'רשימת בדיקה לפני צלילה';
+  String get settings_homeCards_card_preDive => 'רשימות בדיקה';
 
   @override
   String get settings_homeCards_card_recentDives => 'צלילות אחרונות';

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -2638,6 +2638,43 @@ class AppLocalizationsHu extends AppLocalizations {
   String get preDive_dashboard_start => 'Merülés előtti ellenőrzés indítása';
 
   @override
+  String get preDive_templates_view => 'Megtekintés';
+
+  @override
+  String get preDive_edit_titleView =>
+      'Merülés előtti ellenőrzőlista megtekintése';
+
+  @override
+  String get preDive_edit_builtInNotice =>
+      'Beépített ellenőrzőlista. Duplikálja szerkeszthető másolat készítéséhez.';
+
+  @override
+  String get dashboard_checklists_title => 'Ellenőrzőlisták';
+
+  @override
+  String get dashboard_checklists_preDiveLabel => 'Merülés előtt';
+
+  @override
+  String dashboard_checklists_tripLabel(String name) {
+    return 'Utazás: $name';
+  }
+
+  @override
+  String preDive_sessions_startedAt(String when) {
+    return 'Elkezdve: $when';
+  }
+
+  @override
+  String preDive_sessions_completedAt(String when) {
+    return 'Befejezve: $when';
+  }
+
+  @override
+  String preDive_sessions_abortedAt(String when) {
+    return 'Megszakítva: $when';
+  }
+
+  @override
   String get trips_detail_preDive_action => 'Merülés előtti ellenőrzőlista';
 
   @override
@@ -3337,7 +3374,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get settings_homeCards_card_gaugeStrip => 'Állapotjelzők';
 
   @override
-  String get settings_homeCards_card_preDive => 'Merülés előtti ellenőrzőlista';
+  String get settings_homeCards_card_preDive => 'Ellenőrzőlisták';
 
   @override
   String get settings_homeCards_card_recentDives => 'Legutóbbi merülések';

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -2649,6 +2649,42 @@ class AppLocalizationsIt extends AppLocalizations {
   String get preDive_dashboard_start => 'Avvia controllo pre-immersione';
 
   @override
+  String get preDive_templates_view => 'Visualizza';
+
+  @override
+  String get preDive_edit_titleView => 'Visualizza checklist pre-immersione';
+
+  @override
+  String get preDive_edit_builtInNotice =>
+      'Checklist predefinita. Duplicala per ottenere una copia modificabile.';
+
+  @override
+  String get dashboard_checklists_title => 'Checklist';
+
+  @override
+  String get dashboard_checklists_preDiveLabel => 'Pre-immersione';
+
+  @override
+  String dashboard_checklists_tripLabel(String name) {
+    return 'Viaggio: $name';
+  }
+
+  @override
+  String preDive_sessions_startedAt(String when) {
+    return 'Iniziata $when';
+  }
+
+  @override
+  String preDive_sessions_completedAt(String when) {
+    return 'Completata $when';
+  }
+
+  @override
+  String preDive_sessions_abortedAt(String when) {
+    return 'Interrotta $when';
+  }
+
+  @override
   String get trips_detail_preDive_action => 'Checklist pre-immersione';
 
   @override
@@ -3350,7 +3386,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_homeCards_card_gaugeStrip => 'Chip di stato';
 
   @override
-  String get settings_homeCards_card_preDive => 'Checklist pre-immersione';
+  String get settings_homeCards_card_preDive => 'Checklist';
 
   @override
   String get settings_homeCards_card_recentDives => 'Immersioni recenti';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -2631,6 +2631,42 @@ class AppLocalizationsNl extends AppLocalizations {
   String get preDive_dashboard_start => 'Pre-dive check starten';
 
   @override
+  String get preDive_templates_view => 'Bekijken';
+
+  @override
+  String get preDive_edit_titleView => 'Pre-dive checklist bekijken';
+
+  @override
+  String get preDive_edit_builtInNotice =>
+      'Ingebouwde checklist. Dupliceer deze voor een bewerkbare kopie.';
+
+  @override
+  String get dashboard_checklists_title => 'Checklists';
+
+  @override
+  String get dashboard_checklists_preDiveLabel => 'Pre-dive';
+
+  @override
+  String dashboard_checklists_tripLabel(String name) {
+    return 'Reis: $name';
+  }
+
+  @override
+  String preDive_sessions_startedAt(String when) {
+    return 'Gestart $when';
+  }
+
+  @override
+  String preDive_sessions_completedAt(String when) {
+    return 'Voltooid $when';
+  }
+
+  @override
+  String preDive_sessions_abortedAt(String when) {
+    return 'Afgebroken $when';
+  }
+
+  @override
   String get trips_detail_preDive_action => 'Pre-dive checklist';
 
   @override
@@ -3327,7 +3363,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settings_homeCards_card_gaugeStrip => 'Statuschips';
 
   @override
-  String get settings_homeCards_card_preDive => 'Pre-dive checklist';
+  String get settings_homeCards_card_preDive => 'Checklists';
 
   @override
   String get settings_homeCards_card_recentDives => 'Recente duiken';

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -2649,6 +2649,42 @@ class AppLocalizationsPt extends AppLocalizations {
   String get preDive_dashboard_start => 'Iniciar verificação pré-mergulho';
 
   @override
+  String get preDive_templates_view => 'Ver';
+
+  @override
+  String get preDive_edit_titleView => 'Ver Lista de Verificação Pré-Mergulho';
+
+  @override
+  String get preDive_edit_builtInNotice =>
+      'Lista integrada. Duplique-a para obter uma cópia editável.';
+
+  @override
+  String get dashboard_checklists_title => 'Listas de verificação';
+
+  @override
+  String get dashboard_checklists_preDiveLabel => 'Pré-mergulho';
+
+  @override
+  String dashboard_checklists_tripLabel(String name) {
+    return 'Viagem: $name';
+  }
+
+  @override
+  String preDive_sessions_startedAt(String when) {
+    return 'Iniciada $when';
+  }
+
+  @override
+  String preDive_sessions_completedAt(String when) {
+    return 'Concluída $when';
+  }
+
+  @override
+  String preDive_sessions_abortedAt(String when) {
+    return 'Cancelada $when';
+  }
+
+  @override
   String get trips_detail_preDive_action => 'Lista de verificação pré-mergulho';
 
   @override
@@ -3351,7 +3387,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settings_homeCards_card_gaugeStrip => 'Chips de estado';
 
   @override
-  String get settings_homeCards_card_preDive => 'Checklist pré-mergulho';
+  String get settings_homeCards_card_preDive => 'Listas de verificação';
 
   @override
   String get settings_homeCards_card_recentDives => 'Mergulhos recentes';

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -2498,6 +2498,41 @@ class AppLocalizationsZh extends AppLocalizations {
   String get preDive_dashboard_start => '开始潜前检查';
 
   @override
+  String get preDive_templates_view => '查看';
+
+  @override
+  String get preDive_edit_titleView => '查看潜前检查清单';
+
+  @override
+  String get preDive_edit_builtInNotice => '内置检查清单。复制后即可编辑。';
+
+  @override
+  String get dashboard_checklists_title => '检查清单';
+
+  @override
+  String get dashboard_checklists_preDiveLabel => '潜前';
+
+  @override
+  String dashboard_checklists_tripLabel(String name) {
+    return '行程：$name';
+  }
+
+  @override
+  String preDive_sessions_startedAt(String when) {
+    return '开始于 $when';
+  }
+
+  @override
+  String preDive_sessions_completedAt(String when) {
+    return '完成于 $when';
+  }
+
+  @override
+  String preDive_sessions_abortedAt(String when) {
+    return '中止于 $when';
+  }
+
+  @override
   String get trips_detail_preDive_action => '潜前检查清单';
 
   @override
@@ -3173,7 +3208,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_homeCards_card_gaugeStrip => '状态标签';
 
   @override
-  String get settings_homeCards_card_preDive => '潜水前检查清单';
+  String get settings_homeCards_card_preDive => '检查清单';
 
   @override
   String get settings_homeCards_card_recentDives => '最近潜水';

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1077,6 +1077,43 @@
     }
   },
   "preDive_dashboard_start": "Pre-dive check starten",
+  "preDive_templates_view": "Bekijken",
+  "preDive_edit_titleView": "Pre-dive checklist bekijken",
+  "preDive_edit_builtInNotice": "Ingebouwde checklist. Dupliceer deze voor een bewerkbare kopie.",
+  "dashboard_checklists_title": "Checklists",
+  "dashboard_checklists_preDiveLabel": "Pre-dive",
+  "dashboard_checklists_tripLabel": "Reis: {name}",
+  "@dashboard_checklists_tripLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_startedAt": "Gestart {when}",
+  "@preDive_sessions_startedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_completedAt": "Voltooid {when}",
+  "@preDive_sessions_completedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_abortedAt": "Afgebroken {when}",
+  "@preDive_sessions_abortedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
   "trips_detail_preDive_action": "Pre-dive checklist",
   "settings_manage_preDiveChecklists": "Pre-dive checklists",
   "settings_manage_preDiveChecklists_subtitle": "Buddychecks, CCR-opbouwlijsten, uitrusting inpakken",
@@ -6570,7 +6607,7 @@
   "settings_homeCards_resetDialog_confirm": "Herstellen",
   "settings_homeCards_card_hero": "Welkomstkop",
   "settings_homeCards_card_gaugeStrip": "Statuschips",
-  "settings_homeCards_card_preDive": "Pre-dive checklist",
+  "settings_homeCards_card_preDive": "Checklists",
   "settings_homeCards_card_recentDives": "Recente duiken",
   "settings_homeCards_card_quickActions": "Snelle acties",
   "settings_homeCards_card_milestones": "Mijlpalen",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1077,6 +1077,43 @@
     }
   },
   "preDive_dashboard_start": "Iniciar verificação pré-mergulho",
+  "preDive_templates_view": "Ver",
+  "preDive_edit_titleView": "Ver Lista de Verificação Pré-Mergulho",
+  "preDive_edit_builtInNotice": "Lista integrada. Duplique-a para obter uma cópia editável.",
+  "dashboard_checklists_title": "Listas de verificação",
+  "dashboard_checklists_preDiveLabel": "Pré-mergulho",
+  "dashboard_checklists_tripLabel": "Viagem: {name}",
+  "@dashboard_checklists_tripLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_startedAt": "Iniciada {when}",
+  "@preDive_sessions_startedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_completedAt": "Concluída {when}",
+  "@preDive_sessions_completedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_abortedAt": "Cancelada {when}",
+  "@preDive_sessions_abortedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
   "trips_detail_preDive_action": "Lista de verificação pré-mergulho",
   "settings_manage_preDiveChecklists": "Listas de Verificação Pré-Mergulho",
   "settings_manage_preDiveChecklists_subtitle": "Verificações de dupla, listas de montagem de CCR, preparação de equipamento",
@@ -6570,7 +6607,7 @@
   "settings_homeCards_resetDialog_confirm": "Repor",
   "settings_homeCards_card_hero": "Cabeçalho de boas-vindas",
   "settings_homeCards_card_gaugeStrip": "Chips de estado",
-  "settings_homeCards_card_preDive": "Checklist pré-mergulho",
+  "settings_homeCards_card_preDive": "Listas de verificação",
   "settings_homeCards_card_recentDives": "Mergulhos recentes",
   "settings_homeCards_card_quickActions": "Ações rápidas",
   "settings_homeCards_card_milestones": "Marcos",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1171,6 +1171,43 @@
     }
   },
   "preDive_dashboard_start": "开始潜前检查",
+  "preDive_templates_view": "查看",
+  "preDive_edit_titleView": "查看潜前检查清单",
+  "preDive_edit_builtInNotice": "内置检查清单。复制后即可编辑。",
+  "dashboard_checklists_title": "检查清单",
+  "dashboard_checklists_preDiveLabel": "潜前",
+  "dashboard_checklists_tripLabel": "行程：{name}",
+  "@dashboard_checklists_tripLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_startedAt": "开始于 {when}",
+  "@preDive_sessions_startedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_completedAt": "完成于 {when}",
+  "@preDive_sessions_completedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_sessions_abortedAt": "中止于 {when}",
+  "@preDive_sessions_abortedAt": {
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
   "trips_detail_preDive_action": "潜前检查清单",
   "settings_manage_preDiveChecklists": "潜前检查清单",
   "settings_manage_preDiveChecklists_subtitle": "潜伴检查、CCR 组装清单、装备打包",
@@ -6570,7 +6607,7 @@
   "settings_homeCards_resetDialog_confirm": "重置",
   "settings_homeCards_card_hero": "欢迎页眉",
   "settings_homeCards_card_gaugeStrip": "状态标签",
-  "settings_homeCards_card_preDive": "潜水前检查清单",
+  "settings_homeCards_card_preDive": "检查清单",
   "settings_homeCards_card_recentDives": "最近潜水",
   "settings_homeCards_card_quickActions": "快捷操作",
   "settings_homeCards_card_milestones": "里程碑",

--- a/test/core/database/pre_dive_builtin_seed_test.dart
+++ b/test/core/database/pre_dive_builtin_seed_test.dart
@@ -91,4 +91,73 @@ void main() {
       expect(all.first['n'], 4);
     },
   );
+
+  test('GUE EDGE seeds the canonical seven-point sequence in order', () async {
+    await rows('SELECT 1');
+    final items = await rows(
+      'SELECT id, title, sort_order FROM pre_dive_checklist_template_items '
+      "WHERE template_id = 'builtin-predive-gue-edge' ORDER BY sort_order",
+    );
+    expect(items.map((i) => i['id']).toList(), [
+      for (var i = 0; i < 7; i++) 'builtin-predive-gue-edge-$i',
+    ]);
+    // G-U-E E-D-G-E: the mnemonic is the sequence, so the first word of each
+    // title is the assertion.
+    expect(
+      items
+          .map((i) => (i['title']! as String).split(':').first.toLowerCase())
+          .toList(),
+      [
+        'goal',
+        'unified team',
+        'equipment',
+        'exposure',
+        'decompression',
+        'gas',
+        'environment',
+      ],
+    );
+    expect(items.map((i) => i['sort_order']).toList(), [0, 1, 2, 3, 4, 5, 6]);
+  });
+
+  test('re-seed retires the legacy four-item GUE EDGE list', () async {
+    final db = DatabaseService.instance.database;
+    // Recreate a pre-repair database: the canonical rows gone, the legacy
+    // ids present.
+    await db.customStatement(
+      "DELETE FROM pre_dive_checklist_template_items "
+      "WHERE template_id = 'builtin-predive-gue-edge'",
+    );
+    for (var i = 0; i < 4; i++) {
+      await db.customStatement(
+        'INSERT INTO pre_dive_checklist_template_items '
+        '(id, template_id, title, sort_order, item_type, is_required, '
+        'created_at, updated_at) VALUES '
+        "('builtin-predive-gue-$i', 'builtin-predive-gue-edge', "
+        "'Legacy $i', $i, 'check', 1, 0, 0)",
+      );
+    }
+    // Simulate the next open's beforeOpen re-seed.
+    await db.customStatement(kRetireLegacyGueEdgeItemsSql);
+    await db.customStatement(kSeedBuiltInPreDiveTemplateItemsSql);
+
+    final items = await rows(
+      'SELECT id FROM pre_dive_checklist_template_items '
+      "WHERE template_id = 'builtin-predive-gue-edge' ORDER BY sort_order",
+    );
+    expect(items, hasLength(7));
+    expect(
+      items.map((i) => i['id']).where((id) => id == 'builtin-predive-gue-0'),
+      isEmpty,
+    );
+
+    // Running the pair again is a no-op, not a duplication.
+    await db.customStatement(kRetireLegacyGueEdgeItemsSql);
+    await db.customStatement(kSeedBuiltInPreDiveTemplateItemsSql);
+    final again = await rows(
+      'SELECT COUNT(*) AS n FROM pre_dive_checklist_template_items '
+      "WHERE template_id = 'builtin-predive-gue-edge'",
+    );
+    expect(again.first['n'], 7);
+  });
 }

--- a/test/features/checklists/data/repositories/trip_checklist_repository_test.dart
+++ b/test/features/checklists/data/repositories/trip_checklist_repository_test.dart
@@ -291,6 +291,58 @@ void main() {
       expect(progress.total, 2);
     });
 
+    test('getProgressForTrips batches counts and omits empty trips', () async {
+      final other = await tripRepository.createTrip(
+        Trip(
+          id: '',
+          name: 'Truk',
+          startDate: tripStart.add(const Duration(days: 40)),
+          endDate: tripStart.add(const Duration(days: 47)),
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      );
+      final empty = await tripRepository.createTrip(
+        Trip(
+          id: '',
+          name: 'Nothing packed yet',
+          startDate: tripStart.add(const Duration(days: 80)),
+          endDate: tripStart.add(const Duration(days: 87)),
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      );
+
+      final a = await repository.createItem(item(title: 'A'));
+      await repository.createItem(item(title: 'B'));
+      await repository.toggleDone(a.id, isDone: true);
+      await repository.createItem(
+        TripChecklistItem(
+          id: '',
+          tripId: other.id,
+          title: 'Passport',
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      );
+
+      final progress = await repository.getProgressForTrips([
+        testTrip.id,
+        other.id,
+        empty.id,
+      ]);
+
+      expect(progress[testTrip.id], (done: 1, total: 2));
+      expect(progress[other.id], (done: 0, total: 1));
+      // GROUP BY yields no row for a trip with no items, and callers read
+      // that absence as "nothing to show".
+      expect(progress.containsKey(empty.id), isFalse);
+    });
+
+    test('getProgressForTrips on an empty id list is a no-op', () async {
+      expect(await repository.getProgressForTrips([]), isEmpty);
+    });
+
     test('deleteByTripId removes all items', () async {
       await repository.createItem(item(title: 'A'));
       await repository.createItem(item(title: 'B'));

--- a/test/features/checklists/presentation/providers/checklist_providers_test.dart
+++ b/test/features/checklists/presentation/providers/checklist_providers_test.dart
@@ -127,4 +127,98 @@ void main() {
     );
     expect(items.map((i) => i.title).toList(), ['Wetsuit']);
   });
+
+  group('homeTripChecklistProvider', () {
+    Future<Trip> makeTrip(String name, DateTime start, DateTime end) =>
+        TripRepository().createTrip(
+          Trip(
+            id: '',
+            name: name,
+            startDate: start,
+            endDate: end,
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+
+    Future<void> addItem(ProviderContainer c, String tripId) async {
+      await c
+          .read(tripChecklistRepositoryProvider)
+          .createItem(
+            TripChecklistItem(
+              id: '',
+              tripId: tripId,
+              title: 'Pack regs',
+              createdAt: DateTime.now(),
+              updatedAt: DateTime.now(),
+            ),
+          );
+    }
+
+    test('surfaces the next upcoming trip that has items', () async {
+      final now = DateTime.now();
+      final soon = await makeTrip(
+        'Soon',
+        now.add(const Duration(days: 7)),
+        now.add(const Duration(days: 14)),
+      );
+      await makeTrip(
+        'Later',
+        now.add(const Duration(days: 60)),
+        now.add(const Duration(days: 67)),
+      );
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      await addItem(container, soon.id);
+
+      final result = await container.read(homeTripChecklistProvider.future);
+      expect(result, isNotNull);
+      expect(result!.trip.id, soon.id);
+      expect(result.total, 1);
+      expect(result.done, 0);
+    });
+
+    test('a trip already under way wins over one still ahead', () async {
+      final now = DateTime.now();
+      final running = await makeTrip(
+        'Running',
+        now.subtract(const Duration(days: 1)),
+        now.add(const Duration(days: 3)),
+      );
+      final ahead = await makeTrip(
+        'Ahead',
+        now.add(const Duration(days: 2)),
+        now.add(const Duration(days: 9)),
+      );
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      await addItem(container, running.id);
+      await addItem(container, ahead.id);
+
+      final result = await container.read(homeTripChecklistProvider.future);
+      expect(result!.trip.id, running.id);
+    });
+
+    test('a trip with an empty checklist is not surfaced', () async {
+      final now = DateTime.now();
+      await makeTrip(
+        'Empty',
+        now.add(const Duration(days: 5)),
+        now.add(const Duration(days: 12)),
+      );
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      expect(await container.read(homeTripChecklistProvider.future), isNull);
+    });
+
+    test('no trips at all is null, not an error', () async {
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      expect(await container.read(homeTripChecklistProvider.future), isNull);
+    });
+  });
 }

--- a/test/features/checklists/presentation/providers/checklist_providers_test.dart
+++ b/test/features/checklists/presentation/providers/checklist_providers_test.dart
@@ -201,6 +201,56 @@ void main() {
       expect(result!.trip.id, running.id);
     });
 
+    test('an empty nearer trip does not hide a later one with items', () async {
+      // The date-best candidate has nothing on its list. Picking by date and
+      // only then checking for items returned null here and hid the home row
+      // even though a perfectly good checklist existed one trip along.
+      final now = DateTime.now();
+      await makeTrip(
+        'Empty and sooner',
+        now.add(const Duration(days: 3)),
+        now.add(const Duration(days: 6)),
+      );
+      final later = await makeTrip(
+        'Stocked and later',
+        now.add(const Duration(days: 30)),
+        now.add(const Duration(days: 37)),
+      );
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      await addItem(container, later.id);
+
+      final result = await container.read(homeTripChecklistProvider.future);
+      expect(result, isNotNull);
+      expect(result!.trip.id, later.id);
+      expect(result.total, 1);
+    });
+
+    test(
+      'an empty in-progress trip falls through to an upcoming one',
+      () async {
+        final now = DateTime.now();
+        await makeTrip(
+          'Running but empty',
+          now.subtract(const Duration(days: 1)),
+          now.add(const Duration(days: 3)),
+        );
+        final ahead = await makeTrip(
+          'Ahead with items',
+          now.add(const Duration(days: 10)),
+          now.add(const Duration(days: 17)),
+        );
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+        await addItem(container, ahead.id);
+
+        final result = await container.read(homeTripChecklistProvider.future);
+        expect(result!.trip.id, ahead.id);
+      },
+    );
+
     test('a trip with an empty checklist is not surfaced', () async {
       final now = DateTime.now();
       await makeTrip(

--- a/test/features/pre_dive/data/services/checklist_dive_linker_test.dart
+++ b/test/features/pre_dive/data/services/checklist_dive_linker_test.dart
@@ -48,6 +48,7 @@ void main() {
   Future<domain.PreDiveSession> sessionStartedAt(
     DateTime t, {
     String? diverId,
+    DateTime? completedAt,
   }) async {
     final s = await sessions.startSession(
       template: template(),
@@ -59,6 +60,14 @@ void main() {
       'UPDATE pre_dive_sessions SET started_at = ${t.millisecondsSinceEpoch} '
       "WHERE id = '${s.id}'",
     );
+    if (completedAt != null) {
+      await db.customStatement(
+        'UPDATE pre_dive_sessions SET '
+        "status = 'completed', "
+        'completed_at = ${completedAt.millisecondsSinceEpoch} '
+        "WHERE id = '${s.id}'",
+      );
+    }
     return (await sessions.getSessionById(s.id))!;
   }
 
@@ -131,5 +140,72 @@ void main() {
     );
     expect(linked, isTrue);
     expect((await sessions.getSessionById(s.id))!.diveId, 'dive-1');
+  });
+
+  group('the window is anchored on completion, not start', () {
+    test(
+      'a long run that finished just before the splash still links',
+      () async {
+        // Started 4 h out (outside the window on startedAt) but ticked off its
+        // last item 20 min before the dive: it is this dive's checklist.
+        final s = await sessionStartedAt(
+          diveStart.subtract(const Duration(hours: 4)),
+          completedAt: diveStart.subtract(const Duration(minutes: 20)),
+        );
+        final linked = await linker.autoLinkForDive(
+          diveId: 'dive-1',
+          diverId: null,
+          diveStart: diveStart,
+        );
+        expect(linked, isTrue);
+        expect((await sessions.getSessionById(s.id))!.diveId, 'dive-1');
+      },
+    );
+
+    test('a run completed a day earlier does not link', () async {
+      await sessionStartedAt(
+        diveStart.subtract(const Duration(minutes: 30)),
+        completedAt: diveStart.subtract(const Duration(days: 1)),
+      );
+      final linked = await linker.autoLinkForDive(
+        diveId: 'dive-1',
+        diverId: null,
+        diveStart: diveStart,
+      );
+      expect(linked, isFalse);
+    });
+
+    test('nearest completion wins over nearest start', () async {
+      // `early` started closer to the splash but was finished long before it;
+      // `late` started earlier and finished right before the diver got in.
+      final early = await sessionStartedAt(
+        diveStart.subtract(const Duration(minutes: 40)),
+        completedAt: diveStart.subtract(const Duration(minutes: 35)),
+      );
+      final closer = await sessionStartedAt(
+        diveStart.subtract(const Duration(hours: 2)),
+        completedAt: diveStart.subtract(const Duration(minutes: 5)),
+      );
+      await linker.autoLinkForDive(
+        diveId: 'dive-1',
+        diverId: null,
+        diveStart: diveStart,
+      );
+      expect((await sessions.getSessionById(closer.id))!.diveId, 'dive-1');
+      expect((await sessions.getSessionById(early.id))!.diveId, isNull);
+    });
+
+    test('an unfinished run still falls back to its start time', () async {
+      final s = await sessionStartedAt(
+        diveStart.subtract(const Duration(minutes: 25)),
+      );
+      final linked = await linker.autoLinkForDive(
+        diveId: 'dive-1',
+        diverId: null,
+        diveStart: diveStart,
+      );
+      expect(linked, isTrue);
+      expect((await sessions.getSessionById(s.id))!.diveId, 'dive-1');
+    });
   });
 }

--- a/test/features/pre_dive/data/services/checklist_dive_linker_test.dart
+++ b/test/features/pre_dive/data/services/checklist_dive_linker_test.dart
@@ -208,4 +208,36 @@ void main() {
       expect((await sessions.getSessionById(s.id))!.diveId, 'dive-1');
     });
   });
+
+  test('a running session ignores a stale completion stamp', () async {
+    // Contradictory data: status still inProgress, yet a finish stamp sits on
+    // the row 4.5 h before the splash. Anchoring on that stamp puts the run
+    // outside the window and loses the link; the run has not finished, so its
+    // start is the only honest anchor.
+    final s = await sessionStartedAt(
+      diveStart.subtract(const Duration(minutes: 20)),
+    );
+    final db = DatabaseService.instance.database;
+    await db.customStatement(
+      'UPDATE pre_dive_sessions SET completed_at = '
+      '${diveStart.subtract(const Duration(hours: 4, minutes: 30)).millisecondsSinceEpoch} '
+      "WHERE id = '${s.id}'",
+    );
+    final running = (await sessions.getSessionById(s.id))!;
+    expect(running.status, domain.PreDiveSessionStatus.inProgress);
+    expect(running.completedAt, isNotNull);
+    expect(
+      ChecklistDiveLinker.anchorOf(running),
+      running.startedAt,
+      reason: 'a run still in progress anchors on its start',
+    );
+
+    final linked = await linker.autoLinkForDive(
+      diveId: 'dive-1',
+      diverId: null,
+      diveStart: diveStart,
+    );
+    expect(linked, isTrue);
+    expect((await sessions.getSessionById(s.id))!.diveId, 'dive-1');
+  });
 }

--- a/test/features/pre_dive/presentation/pages/pre_dive_session_runner_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_session_runner_page_test.dart
@@ -117,11 +117,12 @@ void main() {
     required PreDiveSession s,
     required List<PreDiveSessionItem> items,
     List<dynamic> extraOverrides = const [],
+    Locale locale = const Locale('en'),
   }) async {
     final repo = _FakeSessionRepo();
     await tester.pumpWidget(
       testApp(
-        locale: const Locale('en'),
+        locale: locale,
         overrides: [
           preDiveSessionRepositoryProvider.overrideWithValue(repo),
           preDiveSessionProvider('s1').overrideWith((ref) async => s),
@@ -210,6 +211,25 @@ void main() {
     // (Date format is locale-dependent; assert the month/day are present.)
     expect(find.textContaining('Aborted'), findsOneWidget);
     expect(find.textContaining('Nov 14'), findsOneWidget);
+  });
+
+  testWidgets('the locked banner localizes its date/time connector', (
+    tester,
+  ) async {
+    // formatDateTime falls back to a hardcoded English "at" unless it is
+    // handed l10n, which left the banner mixing languages.
+    await pumpRunner(
+      tester,
+      s: session(
+        status: PreDiveSessionStatus.completed,
+        completedAt: DateTime(2023, 11, 14, 9, 12),
+      ),
+      items: [item(0, state: PreDiveItemState.done)],
+      locale: const Locale('de'),
+    );
+
+    expect(find.textContaining('bei'), findsOneWidget);
+    expect(find.textContaining(' at '), findsNothing);
   });
 
   testWidgets('locked session is read-only: tiles disabled, no item menu', (

--- a/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
@@ -101,6 +101,9 @@ class _StubSessionRepository implements PreDiveSessionRepository {
 void main() {
   final now = DateTime.fromMillisecondsSinceEpoch(1700000000000);
 
+  // A finished run always carries the stamp the repository writes when it is
+  // completed or aborted, so the fixture mirrors that rather than leaving
+  // completedAt null on a locked session.
   PreDiveSession session(
     String id, {
     String name = 'CCR Build',
@@ -112,6 +115,9 @@ void main() {
     status: status,
     diveId: diveId,
     startedAt: now,
+    completedAt: status == PreDiveSessionStatus.inProgress
+        ? null
+        : now.add(const Duration(minutes: 12)),
     createdAt: now,
     updatedAt: now,
   );
@@ -273,7 +279,7 @@ void main() {
     );
 
     expect(find.text('Solo Check'), findsOneWidget);
-    expect(find.textContaining('In progress'), findsOneWidget);
+    expect(find.textContaining('Started'), findsOneWidget);
     expect(find.byIcon(Icons.pending_outlined), findsOneWidget);
   });
 

--- a/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/core/services/export/excel/pre_dive_excel_export_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/pre_dive/data/repositories/pre_dive_session_repository.dart';
@@ -257,6 +258,58 @@ void main() {
     expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
     expect(find.byIcon(Icons.cancel_outlined), findsOneWidget);
     expect(find.byType(ListTile), findsNWidgets(2));
+  });
+
+  testWidgets('the timestamp connector follows the locale', (tester) async {
+    // formatDateTime falls back to a hardcoded English "at" unless it is
+    // handed l10n, which would leave a German tile reading "... at 14:12".
+    await pumpPage(
+      tester,
+      sessions: [
+        session('done1', name: 'Riff', status: PreDiveSessionStatus.completed),
+      ],
+      items: {
+        'done1': [item('done1', 0, PreDiveItemState.done)],
+      },
+      locale: const Locale('de'),
+    );
+
+    expect(find.textContaining('bei'), findsOneWidget);
+    expect(find.textContaining(' at '), findsNothing);
+  });
+
+  testWidgets('a running row reports its start even with a finish stamp', (
+    tester,
+  ) async {
+    // Contradictory data: in-progress with a completion stamp. Deriving the
+    // displayed time from completedAt and only the label from the status
+    // printed the finish time under a "Started" label.
+    final contradictory = PreDiveSession(
+      id: 'weird',
+      templateName: 'Half-done Check',
+      status: PreDiveSessionStatus.inProgress,
+      startedAt: now,
+      completedAt: now.add(const Duration(hours: 5)),
+      createdAt: now,
+      updatedAt: now,
+    );
+    await pumpPage(
+      tester,
+      sessions: [contradictory],
+      items: {
+        'weird': [item('weird', 0, PreDiveItemState.pending)],
+      },
+    );
+
+    const units = UnitFormatter(AppSettings());
+    expect(
+      find.textContaining('Started ${units.formatDateTime(now)}'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining(units.formatDateTime(contradictory.completedAt)),
+      findsNothing,
+    );
   });
 
   testWidgets('in-progress history tile shows pending icon and status', (

--- a/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
@@ -312,6 +312,76 @@ void main() {
     );
   });
 
+  testWidgets('a terminal run with no finish stamp still shows its status', (
+    tester,
+  ) async {
+    // Legacy or sync-applied rows can reach the list terminal but unstamped.
+    // Folding the status into the timestamp phrase must not drop it: before
+    // this branch the subtitle always carried a separate status label, and a
+    // completed run reading only "Started ..." hides what actually happened.
+    final unstamped = PreDiveSession(
+      id: 'legacy',
+      templateName: 'Old Record',
+      status: PreDiveSessionStatus.completed,
+      startedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    );
+    await pumpPage(
+      tester,
+      sessions: [unstamped],
+      items: {
+        'legacy': [item('legacy', 0, PreDiveItemState.done)],
+      },
+    );
+
+    expect(unstamped.completedAt, isNull);
+    expect(find.textContaining('Completed'), findsOneWidget);
+    // The start is the one time that is certainly true, so it is still shown.
+    expect(find.textContaining('Started'), findsOneWidget);
+  });
+
+  testWidgets('an unstamped aborted run reports Aborted, not Started only', (
+    tester,
+  ) async {
+    final unstamped = PreDiveSession(
+      id: 'legacy2',
+      templateName: 'Bailed Record',
+      status: PreDiveSessionStatus.aborted,
+      startedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    );
+    await pumpPage(
+      tester,
+      sessions: [unstamped],
+      items: {
+        'legacy2': [item('legacy2', 0, PreDiveItemState.skipped)],
+      },
+    );
+
+    expect(find.textContaining('Aborted'), findsOneWidget);
+  });
+
+  testWidgets('a running run is not given a redundant status suffix', (
+    tester,
+  ) async {
+    // "Started ... - In progress" would say the same thing twice; only a
+    // terminal row needs the status spelled out beside its start.
+    await pumpPage(
+      tester,
+      sessions: [
+        session('ip2', name: 'Solo', status: PreDiveSessionStatus.inProgress),
+      ],
+      items: {
+        'ip2': [item('ip2', 0, PreDiveItemState.pending)],
+      },
+    );
+
+    expect(find.textContaining('Started'), findsOneWidget);
+    expect(find.textContaining('In progress'), findsNothing);
+  });
+
   testWidgets('in-progress history tile shows pending icon and status', (
     tester,
   ) async {

--- a/test/features/pre_dive/presentation/pages/pre_dive_template_edit_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_template_edit_page_test.dart
@@ -516,6 +516,39 @@ void main() {
       expect(find.byIcon(Icons.delete_outline), findsNothing);
     });
 
+    testWidgets('item rows show nothing that reads as a control', (
+      tester,
+    ) async {
+      // An empty checkbox was standing in as an alignment spacer, but that
+      // glyph reads as "tap to toggle" on rows whose onTap is null. Nothing
+      // in this mode has a leading control to align with, so the column goes
+      // rather than being filled with a lookalike.
+      await pumpBuiltIn(tester);
+      expect(find.byIcon(Icons.check_box_outline_blank), findsNothing);
+      expect(find.byIcon(Icons.check_box), findsNothing);
+      expect(find.byType(Checkbox), findsNothing);
+
+      final tile = tester.widget<ListTile>(
+        find.widgetWithText(ListTile, 'Goal: agree the objective'),
+      );
+      expect(tile.leading, isNull);
+      expect(tile.onTap, isNull, reason: 'read-only rows are not tappable');
+    });
+
+    testWidgets('an editable template keeps its per-item delete', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        templateId: 'tpl-1',
+        repo: _FakeTemplateRepo(
+          template: templateFixture(),
+          items: [itemFixture('Mine')],
+        ),
+      );
+      expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+    });
+
     testWidgets('a user template keeps its editor', (tester) async {
       await pumpPage(
         tester,

--- a/test/features/pre_dive/presentation/pages/pre_dive_template_edit_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_template_edit_page_test.dart
@@ -479,4 +479,55 @@ void main() {
     expect(repo.savedItems!.length, 1);
     expect(repo.savedItems!.first.title, 'Existing');
   });
+
+  group('a built-in opens as a viewer, not a locked editor', () {
+    Future<void> pumpBuiltIn(WidgetTester tester) => pumpPage(
+      tester,
+      templateId: 'tpl-1',
+      repo: _FakeTemplateRepo(
+        template: templateFixture(name: 'GUE EDGE', isBuiltIn: true),
+        items: [
+          itemFixture('Goal: agree the objective', sortOrder: 0),
+          itemFixture('Gas: analyze and label', sortOrder: 1),
+        ],
+      ),
+    );
+
+    testWidgets('shows the view title and the built-in notice', (tester) async {
+      await pumpBuiltIn(tester);
+      expect(find.text('View Pre-Dive Checklist'), findsOneWidget);
+      expect(
+        find.text('Built-in checklist. Clone it to make an editable copy.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders the items a diver came to read', (tester) async {
+      await pumpBuiltIn(tester);
+      expect(find.text('Goal: agree the objective'), findsOneWidget);
+      expect(find.text('Gas: analyze and label'), findsOneWidget);
+      expect(find.text('GUE EDGE'), findsOneWidget);
+    });
+
+    testWidgets('withholds every editing affordance', (tester) async {
+      await pumpBuiltIn(tester);
+      expect(find.text('Save'), findsNothing);
+      expect(find.text('Add item'), findsNothing);
+      expect(find.byIcon(Icons.delete_outline), findsNothing);
+    });
+
+    testWidgets('a user template keeps its editor', (tester) async {
+      await pumpPage(
+        tester,
+        templateId: 'tpl-1',
+        repo: _FakeTemplateRepo(
+          template: templateFixture(),
+          items: [itemFixture('Mine')],
+        ),
+      );
+      expect(find.text('Edit Pre-Dive Checklist'), findsOneWidget);
+      expect(find.text('Save'), findsOneWidget);
+      expect(find.text('Add item'), findsOneWidget);
+    });
+  });
 }

--- a/test/features/pre_dive/presentation/pages/pre_dive_template_edit_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_template_edit_page_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
@@ -11,10 +13,14 @@ import '../../../../helpers/test_app.dart';
 /// Fake repository that stubs the reads the page performs and captures the
 /// writes so save/create/update/saveItems can be asserted without a database.
 class _FakeTemplateRepo implements PreDiveTemplateRepository {
-  _FakeTemplateRepo({this.template, this.items = const []});
+  _FakeTemplateRepo({this.template, this.items = const [], this.gate});
 
   final PreDiveChecklistTemplate? template;
   final List<PreDiveChecklistTemplateItem> items;
+
+  /// When set, the reads block until it completes, so a test can inspect the
+  /// frame the page renders while the template is still in flight.
+  final Completer<void>? gate;
 
   PreDiveChecklistTemplate? createdTemplate;
   PreDiveChecklistTemplate? updatedTemplate;
@@ -22,13 +28,18 @@ class _FakeTemplateRepo implements PreDiveTemplateRepository {
   List<PreDiveChecklistTemplateItem>? savedItems;
 
   @override
-  Future<PreDiveChecklistTemplate?> getTemplateById(String id) async =>
-      template;
+  Future<PreDiveChecklistTemplate?> getTemplateById(String id) async {
+    if (gate != null) await gate!.future;
+    return template;
+  }
 
   @override
   Future<List<PreDiveChecklistTemplateItem>> getItemsForTemplate(
     String templateId,
-  ) async => items;
+  ) async {
+    if (gate != null) await gate!.future;
+    return items;
+  }
 
   @override
   Future<PreDiveChecklistTemplate> createTemplate(
@@ -561,6 +572,87 @@ void main() {
       expect(find.text('Edit Pre-Dive Checklist'), findsOneWidget);
       expect(find.text('Save'), findsOneWidget);
       expect(find.text('Add item'), findsOneWidget);
+    });
+  });
+
+  group('the loading frame claims no editing it might have to retract', () {
+    testWidgets('an in-flight template offers no Save and no edit title', (
+      tester,
+    ) async {
+      // _readOnly is derived from the fetched row, so on the first frame the
+      // mode is unknown. It must not render the edit chrome there: a built-in
+      // resolving a moment later would have to withdraw a Save button the
+      // diver has already seen.
+      final gate = Completer<void>();
+      final repo = _FakeTemplateRepo(
+        template: templateFixture(),
+        items: [itemFixture('Mine')],
+        gate: gate,
+      );
+      await tester.pumpWidget(
+        testApp(
+          locale: const Locale('en'),
+          overrides: [
+            preDiveTemplateRepositoryProvider.overrideWithValue(repo),
+            validatedCurrentDiverIdProvider.overrideWith(
+              (ref) async => 'diver-1',
+            ),
+          ],
+          child: const PreDiveTemplateEditPage(templateId: 'tpl-1'),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Save'), findsNothing);
+      expect(find.text('Edit Pre-Dive Checklist'), findsNothing);
+      expect(find.text('View Pre-Dive Checklist'), findsOneWidget);
+
+      gate.complete();
+      await tester.pumpAndSettle();
+
+      // A user template upgrades to the editing chrome once it is known.
+      expect(find.text('Edit Pre-Dive Checklist'), findsOneWidget);
+      expect(find.text('Save'), findsOneWidget);
+    });
+
+    testWidgets('a built-in never flashes the edit chrome on the way in', (
+      tester,
+    ) async {
+      final gate = Completer<void>();
+      final repo = _FakeTemplateRepo(
+        template: templateFixture(name: 'GUE EDGE', isBuiltIn: true),
+        items: [itemFixture('Goal')],
+        gate: gate,
+      );
+      await tester.pumpWidget(
+        testApp(
+          locale: const Locale('en'),
+          overrides: [
+            preDiveTemplateRepositoryProvider.overrideWithValue(repo),
+            validatedCurrentDiverIdProvider.overrideWith(
+              (ref) async => 'diver-1',
+            ),
+          ],
+          child: const PreDiveTemplateEditPage(templateId: 'tpl-1'),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('Save'), findsNothing);
+
+      gate.complete();
+      await tester.pumpAndSettle();
+      expect(find.text('View Pre-Dive Checklist'), findsOneWidget);
+      expect(find.text('Save'), findsNothing);
+    });
+
+    testWidgets('a brand new template still gets Save immediately', (
+      tester,
+    ) async {
+      // No fetch happens without a templateId, so nothing should be deferred.
+      await pumpPage(tester);
+      expect(find.text('New Pre-Dive Checklist'), findsOneWidget);
+      expect(find.text('Save'), findsOneWidget);
     });
   });
 }

--- a/test/features/pre_dive/presentation/pages/pre_dive_templates_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_templates_page_test.dart
@@ -288,7 +288,43 @@ void main() {
     expect(find.text('EDIT My CCR List'), findsOneWidget);
   });
 
-  testWidgets('tapping a built-in template opens it read-only', (tester) async {
+  testWidgets('the built-in View menu entry navigates too', (tester) async {
+    // The tile tap and the menu entry are separate call sites; a diver who
+    // reaches for the overflow menu must get the same destination.
+    final router = GoRouter(
+      routes: [
+        GoRoute(path: '/', builder: (_, _) => const PreDiveTemplatesPage()),
+        GoRoute(
+          path: '/pre-dive-checklists/:id/edit',
+          builder: (_, state) =>
+              Scaffold(body: Text('EDIT ${state.pathParameters['id']}')),
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      testAppRouter(
+        router: router,
+        locale: const Locale('en'),
+        overrides: [
+          preDiveTemplatesProvider.overrideWith(
+            (ref) async => [template('BWRAF Buddy Check', builtIn: true)],
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(PopupMenuButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('View'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('EDIT BWRAF Buddy Check'), findsOneWidget);
+  });
+
+  testWidgets('tapping a built-in template navigates to the template page', (
+    tester,
+  ) async {
     final router = GoRouter(
       routes: [
         GoRoute(path: '/', builder: (_, _) => const PreDiveTemplatesPage()),
@@ -314,8 +350,9 @@ void main() {
     await tester.tap(find.text('BWRAF Buddy Check'));
     await tester.pumpAndSettle();
 
-    // Built-ins open: the destination renders them read-only, so a diver can
-    // read what a default checks before deciding to clone it.
+    // Built-ins are no longer a dead tap. The router stub here only proves
+    // navigation happened; that the destination renders them read-only is
+    // pre_dive_template_edit_page_test's job.
     expect(find.textContaining('EDIT'), findsOneWidget);
   });
 }

--- a/test/features/pre_dive/presentation/pages/pre_dive_templates_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_templates_page_test.dart
@@ -288,7 +288,7 @@ void main() {
     expect(find.text('EDIT My CCR List'), findsOneWidget);
   });
 
-  testWidgets('tapping a built-in template does not navigate', (tester) async {
+  testWidgets('tapping a built-in template opens it read-only', (tester) async {
     final router = GoRouter(
       routes: [
         GoRoute(path: '/', builder: (_, _) => const PreDiveTemplatesPage()),
@@ -314,8 +314,8 @@ void main() {
     await tester.tap(find.text('BWRAF Buddy Check'));
     await tester.pumpAndSettle();
 
-    // onTap is null for built-ins, so we stay on the list.
-    expect(find.text('BWRAF Buddy Check'), findsOneWidget);
-    expect(find.textContaining('EDIT'), findsNothing);
+    // Built-ins open: the destination renders them read-only, so a diver can
+    // read what a default checks before deciding to clone it.
+    expect(find.textContaining('EDIT'), findsOneWidget);
   });
 }

--- a/test/features/pre_dive/presentation/widgets/pre_dive_dashboard_card_test.dart
+++ b/test/features/pre_dive/presentation/widgets/pre_dive_dashboard_card_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/checklists/presentation/providers/checklist_providers.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_checklist_template.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
 import 'package:submersion/features/pre_dive/presentation/widgets/pre_dive_dashboard_card.dart';
+import 'package:submersion/features/trips/domain/entities/trip.dart';
 
 import '../../../../helpers/test_app.dart';
 
@@ -38,12 +40,22 @@ void main() {
     updatedAt: now,
   );
 
+  Trip trip() => Trip(
+    id: 't1',
+    name: 'Red Sea',
+    startDate: now,
+    endDate: now.add(const Duration(days: 7)),
+    createdAt: now,
+    updatedAt: now,
+  );
+
   Future<void> pumpCard(
     WidgetTester tester, {
     PreDiveSession? active,
     List<PreDiveSession> sessions = const [],
     List<PreDiveChecklistTemplate>? templates,
     List<PreDiveSessionItem> items = const [],
+    ({Trip trip, int done, int total})? tripChecklist,
   }) async {
     await tester.pumpWidget(
       testApp(
@@ -55,6 +67,7 @@ void main() {
             (ref) async => templates ?? [builtIn()],
           ),
           preDiveSessionItemsProvider('s1').overrideWith((ref) async => items),
+          homeTripChecklistProvider.overrideWith((ref) async => tripChecklist),
         ],
         child: const PreDiveDashboardCard(),
       ),
@@ -89,5 +102,37 @@ void main() {
     final s = session();
     await pumpCard(tester, sessions: [s]);
     expect(find.text('Start pre-dive check'), findsOneWidget);
+  });
+
+  group('trip checklists get their own row rather than the pre-dive one', () {
+    testWidgets('a trip checklist alone surfaces the card', (tester) async {
+      // Pre-dive is unused here: before this row existed the card stayed
+      // hidden and the trip list had no home surface at all.
+      await pumpCard(tester, tripChecklist: (trip: trip(), done: 2, total: 5));
+      expect(find.text('Checklists'), findsOneWidget);
+      expect(find.text('Trip: Red Sea'), findsOneWidget);
+      expect(find.text('2 of 5 to-dos done'), findsOneWidget);
+      expect(find.text('Start pre-dive check'), findsNothing);
+    });
+
+    testWidgets('both rows are labelled apart when both apply', (tester) async {
+      await pumpCard(
+        tester,
+        sessions: [session()],
+        tripChecklist: (trip: trip(), done: 0, total: 3),
+      );
+      expect(find.text('Pre-dive'), findsOneWidget);
+      expect(find.text('Start pre-dive check'), findsOneWidget);
+      expect(find.text('Trip: Red Sea'), findsOneWidget);
+      expect(find.text('0 of 3 to-dos done'), findsOneWidget);
+    });
+
+    testWidgets('no trip checklist leaves the pre-dive row alone', (
+      tester,
+    ) async {
+      await pumpCard(tester, sessions: [session()]);
+      expect(find.text('Start pre-dive check'), findsOneWidget);
+      expect(find.textContaining('Trip:'), findsNothing);
+    });
   });
 }

--- a/test/features/pre_dive/presentation/widgets/pre_dive_dashboard_card_test.dart
+++ b/test/features/pre_dive/presentation/widgets/pre_dive_dashboard_card_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:submersion/features/checklists/presentation/providers/checklist_providers.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_checklist_template.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
@@ -125,6 +126,39 @@ void main() {
       expect(find.text('Start pre-dive check'), findsOneWidget);
       expect(find.text('Trip: Red Sea'), findsOneWidget);
       expect(find.text('0 of 3 to-dos done'), findsOneWidget);
+    });
+
+    testWidgets('the trip row opens that trip', (tester) async {
+      final router = GoRouter(
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const PreDiveDashboardCard()),
+          GoRoute(
+            path: '/trips/:tripId',
+            builder: (_, state) =>
+                Scaffold(body: Text('TRIP ${state.pathParameters['tripId']}')),
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        testAppRouter(
+          router: router,
+          locale: const Locale('en'),
+          overrides: [
+            preDiveActiveSessionProvider.overrideWith((ref) async => null),
+            preDiveSessionsProvider.overrideWith((ref) async => const []),
+            preDiveTemplatesProvider.overrideWith((ref) async => [builtIn()]),
+            homeTripChecklistProvider.overrideWith(
+              (ref) async => (trip: trip(), done: 1, total: 4),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('1 of 4 to-dos done'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('TRIP t1'), findsOneWidget);
     });
 
     testWidgets('no trip checklist leaves the pre-dive row alone', (

--- a/test/features/trips/domain/entities/trip_upcoming_test.dart
+++ b/test/features/trips/domain/entities/trip_upcoming_test.dart
@@ -69,4 +69,44 @@ void main() {
       expect(t.isInProgress, isFalse);
     });
   });
+
+  group('Trip.startsAfter', () {
+    // The clock-free counterpart to isUpcoming/isInProgress: a caller sorting
+    // several trips in one pass measures all of them against one instant
+    // instead of each predicate re-reading DateTime.now().
+    test('a trip starting tomorrow starts after today', () {
+      final t = _trip(
+        start: today.add(const Duration(days: 1)),
+        end: today.add(const Duration(days: 8)),
+      );
+      expect(t.startsAfter(today), isTrue);
+    });
+
+    test('a trip starting today does not start after today', () {
+      // Date-only, so a start of 00:00 today is not "ahead" at 09:00 today.
+      // The instant comparison this replaced said the opposite, and disagreed
+      // with containsDate on the very same trip.
+      final t = _trip(start: today, end: today.add(const Duration(days: 3)));
+      expect(t.startsAfter(today), isFalse);
+      expect(t.containsDate(today), isTrue);
+    });
+
+    test('a trip that started yesterday does not start after today', () {
+      final t = _trip(
+        start: today.subtract(const Duration(days: 1)),
+        end: today.add(const Duration(days: 3)),
+      );
+      expect(t.startsAfter(today), isFalse);
+    });
+
+    test('the reference time of day is ignored, only its date counts', () {
+      final t = _trip(start: today, end: today.add(const Duration(days: 3)));
+      expect(t.startsAfter(today.add(const Duration(hours: 23))), isFalse);
+      expect(
+        t.startsAfter(today.subtract(const Duration(hours: 1))),
+        isTrue,
+        reason: 'an hour before midnight is the previous calendar day',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Four reported defects across the app's two checklist features (pre-dive runs
in `lib/features/pre_dive/`, trip to-do lists in `lib/features/checklists/`).

1. **Pre-dive defaults could not be read until they were cloned.** The
   template list passed `onTap: null` for built-ins, yet
   `PreDiveTemplateEditPage._readOnly` was already a complete read-only mode
   that nothing could reach. Built-ins now open, and the page presents as a
   viewer instead of a locked editor.
2. **GUE EDGE was missing its first three checks.** The seed carried only the
   "EDGE" half of the mnemonic and read its D as "Descent". It now seeds the
   canonical seven-point sequence.
3. **Trip checklists were only reachable through a pre-dive-labelled home
   button.** Home offered exactly one checklist affordance and it routed to
   `/pre-dive-sessions`, a page headed "Pre-Dive Checklists"; trip checklists
   had no home surface at all. The card now hosts both kinds under separate
   labels.
4. **Completion stamps were written but never used or shown.** `completedAt`
   was already set by `_finishSession`, but nothing displayed it and
   `ChecklistDiveLinker` measured its three-hour window from `startedAt`.

## Changes

- `pre_dive_templates_page.dart`: built-in templates open (plus a View entry
  in the overflow menu).
- `pre_dive_template_edit_page.dart`: read-only mode now withholds rather
  than disables Save, Add item and the per-item delete; adds a View title and
  a "clone it to make an editable copy" notice.
- `database.dart`: GUE EDGE seeds Goal, Unified team, Equipment, Exposure,
  Decompression, Gas, Environment under `builtin-predive-gue-edge-0..6`. A
  companion `kRetireLegacyGueEdgeItemsSql` DELETE runs beside the seed in
  `beforeOpen` to repair existing installs, so **no schema rung is needed**:
  `INSERT OR IGNORE` can add a missing row but never rewrite or renumber a
  stale one. Safe unconditionally because built-ins are read-only in the UI,
  excluded from sync export, and session items are independent snapshots with
  no FK back to template items.
- `pre_dive_dashboard_card.dart`: two labelled rows -- the pre-dive row
  unchanged, plus a "Trip: {name}" row with its progress, opening that trip.
  Fed by the new `homeTripChecklistProvider` (a trip already under way beats
  the next upcoming one; trips with empty lists are skipped). The card still
  disappears entirely when neither row applies. `settings_homeCards_card_preDive`
  retitled to "Checklists".
- `checklist_dive_linker.dart`: new `ChecklistDiveLinker.anchorOf` =
  `completedAt ?? startedAt`. Anchoring on start measured from the wrong end,
  so a CCR build or gear-packing list worked through over an hour fell out of
  the window even when it ended minutes before the splash.
- `pre_dive_sessions_page.dart` / `pre_dive_session_runner_page.dart`: show
  Started / Completed / Aborted with `formatDateTime` rather than a bare date.
- Nine new l10n keys across all eleven locales.

### Reviewer note on item 3

This one's wording was ambiguous and the reading was a judgment call. No code
path was found that renders trip-checklist *data* under a pre-dive label; the
conflation is the single home entry point. If a different screen was meant,
this part can be retargeted without touching the other three fixes.

## Test Plan

- [x] `flutter test` passes -- full suite green, 25109 passed / 21 skipped
- [x] `flutter analyze` passes -- no issues, whole project
- [x] Manual testing on: not yet run on a device

New coverage: 4 seed tests (canonical order + idempotent legacy retirement),
4 linker anchoring tests, 4 read-only viewer tests, 3 home-card row tests,
4 `homeTripChecklistProvider` tests.

Fixture bug found and fixed along the way: `pre_dive_sessions_page_test`
built completed and aborted sessions with `completedAt: null`, a state no
repository path can produce.
