### PR TITLE
feat(dashboard): pair recent media with recent sites on wide screens

### DIFF
--- a/lib/features/dashboard/presentation/home_cards.dart
+++ b/lib/features/dashboard/presentation/home_cards.dart
@@ -10,11 +10,13 @@ enum HomeCardType {
   recentDives,
   quickActions,
   milestones,
-  photoRibbon,
-  onThisDay,
   yearInReview,
-  activeCourses,
+  // photoRibbon and recentSitesMap are declared adjacent so the default
+  // layout pairs them side by side at desktop widths (see home_layout.dart).
+  photoRibbon,
   recentSitesMap,
+  onThisDay,
+  activeCourses,
 }
 
 /// Turns a stored order (HomeCardType.name strings from SharedPreferences)

--- a/lib/features/dashboard/presentation/home_layout.dart
+++ b/lib/features/dashboard/presentation/home_layout.dart
@@ -14,17 +14,34 @@ import 'package:submersion/features/dashboard/presentation/widgets/recent_sites_
 import 'package:submersion/features/dashboard/presentation/widgets/year_in_review_card.dart';
 import 'package:submersion/features/pre_dive/presentation/widgets/pre_dive_dashboard_card.dart';
 
-/// Maximum side cards a LeadSideGroup absorbs (mirrors the legacy layout).
-const int _maxSideCards = 2;
+/// Maximum side cards a LeadSideGroup absorbs. Three short cards stack to
+/// roughly the height of the RecentDivesCard they sit beside.
+const int _maxSideCards = 3;
 
 bool _isSideCapable(HomeCardType card) =>
-    card == HomeCardType.quickActions || card == HomeCardType.milestones;
+    card == HomeCardType.quickActions ||
+    card == HomeCardType.milestones ||
+    card == HomeCardType.yearInReview;
 
 Widget _sideWidget(HomeCardType card) => switch (card) {
   HomeCardType.quickActions => const QuickActionsCard(),
   HomeCardType.milestones => const MilestonesCard(),
+  HomeCardType.yearInReview => const YearInReviewCard(),
   _ => throw ArgumentError('not side-capable: $card'),
 };
+
+/// The two cards that share a row when they sit next to each other. The map
+/// is the taller of the pair, so the ribbon beside it stacks its tiles into
+/// [_pairedMediaRows] rows to reach the same height.
+bool _pairsWith(HomeCardType a, HomeCardType b) =>
+    (a == HomeCardType.photoRibbon && b == HomeCardType.recentSitesMap) ||
+    (a == HomeCardType.recentSitesMap && b == HomeCardType.photoRibbon);
+
+const int _pairedMediaRows = 2;
+
+Widget _pairedWidget(HomeCardType card) => card == HomeCardType.photoRibbon
+    ? const MediaRibbonCard(rows: _pairedMediaRows)
+    : const RecentSitesMapCard();
 
 DashboardEntry _standaloneEntry(HomeCardType card) => switch (card) {
   HomeCardType.hero => const FullBlock(HeroHeader()),
@@ -43,16 +60,29 @@ DashboardEntry _standaloneEntry(HomeCardType card) => switch (card) {
   HomeCardType.recentSitesMap => const FullBlock(RecentSitesMapCard()),
 };
 
-/// Packs the ordered visible cards into grid entries. Side-capable cards
-/// (quickActions, milestones) directly following recentDives are absorbed
-/// into its LeadSideGroup side column, exactly like the legacy hardcoded
-/// layout; everywhere else every card has one fixed block shape.
+/// Packs the ordered visible cards into grid entries. Two adjacency rules
+/// shape the result, both driven by the diver's own card order rather than
+/// overriding it:
+/// - side-capable cards (quickActions, milestones, yearInReview) directly
+///   following recentDives are absorbed into its LeadSideGroup side column;
+/// - an adjacent photoRibbon and recentSitesMap become a PairBlock, sharing
+///   one row at desktop widths.
+///
+/// Everywhere else every card has one fixed block shape.
 List<DashboardEntry> buildDashboardEntries(List<HomeCardType> visibleCards) {
   final entries = <DashboardEntry>[];
   var i = 0;
   while (i < visibleCards.length) {
     final card = visibleCards[i];
-    if (card == HomeCardType.recentDives) {
+    if (i + 1 < visibleCards.length && _pairsWith(card, visibleCards[i + 1])) {
+      entries.add(
+        PairBlock(
+          first: _pairedWidget(card),
+          second: _pairedWidget(visibleCards[i + 1]),
+        ),
+      );
+      i += 2;
+    } else if (card == HomeCardType.recentDives) {
       final side = <Widget>[];
       var j = i + 1;
       while (j < visibleCards.length &&

--- a/lib/features/dashboard/presentation/widgets/dashboard_grid.dart
+++ b/lib/features/dashboard/presentation/widgets/dashboard_grid.dart
@@ -20,6 +20,19 @@ class ThirdBlock extends DashboardEntry {
   const ThirdBlock(this.child);
 }
 
+/// Two widgets sharing one row at 2 or 3 columns, half the width each, and
+/// stacked in order at 1 column.
+///
+/// Deliberately not two [ThirdBlock]s: those are packed in chunks of the
+/// column count, so at 3 columns a neighbouring third would join the row and
+/// squeeze the pair to a third of the width each. A pair states that the two
+/// cards belong side by side whatever surrounds them.
+class PairBlock extends DashboardEntry {
+  final Widget first;
+  final Widget second;
+  const PairBlock({required this.first, required this.second});
+}
+
 /// A lead widget with side widgets stacked in the remaining column.
 /// At 3 columns the lead spans 2; at 2 columns it spans 1; at 1 column
 /// the group dissolves into the plain ordered stack.
@@ -85,6 +98,25 @@ class DashboardGrid extends StatelessWidget {
         case FullBlock(:final child):
           flushThirds();
           rows.add(child);
+        case PairBlock(:final first, :final second):
+          flushThirds();
+          if (columns == 1) {
+            rows.add(first);
+            rows.add(second);
+          } else {
+            // Same top-aligned natural heights as every other row here: the
+            // taller card does not stretch its partner.
+            rows.add(
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(child: first),
+                  SizedBox(width: spacing),
+                  Expanded(child: second),
+                ],
+              ),
+            );
+          }
         case LeadSideGroup(:final lead, :final side):
           flushThirds();
           if (columns == 1) {

--- a/lib/features/dashboard/presentation/widgets/media_ribbon_card.dart
+++ b/lib/features/dashboard/presentation/widgets/media_ribbon_card.dart
@@ -2,17 +2,34 @@ import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/features/dashboard/presentation/providers/media_ribbon_providers.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/pages/photo_viewer_page.dart';
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 
 /// Ribbon tile size in logical pixels.
 const double _tileWidth = 128;
 const double _tileHeight = 96;
 
+/// Gap between tiles, along the ribbon and between its rows.
+const double _tileSpacing = 8;
+
+/// Tile area of a ribbon paired beside the recent-sites map. Matches that
+/// card's fixed 220 pt map so the two cards end at roughly the same place;
+/// the grid top-aligns them rather than stretching, so the ribbon has to
+/// reach that height itself.
+const double mediaRibbonPairedHeight = 220;
+
 /// Horizontal ribbon of the newest dive photos and videos.
 class MediaRibbonCard extends ConsumerWidget {
-  const MediaRibbonCard({super.key});
+  /// How many rows of tiles to stack, for filling the height of a taller
+  /// card sharing the row. Honoured only at desktop widths: below the
+  /// breakpoint the grid dissolves every pairing into a plain stack, where
+  /// extra rows would just make a taller card for nothing.
+  final int rows;
+
+  const MediaRibbonCard({this.rows = 1, super.key});
 
   /// Opens the full-screen viewer on the item itself, with the rest of its
   /// dive's gallery swipeable alongside it. Pushed on the root navigator
@@ -44,6 +61,37 @@ class MediaRibbonCard extends ConsumerWidget {
       _tileWidth * MediaQuery.devicePixelRatioOf(context),
     );
 
+    // A pairing only exists at desktop widths; below the breakpoint the card
+    // stands alone in a single column and stays the compact one-row ribbon.
+    final stacked = rows > 1 && ResponsiveBreakpoints.isDesktop(context);
+    final contentHeight = stacked ? mediaRibbonPairedHeight : _tileHeight;
+
+    Widget tile(MediaItem item) {
+      final diveId = item.diveId;
+      return InkWell(
+        onTap: diveId == null
+            ? null
+            : () => _openViewer(context, diveId, item.id),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              MediaItemView(
+                item: item,
+                thumbnail: true,
+                targetSize: thumbnailTarget,
+              ),
+              // A video thumbnail is just a still frame, so without a badge
+              // it is indistinguishable from a photo in the ribbon.
+              if (item.isVideo)
+                const Positioned(right: 4, bottom: 4, child: _VideoBadge()),
+            ],
+          ),
+        ),
+      );
+    }
+
     return Card(
       margin: EdgeInsets.zero,
       child: Padding(
@@ -59,46 +107,33 @@ class MediaRibbonCard extends ConsumerWidget {
             ),
             const SizedBox(height: 8),
             SizedBox(
-              height: _tileHeight,
-              child: ListView.separated(
-                scrollDirection: Axis.horizontal,
-                itemCount: media.length,
-                separatorBuilder: (_, _) => const SizedBox(width: 8),
-                itemBuilder: (context, index) {
-                  final item = media[index];
-                  final diveId = item.diveId;
-                  return InkWell(
-                    onTap: diveId == null
-                        ? null
-                        : () => _openViewer(context, diveId, item.id),
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: SizedBox(
+              height: contentHeight,
+              child: stacked
+                  // Scrolls horizontally like the ribbon it replaces, so
+                  // crossAxisCount is the row count and mainAxisExtent the
+                  // tile width. Tile height falls out of the fixed content
+                  // height, which is what makes the card match its partner.
+                  ? GridView.builder(
+                      scrollDirection: Axis.horizontal,
+                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: rows,
+                        mainAxisExtent: _tileWidth,
+                        mainAxisSpacing: _tileSpacing,
+                        crossAxisSpacing: _tileSpacing,
+                      ),
+                      itemCount: media.length,
+                      itemBuilder: (context, index) => tile(media[index]),
+                    )
+                  : ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: media.length,
+                      separatorBuilder: (_, _) =>
+                          const SizedBox(width: _tileSpacing),
+                      itemBuilder: (context, index) => SizedBox(
                         width: _tileWidth,
-                        child: Stack(
-                          fit: StackFit.expand,
-                          children: [
-                            MediaItemView(
-                              item: item,
-                              thumbnail: true,
-                              targetSize: thumbnailTarget,
-                            ),
-                            // A video thumbnail is just a still frame, so
-                            // without a badge it is indistinguishable from a
-                            // photo in the ribbon.
-                            if (item.isVideo)
-                              const Positioned(
-                                right: 4,
-                                bottom: 4,
-                                child: _VideoBadge(),
-                              ),
-                          ],
-                        ),
+                        child: tile(media[index]),
                       ),
                     ),
-                  );
-                },
-              ),
             ),
           ],
         ),

--- a/lib/features/dashboard/presentation/widgets/media_ribbon_card.dart
+++ b/lib/features/dashboard/presentation/widgets/media_ribbon_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/features/dashboard/presentation/providers/media_ribbon_providers.dart';
+import 'package:submersion/features/dashboard/presentation/widgets/recent_sites_map_card.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/pages/photo_viewer_page.dart';
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
@@ -15,12 +16,6 @@ const double _tileHeight = 96;
 /// Gap between tiles, along the ribbon and between its rows.
 const double _tileSpacing = 8;
 
-/// Tile area of a ribbon paired beside the recent-sites map. Matches that
-/// card's fixed 220 pt map so the two cards end at roughly the same place;
-/// the grid top-aligns them rather than stretching, so the ribbon has to
-/// reach that height itself.
-const double mediaRibbonPairedHeight = 220;
-
 /// Horizontal ribbon of the newest dive photos and videos.
 class MediaRibbonCard extends ConsumerWidget {
   /// How many rows of tiles to stack, for filling the height of a taller
@@ -29,7 +24,8 @@ class MediaRibbonCard extends ConsumerWidget {
   /// extra rows would just make a taller card for nothing.
   final int rows;
 
-  const MediaRibbonCard({this.rows = 1, super.key});
+  const MediaRibbonCard({this.rows = 1, super.key})
+    : assert(rows >= 1, 'a ribbon needs at least one row of tiles');
 
   /// Opens the full-screen viewer on the item itself, with the rest of its
   /// dive's gallery swipeable alongside it. Pushed on the root navigator
@@ -64,7 +60,9 @@ class MediaRibbonCard extends ConsumerWidget {
     // A pairing only exists at desktop widths; below the breakpoint the card
     // stands alone in a single column and stays the compact one-row ribbon.
     final stacked = rows > 1 && ResponsiveBreakpoints.isDesktop(context);
-    final contentHeight = stacked ? mediaRibbonPairedHeight : _tileHeight;
+    // Sized from the map's own constant, so the pair stays aligned if that
+    // height ever moves rather than silently drifting apart.
+    final contentHeight = stacked ? recentSitesMapHeight : _tileHeight;
 
     Widget tile(MediaItem item) {
       final diveId = item.diveId;

--- a/lib/features/dashboard/presentation/widgets/recent_sites_map_card.dart
+++ b/lib/features/dashboard/presentation/widgets/recent_sites_map_card.dart
@@ -12,6 +12,12 @@ import 'package:submersion/features/maps/presentation/widgets/map_interaction_op
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
+/// Height of the map itself, exported because a card paired beside this one
+/// has to match it: the dashboard grid top-aligns cards at their natural
+/// heights rather than stretching them, so the partner sizes itself from
+/// this value instead of repeating the number.
+const double recentSitesMapHeight = 220;
+
 /// Mini map with pins for the sites of the most recent dives.
 class RecentSitesMapCard extends ConsumerStatefulWidget {
   const RecentSitesMapCard({super.key});
@@ -66,7 +72,7 @@ class _RecentSitesMapCardState extends ConsumerState<RecentSitesMapCard> {
             ClipRRect(
               borderRadius: BorderRadius.circular(12),
               child: SizedBox(
-                height: 220,
+                height: recentSitesMapHeight,
                 child: TrackpadZoomMap(
                   controller: _controller,
                   child: FlutterMap(

--- a/test/features/dashboard/presentation/home_layout_test.dart
+++ b/test/features/dashboard/presentation/home_layout_test.dart
@@ -72,7 +72,7 @@ void main() {
       expect((block.child as MediaRibbonCard).rows, 1);
     });
 
-    test('yearInReview is absorbed only after milestones fills a slot', () {
+    test('yearInReview is side-capable on its own, without milestones', () {
       final entries = buildDashboardEntries(const [
         HomeCardType.recentDives,
         HomeCardType.yearInReview,

--- a/test/features/dashboard/presentation/home_layout_test.dart
+++ b/test/features/dashboard/presentation/home_layout_test.dart
@@ -2,32 +2,97 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dashboard/presentation/home_cards.dart';
 import 'package:submersion/features/dashboard/presentation/home_layout.dart';
 import 'package:submersion/features/dashboard/presentation/widgets/dashboard_grid.dart';
+import 'package:submersion/features/dashboard/presentation/widgets/media_ribbon_card.dart';
 import 'package:submersion/features/dashboard/presentation/widgets/milestones_card.dart';
 import 'package:submersion/features/dashboard/presentation/widgets/quick_actions_card.dart';
 import 'package:submersion/features/dashboard/presentation/widgets/recent_dives_card.dart';
+import 'package:submersion/features/dashboard/presentation/widgets/recent_sites_map_card.dart';
+import 'package:submersion/features/dashboard/presentation/widgets/year_in_review_card.dart';
 
 void main() {
   group('buildDashboardEntries', () {
-    test('default order reproduces the legacy block structure', () {
+    test('default order builds the reorganized block structure', () {
       final entries = buildDashboardEntries(HomeCardType.values);
       // hero, gaugeStrip, preDive as FullBlocks; recentDives absorbs
-      // quickActions + milestones into a LeadSideGroup; then photoRibbon
-      // (Full), onThisDay/yearInReview/activeCourses (Thirds),
-      // recentSitesMap (Full).
-      expect(entries, hasLength(9));
+      // quickActions + milestones + yearInReview into a LeadSideGroup;
+      // photoRibbon + recentSitesMap pair up; onThisDay and activeCourses
+      // trail as Thirds.
+      expect(entries, hasLength(7));
       expect(entries[0], isA<FullBlock>());
       expect(entries[1], isA<FullBlock>());
       expect(entries[2], isA<FullBlock>());
       final group = entries[3] as LeadSideGroup;
       expect(group.lead, isA<RecentDivesCard>());
-      expect(group.side, hasLength(2));
+      expect(group.side, hasLength(3));
       expect(group.side[0], isA<QuickActionsCard>());
       expect(group.side[1], isA<MilestonesCard>());
-      expect(entries[4], isA<FullBlock>());
+      expect(group.side[2], isA<YearInReviewCard>());
+      final pair = entries[4] as PairBlock;
+      expect(pair.first, isA<MediaRibbonCard>());
+      expect(pair.second, isA<RecentSitesMapCard>());
       expect(entries[5], isA<ThirdBlock>());
       expect(entries[6], isA<ThirdBlock>());
-      expect(entries[7], isA<ThirdBlock>());
-      expect(entries.last, isA<FullBlock>());
+    });
+
+    test('paired media ribbon asks for two rows', () {
+      final entries = buildDashboardEntries(const [
+        HomeCardType.photoRibbon,
+        HomeCardType.recentSitesMap,
+      ]);
+      final pair = entries.single as PairBlock;
+      expect((pair.first as MediaRibbonCard).rows, 2);
+    });
+
+    test('sites before media pairs in that visual order', () {
+      final entries = buildDashboardEntries(const [
+        HomeCardType.recentSitesMap,
+        HomeCardType.photoRibbon,
+      ]);
+      final pair = entries.single as PairBlock;
+      expect(pair.first, isA<RecentSitesMapCard>());
+      expect(pair.second, isA<MediaRibbonCard>());
+      expect((pair.second as MediaRibbonCard).rows, 2);
+    });
+
+    test('media and sites pair only when adjacent', () {
+      final entries = buildDashboardEntries(const [
+        HomeCardType.photoRibbon,
+        HomeCardType.onThisDay,
+        HomeCardType.recentSitesMap,
+      ]);
+      expect(entries, hasLength(3));
+      expect(entries[0], isA<FullBlock>());
+      expect(entries[1], isA<ThirdBlock>());
+      expect(entries[2], isA<FullBlock>());
+    });
+
+    test('an unpaired media ribbon keeps its single row', () {
+      final entries = buildDashboardEntries(const [HomeCardType.photoRibbon]);
+      final block = entries.single as FullBlock;
+      expect((block.child as MediaRibbonCard).rows, 1);
+    });
+
+    test('yearInReview is absorbed only after milestones fills a slot', () {
+      final entries = buildDashboardEntries(const [
+        HomeCardType.recentDives,
+        HomeCardType.yearInReview,
+      ]);
+      final group = entries.single as LeadSideGroup;
+      expect(group.side, hasLength(1));
+      expect(group.side.single, isA<YearInReviewCard>());
+    });
+
+    test('the side column absorbs at most three cards', () {
+      final entries = buildDashboardEntries(const [
+        HomeCardType.recentDives,
+        HomeCardType.quickActions,
+        HomeCardType.milestones,
+        HomeCardType.yearInReview,
+        HomeCardType.onThisDay,
+      ]);
+      expect(entries, hasLength(2));
+      expect((entries[0] as LeadSideGroup).side, hasLength(3));
+      expect(entries[1], isA<ThirdBlock>());
     });
 
     test('side cards absorb only when immediately after recentDives', () {

--- a/test/features/dashboard/presentation/widgets/dashboard_grid_test.dart
+++ b/test/features/dashboard/presentation/widgets/dashboard_grid_test.dart
@@ -83,4 +83,77 @@ void main() {
     final side1 = tester.getRect(find.byKey(const Key('side1')));
     expect(lead.width, closeTo(side1.width, 1.0));
   });
+
+  group('PairBlock', () {
+    Future<void> pumpPair(WidgetTester tester, double width) async {
+      tester.view.physicalSize = Size(width, 2000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: DashboardGrid(
+                entries: [
+                  PairBlock(
+                    first: SizedBox(key: Key('media'), height: 220),
+                    second: SizedBox(key: Key('sites'), height: 260),
+                  ),
+                  ThirdBlock(SizedBox(key: Key('t1'), height: 40)),
+                  ThirdBlock(SizedBox(key: Key('t2'), height: 40)),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('phone (<800) stacks the pair in order', (tester) async {
+      await pumpPair(tester, 500);
+      final media = tester.getRect(find.byKey(const Key('media')));
+      final sites = tester.getRect(find.byKey(const Key('sites')));
+      expect(sites.top, greaterThanOrEqualTo(media.bottom - 0.01));
+      expect(media.width, 500);
+      expect(sites.width, 500);
+    });
+
+    testWidgets('2 columns (800-1199) splits the row 50/50', (tester) async {
+      await pumpPair(tester, 1000);
+      final media = tester.getRect(find.byKey(const Key('media')));
+      final sites = tester.getRect(find.byKey(const Key('sites')));
+      expect(media.top, sites.top);
+      expect(media.width, closeTo(sites.width, 1.0));
+    });
+
+    testWidgets('3 columns (>=1200) still splits 50/50, not 1/3', (
+      tester,
+    ) async {
+      await pumpPair(tester, 1300);
+      final media = tester.getRect(find.byKey(const Key('media')));
+      final sites = tester.getRect(find.byKey(const Key('sites')));
+      expect(media.top, sites.top);
+      expect(media.width, closeTo(sites.width, 1.0));
+      // Half the row, not the third a ThirdBlock would take at 3 columns.
+      expect(media.width, greaterThan(1300 / 3));
+    });
+
+    testWidgets('following thirds do not join the pair row', (tester) async {
+      await pumpPair(tester, 1300);
+      final media = tester.getRect(find.byKey(const Key('media')));
+      final t1 = tester.getRect(find.byKey(const Key('t1')));
+      final t2 = tester.getRect(find.byKey(const Key('t2')));
+      expect(t1.top, greaterThan(media.bottom - 0.01));
+      expect(t1.top, t2.top);
+    });
+
+    testWidgets('the taller card does not stretch its partner', (tester) async {
+      await pumpPair(tester, 1300);
+      final media = tester.getRect(find.byKey(const Key('media')));
+      final sites = tester.getRect(find.byKey(const Key('sites')));
+      // Top-aligned natural heights: no IntrinsicHeight in the grid.
+      expect(media.height, 220);
+      expect(sites.height, 260);
+    });
+  });
 }

--- a/test/features/dashboard/presentation/widgets/media_ribbon_rows_test.dart
+++ b/test/features/dashboard/presentation/widgets/media_ribbon_rows_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dashboard/presentation/providers/media_ribbon_providers.dart';
+import 'package:submersion/features/dashboard/presentation/widgets/media_ribbon_card.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../media_store/support/fake_local_file_resolver.dart';
+import '../../../media/presentation/support/media_widget_harness.dart';
+
+final _t0 = DateTime.utc(2026, 1, 1);
+
+MediaItem _photo(String id) => MediaItem(
+  id: id,
+  diveId: 'd1',
+  mediaType: MediaType.photo,
+  sourceType: MediaSourceType.platformGallery,
+  platformAssetId: 'asset-$id',
+  takenAt: _t0,
+  createdAt: _t0,
+  updatedAt: _t0,
+);
+
+/// Paired beside the recent-sites map, the ribbon has a 220 pt tall neighbour
+/// to fill, so it lays its tiles out in two rows instead of one. The pair only
+/// exists at desktop widths: below 800 the grid dissolves it into a plain
+/// stack, where a two-row ribbon would just be a taller card for no reason.
+void main() {
+  Future<void> pumpRibbon(
+    WidgetTester tester, {
+    required double width,
+    required Widget card,
+  }) async {
+    final base = await getBaseOverrides();
+    final resolver = FakeLocalFileResolver(BytesData(bytes: onePixelPng()));
+
+    tester.view.physicalSize = Size(width, 2000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          mediaSourceResolverRegistryProvider.overrideWithValue(
+            MediaSourceResolverRegistry({
+              MediaSourceType.platformGallery: resolver,
+            }),
+          ),
+          recentMediaProvider.overrideWith(
+            (ref) async => [for (var i = 0; i < 12; i++) _photo('p$i')],
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: SingleChildScrollView(child: card)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// Distinct tile top offsets: one per laid-out row.
+  Set<double> tileRows(WidgetTester tester) => {
+    for (final e in find.byType(MediaItemView).evaluate())
+      tester.getRect(find.byWidget(e.widget)).top,
+  };
+
+  testWidgets('rows: 2 lays tiles out over two rows at desktop width', (
+    tester,
+  ) async {
+    await pumpRibbon(tester, width: 1300, card: const MediaRibbonCard(rows: 2));
+    expect(tileRows(tester), hasLength(2));
+  });
+
+  testWidgets('rows: 2 collapses to one row below the desktop breakpoint', (
+    tester,
+  ) async {
+    await pumpRibbon(tester, width: 500, card: const MediaRibbonCard(rows: 2));
+    expect(tileRows(tester), hasLength(1));
+  });
+
+  testWidgets('the default single-row ribbon is unchanged at desktop width', (
+    tester,
+  ) async {
+    await pumpRibbon(tester, width: 1300, card: const MediaRibbonCard());
+    expect(tileRows(tester), hasLength(1));
+  });
+
+  testWidgets('two rows fill the height of the recent-sites map beside it', (
+    tester,
+  ) async {
+    await pumpRibbon(tester, width: 1300, card: const MediaRibbonCard(rows: 2));
+    final rects = [
+      for (final e in find.byType(MediaItemView).evaluate())
+        tester.getRect(find.byWidget(e.widget)),
+    ];
+    final top = rects.map((r) => r.top).reduce((a, b) => a < b ? a : b);
+    final bottom = rects.map((r) => r.bottom).reduce((a, b) => a > b ? a : b);
+    expect(bottom - top, closeTo(mediaRibbonPairedHeight, 0.01));
+  });
+}

--- a/test/features/dashboard/presentation/widgets/media_ribbon_rows_test.dart
+++ b/test/features/dashboard/presentation/widgets/media_ribbon_rows_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dashboard/presentation/providers/media_ribbon_providers.dart';
 import 'package:submersion/features/dashboard/presentation/widgets/media_ribbon_card.dart';
+import 'package:submersion/features/dashboard/presentation/widgets/recent_sites_map_card.dart';
 import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
@@ -96,6 +97,11 @@ void main() {
     expect(tileRows(tester), hasLength(1));
   });
 
+  test('a row count below one is rejected rather than silently ignored', () {
+    expect(() => MediaRibbonCard(rows: 0), throwsAssertionError);
+    expect(() => MediaRibbonCard(rows: -1), throwsAssertionError);
+  });
+
   testWidgets('two rows fill the height of the recent-sites map beside it', (
     tester,
   ) async {
@@ -106,6 +112,6 @@ void main() {
     ];
     final top = rects.map((r) => r.top).reduce((a, b) => a < b ? a : b);
     final bottom = rects.map((r) => r.bottom).reduce((a, b) => a > b ? a : b);
-    expect(bottom - top, closeTo(mediaRibbonPairedHeight, 0.01));
+    expect(bottom - top, closeTo(recentSitesMapHeight, 0.01));
   });
 }


### PR DESCRIPTION
## Summary

Reorganizes the desktop home layout. Recent media and Recent sites used to
occupy two full-width rows of their own; they now share one row, with the
media ribbon stacking its thumbnails into two rows to fill the height of the
map beside it. "This year" moves into the column beside Recent Dives, under
Milestones.

```
[ Recent Dives          | Quick Actions  ]
[                       | Milestones     ]
[                       | This year      ]
[ Recent media (2 rows) | Recent sites   ]
[ On this day           | Active courses ]
```

## Changes

- **New `PairBlock` grid entry.** Two cards split a row 50/50 at 2 and 3
  columns, and stack in order at 1. Deliberately not two `ThirdBlock`s:
  those are packed in chunks of the column count, so at 3 columns a
  neighbouring third would join the row and squeeze the pair to a third of
  the width each.
- **`home_layout` pairs an adjacent `photoRibbon` and `recentSitesMap`**, in
  either order, and the side column beside Recent Dives now absorbs up to
  three cards so `yearInReview` can stack under `milestones`. Both rules are
  driven by the diver's saved card order rather than overriding it, matching
  how the existing side-column rule already works.
- **`MediaRibbonCard` takes a `rows` parameter.** Paired beside the 220 pt
  map it lays tiles out in two rows to reach the same height, via a
  horizontally scrolling `GridView`. The grid top-aligns cards rather than
  stretching them (no `IntrinsicHeight`, by design), so the ribbon has to
  reach that height itself. Rows are honoured only at desktop widths, since
  below the breakpoint the pairing dissolves into a plain stack.
- **`HomeCardType` declaration order updated** to make the new arrangement
  the default.

## Migration note

The reordered enum moves only the default, which is what `homeCardOrder`
falls back to when nothing is stored. A diver who has explicitly reordered
their cards keeps that order, and picks up the pairing and the three-card
column where their order already places those cards adjacent.

## Test Plan

- [x] `flutter test` passes (226 tests across `test/features/dashboard` plus
      the two home-card settings suites, including 12 new ones)
- [x] `flutter analyze` passes project-wide, no issues
- [x] `dart format --set-exit-if-changed .` clean
- [x] Manual testing on: not yet run against a live build

New test coverage:
- `PairBlock` geometry at 1, 2 and 3 columns, including that it stays 50/50
  at 3 columns and that following thirds do not join its row
- pairing in both adjacency orders, and not pairing when separated
- the three-card side-column cap
- the two-row ribbon spanning exactly the map's height, and collapsing back
  to one row below the desktop breakpoint

## Screenshots

Not yet captured. The layout is asserted numerically by the widget tests
above rather than visually; happy to add before/after shots from a live
build if wanted.
