### PR TITLE
feat(dive-centers): add FFESSM to the affiliation options

### DIFF
--- a/lib/features/dive_centers/presentation/pages/dive_center_edit_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_edit_page.dart
@@ -73,6 +73,7 @@ class _DiveCenterEditPageState extends ConsumerState<DiveCenterEditPage> {
     'RAID',
     'BSAC',
     'CMAS',
+    'FFESSM',
     'IANTD',
     'PSAI',
   ];


### PR DESCRIPTION
The dive-center editor's **Affiliations** chips are a hardcoded list
(`_availableAffiliations` in `dive_center_edit_page.dart`): PADI, SSI,
NAUI, SDI/TDI, GUE, RAID, BSAC, CMAS, IANTD, PSAI. FFESSM is missing even
though #1607 made it a built-in `CertificationAgency`, so a French club
can't record its own federation.

Adds `'FFESSM'` next to `'CMAS'` (FFESSM is CMAS's French member
federation). `affiliations` is stored as `List<String>`, so this is
purely the picker list; the chip label is the raw string, no l10n key
needed. `dart analyze` + dive_centers tests green.