### PR TITLE
fix(sync): give photo species tags their own clock (#1638)

### DIFF
--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -105,6 +105,7 @@ class SyncRepository {
     'viewConfigs': (table: 'view_configs', pk: 'id'),
     'media': (table: 'media', pk: 'id'),
     'mediaEnrichment': (table: 'media_enrichment', pk: 'id'),
+    'mediaSpecies': (table: 'media_species', pk: 'id'),
     'species': (table: 'species', pk: 'id'),
     'fieldPresets': (table: 'field_presets', pk: 'id'),
     'qualityFindings': (table: 'quality_findings', pk: 'id'),
@@ -588,6 +589,18 @@ class SyncRepository {
       entityType: 'equipmentSetGeofences',
       table: 'equipment_set_geofences',
       timestamp: 'updated_at',
+      filter: null,
+    ),
+    // Species tags on photos, which gained the column in v195 (issue
+    // #1638). Every tag written before then is NULL here, so without this
+    // entry a diver's existing tags would stay invisible to the incremental
+    // export until the tag happened to be removed and re-added. The table
+    // has no updated_at; a tag is write-once, so created_at is the row's
+    // local update time.
+    (
+      entityType: 'mediaSpecies',
+      table: 'media_species',
+      timestamp: 'created_at',
       filter: null,
     ),
     // The packed sample series (schema v182). A row can reach these tables

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1451,6 +1451,15 @@ class MediaSpecies extends Table {
   TextColumn get notes => text().nullable()();
   IntColumn get createdAt => integer()();
 
+  /// Hybrid Logical Clock, added in v195 (issue #1638). The row is
+  /// write-once, so the clock is not here to resolve conflicts: it is what
+  /// makes the tag visible to the incremental export, which ships rows whose
+  /// `hlc` is above the peer watermark. Before v195 this table rode the
+  /// parent `media.hlc`, and since tagging a photo never edits the photo,
+  /// a tag reached peers only on a full base publish. Nullable: rows written
+  /// before v195 are stamped by `SyncRepository.backfillMissingHlc`.
+  TextColumn get hlc => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -3415,7 +3424,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 194;
+  static const int currentSchemaVersion = 195;
 
   /// The oldest schema whose reader can apply this build's sync payloads
   /// without loss or misinterpretation (the compatibility floor).
@@ -3902,6 +3911,15 @@ class AppDatabase extends _$AppDatabase {
     // at or below the shipped version never runs its onUpgrade step.
     191,
     194,
+    // v195: media_species.hlc, so a species tag on a photo publishes in an
+    // incremental changeset instead of waiting for a full base publish
+    // (issue #1638). Additive nullable column; the one-time stamp of the
+    // rows already on disk is SyncRepository.backfillMissingHlc, which runs
+    // at the start of every sync. Renumbered from 192: main landed the
+    // transmitter-serial rung at 194 while this branch was open, 192 and 193
+    // are held by other open branches, and a rung at or below the shipped
+    // version never runs its onUpgrade step.
+    195,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -6486,6 +6504,19 @@ class AppDatabase extends _$AppDatabase {
         'REAL NOT NULL DEFAULT ${entry.value}',
       );
     }
+  }
+
+  /// The v195 media_species.hlc column (issue #1638): the tag's own clock,
+  /// which is what puts it in an incremental changeset. PRAGMA-guarded so a
+  /// healthy database no-ops and a partial schema does not throw. Called
+  /// from the v195 onUpgrade step and the beforeOpen backstop, matching the
+  /// other additive column helpers.
+  Future<void> _assertMediaSpeciesHlcColumn() async {
+    final cols = await customSelect("PRAGMA table_info('media_species')").get();
+    if (cols.isEmpty) return;
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    if (names.contains('hlc')) return;
+    await customStatement('ALTER TABLE media_species ADD COLUMN hlc TEXT');
   }
 
   /// Owning-source FK on dive_profiles (issue #1149). PRAGMA-guarded so a
@@ -10328,6 +10359,15 @@ class AppDatabase extends _$AppDatabase {
           await _assertTankTransmitterSerialColumn();
         }
         if (from < 194) await reportProgress();
+        // v195: media_species gains its own clock (issue #1638). Additive
+        // nullable column. The rows already on disk stay NULL here and are
+        // stamped by SyncRepository.backfillMissingHlc at the start of the
+        // next sync, which is also what publishes them to peers. Renumbered
+        // from 192, which is held by another open branch.
+        if (from < 195) {
+          await _assertMediaSpeciesHlcColumn();
+        }
+        if (from < 195) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -10502,6 +10542,11 @@ class AppDatabase extends _$AppDatabase {
         // columns. A database that arrives by restore or sync-adopt never
         // runs onUpgrade, and reading a plan without them throws.
         await _assertPlanAscentRateColumns();
+
+        // v195 backstop: re-assert media_species.hlc. A database that
+        // arrives by restore or sync-adopt never runs onUpgrade, and both
+        // reading a tag and stamping one throw without the column.
+        await _assertMediaSpeciesHlcColumn();
 
         // v157 backstop: re-assert the default service price columns (issue
         // #829; same parallel-branch version-collision self-heal).

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -5910,27 +5910,24 @@ class SyncDataSerializer {
     return out;
   }
 
-  /// `media_species` has no clock of its own, so an incremental export
-  /// ships the tags of every photo whose `media.hlc` advanced; a full export
-  /// ships the table.
+  /// `media_species` carries its own clock since v195, so an incremental
+  /// export filters on the tag's `hlc`; a full export ships the table.
+  ///
+  /// It rode the parent `media.hlc` until then, which silently dropped every
+  /// tag: tagging a photo does not edit the photo, so the parent clock never
+  /// advanced past the peer watermark and the tag reached other devices only
+  /// on a full base publish (issue #1638). Tags written before v195 have a
+  /// NULL `hlc` (and `NULL > watermark` is not true, so they would never
+  /// publish); `SyncRepository.backfillMissingHlc` stamps them at the start
+  /// of the next sync.
   Future<List<Map<String, dynamic>>> _exportMediaSpecies(
     String? hlcSince,
   ) async {
+    final query = _db.select(_db.mediaSpecies);
     if (hlcSince != null) {
-      final modifiedMedia = await (_db.select(
-        _db.media,
-      )..where((t) => t.hlc.isBiggerThanValue(hlcSince))).get();
-      final mediaIds = modifiedMedia.map((m) => m.id).toSet();
-      if (mediaIds.isEmpty) return [];
-
-      return _childRowsOf(
-        mediaIds,
-        (chunk) => (_db.select(
-          _db.mediaSpecies,
-        )..where((t) => t.mediaId.isIn(chunk))).get(),
-      );
+      query.where((t) => t.hlc.isBiggerThanValue(hlcSince));
     }
-    final rows = await _db.select(_db.mediaSpecies).get();
+    final rows = await query.get();
     return rows.map((r) => r.toJson()).toList();
   }
 

--- a/lib/features/media/data/repositories/media_species_repository.dart
+++ b/lib/features/media/data/repositories/media_species_repository.dart
@@ -16,10 +16,12 @@ import 'package:submersion/features/media/domain/entities/species_tag_chip.dart'
 /// Species tags on photos: the `media_species` link table.
 ///
 /// A tag sits on a photo that already belongs to a dive or a site; this
-/// repository never creates media rows. The table has no `hlc` column, so
-/// like `site_species` it syncs as a clockless child: add marks the row
-/// pending, remove tombstones it by id, and the incremental export keys off
-/// the parent `media.hlc`.
+/// repository never creates media rows. The row is write-once but carries
+/// its own `hlc` (v195): add marks the row pending, which stamps the clock
+/// the incremental export filters on, and remove tombstones it by id.
+/// Riding the parent `media.hlc` instead, as this table did until v195,
+/// published nothing, because tagging a photo never edits the photo
+/// (issue #1638).
 class MediaSpeciesRepository {
   AppDatabase get _db => DatabaseService.instance.database;
   final SyncRepository _syncRepository = SyncRepository();

--- a/lib/features/media/data/repositories/media_species_repository.dart
+++ b/lib/features/media/data/repositories/media_species_repository.dart
@@ -17,8 +17,10 @@ import 'package:submersion/features/media/domain/entities/species_tag_chip.dart'
 ///
 /// A tag sits on a photo that already belongs to a dive or a site; this
 /// repository never creates media rows. The row is write-once but carries
-/// its own `hlc` (v195): add marks the row pending, which stamps the clock
-/// the incremental export filters on, and remove tombstones it by id.
+/// its own `hlc` (v195). Adding a tag marks the row pending, and that is
+/// what stamps the clock; the incremental export then filters on it.
+/// Removing a tag tombstones the row by id.
+///
 /// Riding the parent `media.hlc` instead, as this table did until v195,
 /// published nothing, because tagging a photo never edits the photo
 /// (issue #1638).

--- a/test/core/database/migration_v194_tank_transmitter_serial_test.dart
+++ b/test/core/database/migration_v194_tank_transmitter_serial_test.dart
@@ -49,10 +49,11 @@ void main() {
     expect(row.data['transmitter_serial'], isNull);
   });
 
-  test('migration list includes v194 and schema is exactly 194', () {
-    // The newest rung owns the exact assertion; relax to
-    // greaterThanOrEqualTo when the next rung lands.
-    expect(AppDatabase.currentSchemaVersion, 194);
+  test('migration list includes v194', () {
+    // Relaxed as its own comment instructed when the next rung (v195,
+    // media_species.hlc) landed: the exact assertion is the newest rung's
+    // job and moves with it.
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(194));
     expect(AppDatabase.migrationVersions, contains(194));
   });
 

--- a/test/core/database/migration_v195_media_species_hlc_test.dart
+++ b/test/core/database/migration_v195_media_species_hlc_test.dart
@@ -1,0 +1,101 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+
+/// v195 gives `media_species` its own Hybrid Logical Clock (issue #1638).
+/// Until then the table rode the parent `media.hlc`, and since tagging a
+/// photo never edits the photo, the parent clock never advanced and the tag
+/// was invisible to every incremental changeset.
+void main() {
+  test('v195 is the current schema version and is in the ladder', () {
+    // Renumbered from 192: main landed the transmitter-serial rung at 194
+    // while this branch was open, 192 and 193 are held by other open
+    // branches, and a rung at or below the shipped version never runs its
+    // onUpgrade step. This is the newest rung, so it owns the exact
+    // assertion; relax it to greaterThanOrEqualTo when the next one lands.
+    expect(AppDatabase.currentSchemaVersion, 195);
+    expect(AppDatabase.migrationVersions, contains(195));
+  });
+
+  test('a fresh database has media_species.hlc', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('media_species')")
+        .get();
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    expect(names, contains('hlc'));
+  });
+
+  test('the column is nullable, so a pre-v195 row stays readable', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('media_species')")
+        .get();
+    final hlc = cols.firstWhere((c) => c.read<String>('name') == 'hlc');
+    // A NOT NULL column would break the backfill's own precondition: it
+    // finds the legacy rows by `hlc IS NULL`.
+    expect(hlc.read<int>('notnull'), 0);
+  });
+
+  test(
+    'a database stranded before v195 gains the column via beforeOpen',
+    () async {
+      // A database that arrives by restore or sync-adopt never runs onUpgrade,
+      // so the backstop is the only thing that adds the column there.
+      final nativeDb = NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute('''
+          CREATE TABLE media_species (
+            id TEXT NOT NULL PRIMARY KEY,
+            media_id TEXT NOT NULL,
+            species_id TEXT NOT NULL,
+            sighting_id TEXT,
+            bbox_x REAL,
+            bbox_y REAL,
+            bbox_width REAL,
+            bbox_height REAL,
+            notes TEXT,
+            created_at INTEGER NOT NULL
+          )
+        ''');
+          rawDb.execute(
+            "INSERT INTO media_species (id, media_id, species_id, created_at) "
+            "VALUES ('tag-legacy', 'p1', 'c1', 1000)",
+          );
+        },
+      );
+      final db = AppDatabase(nativeDb);
+      addTearDown(db.close);
+
+      final cols = await db
+          .customSelect("PRAGMA table_info('media_species')")
+          .get();
+      expect(cols.map((c) => c.read<String>('name')), contains('hlc'));
+      final row = await db
+          .customSelect("SELECT hlc FROM media_species WHERE id = 'tag-legacy'")
+          .getSingle();
+      expect(
+        row.read<String?>('hlc'),
+        isNull,
+        reason: 'the rung only adds the column; the backfill stamps the rows',
+      );
+    },
+  );
+
+  test('the assert is a no-op when the table is absent', () async {
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('CREATE TABLE unrelated (id TEXT)');
+      },
+    );
+    final db = AppDatabase(nativeDb);
+    addTearDown(db.close);
+
+    await db.customSelect('SELECT 1').get();
+  });
+}

--- a/test/core/database/migration_v195_media_species_hlc_test.dart
+++ b/test/core/database/migration_v195_media_species_hlc_test.dart
@@ -3,6 +3,21 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:submersion/core/database/database.dart';
 
+const _preV195MediaSpecies = '''
+  CREATE TABLE media_species (
+    id TEXT NOT NULL PRIMARY KEY,
+    media_id TEXT NOT NULL,
+    species_id TEXT NOT NULL,
+    sighting_id TEXT,
+    bbox_x REAL,
+    bbox_y REAL,
+    bbox_width REAL,
+    bbox_height REAL,
+    notes TEXT,
+    created_at INTEGER NOT NULL
+  )
+''';
+
 /// v195 gives `media_species` its own Hybrid Logical Clock (issue #1638).
 /// Until then the table rode the parent `media.hlc`, and since tagging a
 /// photo never edits the photo, the parent clock never advanced and the tag
@@ -49,20 +64,7 @@ void main() {
       // so the backstop is the only thing that adds the column there.
       final nativeDb = NativeDatabase.memory(
         setup: (rawDb) {
-          rawDb.execute('''
-          CREATE TABLE media_species (
-            id TEXT NOT NULL PRIMARY KEY,
-            media_id TEXT NOT NULL,
-            species_id TEXT NOT NULL,
-            sighting_id TEXT,
-            bbox_x REAL,
-            bbox_y REAL,
-            bbox_width REAL,
-            bbox_height REAL,
-            notes TEXT,
-            created_at INTEGER NOT NULL
-          )
-        ''');
+          rawDb.execute(_preV195MediaSpecies);
           rawDb.execute(
             "INSERT INTO media_species (id, media_id, species_id, created_at) "
             "VALUES ('tag-legacy', 'p1', 'c1', 1000)",
@@ -86,6 +88,43 @@ void main() {
       );
     },
   );
+
+  test('v195 adds the column on upgrade, preserving tags', () async {
+    // A database one version back, so opening it runs onUpgrade rather than
+    // onCreate. The rung and the backstop deliberately call the same
+    // idempotent helper, so this cannot prove which of the two added the
+    // column; what it does pin is that an upgrading database ends up with
+    // the column AND keeps the tags it already had.
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 194');
+        rawDb.execute(_preV195MediaSpecies);
+        rawDb.execute(
+          'INSERT INTO media_species (id, media_id, species_id, created_at) '
+          "VALUES ('tag-1', 'p1', 'c1', 1000)",
+        );
+      },
+    );
+    final db = AppDatabase(nativeDb);
+    addTearDown(db.close);
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('media_species')")
+        .get();
+    expect(cols.map((c) => c.read<String>('name')), contains('hlc'));
+
+    // Column-only rung: the tag survives with its links intact and a null
+    // clock, which is what backfillMissingHlc then stamps.
+    final row = await db
+        .customSelect(
+          'SELECT media_id, species_id, hlc FROM media_species '
+          "WHERE id = 'tag-1'",
+        )
+        .getSingle();
+    expect(row.data['media_id'], 'p1');
+    expect(row.data['species_id'], 'c1');
+    expect(row.read<String?>('hlc'), isNull);
+  });
 
   test('the assert is a no-op when the table is absent', () async {
     final nativeDb = NativeDatabase.memory(

--- a/test/core/services/sync/sync_hlc_backfill_test.dart
+++ b/test/core/services/sync/sync_hlc_backfill_test.dart
@@ -178,6 +178,32 @@ void main() {
     expect(await hlcOf('equipment_set_geofences', 'fence-1'), isNotNull);
   });
 
+  /// A species tag written before v195, when media_species had no clock of
+  /// its own. The photo and species it points at exist; only the tag's hlc
+  /// is missing, exactly as an affected build left it (issue #1638).
+  Future<void> seedLegacyMediaSpeciesTag() async {
+    await seedLegacyEnrichment('e-tag');
+    await db.customStatement(
+      "INSERT INTO species (id, common_name, category, is_built_in) "
+      "VALUES ('sp-1', 'Grouper', 'fish', 0)",
+    );
+    await db.customStatement(
+      'INSERT INTO media_species (id, media_id, species_id, created_at) '
+      "VALUES ('tag-1', 'm1', 'sp-1', 1000)",
+    );
+  }
+
+  test('stamps and publishes species tags written before v195', () async {
+    await seedLegacyMediaSpeciesTag();
+
+    await SyncRepository().backfillMissingHlc();
+
+    // Without this the diver's existing tags stay invisible to the
+    // incremental export until the tag is removed and re-added.
+    expect(await hlcOf('media_species', 'tag-1'), isNotNull);
+    expect(await pendingIdsFor('mediaSpecies'), contains('tag-1'));
+  });
+
   test('marks the backfilled rows pending so they publish', () async {
     await seedUnstampedEntities();
 

--- a/test/core/services/sync/sync_media_species_registration_test.dart
+++ b/test/core/services/sync/sync_media_species_registration_test.dart
@@ -1,4 +1,7 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/sync_service.dart';
 import 'package:submersion/features/media/data/repositories/media_species_repository.dart';
@@ -8,9 +11,10 @@ import '../../../helpers/test_database.dart';
 
 void main() {
   late SyncDataSerializer serializer;
+  late AppDatabase db;
 
   setUp(() async {
-    await setUpTestDatabase();
+    db = await setUpTestDatabase();
     serializer = SyncDataSerializer();
     await insertTestDive(id: 'd1', at: DateTime(2024, 1, 10));
     await insertTestSpecies(id: 'c1', name: 'Grouper');
@@ -74,4 +78,58 @@ void main() {
       ('speciesId', 'species', false),
     });
   });
+
+  Future<String?> hlcOf(String table, String id) async {
+    final row = await db
+        .customSelect(
+          'SELECT hlc FROM "$table" WHERE id = ?',
+          variables: [Variable.withString(id)],
+        )
+        .getSingleOrNull();
+    return row?.read<String?>('hlc');
+  }
+
+  test('a tag written through the repository is stamped with an hlc', () async {
+    final tag = await MediaSpeciesRepository().addTag(
+      mediaId: 'p1',
+      speciesId: 'c1',
+    );
+
+    // A null hlc is invisible to the incremental export forever: the filter
+    // is `hlc > watermark` and SQL `NULL > x` is not true. Writing through
+    // the repository is the only way to catch it -- the remote apply path
+    // carries the peer's hlc in the payload and would mask the gap.
+    expect(await hlcOf('media_species', tag.id), isNotNull);
+  });
+
+  test(
+    'an incremental changeset carries a tag on an untouched photo',
+    () async {
+      // The photo was published on an earlier sync and tagging does not edit
+      // it, so its own clock never advances past the watermark (issue #1638).
+      await SyncRepository().markRecordPending(
+        entityType: 'media',
+        recordId: 'p1',
+        localUpdatedAt: 1000,
+      );
+      final watermark = await hlcOf('media', 'p1');
+      expect(watermark, isNotNull);
+
+      final tag = await MediaSpeciesRepository().addTag(
+        mediaId: 'p1',
+        speciesId: 'c1',
+      );
+      final payload = await serializer.exportChangeset(
+        deviceId: 'device-1',
+        hlcWatermark: watermark,
+        deletions: const [],
+      );
+
+      expect(
+        payload.data.mediaSpecies.map((r) => r['id']),
+        contains(tag.id),
+        reason: 'the tag is newer than the watermark and must publish',
+      );
+    },
+  );
 }


### PR DESCRIPTION
Fixes #1638.

## The bug

A species tag added to a photo on one device never reached the other devices.
Untagging did propagate, which made the gap easy to miss.

The incremental export ships rows whose `hlc` is above the peer watermark.
`media_species` had no clock of its own, so `_exportMediaSpecies` rode the
parent: it selected photos whose `media.hlc` had advanced and gathered their
tags. Tagging a photo does not edit the photo, so the parent clock never moved
past the watermark and the tag appeared in no changeset. It crossed only on a
full base publish, which is why this reads as working sync in casual testing.

Removal was unaffected because `removeTag` writes a tombstone by row id, and
tombstones travel independently of the `hlc` filter.

`site_species` (expected species at a dive site) has the identical shape:
`addExpectedSpecies` never touches the parent `dive_sites` row. That is a
separate feature and is left alone here; it wants its own issue.

## The fix

`media_species` gets its own `hlc` (schema v195), is registered in
`SyncRepository.hlcTargets` so `markRecordPending` stamps it, and the export
filters on the tag's own clock.

This follows the five tables fixed in #1144 rather than the ride-the-parent
alternative, for two reasons:

- Re-stamping the parent would drag the whole media row through the merge,
  where a locally pending row makes the engine skip a peer's update to that
  row. Every tag would open a window for losing another device's backup stamps
  on that photo.
- Only an own clock lets the existing `backfillMissingHlc` sweep heal the tags
  **already on disk**. Ride-the-parent would leave a diver's existing tags
  stranded until the photo itself was edited, which matters because the
  reporter already has tags that never crossed.

The column is additive and nullable, applied by a PRAGMA-guarded helper from
both the v195 rung and the `beforeOpen` backstop, so a database arriving by
restore or sync-adopt gains it too. The rung is numbered 195, not 192: main
landed the transmitter-serial rung at 194 while this branch was open, 192 and
193 are held by other open branches, and a rung at or below the shipped
version never runs its onUpgrade step. The v194 test's exact
`currentSchemaVersion` assertion is relaxed to `greaterThanOrEqualTo`, as its
own comment instructs, and the exact tripwire moves to the v195 test.
Tags written before v195 carry a NULL
`hlc`; `backfillMissingHlc` stamps them at the start of the next sync, which is
also what publishes them.

## Tests

The regression test writes through the repository rather than `upsertRecord`:
the remote apply path carries the peer's `hlc` in the payload and would mask a
missing stamp. It publishes a changeset at the photo's own watermark and
asserts the tag is in it. Against the unfixed code the exported list is empty,
and the `SELECT hlc` assertion fails on a column that does not exist.

- `sync_media_species_registration_test`: the repository stamps an `hlc`; an
  incremental changeset carries a tag on an untouched photo.
- `sync_hlc_backfill_test`: a pre-v195 tag is stamped and marked pending.
- `migration_v195_media_species_hlc_test`: fresh database has the column, it is
  nullable, an upgrading database gains it through `onUpgrade` and keeps its
  existing tags, a stranded database gains it through `beforeOpen`, and the
  helper no-ops when the table is absent.
- The v191 test's exact-version tripwire moves to the new rung, per the house
  convention that only the newest rung pins the literal.

Full suite: 25124 passed. Six failures, all in `test/features/media_store/`,
are 30-second timeouts under the local run's 23-way parallelism; that directory
passes 348/348 in 22 seconds on its own and none of it touches
`media_species`.

