### PR TITLE
feat(dashboard): draw the real dive profile chart on the home tab

### DIFF
--- a/lib/features/dashboard/presentation/providers/dashboard_providers.dart
+++ b/lib/features/dashboard/presentation/providers/dashboard_providers.dart
@@ -51,36 +51,6 @@ final recentDivesProvider = FutureProvider<List<Dive>>((ref) async {
   return recent;
 });
 
-/// Depth profile of the newest dive, for the recent-dives preview chart.
-///
-/// [recentDivesProvider] hydrates its dives through `getDiveById`, which reads
-/// the `dives` row only and leaves `Dive.profile` empty -- the list path
-/// deliberately avoids dragging thousands of sample rows into a summary view.
-/// The batch cache it does populate holds ~20-point sparkline summaries, which
-/// is enough for a tile-sized mini chart but too coarse for a preview several
-/// hundred pixels wide. So this fetches the real samples, for the newest dive
-/// only, and only when a caller actually watches it.
-///
-/// Null when there are no dives, or when the newest dive has no profile
-/// (manually logged dives usually do not).
-final latestDiveProfileProvider = FutureProvider<List<DiveProfilePoint>?>((
-  ref,
-) async {
-  final repository = ref.watch(diveRepositoryProvider);
-  // The dive-detail tick, not the dives tick: this reads
-  // dive_profile_series, and
-  // samples change without the dives row changing (a reparse or a sync pull
-  // rewrites the profile in place). watchDivesChanges would leave the chart
-  // showing the pre-reparse shape.
-  ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
-
-  final recent = await ref.watch(recentDivesProvider.future);
-  if (recent.isEmpty) return null;
-
-  final profile = await repository.getDiveProfile(recent.first.id);
-  return profile.isEmpty ? null : profile;
-});
-
 /// Current diver provider (re-exported for convenience)
 final dashboardDiverProvider = FutureProvider<Diver?>((ref) async {
   return ref.watch(currentDiverProvider.future);

--- a/lib/features/dashboard/presentation/widgets/recent_dive_profile_preview.dart
+++ b/lib/features/dashboard/presentation/widgets/recent_dive_profile_preview.dart
@@ -1,6 +1,3 @@
-import 'dart:math' as math;
-
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -8,14 +5,11 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/profile_decimator.dart';
+import 'package:submersion/features/dive_log/presentation/pages/fullscreen_profile_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart_host.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
-
-/// Points kept for rendering. A preview is a few hundred pixels wide, so more
-/// samples than this cannot resolve to distinct pixels; the decimator keeps
-/// the depth envelope, so the max-depth spike survives the reduction.
-const int _renderPoints = 240;
 
 /// Depth profile of the newest dive, shown beside the recent-dives list on
 /// wide windows.
@@ -25,63 +19,66 @@ const int _renderPoints = 240;
 /// This fills it with the one thing a dive list row cannot show: the shape of
 /// the dive.
 ///
-/// Deliberately not [DiveProfileChart]: that widget is ~5,800 lines carrying
-/// touch recognisers, tooltips, playback, tissue curves and safety findings,
-/// and mounting it on the home screen would cost the first frame far more
-/// than a static preview is worth. This is read-only and non-interactive;
-/// tapping anywhere opens the dive itself.
+/// Draws the real [DiveProfileChart] through [DiveProfileChartHost], not a
+/// simplified rendition of it: same curves, same legend, same markers, same
+/// gestures. The legend's metric toggles are app-wide session state, so a
+/// curve the diver turned on in dive details is already on here.
 class RecentDiveProfilePreview extends ConsumerWidget {
   const RecentDiveProfilePreview({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final divesAsync = ref.watch(recentDivesProvider);
-    final dive = divesAsync.valueOrNull?.firstOrNull;
-    if (dive == null) return const SizedBox.shrink();
+    final newest = divesAsync.valueOrNull?.firstOrNull;
+    if (newest == null) return const SizedBox.shrink();
 
-    final profileAsync = ref.watch(latestDiveProfileProvider);
+    // Re-read the dive through the detail provider rather than charting the
+    // list's copy: that one refreshes on `dives`-table writes only, so a
+    // reparse or a sync pull rewriting the samples in place would leave this
+    // chart showing the pre-reparse shape.
+    final diveAsync = ref.watch(diveProvider(newest.id));
 
     return Card(
       margin: EdgeInsets.zero,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: () => context.push('/dives/${dive.id}'),
-        child: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _Header(dive: dive),
-              const SizedBox(height: 8),
-              Expanded(
-                child: profileAsync.when(
-                  data: (profile) => profile == null
-                      ? _Placeholder(
-                          icon: Icons.show_chart,
-                          message:
-                              context.l10n.dashboard_recentDives_noProfileData,
-                        )
-                      : _ProfileChart(profile: profile),
-                  loading: () =>
-                      const Center(child: CircularProgressIndicator()),
-                  // A failed load and a dive with no samples are different
-                  // facts. Reporting "no profile data" for a failure hides the
-                  // error and tells the diver something untrue about the dive.
-                  error: (_, _) => _Placeholder(
-                    icon: Icons.error_outline,
-                    message:
-                        context.l10n.dashboard_recentDives_profileLoadError,
-                  ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _Header(dive: diveAsync.value ?? newest),
+            const SizedBox(height: 8),
+            Expanded(
+              child: diveAsync.when(
+                data: (dive) => dive == null || dive.profile.isEmpty
+                    ? _Placeholder(
+                        icon: Icons.show_chart,
+                        message:
+                            context.l10n.dashboard_recentDives_noProfileData,
+                      )
+                    : DiveProfileChartHost(dive: dive),
+                loading: () => const Center(child: CircularProgressIndicator()),
+                // A failed load and a dive with no samples are different
+                // facts. Reporting "no profile data" for a failure hides the
+                // error and tells the diver something untrue about the dive.
+                error: (_, _) => _Placeholder(
+                  icon: Icons.error_outline,
+                  message: context.l10n.dashboard_recentDives_profileLoadError,
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
   }
 }
 
+/// Title, site and max depth, with the affordances the dive detail page puts
+/// above its own chart that still make sense here.
+///
+/// The card as a whole is deliberately not tappable: the chart under this row
+/// has its own pan, zoom, tooltip and range gestures, and an ancestor InkWell
+/// would swallow them.
 class _Header extends ConsumerWidget {
   const _Header({required this.dive});
 
@@ -96,27 +93,34 @@ class _Header extends ConsumerWidget {
     return Row(
       children: [
         Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                context.l10n.dashboard_recentDives_latestProfileTitle,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              if (siteName != null && siteName.isNotEmpty)
-                Text(
-                  siteName,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(8),
+            onTap: () => context.push('/dives/${dive.id}'),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    context.l10n.dashboard_recentDives_latestProfileTitle,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-            ],
+                  if (siteName != null && siteName.isNotEmpty)
+                    Text(
+                      siteName,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                ],
+              ),
+            ),
           ),
         ),
         if (dive.maxDepth != null)
@@ -127,124 +131,20 @@ class _Header extends ConsumerWidget {
               color: theme.colorScheme.primary,
             ),
           ),
+        IconButton(
+          icon: const Icon(Icons.fullscreen),
+          tooltip: context.l10n.diveLog_detail_tooltip_viewFullscreen,
+          visualDensity: VisualDensity.compact,
+          // Root navigator, not the ShellRoute's: pushing on the shell
+          // navigator renders the page inside MainScaffold, leaving the bottom
+          // navigation bar painted under a supposedly fullscreen chart (#811).
+          onPressed: () => Navigator.of(context, rootNavigator: true).push(
+            MaterialPageRoute<void>(
+              builder: (_) => FullscreenProfilePage(diveId: dive.id),
+            ),
+          ),
+        ),
       ],
-    );
-  }
-}
-
-class _ProfileChart extends ConsumerWidget {
-  const _ProfileChart({required this.profile});
-
-  final List<DiveProfilePoint> profile;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    final formatter = UnitFormatter(ref.watch(settingsProvider));
-    final lineColor = theme.colorScheme.primary;
-
-    // Depths are stored in metres; convert before plotting so the axis labels
-    // and the curve agree with the diver's unit setting.
-    final kept = decimateSeriesIndices([
-      for (final p in profile) p.depth,
-    ], targetPoints: _renderPoints);
-    final spots = [
-      for (final i in kept)
-        FlSpot(
-          profile[i].timestamp / 60.0,
-          -formatter.convertDepth(profile[i].depth),
-        ),
-    ];
-    if (spots.length < 2) {
-      return _Placeholder(
-        icon: Icons.show_chart,
-        message: context.l10n.dashboard_recentDives_noProfileData,
-      );
-    }
-
-    final deepest = spots.map((s) => -s.y).reduce(math.max);
-    final lastMinute = spots.last.x;
-    // A little headroom under the deepest point so the trace never touches
-    // the axis, and a floor so a shallow dive still gets a sane scale.
-    final depthAxisMax = math.max(deepest * 1.15, 1.0);
-
-    return LineChart(
-      LineChartData(
-        minX: 0,
-        maxX: lastMinute <= 0 ? 1 : lastMinute,
-        minY: -depthAxisMax,
-        maxY: 0,
-        gridData: FlGridData(
-          show: true,
-          drawVerticalLine: false,
-          getDrawingHorizontalLine: (_) => FlLine(
-            color: theme.colorScheme.outlineVariant.withValues(alpha: 0.5),
-            strokeWidth: 1,
-          ),
-        ),
-        titlesData: FlTitlesData(
-          topTitles: const AxisTitles(),
-          rightTitles: const AxisTitles(),
-          leftTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              reservedSize: 42,
-              getTitlesWidget: (value, meta) {
-                if (value == meta.max || value == meta.min) {
-                  return const SizedBox.shrink();
-                }
-                return Padding(
-                  padding: const EdgeInsets.only(right: 4),
-                  child: Text(
-                    '${(-value).round()}${formatter.depthSymbol}',
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                );
-              },
-            ),
-          ),
-          bottomTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              reservedSize: 22,
-              getTitlesWidget: (value, meta) {
-                if (value == meta.max || value == meta.min) {
-                  return const SizedBox.shrink();
-                }
-                return Text(
-                  context.l10n.dashboard_recentDives_profileMinutes(
-                    value.round(),
-                  ),
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                );
-              },
-            ),
-          ),
-        ),
-        borderData: FlBorderData(show: false),
-        // Static preview: the interactive chart lives on the dive detail page,
-        // and a touch handler here would fight the InkWell that opens it.
-        lineTouchData: const LineTouchData(enabled: false),
-        lineBarsData: [
-          LineChartBarData(
-            spots: spots,
-            isCurved: true,
-            curveSmoothness: 0.2,
-            color: lineColor,
-            barWidth: 2,
-            isStrokeCapRound: true,
-            dotData: const FlDotData(show: false),
-            belowBarData: BarAreaData(
-              show: true,
-              color: lineColor.withValues(alpha: 0.12),
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/lib/features/dashboard/presentation/widgets/recent_dive_profile_preview.dart
+++ b/lib/features/dashboard/presentation/widgets/recent_dive_profile_preview.dart
@@ -37,6 +37,12 @@ class RecentDiveProfilePreview extends ConsumerWidget {
     // reparse or a sync pull rewriting the samples in place would leave this
     // chart showing the pre-reparse shape.
     final diveAsync = ref.watch(diveProvider(newest.id));
+    // A loaded null is "no such dive", the way the detail page reads it: the
+    // newest dive was deleted between the list read and this one, and the
+    // list is about to drop it too. Collapse the slot, as this widget already
+    // does when there is no dive at all. Falling through to "no profile data"
+    // would state a different, and untrue, fact about a dive that is gone.
+    if (diveAsync case AsyncData(value: null)) return const SizedBox.shrink();
 
     return Card(
       margin: EdgeInsets.zero,
@@ -49,6 +55,9 @@ class RecentDiveProfilePreview extends ConsumerWidget {
             const SizedBox(height: 8),
             Expanded(
               child: diveAsync.when(
+                // The null arm is unreachable, and present only to satisfy
+                // the provider's nullable type: AsyncData(value: null)
+                // returned above.
                 data: (dive) => dive == null || dive.profile.isEmpty
                     ? _Placeholder(
                         icon: Icons.show_chart,

--- a/lib/features/dashboard/presentation/widgets/recent_dives_card.dart
+++ b/lib/features/dashboard/presentation/widgets/recent_dives_card.dart
@@ -20,10 +20,12 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// plus the gap before the split is allowed.
 const double _splitMinWidth = kMasterPaneWidth + 12 + 320;
 
-/// Height of the profile preview. Roughly the height of three detailed dive
-/// cards, so the two halves of the split read as one block at the default
-/// three recent dives.
-const double _previewHeight = 300;
+/// Height of the profile preview.
+///
+/// Roughly the height of three detailed dive cards, so the two halves of the
+/// split read as one block at the default three recent dives, plus the room
+/// the full chart's legend row and gas timeline strip take above the plot.
+const double _previewHeight = 380;
 
 /// A section showing recent dives with the same tile format as the dive list
 class RecentDivesCard extends ConsumerWidget {

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -39,16 +39,13 @@ import 'package:submersion/features/courses/presentation/providers/course_provid
 import 'package:submersion/features/dive_3d/presentation/pages/dive_3d_page.dart';
 import 'package:submersion/features/dive_3d/presentation/pages/spatial_site_page.dart';
 import 'package:submersion/features/dive_computer/presentation/providers/reparse_providers.dart';
-import 'package:submersion/features/dive_log/data/services/gas_usage_segments_service.dart';
 import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
-import 'package:submersion/features/dive_log/data/services/profile_markers_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
 import 'package:submersion/features/dive_log/presentation/formatters/dive_mode_label.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_detail_ui_providers.dart';
-import 'package:submersion/features/dive_log/presentation/providers/chart_tank_pressures_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_mode_badge.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_sighting_row.dart';
@@ -56,13 +53,11 @@ import 'package:submersion/features/dive_log/presentation/widgets/dive_type_badg
 import 'package:submersion/shared/utils/ink_centered_text_style.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_nav_buttons.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_analysis_providers.dart';
-import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
 import 'package:submersion/features/dive_log/presentation/pages/fullscreen_profile_page.dart';
 import 'package:submersion/features/dive_log/presentation/utils/sac_normalization.dart';
 import 'package:submersion/features/media/presentation/pages/dive_species_photo_viewer_page.dart';
 import 'package:submersion/features/media/presentation/providers/species_media_providers.dart';
-import 'package:submersion/features/planner/presentation/providers/plan_overlay_provider.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
 import 'package:submersion/features/pre_dive/presentation/widgets/link_session_picker.dart';
@@ -74,9 +69,7 @@ import 'package:submersion/features/dive_log/presentation/providers/profile_trac
 import 'package:submersion/features/dive_log/presentation/providers/profile_range_provider.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/buoyancy_section.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/collapsible_section.dart';
-import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/safety_finding_highlight.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_safety_summary_section.dart';
 import 'package:submersion/features/safety/domain/services/altitude_flag.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_locations_map.dart';
@@ -91,10 +84,9 @@ import 'package:submersion/features/dive_log/presentation/providers/active_sourc
 import 'package:submersion/features/dive_log/presentation/widgets/compact_deco_status_card.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/compact_tissue_loading_card.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/cylinders_card.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart_host.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/environment_enum_display.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/o2_toxicity_card.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/photo_marker_layout.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/playback_controls.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/playback_stats_panel.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/range_stats_panel.dart';
@@ -603,7 +595,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         final attribution = FieldAttributionService.computeAttribution(
           dataSources,
           viewedSourceId: viewedSourceId,
-          nameOf: (s) => resolveSourceName(s, _sourceNameLabels(context)),
+          nameOf: (s) => resolveSourceName(s, sourceNameLabelsFor(context)),
         );
         final showBadges =
             settings.showDataSourceBadges && attribution.isNotEmpty;
@@ -643,7 +635,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         final attribution = FieldAttributionService.computeAttribution(
           dataSources,
           viewedSourceId: viewedSourceId,
-          nameOf: (s) => resolveSourceName(s, _sourceNameLabels(context)),
+          nameOf: (s) => resolveSourceName(s, sourceNameLabelsFor(context)),
         );
         final showBadges =
             settings.showDataSourceBadges && attribution.isNotEmpty;
@@ -1826,30 +1818,6 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
 
   /// Localized fallback labels for [resolveSourceName], the shared
   /// name-resolution path for every attribution surface on this page.
-  SourceNameLabels _sourceNameLabels(BuildContext context) {
-    return SourceNameLabels(
-      unknownComputer: context.l10n.diveLog_sources_unknownComputer,
-      manualEntry: context.l10n.diveLog_sources_manualEntry,
-      importedFile: context.l10n.diveLog_sources_importedFile,
-      editedSuffix: context.l10n.diveLog_sources_editedSuffix,
-    );
-  }
-
-  /// Resolves computerId -> display name for a dive's data sources via the
-  /// shared [resolveSourceName] fallback chain. Sources without a computerId
-  /// (manual entries, edited profiles) are skipped — callers key off
-  /// computerId, so there's nothing to attach the name to.
-  Map<String, String> _computerDisplayNames(
-    BuildContext context,
-    List<DiveDataSource> dataSources,
-  ) {
-    final labels = _sourceNameLabels(context);
-    return {
-      for (final source in dataSources)
-        if (source.computerId != null)
-          source.computerId!: resolveSourceName(source, labels),
-    };
-  }
 
   Widget _buildProfileSection(BuildContext context, WidgetRef ref, Dive dive) {
     // Every async chart input below is read through the built-in
@@ -1869,25 +1837,6 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         )
         .value;
 
-    // Get marker settings
-    final showMaxDepthMarker = ref.watch(showMaxDepthMarkerProvider);
-    final showPressureThresholdMarkers = ref.watch(
-      showPressureThresholdMarkersProvider,
-    );
-
-    // Get gas switches for segment coloring
-    final gasSwitchesAsync = ref.watch(gasSwitchesProvider(dive.id));
-
-    // Get per-tank pressure data for multi-tank visualization
-    final tankPressuresAsync = ref.watch(
-      activeSourceTankPressuresProvider(dive.id),
-    );
-    final tankPressures = tankPressuresAsync.value;
-    // Chart-only: real pressures augmented with linear estimates (#197).
-    final estimatedTankPressures = ref
-        .watch(estimatedTankPressuresProvider(dive.id))
-        .value;
-
     // Get playback state
     final playbackState = ref.watch(playbackProvider(dive.id));
 
@@ -1901,8 +1850,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         const <String, SourceProfile>{};
     final dataSources =
         ref.watch(diveDataSourcesProvider(dive.id)).value ?? const [];
-    final computerNames = _computerDisplayNames(context, dataSources);
-    final labels = _sourceNameLabels(context);
+    final labels = sourceNameLabelsFor(context);
     // Per-source rendering exists because two computers recording one dive
     // disagree sample by sample (#543); the halves of a split dive a Combine
     // stitched together are not that, and drawing one of those would hide the
@@ -1930,140 +1878,13 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
       for (final (index, s) in dataSources.indexed) s.id: sourceColorAt(index),
     };
 
-    // Per-computer color, so the Cylinders / Tank Pressures rows can mark
-    // which computer a tank belongs to when two computers logged tanks
-    // sharing the same gas mix (otherwise identical swatches).
-    final computerColorById = <String, Color>{
-      for (final (index, s) in dataSources.indexed)
-        if (s.computerId != null) s.computerId!: sourceColorAt(index),
-    };
-    final tankSourceColors = isMultiSource
-        ? <String, Color>{
-            for (final t in dive.tanks)
-              if (t.computerId != null &&
-                  computerColorById[t.computerId] != null)
-                t.id: computerColorById[t.computerId]!,
-          }
-        : null;
-
-    // The chart's main series: the active source's own points on a
-    // multi-source dive; dive.profile otherwise (identical for the primary).
-    // activeSourceProfileProvider is the one rule for this, shared with the
-    // dive-list panel and the selected-point lookups further down (#543).
-    // Attribution (activeComputerId) reads the SAME result, so the drawn
-    // points and the computer they are credited to can never disagree; the
-    // direct lookup only serves single-source dives, where the provider
-    // yields null and dive.profile is drawn.
-    final resolvedActive = ref.watch(activeSourceProfileProvider(dive.id));
-    final activeProfile =
-        resolvedActive ??
-        (activeSource == null ? null : sourceProfiles[activeSource.id]);
-    // A metadata-only active source has an entry with no points; the chart
-    // then renders its empty-profile placeholder instead of silently
-    // falling back to the primary's profile (mixed attribution).
-    //
-    // Everything overlaid on the chart is derived from THIS series, never
-    // from dive.profile: the merged series spans every source, so markers
-    // computed against it can report a depth the drawn curve never reaches
-    // and a range extent that runs past its end (#1167).
-    final chartProfile = resolvedActive?.points ?? dive.profile;
-
-    // Keep the playback and range extents on the drawn series.
-    //
-    // Deliberately not a one-shot "initialize if still zero": the data
-    // sources load asynchronously, so the first build falls back to
-    // dive.profile and a zero-guard would freeze the merged series' extent
-    // in place forever. The active source can also change at any time. Both
-    // cases leave the range slider running past the end of the visible curve
-    // (#1167). Re-initializing resets playback position and range selection,
-    // which is the wanted behavior when the series underneath them changed.
-    //
-    // The comparison runs here in build, against state this method already
-    // watches, so a frame callback is only scheduled on the rare build that
-    // has work to do. Scheduling unconditionally would queue a no-op closure
-    // 40 times a second while a profile plays: the playback timer ticks every
-    // 25ms and this page watches its state.
-    if (chartProfile.isNotEmpty) {
-      final maxTimestamp = chartProfile.last.timestamp;
-      if (playbackState.maxTimestamp != maxTimestamp ||
-          rangeState.maxTimestamp != maxTimestamp) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          // Re-read rather than trusting the build-time snapshot: the rest of
-          // the frame may have moved either extent already.
-          if (ref.read(playbackProvider(dive.id)).maxTimestamp !=
-              maxTimestamp) {
-            ref
-                .read(playbackProvider(dive.id).notifier)
-                .initialize(maxTimestamp);
-          }
-          if (ref.read(rangeSelectionProvider(dive.id)).maxTimestamp !=
-              maxTimestamp) {
-            ref
-                .read(rangeSelectionProvider(dive.id).notifier)
-                .initialize(maxTimestamp);
-          }
-        });
-      }
-    }
-
-    // Calculate profile markers (with tank pressure data for accurate thresholds)
-    final markers = _calculateProfileMarkers(
-      profile: chartProfile,
-      tanks: dive.tanks,
-      analysis: analysis,
-      showMaxDepth: showMaxDepthMarker,
-      showPressureThresholds: showPressureThresholdMarkers,
-      tankPressures: tankPressures,
-    );
-
-    final photoMedia =
-        ref.watch(mediaForDiveProvider(dive.id)).value ?? const [];
-    final photoMarkers = chartProfile.isEmpty
-        ? const <PhotoChartMarker>[]
-        : photoMarkersFromMedia(
-            photoMedia,
-            maxProfileSeconds: chartProfile.last.timestamp,
-          );
-
-    // Overlay ids are session state and can briefly outlive their source
-    // rows (e.g. right after a split); skip any stale entries instead of
-    // crashing on the lookup.
-    final sourceById = {for (final s in dataSources) s.id: s};
-    // Plan-vs-actual: the planned profile this dive was converted from,
-    // ghosted next to the actual logged profile.
-    final plannedOverlay = ref
-        .watch(plannedProfileOverlayProvider(dive.id))
-        .value;
-    final overlays = <ChartSourceOverlay>[
-      for (final id in overlayIds)
-        if (id != activeSource?.id &&
-            sourceProfiles[id] != null &&
-            sourceById[id] != null)
-          ChartSourceOverlay(
-            sourceId: id,
-            name: resolveSourceName(
-              sourceById[id]!,
-              labels,
-              edited: sourceProfiles[id]!.isEdited,
-            ),
-            color: sourceColorById[id] ?? sourceColorAt(0),
-            computerId: sourceProfiles[id]!.computerId,
-            points: sourceProfiles[id]!.points,
-            // This source's own computed analysis, for overlay curves with
-            // no raw per-point device field (deco stops, and future
-            // metrics) to fall back on. Cached by the (diveId, sourceId)
-            // family key, so toggling the eye icon doesn't re-run Buhlmann.
-            analysis: ref
-                .watch(
-                  sourceProfileAnalysisProvider((
-                    diveId: dive.id,
-                    sourceId: id,
-                  )),
-                )
-                .valueOrNull,
-          ),
-      ?plannedOverlay,
-    ];
+    // The series the chart draws, resolved by the same one rule the chart
+    // itself uses (#543): the active source's own points on a multi-source
+    // dive, dive.profile otherwise. The point count, the playback stats and
+    // the range panel below all index it, so they must read the same series
+    // the curve was drawn from.
+    final chartProfile =
+        ref.watch(activeSourceProfileProvider(dive.id))?.points ?? dive.profile;
 
     // Get unit formatter
     final settings = ref.watch(settingsProvider);
@@ -2174,170 +1995,10 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
             ),
             const SizedBox(height: 8),
             // Chart with optional range selection overlay
-            LayoutBuilder(
-              builder: (context, constraints) {
-                final trackingIndex = ref.watch(
-                  profileTrackingIndexProvider(diveId),
-                );
-                final selectedFinding = ref.watch(
-                  selectedSafetyFindingProvider(diveId),
-                );
-                final safetyReview = ref
-                    .watch(safetyReviewProvider(diveId))
-                    .value;
-                final appSettings = ref.watch(settingsProvider);
-                final laneFindings = appSettings.safetyReviewEnabled
-                    ? chartSafetyFindings(
-                        safetyReview,
-                        appSettings.safetyReviewDisabledRules,
-                      )
-                    : const <SafetyFinding>[];
-                // Gate the highlight on lane membership: with safety review
-                // (or the finding's rule) disabled neither the lane nor the
-                // section renders, so an ungated highlight would be stuck on
-                // the chart with no UI to clear it.
-                final visibleSelectedFinding =
-                    selectedFinding != null &&
-                        laneFindings.any((f) => f.id == selectedFinding.id)
-                    ? selectedFinding
-                    : null;
-                return Stack(
-                  children: [
-                    MouseRegion(
-                      onExit: (_) {
-                        ref
-                                .read(
-                                  profileTrackingIndexProvider(diveId).notifier,
-                                )
-                                .state =
-                            null;
-                      },
-                      child: DiveProfileChart(
-                        exportKey: _profileChartExportKey,
-                        profile: chartProfile,
-                        overlays: overlays.isEmpty ? null : overlays,
-                        activeComputerId: activeProfile?.computerId,
-                        diveDuration: dive.effectiveRuntime,
-                        maxDepth: dive.maxDepth,
-                        ceilingCurve: analysis?.ceilingCurve,
-                        decoStopCurve: analysis?.decoStopCurve,
-                        ascentRates: analysis?.ascentRates,
-                        events: analysis?.events,
-                        ndlCurve: analysis?.ndlCurve,
-                        sacCurve: analysis?.smoothedSacCurve,
-                        ppO2Curve: analysis?.ppO2Curve,
-                        o2SensorCurves: analysis?.o2SensorCurves,
-                        o2CellMvCurves: analysis?.o2CellMvCurves,
-                        ppO2FromSensorAverage:
-                            analysis?.ppO2FromSensorAverage ?? false,
-                        ppN2Curve: analysis?.ppN2Curve,
-                        ppHeCurve: analysis?.ppHeCurve,
-                        modCurve: analysis?.modCurve,
-                        densityCurve: analysis?.densityCurve,
-                        gfCurve: analysis?.gfCurve,
-                        surfaceGfCurve: analysis?.surfaceGfCurve,
-                        meanDepthCurve: analysis?.meanDepthCurve,
-                        ttsCurve: analysis?.ttsCurve,
-                        gtrCurve: analysis?.gtrCurve,
-                        cnsCurve: analysis?.cnsCurve,
-                        otuCurve: analysis?.otuCurve,
-                        tankVolume: dive.tanks
-                            .where((t) => t.volume != null && t.volume! > 0)
-                            .map((t) => t.volume!)
-                            .firstOrNull,
-                        sacNormalizationFactor: calculateSacNormalizationFactor(
-                          dive,
-                          analysis,
-                        ),
-                        markers: markers,
-                        photoMarkers: photoMarkers.isEmpty
-                            ? null
-                            : photoMarkers,
-                        showMaxDepthMarker: showMaxDepthMarker,
-                        showPressureThresholdMarkers:
-                            showPressureThresholdMarkers,
-                        tanks: dive.tanks,
-                        tankPressures:
-                            estimatedTankPressures?.pressures ?? tankPressures,
-                        estimatedTankIds:
-                            estimatedTankPressures?.estimatedTankIds,
-                        tankSourceColors: tankSourceColors,
-                        gasSwitches: gasSwitchesAsync.value,
-                        gasSegments:
-                            (dive.tanks.isEmpty || chartProfile.isEmpty)
-                            ? null
-                            : buildGasUsageSegments(
-                                tanks: dive.tanks,
-                                gasSwitches: gasSwitchesAsync.value ?? const [],
-                                diveDurationSeconds:
-                                    chartProfile.last.timestamp,
-                                firstSampleSeconds:
-                                    chartProfile.first.timestamp,
-                              ),
-                        diveDurationSeconds: chartProfile.isEmpty
-                            ? null
-                            : chartProfile.last.timestamp,
-                        computerNames: computerNames,
-                        playbackTimestamp: playbackState.isActive
-                            ? playbackState.currentTimestamp
-                            : null,
-                        highlightedTimestamp:
-                            trackingIndex != null &&
-                                trackingIndex < chartProfile.length
-                            ? chartProfile[trackingIndex].timestamp
-                            : null,
-                        highlightRange: profileHighlightRangeFor(
-                          visibleSelectedFinding,
-                          Theme.of(context).colorScheme,
-                        ),
-                        safetyFindings: laneFindings.isEmpty
-                            ? null
-                            : laneFindings,
-                        selectedSafetyFindingId: visibleSelectedFinding?.id,
-                        onSafetyFindingTap: (finding) {
-                          final notifier = ref.read(
-                            selectedSafetyFindingProvider(diveId).notifier,
-                          );
-                          notifier.state = notifier.state?.id == finding.id
-                              ? null
-                              : finding;
-                        },
-                        onSafetyFindingDismiss: (finding) =>
-                            setSafetyFindingDismissed(
-                              ref,
-                              finding: finding,
-                              dismissed: true,
-                            ),
-                        onSafetyFindingDetails: (_) => _scrollToSafetySection(),
-                        // Range handles are drawn by the chart itself so they
-                        // land on the plot rect at any zoom (issue #1579).
-                        rangeSelection: rangeState.isEnabled
-                            ? (
-                                startSeconds: rangeState.startTimestamp ?? 0,
-                                endSeconds:
-                                    rangeState.endTimestamp ??
-                                    rangeState.maxTimestamp,
-                                maxSeconds: rangeState.maxTimestamp,
-                              )
-                            : null,
-                        onRangeChanged: (start, end) => ref
-                            .read(rangeSelectionProvider(dive.id).notifier)
-                            .setRange(start, end),
-                        onPointSelected: (index) {
-                          ref
-                                  .read(
-                                    profileTrackingIndexProvider(
-                                      diveId,
-                                    ).notifier,
-                                  )
-                                  .state =
-                              index;
-                        },
-                      ),
-                    ),
-                  ],
-                );
-              },
+            DiveProfileChartHost(
+              dive: dive,
+              exportKey: _profileChartExportKey,
+              onSafetyFindingDetails: (_) => _scrollToSafetySection(),
             ),
             // Profile point count (bottom-right, inline with x-axis)
             Align(
@@ -3695,44 +3356,6 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   /// positioned from is the active source's, so indexing it into the merged
   /// series would place the max-depth flag at another computer's reading
   /// (#1167).
-  List<ProfileMarker> _calculateProfileMarkers({
-    required List<DiveProfilePoint> profile,
-    required List<DiveTank> tanks,
-    required ProfileAnalysis? analysis,
-    required bool showMaxDepth,
-    required bool showPressureThresholds,
-    Map<String, List<TankPressurePoint>>? tankPressures,
-  }) {
-    final markers = <ProfileMarker>[];
-
-    if (profile.isEmpty) return markers;
-
-    // Add max depth marker
-    if (showMaxDepth && analysis != null) {
-      final maxDepthMarker = ProfileMarkersService.getMaxDepthMarker(
-        profile: profile,
-        maxDepthTimestamp: analysis.maxDepthTimestamp,
-        maxDepth: analysis.maxDepth,
-      );
-      if (maxDepthMarker != null) {
-        markers.add(maxDepthMarker);
-      }
-    }
-
-    // Add pressure threshold markers (using per-tank data when available)
-    if (showPressureThresholds && tanks.isNotEmpty) {
-      markers.addAll(
-        ProfileMarkersService.getPressureThresholdMarkers(
-          profile: profile,
-          tanks: tanks,
-          tankPressures: tankPressures,
-        ),
-      );
-    }
-
-    return markers;
-  }
-
   Widget _buildEnvironmentSection(
     BuildContext context,
     Dive dive,

--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -19,6 +19,7 @@ import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
 import 'package:submersion/features/dive_log/domain/entities/profile_event.dart';
 import 'package:submersion/features/dive_log/domain/services/computer_cns_extractor.dart';
@@ -1232,7 +1233,18 @@ final sourceProfileAnalysisProvider =
         final sources = await ref.watch(
           diveDataSourcesProvider(key.diveId).future,
         );
-        if (sources.length < 2) {
+        final profiles = await ref.watch(
+          sourceProfilesProvider(key.diveId).future,
+        );
+        // usesPerSourceRendering, the same rule the chart picks its series
+        // with, and deliberately not a source count. The sequential halves of
+        // a Combine are two sources that every profile surface still draws as
+        // the merged dive.profile, because drawing one half would hide the
+        // rest of the dive (#1451). A count does not see that, and analysing
+        // one half while the chart shows the whole dive pairs half-length
+        // curves with a full-length series: the curves run out midway and the
+        // samples they do cover are the wrong ones.
+        if (!usesPerSourceRendering(sources, profiles.values)) {
           return await ref.watch(profileAnalysisProvider(key.diveId).future);
         }
         final primaryId =
@@ -1251,9 +1263,6 @@ final sourceProfileAnalysisProvider =
             : primaryId;
         final dive = await ref.watch(analysisDiveProvider(key.diveId).future);
         if (dive == null) return null;
-        final profiles = await ref.watch(
-          sourceProfilesProvider(key.diveId).future,
-        );
         final sourceProfile = profiles[effectiveSourceId];
         if (sourceProfile == null) {
           // Bucket unavailable (still loading, or stale id): fall back to

--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -1233,17 +1233,24 @@ final sourceProfileAnalysisProvider =
         final sources = await ref.watch(
           diveDataSourcesProvider(key.diveId).future,
         );
+        // One source can never render per-source, so answer it without
+        // reading the buckets at all: this is the common case, and
+        // sourceProfilesProvider is a database round trip.
+        if (sources.length < 2) {
+          return await ref.watch(profileAnalysisProvider(key.diveId).future);
+        }
         final profiles = await ref.watch(
           sourceProfilesProvider(key.diveId).future,
         );
+        // Two or more sources is necessary but not sufficient, so gate on
         // usesPerSourceRendering, the same rule the chart picks its series
-        // with, and deliberately not a source count. The sequential halves of
-        // a Combine are two sources that every profile surface still draws as
-        // the merged dive.profile, because drawing one half would hide the
-        // rest of the dive (#1451). A count does not see that, and analysing
-        // one half while the chart shows the whole dive pairs half-length
-        // curves with a full-length series: the curves run out midway and the
-        // samples they do cover are the wrong ones.
+        // with. The sequential halves of a Combine are two sources that every
+        // profile surface still draws as the merged dive.profile, because
+        // drawing one half would hide the rest of the dive (#1451). A count
+        // alone does not see that, and analysing one half while the chart
+        // shows the whole dive pairs half-length curves with a full-length
+        // series: they run out midway and the samples they do cover are the
+        // wrong ones.
         if (!usesPerSourceRendering(sources, profiles.values)) {
           return await ref.watch(profileAnalysisProvider(key.diveId).future);
         }

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart_host.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart_host.dart
@@ -244,9 +244,19 @@ class DiveProfileChartHost extends ConsumerWidget {
     // computed against it can report a depth the drawn curve never reaches
     // and a range extent that runs past its end (#1167).
     final resolvedActive = ref.watch(activeSourceProfileProvider(diveId));
+    // Attribution follows the drawn series, because activeComputerId is what
+    // gates every per-computer layer (tank pressure traces, events).
+    //
+    // A non-null resolvedActive means one source's bucket is drawn, so that
+    // source owns the series. Null means the merged dive.profile is drawn,
+    // and then it depends on how many sources went into the union: on a
+    // single-source dive the union IS that source, so it still owns it, but
+    // on a Combine's sequential halves the union spans several computers and
+    // none of them owns it (#1451). Naming one there hid the other half's
+    // tank pressures and events while its depth samples stayed on the chart.
     final activeProfile =
         resolvedActive ??
-        (activeSource == null ? null : sourceProfiles[activeSource.id]);
+        (dataSources.length == 1 ? sourceProfiles[dataSources.first.id] : null);
     final chartProfile = resolvedActive?.points ?? dive.profile;
 
     _keepExtentsOnDrawnSeries(

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart_host.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart_host.dart
@@ -1,0 +1,471 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/services/gas_usage_segments_service.dart';
+import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart'
+    show ProfileAnalysis;
+import 'package:submersion/features/dive_log/data/services/profile_markers_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
+import 'package:submersion/features/dive_log/domain/services/source_name_resolver.dart';
+import 'package:submersion/features/dive_log/presentation/providers/active_source_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/chart_tank_pressures_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_playback_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_range_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_tracking_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
+import 'package:submersion/features/dive_log/presentation/utils/sac_normalization.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/photo_marker_layout.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_finding_highlight.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/source_bar.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
+import 'package:submersion/features/planner/presentation/providers/plan_overlay_provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Localized source-name fallbacks, for [resolveSourceName].
+SourceNameLabels sourceNameLabelsFor(BuildContext context) {
+  return SourceNameLabels(
+    unknownComputer: context.l10n.diveLog_sources_unknownComputer,
+    manualEntry: context.l10n.diveLog_sources_manualEntry,
+    importedFile: context.l10n.diveLog_sources_importedFile,
+    editedSuffix: context.l10n.diveLog_sources_editedSuffix,
+  );
+}
+
+/// Resolves computerId -> display name for a dive's data sources via the
+/// shared [resolveSourceName] fallback chain. Sources without a computerId
+/// (manual entries, edited profiles) are skipped: callers key off computerId,
+/// so there's nothing to attach the name to.
+Map<String, String> computerDisplayNames(
+  BuildContext context,
+  List<DiveDataSource> dataSources,
+) {
+  final labels = sourceNameLabelsFor(context);
+  return {
+    for (final source in dataSources)
+      if (source.computerId != null)
+        source.computerId!: resolveSourceName(source, labels),
+  };
+}
+
+/// The chart's max-depth and pressure-threshold pins, for the series actually
+/// drawn.
+List<ProfileMarker> profileChartMarkers({
+  required List<DiveProfilePoint> profile,
+  required List<DiveTank> tanks,
+  required ProfileAnalysis? analysis,
+  required bool showMaxDepth,
+  required bool showPressureThresholds,
+  Map<String, List<TankPressurePoint>>? tankPressures,
+}) {
+  final markers = <ProfileMarker>[];
+
+  if (profile.isEmpty) return markers;
+
+  if (showMaxDepth && analysis != null) {
+    final maxDepthMarker = ProfileMarkersService.getMaxDepthMarker(
+      profile: profile,
+      maxDepthTimestamp: analysis.maxDepthTimestamp,
+      maxDepth: analysis.maxDepth,
+    );
+    if (maxDepthMarker != null) {
+      markers.add(maxDepthMarker);
+    }
+  }
+
+  if (showPressureThresholds && tanks.isNotEmpty) {
+    markers.addAll(
+      ProfileMarkersService.getPressureThresholdMarkers(
+        profile: profile,
+        tanks: tanks,
+        tankPressures: tankPressures,
+      ),
+    );
+  }
+
+  return markers;
+}
+
+/// A fully wired [DiveProfileChart] for [dive].
+///
+/// Every surface that shows a dive's profile draws the same chart with the
+/// same inputs: the dive detail page, and the latest-dive slot on the home
+/// tab. Those inputs are ~40 derived values pulled from a dozen providers
+/// (per-source profiles and their analyses, overlays, markers, photo pins,
+/// tank pressures, gas segments, safety findings, range and playback state),
+/// and hand-copying that list per call site is how two surfaces silently
+/// stop agreeing about the same dive. This is the one copy.
+///
+/// Only genuinely host-specific concerns stay parameters. Everything else,
+/// including the legend's metric toggles ([profileLegendProvider] is a single
+/// app-wide notifier), is shared state, so turning on a curve in dive details
+/// turns it on everywhere the chart is drawn.
+class DiveProfileChartHost extends ConsumerWidget {
+  const DiveProfileChartHost({
+    super.key,
+    required this.dive,
+    this.exportKey,
+    this.legendLeading,
+    this.tooltipBelow = false,
+    this.onTooltipData,
+    this.onSafetyFindingDetails,
+  });
+
+  /// The hydrated dive: tanks and profile samples included. A dive loaded for
+  /// a list view carries neither, and would draw an empty chart.
+  final Dive dive;
+
+  /// Repaint boundary key for "export profile as image".
+  final GlobalKey? exportKey;
+
+  /// Rendered at the head of the legend row (the fullscreen page's close
+  /// button and title).
+  final Widget? legendLeading;
+
+  /// Hand tooltip rows to the host instead of painting them over the plot.
+  /// Needed where there is no headroom above the chart for the painted
+  /// tooltip to land in.
+  final bool tooltipBelow;
+
+  final void Function(List<TooltipRow>? rows)? onTooltipData;
+
+  /// "Show me the details" on a safety finding's callout. Null hides the
+  /// action, which is right wherever the safety section is not on screen to
+  /// scroll to.
+  final void Function(SafetyFinding finding)? onSafetyFindingDetails;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final diveId = dive.id;
+
+    // Every async chart input below is read through the built-in
+    // AsyncValue.value, which keeps the previous value while a provider
+    // reloads. The valueOrNull polyfill returns null during a reload, and
+    // these providers reload behind any detail change tick (the first-view
+    // safety review write included): the chart would drop its overlays and
+    // estimated pressure series for a frame, then draw them again (#1468).
+    final activeSourceId = ref.watch(activeDiveSourceProvider(diveId));
+    final analysis = ref
+        .watch(
+          sourceProfileAnalysisProvider((
+            diveId: diveId,
+            sourceId: activeSourceId,
+          )),
+        )
+        .value;
+
+    final showMaxDepthMarker = ref.watch(showMaxDepthMarkerProvider);
+    final showPressureThresholdMarkers = ref.watch(
+      showPressureThresholdMarkersProvider,
+    );
+
+    final gasSwitches = ref.watch(gasSwitchesProvider(diveId)).value;
+
+    // Per-tank pressures, augmented for the chart only with linear estimates
+    // between the samples a computer actually reported (#197).
+    final tankPressures = ref
+        .watch(activeSourceTankPressuresProvider(diveId))
+        .value;
+    final estimatedTankPressures = ref
+        .watch(estimatedTankPressuresProvider(diveId))
+        .value;
+
+    final playbackState = ref.watch(playbackProvider(diveId));
+    final rangeState = ref.watch(rangeSelectionProvider(diveId));
+
+    final sourceProfiles =
+        ref.watch(sourceProfilesProvider(diveId)).value ??
+        const <String, SourceProfile>{};
+    final dataSources =
+        ref.watch(diveDataSourcesProvider(diveId)).value ??
+        const <DiveDataSource>[];
+    final computerNames = computerDisplayNames(context, dataSources);
+    final labels = sourceNameLabelsFor(context);
+
+    // Per-source rendering exists because two computers recording one dive
+    // disagree sample by sample (#543); the halves of a split dive a Combine
+    // stitched together are not that, and drawing one of those would hide the
+    // rest of the dive (#1451).
+    final isMultiSource = usesPerSourceRendering(
+      dataSources,
+      sourceProfiles.values,
+    );
+
+    final overlayIds = ref.watch(overlaySourcesProvider(diveId));
+
+    final primarySource =
+        dataSources.where((s) => s.isPrimary).firstOrNull ??
+        dataSources.firstOrNull;
+    final activeSource = activeSourceId == null
+        ? primarySource
+        : dataSources.where((s) => s.id == activeSourceId).firstOrNull ??
+              primarySource;
+
+    // Stable color per source, assigned by data-source order (never changes
+    // as overlays toggle).
+    final sourceColorById = <String, Color>{
+      for (final (index, s) in dataSources.indexed) s.id: sourceColorAt(index),
+    };
+
+    // Per-computer color, so tank rings can mark which computer a tank
+    // belongs to when two computers logged tanks sharing the same gas mix
+    // (otherwise identical swatches).
+    final computerColorById = <String, Color>{
+      for (final (index, s) in dataSources.indexed)
+        if (s.computerId != null) s.computerId!: sourceColorAt(index),
+    };
+    final tankSourceColors = isMultiSource
+        ? <String, Color>{
+            for (final t in dive.tanks)
+              if (t.computerId != null &&
+                  computerColorById[t.computerId] != null)
+                t.id: computerColorById[t.computerId]!,
+          }
+        : null;
+
+    // The chart's main series: the active source's own points on a
+    // multi-source dive; dive.profile otherwise (identical for the primary).
+    // Attribution (activeComputerId) reads the SAME result, so the drawn
+    // points and the computer they are credited to can never disagree.
+    //
+    // A metadata-only active source has an entry with no points; the chart
+    // then renders its empty-profile placeholder instead of silently falling
+    // back to the primary's profile (mixed attribution).
+    //
+    // Everything overlaid on the chart is derived from THIS series, never
+    // from dive.profile: the merged series spans every source, so markers
+    // computed against it can report a depth the drawn curve never reaches
+    // and a range extent that runs past its end (#1167).
+    final resolvedActive = ref.watch(activeSourceProfileProvider(diveId));
+    final activeProfile =
+        resolvedActive ??
+        (activeSource == null ? null : sourceProfiles[activeSource.id]);
+    final chartProfile = resolvedActive?.points ?? dive.profile;
+
+    _keepExtentsOnDrawnSeries(ref, chartProfile, playbackState, rangeState);
+
+    final markers = profileChartMarkers(
+      profile: chartProfile,
+      tanks: dive.tanks,
+      analysis: analysis,
+      showMaxDepth: showMaxDepthMarker,
+      showPressureThresholds: showPressureThresholdMarkers,
+      tankPressures: tankPressures,
+    );
+
+    final photoMedia =
+        ref.watch(mediaForDiveProvider(diveId)).value ?? const [];
+    final photoMarkers = chartProfile.isEmpty
+        ? const <PhotoChartMarker>[]
+        : photoMarkersFromMedia(
+            photoMedia,
+            maxProfileSeconds: chartProfile.last.timestamp,
+          );
+
+    // Overlay ids are session state and can briefly outlive their source rows
+    // (e.g. right after a split); skip any stale entries instead of crashing
+    // on the lookup.
+    final sourceById = {for (final s in dataSources) s.id: s};
+    // Plan-vs-actual: the planned profile this dive was converted from,
+    // ghosted next to the actual logged profile.
+    final plannedOverlay = ref
+        .watch(plannedProfileOverlayProvider(diveId))
+        .value;
+    final overlays = <ChartSourceOverlay>[
+      for (final id in overlayIds)
+        if (id != activeSource?.id &&
+            sourceProfiles[id] != null &&
+            sourceById[id] != null)
+          ChartSourceOverlay(
+            sourceId: id,
+            name: resolveSourceName(
+              sourceById[id]!,
+              labels,
+              edited: sourceProfiles[id]!.isEdited,
+            ),
+            color: sourceColorById[id] ?? sourceColorAt(0),
+            computerId: sourceProfiles[id]!.computerId,
+            points: sourceProfiles[id]!.points,
+            // This source's own computed analysis, for overlay curves with no
+            // raw per-point device field to fall back on. Cached by the
+            // (diveId, sourceId) family key, so toggling the eye icon doesn't
+            // re-run Buhlmann.
+            analysis: ref
+                .watch(
+                  sourceProfileAnalysisProvider((diveId: diveId, sourceId: id)),
+                )
+                .valueOrNull,
+          ),
+      ?plannedOverlay,
+    ];
+
+    final trackingIndex = ref.watch(profileTrackingIndexProvider(diveId));
+    final selectedFinding = ref.watch(selectedSafetyFindingProvider(diveId));
+    final safetyReview = ref.watch(safetyReviewProvider(diveId)).value;
+    final appSettings = ref.watch(settingsProvider);
+    final laneFindings = appSettings.safetyReviewEnabled
+        ? chartSafetyFindings(
+            safetyReview,
+            appSettings.safetyReviewDisabledRules,
+          )
+        : const <SafetyFinding>[];
+    // Gate the highlight on lane membership: with safety review (or the
+    // finding's rule) disabled neither the lane nor the section renders, so an
+    // ungated highlight would be stuck on the chart with no UI to clear it.
+    final visibleSelectedFinding =
+        selectedFinding != null &&
+            laneFindings.any((f) => f.id == selectedFinding.id)
+        ? selectedFinding
+        : null;
+
+    return MouseRegion(
+      onExit: (_) {
+        ref.read(profileTrackingIndexProvider(diveId).notifier).state = null;
+      },
+      child: DiveProfileChart(
+        exportKey: exportKey,
+        profile: chartProfile,
+        overlays: overlays.isEmpty ? null : overlays,
+        activeComputerId: activeProfile?.computerId,
+        diveDuration: dive.effectiveRuntime,
+        maxDepth: dive.maxDepth,
+        legendLeading: legendLeading,
+        tooltipBelow: tooltipBelow,
+        onTooltipData: onTooltipData,
+        ceilingCurve: analysis?.ceilingCurve,
+        decoStopCurve: analysis?.decoStopCurve,
+        ascentRates: analysis?.ascentRates,
+        events: analysis?.events,
+        ndlCurve: analysis?.ndlCurve,
+        sacCurve: analysis?.smoothedSacCurve,
+        ppO2Curve: analysis?.ppO2Curve,
+        o2SensorCurves: analysis?.o2SensorCurves,
+        o2CellMvCurves: analysis?.o2CellMvCurves,
+        ppO2FromSensorAverage: analysis?.ppO2FromSensorAverage ?? false,
+        ppN2Curve: analysis?.ppN2Curve,
+        ppHeCurve: analysis?.ppHeCurve,
+        modCurve: analysis?.modCurve,
+        densityCurve: analysis?.densityCurve,
+        gfCurve: analysis?.gfCurve,
+        surfaceGfCurve: analysis?.surfaceGfCurve,
+        meanDepthCurve: analysis?.meanDepthCurve,
+        ttsCurve: analysis?.ttsCurve,
+        gtrCurve: analysis?.gtrCurve,
+        cnsCurve: analysis?.cnsCurve,
+        otuCurve: analysis?.otuCurve,
+        tankVolume: dive.tanks
+            .where((t) => t.volume != null && t.volume! > 0)
+            .map((t) => t.volume!)
+            .firstOrNull,
+        sacNormalizationFactor: calculateSacNormalizationFactor(dive, analysis),
+        markers: markers,
+        photoMarkers: photoMarkers.isEmpty ? null : photoMarkers,
+        showMaxDepthMarker: showMaxDepthMarker,
+        showPressureThresholdMarkers: showPressureThresholdMarkers,
+        tanks: dive.tanks,
+        tankPressures: estimatedTankPressures?.pressures ?? tankPressures,
+        estimatedTankIds: estimatedTankPressures?.estimatedTankIds,
+        tankSourceColors: tankSourceColors,
+        gasSwitches: gasSwitches,
+        gasSegments: (dive.tanks.isEmpty || chartProfile.isEmpty)
+            ? null
+            : buildGasUsageSegments(
+                tanks: dive.tanks,
+                gasSwitches: gasSwitches ?? const [],
+                diveDurationSeconds: chartProfile.last.timestamp,
+                firstSampleSeconds: chartProfile.first.timestamp,
+              ),
+        diveDurationSeconds: chartProfile.isEmpty
+            ? null
+            : chartProfile.last.timestamp,
+        computerNames: computerNames,
+        playbackTimestamp: playbackState.isActive
+            ? playbackState.currentTimestamp
+            : null,
+        highlightedTimestamp:
+            trackingIndex != null && trackingIndex < chartProfile.length
+            ? chartProfile[trackingIndex].timestamp
+            : null,
+        highlightRange: profileHighlightRangeFor(
+          visibleSelectedFinding,
+          Theme.of(context).colorScheme,
+        ),
+        safetyFindings: laneFindings.isEmpty ? null : laneFindings,
+        selectedSafetyFindingId: visibleSelectedFinding?.id,
+        onSafetyFindingTap: (finding) {
+          final notifier = ref.read(
+            selectedSafetyFindingProvider(diveId).notifier,
+          );
+          notifier.state = notifier.state?.id == finding.id ? null : finding;
+        },
+        onSafetyFindingDismiss: (finding) =>
+            setSafetyFindingDismissed(ref, finding: finding, dismissed: true),
+        onSafetyFindingDetails: onSafetyFindingDetails,
+        // Range handles are drawn by the chart itself so they land on the
+        // plot rect at any zoom (#1579).
+        rangeSelection: rangeState.isEnabled
+            ? (
+                startSeconds: rangeState.startTimestamp ?? 0,
+                endSeconds: rangeState.endTimestamp ?? rangeState.maxTimestamp,
+                maxSeconds: rangeState.maxTimestamp,
+              )
+            : null,
+        onRangeChanged: (start, end) => ref
+            .read(rangeSelectionProvider(diveId).notifier)
+            .setRange(start, end),
+        onPointSelected: (index) {
+          ref.read(profileTrackingIndexProvider(diveId).notifier).state = index;
+        },
+      ),
+    );
+  }
+
+  /// Keep the playback and range extents on the series the chart draws.
+  ///
+  /// Deliberately not a one-shot "initialize if still zero": the data sources
+  /// load asynchronously, so the first build falls back to dive.profile and a
+  /// zero-guard would freeze the merged series' extent in place forever. The
+  /// active source can also change at any time. Both cases leave the range
+  /// slider running past the end of the visible curve (#1167).
+  /// Re-initializing resets playback position and range selection, which is
+  /// the wanted behavior when the series underneath them changed.
+  ///
+  /// The comparison runs in build, against state this widget already watches,
+  /// so a frame callback is only scheduled on the rare build that has work to
+  /// do. Scheduling unconditionally would queue a no-op closure 40 times a
+  /// second while a profile plays: the playback timer ticks every 25ms and
+  /// this widget watches its state.
+  void _keepExtentsOnDrawnSeries(
+    WidgetRef ref,
+    List<DiveProfilePoint> chartProfile,
+    PlaybackState playbackState,
+    RangeSelectionState rangeState,
+  ) {
+    if (chartProfile.isEmpty) return;
+    final maxTimestamp = chartProfile.last.timestamp;
+    if (playbackState.maxTimestamp == maxTimestamp &&
+        rangeState.maxTimestamp == maxTimestamp) {
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // Re-read rather than trusting the build-time snapshot: the rest of the
+      // frame may have moved either extent already.
+      if (ref.read(playbackProvider(dive.id)).maxTimestamp != maxTimestamp) {
+        ref.read(playbackProvider(dive.id).notifier).initialize(maxTimestamp);
+      }
+      if (ref.read(rangeSelectionProvider(dive.id)).maxTimestamp !=
+          maxTimestamp) {
+        ref
+            .read(rangeSelectionProvider(dive.id).notifier)
+            .initialize(maxTimestamp);
+      }
+    });
+  }
+}

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart_host.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart_host.dart
@@ -249,7 +249,13 @@ class DiveProfileChartHost extends ConsumerWidget {
         (activeSource == null ? null : sourceProfiles[activeSource.id]);
     final chartProfile = resolvedActive?.points ?? dive.profile;
 
-    _keepExtentsOnDrawnSeries(ref, chartProfile, playbackState, rangeState);
+    _keepExtentsOnDrawnSeries(
+      context,
+      ref,
+      chartProfile,
+      playbackState,
+      rangeState,
+    );
 
     final markers = profileChartMarkers(
       profile: chartProfile,
@@ -301,7 +307,7 @@ class DiveProfileChartHost extends ConsumerWidget {
                 .watch(
                   sourceProfileAnalysisProvider((diveId: diveId, sourceId: id)),
                 )
-                .valueOrNull,
+                .value,
           ),
       ?plannedOverlay,
     ];
@@ -443,6 +449,7 @@ class DiveProfileChartHost extends ConsumerWidget {
   /// second while a profile plays: the playback timer ticks every 25ms and
   /// this widget watches its state.
   void _keepExtentsOnDrawnSeries(
+    BuildContext context,
     WidgetRef ref,
     List<DiveProfilePoint> chartProfile,
     PlaybackState playbackState,
@@ -455,6 +462,14 @@ class DiveProfileChartHost extends ConsumerWidget {
       return;
     }
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      // riverpod's own liveness check: a ConsumerWidget's ref throws a
+      // StateError, in release as well as debug, once its element is gone.
+      // Scheduled from build, this callback drains at the end of that same
+      // frame and so has never yet outlived the widget (probed against a
+      // LayoutBuilder that drops the chart on resize: still mounted). The
+      // guard is here so that stays a scheduling detail rather than a
+      // precondition, for whoever next moves the call off the build path.
+      if (!context.mounted) return;
       // Re-read rather than trusting the build-time snapshot: the rest of the
       // frame may have moved either extent already.
       if (ref.read(playbackProvider(dive.id)).maxTimestamp != maxTimestamp) {

--- a/test/features/dashboard/presentation/widgets/recent_dive_profile_preview_test.dart
+++ b/test/features/dashboard/presentation/widgets/recent_dive_profile_preview_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
 import 'package:submersion/features/dashboard/presentation/widgets/recent_dive_profile_preview.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/fullscreen_profile_page.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_legend.dart';
@@ -136,6 +137,21 @@ void main() {
     expect(find.byType(Card), findsNothing);
     expect(find.text('Latest dive profile'), findsNothing);
     expect(find.text('No profile data for this dive'), findsNothing);
+  });
+
+  // The button this slot gained with the full chart: the plot is small here,
+  // so "give it the whole window" is the affordance that makes the slot
+  // usable rather than merely accurate.
+  testWidgets('opens the fullscreen profile from the header button', (
+    tester,
+  ) async {
+    await _pump(tester, profile: _profile());
+
+    expect(find.byIcon(Icons.fullscreen), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.fullscreen));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FullscreenProfilePage), findsOneWidget);
   });
 
   // The home slot is a fixed-height box, and the full chart carries a legend

--- a/test/features/dashboard/presentation/widgets/recent_dive_profile_preview_test.dart
+++ b/test/features/dashboard/presentation/widgets/recent_dive_profile_preview_test.dart
@@ -2,11 +2,13 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
 import 'package:submersion/features/dashboard/presentation/widgets/recent_dive_profile_preview.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_legend.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
@@ -29,21 +31,19 @@ Future<void> _pump(
   WidgetTester tester, {
   List<DiveProfilePoint>? profile,
   Object? error,
-  DepthUnit depthUnit = DepthUnit.meters,
 }) async {
-  final settings = MockSettingsNotifier(AppSettings(depthUnit: depthUnit));
+  final settings = MockSettingsNotifier(const AppSettings());
   final overrides = await getBaseOverrides(settingsNotifier: settings);
+  final listCopy = createTestDiveWithBottomTime(id: 'd1');
 
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         ...overrides,
-        recentDivesProvider.overrideWith(
-          (ref) async => [createTestDiveWithBottomTime(id: 'd1')],
-        ),
-        latestDiveProfileProvider.overrideWith((ref) async {
+        recentDivesProvider.overrideWith((ref) async => [listCopy]),
+        diveProvider('d1').overrideWith((ref) async {
           if (error != null) throw error;
-          return profile;
+          return listCopy.copyWith(profile: profile ?? const []);
         }),
       ].cast(),
       child: MaterialApp.router(
@@ -56,7 +56,7 @@ Future<void> _pump(
               builder: (context, state) => const Scaffold(
                 body: SizedBox(
                   width: 700,
-                  height: 300,
+                  height: 380,
                   child: RecentDiveProfilePreview(),
                 ),
               ),
@@ -74,10 +74,14 @@ Future<void> _pump(
 }
 
 void main() {
-  testWidgets('charts the profile of the newest dive', (tester) async {
+  // The whole point of the slot: the home tab draws the same chart the dive
+  // detail page draws, not a simplified rendition that drifts away from it.
+  testWidgets('charts the newest dive with the dive-detail chart', (
+    tester,
+  ) async {
     await _pump(tester, profile: _profile());
 
-    expect(find.byType(LineChart), findsOneWidget);
+    expect(find.byType(DiveProfileChart), findsOneWidget);
     expect(find.text('Latest dive profile'), findsOneWidget);
   });
 
@@ -88,7 +92,7 @@ void main() {
   ) async {
     await _pump(tester, profile: null);
 
-    expect(find.byType(LineChart), findsNothing);
+    expect(find.byType(DiveProfileChart), findsNothing);
     expect(find.text('No profile data for this dive'), findsOneWidget);
   });
 
@@ -100,27 +104,38 @@ void main() {
   ) async {
     await _pump(tester, error: Exception('db unavailable'));
 
-    expect(find.byType(LineChart), findsNothing);
+    expect(find.byType(DiveProfileChart), findsNothing);
     expect(find.text('No profile data for this dive'), findsNothing);
     expect(find.text("Couldn't load the dive profile"), findsOneWidget);
   });
 
-  testWidgets('plots depth in the diver\'s configured unit', (tester) async {
-    await _pump(tester, profile: _profile(), depthUnit: DepthUnit.feet);
-
-    final chart = tester.widget<LineChart>(find.byType(LineChart));
-    final deepest = chart.data.lineBarsData.single.spots
-        .map((s) => -s.y)
-        .reduce((a, b) => a > b ? a : b);
-
-    // 30 m is ~98.4 ft; in metres the deepest plotted value would be 30.
-    expect(deepest, greaterThan(90));
-  });
-
-  testWidgets('opens the dive when tapped', (tester) async {
+  // The home slot is a fixed-height box, and the full chart carries a legend
+  // row (and, on a dive with tanks, a gas timeline strip) above its plot. If
+  // that box is ever trimmed back to what the old static preview needed, the
+  // chart overflows it rather than shrinking the plot to nothing.
+  testWidgets('the full chart fits the height the home slot gives it', (
+    tester,
+  ) async {
     await _pump(tester, profile: _profile());
 
-    await tester.tap(find.byType(RecentDiveProfilePreview));
+    expect(tester.takeException(), isNull);
+    expect(find.byType(DiveProfileLegend), findsOneWidget);
+    // The plot must still be the bulk of the slot once the legend has taken
+    // its share, or the chart is there in name only.
+    expect(
+      tester.getSize(find.byType(LineChart).first).height,
+      greaterThan(200),
+    );
+  });
+
+  // The chart owns pan, zoom, tooltip and range gestures, so the card cannot
+  // be one big tap target the way a static preview could be. The header is.
+  testWidgets('opens the dive from the header, not from the chart', (
+    tester,
+  ) async {
+    await _pump(tester, profile: _profile());
+
+    await tester.tap(find.text('Latest dive profile'));
     await tester.pumpAndSettle();
 
     expect(find.text('detail'), findsOneWidget);

--- a/test/features/dashboard/presentation/widgets/recent_dive_profile_preview_test.dart
+++ b/test/features/dashboard/presentation/widgets/recent_dive_profile_preview_test.dart
@@ -31,7 +31,18 @@ Future<void> _pump(
   WidgetTester tester, {
   List<DiveProfilePoint>? profile,
   Object? error,
+  bool notFound = false,
 }) async {
+  // A host locale the app actually translates into, so the English finders
+  // below pass only because the MaterialApp pins `en`. Drop the pin and every
+  // test in this file fails, which is the point: unpinned, they would pass on
+  // en_US CI and fail on a translator's machine.
+  tester.platformDispatcher.localesTestValue = const [
+    Locale('fr'),
+    Locale('en'),
+  ];
+  addTearDown(tester.platformDispatcher.clearLocalesTestValue);
+
   final settings = MockSettingsNotifier(const AppSettings());
   final overrides = await getBaseOverrides(settingsNotifier: settings);
   final listCopy = createTestDiveWithBottomTime(id: 'd1');
@@ -43,10 +54,15 @@ Future<void> _pump(
         recentDivesProvider.overrideWith((ref) async => [listCopy]),
         diveProvider('d1').overrideWith((ref) async {
           if (error != null) throw error;
+          if (notFound) return null;
           return listCopy.copyWith(profile: profile ?? const []);
         }),
       ].cast(),
       child: MaterialApp.router(
+        // Pinned: every finder below matches an English literal, and an
+        // unpinned MaterialApp resolves against the HOST's locale list, so
+        // these pass on en_US CI and fail on a translator's machine.
+        locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         routerConfig: GoRouter(
@@ -107,6 +123,19 @@ void main() {
     expect(find.byType(DiveProfileChart), findsNothing);
     expect(find.text('No profile data for this dive'), findsNothing);
     expect(find.text("Couldn't load the dive profile"), findsOneWidget);
+  });
+
+  // "The dive is gone" and "the dive has no samples" are different facts, the
+  // same way a load failure is. The newest dive can be deleted between the
+  // recent-dives read and this one, and the list is about to drop it too, so
+  // the slot collapses rather than describing a dive that no longer exists.
+  testWidgets('collapses when the dive is not found, rather than claiming '
+      'it has no profile', (tester) async {
+    await _pump(tester, notFound: true);
+
+    expect(find.byType(Card), findsNothing);
+    expect(find.text('Latest dive profile'), findsNothing);
+    expect(find.text('No profile data for this dive'), findsNothing);
   });
 
   // The home slot is a fixed-height box, and the full chart carries a legend

--- a/test/features/dashboard/presentation/widgets/recent_dives_card_test.dart
+++ b/test/features/dashboard/presentation/widgets/recent_dives_card_test.dart
@@ -165,7 +165,7 @@ void main() {
             recentDivesProvider.overrideWith((ref) async => dives),
             // Keep the preview off the database; the split itself is what
             // this group is about.
-            latestDiveProfileProvider.overrideWith((ref) async => null),
+            diveProvider(dives.first.id).overrideWith((ref) async => null),
           ].cast(),
           child: MaterialApp.router(
             localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/test/features/dive_log/presentation/providers/source_profile_analysis_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/source_profile_analysis_provider_test.dart
@@ -229,6 +229,68 @@ void main() {
     expect(analysis!.ascentRates.length, primaryBucket.length);
   });
 
+  // usesPerSourceRendering, the rule every profile surface picks its series
+  // with, is false for the sequential halves of a Combine even though there
+  // are two sources (#1451): those surfaces draw the merged dive.profile,
+  // because drawing one half would hide the rest of the dive. A source count
+  // does not see that, so the analysis was computed over the primary half and
+  // index-paired against a chart showing the whole dive: every curve ran out
+  // halfway along, and the ones that did land were on the wrong samples.
+  test('a Combine\'s sequential halves analyse the merged dive.profile the '
+      'chart actually draws (#1451)', () async {
+    // Non-overlapping: the halves meet end to end, exactly what a Combine
+    // produces and what sourceProfilesAreSequential detects.
+    final firstHalf = _profile(100);
+    final secondHalf = _profile(100, startOffsetSeconds: 200);
+    final merged = [...firstHalf, ...secondHalf];
+
+    final dive = Dive(
+      id: 'dive-1',
+      dateTime: DateTime(2026, 5, 7),
+      profile: merged,
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(_prefs),
+        diverRepositoryProvider.overrideWithValue(_FakeDiverRepository()),
+        settingsProvider.overrideWith((ref) => _SettingsNotifier(ref)),
+        analysisDiveProvider('dive-1').overrideWith((ref) async => dive),
+        diveDataSourcesProvider('dive-1').overrideWith(
+          (ref) async => [
+            source('src-a', 'dc-a', true),
+            source('src-b', 'dc-b', false),
+          ],
+        ),
+        sourceProfilesProvider('dive-1').overrideWith(
+          (ref) async => {
+            'src-a': SourceProfile(
+              sourceId: 'src-a',
+              computerId: 'dc-a',
+              isEdited: false,
+              points: firstHalf,
+            ),
+            'src-b': SourceProfile(
+              sourceId: 'src-b',
+              computerId: 'dc-b',
+              isEdited: false,
+              points: secondHalf,
+            ),
+          },
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final analysis = await container.read(
+      sourceProfileAnalysisProvider((diveId: 'dive-1', sourceId: null)).future,
+    );
+
+    expect(analysis, isNotNull);
+    // The whole dive, not one half of it.
+    expect(analysis!.ascentRates.length, merged.length);
+  });
+
   test('single-source dives keep using dive.profile', () async {
     final profile = _profile(80);
     final dive = Dive(

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_host_combine_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_host_combine_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart_host.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Attribution on a dive whose sources are consecutive halves (#1451).
+///
+/// `usesPerSourceRendering` is false for those, so every profile surface
+/// draws the merged `dive.profile` rather than one source's bucket. The
+/// chart gates each per-computer layer on `activeComputerId`: a computer
+/// draws when it matches, when it is overlaid, or when nothing is active at
+/// all. Naming one half's computer there therefore hid the OTHER half's tank
+/// pressures and events, while its depth samples stayed on the chart, because
+/// a Combine renders no source bar to overlay the other half from.
+void main() {
+  final now = DateTime(2026, 5, 7);
+
+  // Two computers that never overlap: the first logs 0-180s, the second
+  // picks up at 240s. This is the shape sourceProfilesAreSequential detects.
+  const firstHalf = [
+    DiveProfilePoint(timestamp: 0, depth: 0.0),
+    DiveProfilePoint(timestamp: 60, depth: 18.0),
+    DiveProfilePoint(timestamp: 120, depth: 20.0),
+    DiveProfilePoint(timestamp: 180, depth: 5.0),
+  ];
+  const secondHalf = [
+    DiveProfilePoint(timestamp: 240, depth: 6.0),
+    DiveProfilePoint(timestamp: 300, depth: 22.0),
+    DiveProfilePoint(timestamp: 360, depth: 0.0),
+  ];
+  const merged = [...firstHalf, ...secondHalf];
+
+  DiveDataSource sourceOf(
+    String id,
+    String computerId, {
+    required bool primary,
+  }) => DiveDataSource(
+    id: id,
+    diveId: 'test-dive-1',
+    computerId: computerId,
+    isPrimary: primary,
+    computerName: computerId,
+    importedAt: now,
+    createdAt: now,
+  );
+
+  Future<DiveProfileChart> pumpHost(
+    WidgetTester tester, {
+    required List<DiveDataSource> sources,
+    required Map<String, SourceProfile> profiles,
+    required List<DiveProfilePoint> diveProfile,
+  }) async {
+    final dive = createTestDiveWithBottomTime().copyWith(profile: diveProfile);
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          diveProvider(dive.id).overrideWith((ref) async => dive),
+          diveDataSourcesProvider(dive.id).overrideWith((ref) async => sources),
+          sourceProfilesProvider(dive.id).overrideWith((ref) async => profiles),
+          gasSwitchesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+          sourceProfileAnalysisProvider((
+            diveId: dive.id,
+            sourceId: null,
+          )).overrideWith((ref) async => null),
+        ],
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 500,
+              child: DiveProfileChartHost(dive: dive),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    return tester.widget<DiveProfileChart>(find.byType(DiveProfileChart));
+  }
+
+  testWidgets('a Combine credits the merged series to no single computer', (
+    tester,
+  ) async {
+    final chart = await pumpHost(
+      tester,
+      sources: [
+        sourceOf('src-a', 'dc-a', primary: true),
+        sourceOf('src-b', 'dc-b', primary: false),
+      ],
+      profiles: {
+        'src-a': const SourceProfile(
+          sourceId: 'src-a',
+          computerId: 'dc-a',
+          isEdited: false,
+          points: firstHalf,
+        ),
+        'src-b': const SourceProfile(
+          sourceId: 'src-b',
+          computerId: 'dc-b',
+          isEdited: false,
+          points: secondHalf,
+        ),
+      },
+      diveProfile: merged,
+    );
+
+    // Guards the premise: both halves are on screen.
+    expect(chart.profile, merged);
+    // So neither half's computer may gate the per-computer layers.
+    expect(chart.activeComputerId, isNull);
+  });
+
+  // The counterweight: a single source's union IS that source, so it still
+  // owns the series and keeps its attribution. Without this, "return null
+  // whenever no per-source bucket is drawn" would look equally correct.
+  testWidgets('a single-source dive still credits its own computer', (
+    tester,
+  ) async {
+    final chart = await pumpHost(
+      tester,
+      sources: [sourceOf('src-a', 'dc-a', primary: true)],
+      profiles: {
+        'src-a': const SourceProfile(
+          sourceId: 'src-a',
+          computerId: 'dc-a',
+          isEdited: false,
+          points: firstHalf,
+        ),
+      },
+      diveProfile: firstHalf,
+    );
+
+    expect(chart.activeComputerId, 'dc-a');
+  });
+}


### PR DESCRIPTION
## Summary

The latest-dive slot on the home tab drew a bespoke `LineChart`: depth only, no legend, no analysis curves, no markers, no gestures. It looked nothing like the chart the same dive gets on the dive detail page.

The chart wiring on the detail page is ~80 properties derived from a dozen providers, and it was already copied three times (detail page, fullscreen page, dive-list side panel). Rather than write a fourth copy, this extracts it into one widget that both surfaces render through, so "the same chart" is true by construction instead of by copy-paste that drifts.

`profileLegendProvider` is a single app-wide notifier rather than a per-dive family, so every metric toggle, right-axis choice and per-tank visibility the diver sets in dive details already applies on the home tab. That is where "with all options" comes from for free.

## Changes

- **New `DiveProfileChartHost`** turns a hydrated `Dive` into a fully configured `DiveProfileChart`: per-source profiles and their analyses, source overlays, the planned-profile ghost, max-depth and pressure-threshold markers, photo pins, estimated tank pressures, gas segments and switches, the safety-findings lane, range selection, playback and cursor tracking. Only host-specific concerns stay parameters (`exportKey`, `legendLeading`, `tooltipBelow`, `onTooltipData`, `onSafetyFindingDetails`).
- **Dive detail page renders through it**, so it stays the reference implementation. Net -407 lines (6,011 to 5,634); its toolbar, point count, sources bar, playback and range panels are untouched. Three private helpers became shared functions.
- **The playback/range extent re-initialization moved into the host.** It exists to stop the range slider running past the end of the drawn curve (#1167), and that invariant belongs to whoever draws the curve, or the home tab would reintroduce the bug on its own copy.
- **The home card** re-reads the newest dive through `diveProvider` instead of charting the recent-dives list copy: that list refreshes on `dives`-table writes only, so a reparse rewriting samples in place would have left a stale shape on screen.
- **The whole-card `InkWell` is gone**, since it would swallow the chart's own pan, zoom, tooltip and range gestures. The header is the tap target and gains a fullscreen button.
- **Slot height 300 -> 380**, to seat the legend row above the plot. Measured in the new test: legend 34px, plot 274px, no overflow. That is more plot than the old static preview had at 300px.
- **`latestDiveProfileProvider` dropped.** It only fed this preview, and it re-fetched samples the dive already carried: its comment claimed `getDiveById` leaves `Dive.profile` empty, but that call goes through `_mapRowToDive`, which hydrates tanks, tank series and the merged profile.

## Test Plan

- [x] `flutter test` passes (25,091 passed, 21 skipped, 0 failures)
- [x] `flutter analyze` passes (clean across the project)
- [x] `dart format .` clean
- [x] New regression test asserts the full chart fits the fixed-height home slot without overflowing, and that the plot still gets the bulk of it
- [x] Manual testing on: macOS, wide window (home tab split only renders above `kMasterPaneWidth + 12 + 320`)

## Notes

Deliberately out of scope: the fullscreen page and the dive-list side panel still carry their own copies of the wiring. They have intentional differences (`tooltipBelow`, `legendLeading`, overlay tooltips) that the host already supports, but converting them touches heavy test suites and belongs in a separate change.
