### PR TITLE
fix(ui): make find-as-you-type dropdowns keyboard navigable

### DIFF
--- a/lib/features/checklists/presentation/widgets/checklist_item_edit_sheet.dart
+++ b/lib/features/checklists/presentation/widgets/checklist_item_edit_sheet.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/checklists/presentation/providers/checklist_
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
+import 'package:submersion/shared/widgets/forms/autocomplete_options_list.dart';
 
 /// Bottom sheet for creating or editing a trip checklist item.
 Future<void> showChecklistItemEditSheet({
@@ -81,10 +82,22 @@ class _ChecklistItemEditSheetState
     if (picked != null) setState(() => _dueDate = picked);
   }
 
+  /// Folds a typed category onto an existing one that differs only in case,
+  /// so 'diving' lands in the existing 'Diving' group rather than creating a
+  /// near-duplicate. Unmatched input keeps the casing the user typed.
+  String _canonicalCategory(String typed) {
+    if (typed.isEmpty) return typed;
+    final lower = typed.toLowerCase();
+    for (final suggestion in widget.categorySuggestions) {
+      if (suggestion.toLowerCase() == lower) return suggestion;
+    }
+    return typed;
+  }
+
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) return;
     final repository = ref.read(tripChecklistRepositoryProvider);
-    final category = _categoryController.text.trim();
+    final category = _canonicalCategory(_categoryController.text.trim());
     final existing = widget.item;
     if (existing == null) {
       await repository.createItem(
@@ -145,26 +158,12 @@ class _ChecklistItemEditSheetState
               optionsBuilder: (value) => widget.categorySuggestions.where(
                 (c) => c.toLowerCase().contains(value.text.toLowerCase()),
               ),
-              onSelected: (selection) => _categoryController.text = selection,
-              optionsViewBuilder: (context, onSelected, options) => Align(
-                alignment: AlignmentDirectional.topStart,
-                child: Material(
-                  elevation: 4,
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: ListView(
-                      shrinkWrap: true,
-                      children: [
-                        for (final option in options)
-                          ListTile(
-                            title: Text(option),
-                            onTap: () => onSelected(option),
-                          ),
-                      ],
-                    ),
+              optionsViewBuilder: (context, onSelected, options) =>
+                  AutocompleteOptionsList<String>(
+                    options: options,
+                    onSelected: onSelected,
+                    labelFor: (option) => option,
                   ),
-                ),
-              ),
               fieldViewBuilder:
                   (context, controller, focusNode, onFieldSubmitted) =>
                       TextFormField(
@@ -173,6 +172,9 @@ class _ChecklistItemEditSheetState
                         decoration: InputDecoration(
                           labelText: context.l10n.checklists_item_categoryLabel,
                         ),
+                        // Commits the arrow-key highlight; a no-op when no
+                        // suggestion list is open, so free text still saves.
+                        onFieldSubmitted: (_) => onFieldSubmitted(),
                       ),
             ),
             const SizedBox(height: 8),

--- a/lib/features/checklists/presentation/widgets/trip_checklist_section.dart
+++ b/lib/features/checklists/presentation/widgets/trip_checklist_section.dart
@@ -41,11 +41,7 @@ class TripChecklistSection extends ConsumerWidget {
       );
     }
 
-    final categorySuggestions = items
-        .map((i) => i.category)
-        .whereType<String>()
-        .toSet()
-        .toList();
+    final categorySuggestions = _distinctCategories(items);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -207,9 +203,14 @@ class TripChecklistSection extends ConsumerWidget {
     final theme = Theme.of(context);
     final repository = ref.read(tripChecklistRepositoryProvider);
     // Group by category preserving first-seen order; null category last.
+    // Keyed case-insensitively so 'diving' and 'Diving' are one group,
+    // labelled with the casing that appeared first.
+    final labels = <String, String>{};
     final grouped = <String?, List<TripChecklistItem>>{};
     for (final item in items.where((i) => i.category != null)) {
-      grouped.putIfAbsent(item.category, () => []).add(item);
+      final key = item.category!.toLowerCase();
+      final label = labels.putIfAbsent(key, () => item.category!);
+      grouped.putIfAbsent(label, () => []).add(item);
     }
     final uncategorized = items.where((i) => i.category == null).toList();
     if (uncategorized.isNotEmpty) grouped[null] = uncategorized;
@@ -248,4 +249,16 @@ class TripChecklistSection extends ConsumerWidget {
     });
     return widgets;
   }
+}
+
+/// Distinct categories in first-seen order, folding entries that differ only
+/// in case so the suggestion list offers 'Diving' once rather than once per
+/// casing a diver has typed.
+List<String> _distinctCategories(List<TripChecklistItem> items) {
+  final seen = <String>{};
+  final categories = <String>[];
+  for (final category in items.map((i) => i.category).whereType<String>()) {
+    if (seen.add(category.toLowerCase())) categories.add(category);
+  }
+  return categories;
 }

--- a/lib/features/dive_log/presentation/widgets/custom_field_input_row.dart
+++ b/lib/features/dive_log/presentation/widgets/custom_field_input_row.dart
@@ -58,6 +58,8 @@ class CustomFieldInputRow extends StatelessWidget {
                   onChanged: (value) {
                     onChanged(field.copyWith(key: value));
                   },
+                  // Commits the arrow-key highlight from the suggestion list.
+                  onFieldSubmitted: (_) => onSubmitted(),
                 );
               },
             ),

--- a/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
@@ -15,6 +15,7 @@ import 'package:submersion/features/buddies/presentation/providers/buddy_provide
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/weekday_filter_selector.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
+import 'package:submersion/shared/widgets/forms/autocomplete_options_list.dart';
 
 /// Filter sheet for dive list
 class DiveFilterSheet extends ConsumerStatefulWidget {
@@ -870,33 +871,13 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
                                     onSubmitted: (_) => onFieldSubmitted(),
                                   );
                                 },
-                            optionsViewBuilder: (context, onSelected, options) {
-                              return Align(
-                                alignment: Alignment.topLeft,
-                                child: Material(
-                                  elevation: 4.0,
-                                  child: ConstrainedBox(
-                                    constraints: const BoxConstraints(
-                                      maxHeight: 200,
+                            optionsViewBuilder:
+                                (context, onSelected, options) =>
+                                    AutocompleteOptionsList<String>(
+                                      options: options,
+                                      onSelected: onSelected,
+                                      labelFor: (option) => option,
                                     ),
-                                    child: ListView.builder(
-                                      padding: EdgeInsets.zero,
-                                      shrinkWrap: true,
-                                      itemCount: options.length,
-                                      itemBuilder:
-                                          (BuildContext context, int index) {
-                                            final String option = options
-                                                .elementAt(index);
-                                            return ListTile(
-                                              title: Text(option),
-                                              onTap: () => onSelected(option),
-                                            );
-                                          },
-                                    ),
-                                  ),
-                                ),
-                              );
-                            },
                           );
                         },
                       ),

--- a/lib/features/import_wizard/presentation/widgets/import_tags_field.dart
+++ b/lib/features/import_wizard/presentation/widgets/import_tags_field.dart
@@ -163,12 +163,16 @@ class _ImportTagsFieldState extends State<ImportTagsField> {
                     contentPadding: const EdgeInsets.symmetric(vertical: 8),
                   ),
                   onSubmitted: (text) {
-                    // With suggestions open, Enter commits the highlighted
-                    // one; adding the typed text too would add two tags.
-                    if (_filteredSuggestions(text).isEmpty) {
-                      _submitTag(text);
-                    }
+                    // Give RawAutocomplete first refusal: it commits the
+                    // highlighted suggestion, but only while the options
+                    // overlay is actually showing. Whether suggestions merely
+                    // exist is not the same question, since Escape closes the
+                    // overlay and leaves them matching.
                     onSubmitted();
+                    // Committing a suggestion clears the field via onSelected,
+                    // so text still standing means nothing was committed and
+                    // the typed tag is what the user meant.
+                    if (controller.text == text) _submitTag(text);
                   },
                 ),
               ),

--- a/lib/features/import_wizard/presentation/widgets/import_tags_field.dart
+++ b/lib/features/import_wizard/presentation/widgets/import_tags_field.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:submersion/features/import_wizard/domain/models/tag_selection.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/forms/autocomplete_options_list.dart';
 
 /// Multi-tag chip field with autocomplete for the import review step.
 ///
@@ -162,7 +163,11 @@ class _ImportTagsFieldState extends State<ImportTagsField> {
                     contentPadding: const EdgeInsets.symmetric(vertical: 8),
                   ),
                   onSubmitted: (text) {
-                    _submitTag(text);
+                    // With suggestions open, Enter commits the highlighted
+                    // one; adding the typed text too would add two tags.
+                    if (_filteredSuggestions(text).isEmpty) {
+                      _submitTag(text);
+                    }
                     onSubmitted();
                   },
                 ),
@@ -170,32 +175,14 @@ class _ImportTagsFieldState extends State<ImportTagsField> {
             ],
           );
         },
-        optionsViewBuilder: (context, onSelected, options) {
-          return Align(
-            alignment: Alignment.topLeft,
-            child: Material(
-              elevation: 4,
-              borderRadius: BorderRadius.circular(8),
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxHeight: 200),
-                child: ListView.builder(
-                  padding: EdgeInsets.zero,
-                  shrinkWrap: true,
-                  itemCount: options.length,
-                  itemBuilder: (context, index) {
-                    final tag = options.elementAt(index);
-                    return ListTile(
-                      dense: true,
-                      leading: Icon(Icons.label, color: tag.color, size: 20),
-                      title: Text(tag.name),
-                      onTap: () => onSelected(tag),
-                    );
-                  },
-                ),
-              ),
+        optionsViewBuilder: (context, onSelected, options) =>
+            AutocompleteOptionsList<Tag>(
+              options: options,
+              onSelected: onSelected,
+              labelFor: (tag) => tag.name,
+              leadingFor: (context, tag) =>
+                  Icon(Icons.label, color: tag.color, size: 20),
             ),
-          );
-        },
       ),
     );
   }

--- a/lib/shared/widgets/forms/autocomplete_options_list.dart
+++ b/lib/shared/widgets/forms/autocomplete_options_list.dart
@@ -11,9 +11,11 @@ import 'package:flutter/scheduler.dart';
 /// highlighted row and keeps it scrolled into view, so arrow keys move a
 /// visible selection and Enter commits it.
 ///
-/// The field paired with this list must forward its submit callback
-/// (`onSubmitted: (_) => onFieldSubmitted()`), otherwise Enter has no way to
-/// commit the highlighted option.
+/// The field paired with this list must forward the `onFieldSubmitted`
+/// callback that [RawAutocomplete] hands to its `fieldViewBuilder`:
+/// `onFieldSubmitted: (_) => onFieldSubmitted()` on a [TextFormField], or
+/// `onSubmitted: (_) => onFieldSubmitted()` on a [TextField]. Without it,
+/// Enter has no way to commit the highlighted option.
 class AutocompleteOptionsList<T extends Object> extends StatelessWidget {
   const AutocompleteOptionsList({
     super.key,
@@ -52,6 +54,9 @@ class AutocompleteOptionsList<T extends Object> extends StatelessWidget {
       child: Material(
         elevation: 4,
         borderRadius: BorderRadius.circular(8),
+        // Without a clip the rows' ink splashes paint past the rounded
+        // corners of the overlay.
+        clipBehavior: Clip.antiAlias,
         child: ConstrainedBox(
           constraints: BoxConstraints(maxHeight: maxHeight),
           child: ListView.builder(

--- a/lib/shared/widgets/forms/autocomplete_options_list.dart
+++ b/lib/shared/widgets/forms/autocomplete_options_list.dart
@@ -67,10 +67,11 @@ class _AutocompleteOptionsListState<T extends Object>
 
   /// Brings the row at [index] on screen after the frame that highlighted it.
   ///
-  /// Keyboard navigation can land far outside the rows the [ListView] has
-  /// built (jump-to-first/last, PageUp/PageDown), and [Scrollable.ensureVisible]
-  /// needs a live context, so fall back to scrolling to the end the option
-  /// lies past and let the next frame build it.
+  /// The jump-to-first and jump-to-last intents can land outside the rows the
+  /// [ListView] has built, and [Scrollable.ensureVisible] needs a live
+  /// context, so those fall back to scrolling to that end of the list. The
+  /// stepping intents (arrow keys, PageUp/PageDown) move only a few rows at a
+  /// time, so their target is already built and takes the exact path.
   void _scrollHighlightIntoView(int index) {
     SchedulerBinding.instance.addPostFrameCallback((_) {
       // A newer highlight has superseded this one, e.g. while an arrow key
@@ -80,6 +81,7 @@ class _AutocompleteOptionsListState<T extends Object>
 
       final rowContext = _rowKeys[index]?.currentContext;
       if (rowContext == null) {
+        // Only a jump to one end of the list can outrun the built rows.
         _scrollController.jumpTo(
           index == 0 ? 0 : _scrollController.position.maxScrollExtent,
         );

--- a/lib/shared/widgets/forms/autocomplete_options_list.dart
+++ b/lib/shared/widgets/forms/autocomplete_options_list.dart
@@ -16,7 +16,7 @@ import 'package:flutter/scheduler.dart';
 /// `onFieldSubmitted: (_) => onFieldSubmitted()` on a [TextFormField], or
 /// `onSubmitted: (_) => onFieldSubmitted()` on a [TextField]. Without it,
 /// Enter has no way to commit the highlighted option.
-class AutocompleteOptionsList<T extends Object> extends StatelessWidget {
+class AutocompleteOptionsList<T extends Object> extends StatefulWidget {
   const AutocompleteOptionsList({
     super.key,
     required this.options,
@@ -43,12 +43,65 @@ class AutocompleteOptionsList<T extends Object> extends StatelessWidget {
   final bool dense;
 
   @override
+  State<AutocompleteOptionsList<T>> createState() =>
+      _AutocompleteOptionsListState<T>();
+}
+
+class _AutocompleteOptionsListState<T extends Object>
+    extends State<AutocompleteOptionsList<T>> {
+  final _scrollController = ScrollController();
+
+  // Keyed by position rather than by option value: two suggestions can be
+  // equal strings, and duplicate global keys would break the tree.
+  final _rowKeys = <int, GlobalKey>{};
+
+  int? _highlighted;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  GlobalKey _rowKey(int index) => _rowKeys.putIfAbsent(index, GlobalKey.new);
+
+  /// Brings the row at [index] on screen after the frame that highlighted it.
+  ///
+  /// Keyboard navigation can land far outside the rows the [ListView] has
+  /// built (jump-to-first/last, PageUp/PageDown), and [Scrollable.ensureVisible]
+  /// needs a live context, so fall back to scrolling to the end the option
+  /// lies past and let the next frame build it.
+  void _scrollHighlightIntoView(int index) {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      // A newer highlight has superseded this one, e.g. while an arrow key
+      // is held down; that scroll is already scheduled.
+      if (!mounted || index != _highlighted) return;
+      if (!_scrollController.hasClients) return;
+
+      final rowContext = _rowKeys[index]?.currentContext;
+      if (rowContext == null) {
+        _scrollController.jumpTo(
+          index == 0 ? 0 : _scrollController.position.maxScrollExtent,
+        );
+        return;
+      }
+      Scrollable.ensureVisible(rowContext, alignment: 0.5);
+    }, debugLabel: 'AutocompleteOptionsList.ensureVisible');
+  }
+
+  @override
   Widget build(BuildContext context) {
     final highlighted = AutocompleteHighlightedOption.of(context);
     final theme = Theme.of(context);
     // optionsBuilder commonly returns a lazy Iterable; materialise it once so
     // indexing rows is not quadratic in the number of matches.
-    final items = options.toList(growable: false);
+    final items = widget.options.toList(growable: false);
+
+    if (highlighted != _highlighted) {
+      _highlighted = highlighted;
+      if (highlighted < items.length) _scrollHighlightIntoView(highlighted);
+    }
+
     return Align(
       alignment: AlignmentDirectional.topStart,
       child: Material(
@@ -58,34 +111,22 @@ class AutocompleteOptionsList<T extends Object> extends StatelessWidget {
         // corners of the overlay.
         clipBehavior: Clip.antiAlias,
         child: ConstrainedBox(
-          constraints: BoxConstraints(maxHeight: maxHeight),
+          constraints: BoxConstraints(maxHeight: widget.maxHeight),
           child: ListView.builder(
+            controller: _scrollController,
             padding: EdgeInsets.zero,
             shrinkWrap: true,
             itemCount: items.length,
             itemBuilder: (context, index) {
               final option = items[index];
-              final isHighlighted = index == highlighted;
-              return Builder(
-                builder: (context) {
-                  if (isHighlighted) {
-                    // Keep the keyboard-driven selection on screen. Scheduled
-                    // post-frame because the row is being laid out right now.
-                    SchedulerBinding.instance.addPostFrameCallback((_) {
-                      if (context.mounted) {
-                        Scrollable.ensureVisible(context, alignment: 0.5);
-                      }
-                    });
-                  }
-                  return ListTile(
-                    dense: dense,
-                    selected: isHighlighted,
-                    selectedTileColor: theme.focusColor,
-                    leading: leadingFor?.call(context, option),
-                    title: Text(labelFor(option)),
-                    onTap: () => onSelected(option),
-                  );
-                },
+              return ListTile(
+                key: _rowKey(index),
+                dense: widget.dense,
+                selected: index == highlighted,
+                selectedTileColor: theme.focusColor,
+                leading: widget.leadingFor?.call(context, option),
+                title: Text(widget.labelFor(option)),
+                onTap: () => widget.onSelected(option),
               );
             },
           ),

--- a/lib/shared/widgets/forms/autocomplete_options_list.dart
+++ b/lib/shared/widgets/forms/autocomplete_options_list.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+
+/// Dropdown list for a [RawAutocomplete] options overlay that honours the
+/// keyboard.
+///
+/// [RawAutocomplete] already binds the arrow keys to its own intents and
+/// tracks the highlighted option in [AutocompleteHighlightedOption]; an
+/// options view that ignores that notifier leaves keyboard navigation
+/// invisible and therefore unusable. This list reads it, paints the
+/// highlighted row and keeps it scrolled into view, so arrow keys move a
+/// visible selection and Enter commits it.
+///
+/// The field paired with this list must forward its submit callback
+/// (`onSubmitted: (_) => onFieldSubmitted()`), otherwise Enter has no way to
+/// commit the highlighted option.
+class AutocompleteOptionsList<T extends Object> extends StatelessWidget {
+  const AutocompleteOptionsList({
+    super.key,
+    required this.options,
+    required this.onSelected,
+    required this.labelFor,
+    this.leadingFor,
+    this.maxHeight = 200,
+    this.dense = true,
+  });
+
+  /// Options as handed to `optionsViewBuilder`, in highlight order.
+  final Iterable<T> options;
+
+  /// Called with the chosen option, by tap or by keyboard.
+  final AutocompleteOnSelected<T> onSelected;
+
+  /// Display text for an option.
+  final String Function(T option) labelFor;
+
+  /// Optional leading widget (an icon, a colour swatch) per option.
+  final Widget Function(BuildContext context, T option)? leadingFor;
+
+  final double maxHeight;
+  final bool dense;
+
+  @override
+  Widget build(BuildContext context) {
+    final highlighted = AutocompleteHighlightedOption.of(context);
+    final theme = Theme.of(context);
+    // optionsBuilder commonly returns a lazy Iterable; materialise it once so
+    // indexing rows is not quadratic in the number of matches.
+    final items = options.toList(growable: false);
+    return Align(
+      alignment: AlignmentDirectional.topStart,
+      child: Material(
+        elevation: 4,
+        borderRadius: BorderRadius.circular(8),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxHeight: maxHeight),
+          child: ListView.builder(
+            padding: EdgeInsets.zero,
+            shrinkWrap: true,
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              final option = items[index];
+              final isHighlighted = index == highlighted;
+              return Builder(
+                builder: (context) {
+                  if (isHighlighted) {
+                    // Keep the keyboard-driven selection on screen. Scheduled
+                    // post-frame because the row is being laid out right now.
+                    SchedulerBinding.instance.addPostFrameCallback((_) {
+                      if (context.mounted) {
+                        Scrollable.ensureVisible(context, alignment: 0.5);
+                      }
+                    });
+                  }
+                  return ListTile(
+                    dense: dense,
+                    selected: isHighlighted,
+                    selectedTileColor: theme.focusColor,
+                    leading: leadingFor?.call(context, option),
+                    title: Text(labelFor(option)),
+                    onTap: () => onSelected(option),
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/forms/suggestion_form_row.dart
+++ b/lib/shared/widgets/forms/suggestion_form_row.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/text/fuzzy_match.dart';
+import 'package:submersion/shared/widgets/forms/autocomplete_options_list.dart';
 import 'package:submersion/shared/widgets/forms/form_style.dart';
 
 /// Row-styled autocomplete text field: label left, always-mounted bare
@@ -120,31 +121,12 @@ class _SuggestionFormRowState extends State<SuggestionFormRow> {
                           onFieldSubmitted: (_) => onFieldSubmitted(),
                         );
                       },
-                  optionsViewBuilder: (context, onSelected, options) {
-                    return Align(
-                      alignment: Alignment.topLeft,
-                      child: Material(
-                        elevation: 4,
-                        borderRadius: BorderRadius.circular(8),
-                        child: ConstrainedBox(
-                          constraints: const BoxConstraints(maxHeight: 200),
-                          child: ListView.builder(
-                            padding: EdgeInsets.zero,
-                            shrinkWrap: true,
-                            itemCount: options.length,
-                            itemBuilder: (context, index) {
-                              final option = options.elementAt(index);
-                              return ListTile(
-                                dense: true,
-                                title: Text(option),
-                                onTap: () => onSelected(option),
-                              );
-                            },
-                          ),
-                        ),
+                  optionsViewBuilder: (context, onSelected, options) =>
+                      AutocompleteOptionsList<String>(
+                        options: options,
+                        onSelected: onSelected,
+                        labelFor: (option) => option,
                       ),
-                    );
-                  },
                 ),
               ),
               if (widget.trailing != null) ...[

--- a/test/features/checklists/presentation/widgets/checklist_item_edit_sheet_test.dart
+++ b/test/features/checklists/presentation/widgets/checklist_item_edit_sheet_test.dart
@@ -21,6 +21,9 @@ Future<void> _openSheet(
 }) async {
   await tester.pumpWidget(
     testApp(
+      // Every finder below matches a localized label, so the UI language has
+      // to be deterministic rather than the host machine's.
+      locale: const Locale('en'),
       child: Builder(
         builder: (context) => TextButton(
           onPressed: () => showChecklistItemEditSheet(

--- a/test/features/checklists/presentation/widgets/checklist_item_edit_sheet_test.dart
+++ b/test/features/checklists/presentation/widgets/checklist_item_edit_sheet_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:submersion/features/checklists/data/repositories/trip_checklist_repository.dart';
@@ -229,4 +230,109 @@ void main() {
     // A due-date chip with a clear button now replaces the calendar icon.
     expect(find.byIcon(Icons.clear), findsOneWidget);
   });
+
+  testWidgets(
+    'the category suggestion list is navigable with the arrow keys and '
+    'committed with Enter',
+    (tester) async {
+      await _openSheet(
+        tester,
+        tripId: trip.id,
+        categorySuggestions: const ['Gases', 'Galley', 'Bookings'],
+      );
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Category'),
+        'Ga',
+      );
+      await tester.pumpAndSettle();
+
+      // Both matches are offered, with the first one highlighted.
+      expect(
+        tester
+            .widget<ListTile>(find.widgetWithText(ListTile, 'Gases'))
+            .selected,
+        isTrue,
+      );
+      expect(
+        tester
+            .widget<ListTile>(find.widgetWithText(ListTile, 'Galley'))
+            .selected,
+        isFalse,
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(
+        tester
+            .widget<ListTile>(find.widgetWithText(ListTile, 'Galley'))
+            .selected,
+        isTrue,
+      );
+
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Title'),
+        'Fill twinset',
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      final items = await checklistRepository.getByTripId(trip.id);
+      expect(items.single.category, 'Galley');
+    },
+  );
+
+  testWidgets('a category typed in a different case folds onto the existing '
+      'one', (tester) async {
+    await _openSheet(
+      tester,
+      tripId: trip.id,
+      categorySuggestions: const ['Diving', 'Bookings'],
+    );
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Title'),
+      'Check torch',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Category'),
+      'diving',
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    final items = await checklistRepository.getByTripId(trip.id);
+    expect(items.single.category, 'Diving');
+  });
+
+  testWidgets(
+    'a category with no case-insensitive match keeps what was typed',
+    (tester) async {
+      await _openSheet(
+        tester,
+        tripId: trip.id,
+        categorySuggestions: const ['Diving'],
+      );
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Title'),
+        'Renew insurance',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Category'),
+        'paperwork',
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      final items = await checklistRepository.getByTripId(trip.id);
+      expect(items.single.category, 'paperwork');
+    },
+  );
 }

--- a/test/features/checklists/presentation/widgets/trip_checklist_section_test.dart
+++ b/test/features/checklists/presentation/widgets/trip_checklist_section_test.dart
@@ -400,4 +400,33 @@ void main() {
       expect(clearItem.enabled, isFalse);
     });
   });
+
+  testWidgets('categories differing only in case form one group', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          tripChecklistProvider('t1').overrideWith(
+            (ref) async => [
+              _item(id: 'i1', title: 'Service regulator', category: 'Diving'),
+              _item(id: 'i2', title: 'Pack fins', category: 'diving'),
+              _item(id: 'i3', title: 'Book flights', category: 'Bookings'),
+            ],
+          ),
+        ],
+        child: SingleChildScrollView(
+          child: TripChecklistSection(trip: _trip(upcoming: true)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // One heading, labelled with the casing that appeared first.
+    expect(find.text('Diving'), findsOneWidget);
+    expect(find.text('diving'), findsNothing);
+    expect(find.text('Service regulator'), findsOneWidget);
+    expect(find.text('Pack fins'), findsOneWidget);
+    expect(find.text('Bookings'), findsOneWidget);
+  });
 }

--- a/test/features/dive_log/presentation/widgets/custom_field_input_row_test.dart
+++ b/test/features/dive_log/presentation/widgets/custom_field_input_row_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/domain/entities/dive_custom_field.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/custom_field_input_row.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+Widget _host({
+  required DiveCustomField field,
+  required List<String> keySuggestions,
+  required ValueChanged<DiveCustomField> onChanged,
+}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: CustomFieldInputRow(
+        index: 0,
+        field: field,
+        keySuggestions: keySuggestions,
+        onChanged: onChanged,
+        onDelete: () {},
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('the key field offers matching suggestions', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        field: const DiveCustomField(id: 'f1', key: '', value: ''),
+        keySuggestions: const ['Visibility', 'Vis notes', 'Current'],
+        onChanged: (_) {},
+      ),
+    );
+
+    await tester.enterText(find.byType(TextFormField).first, 'Vis');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Visibility'), findsOneWidget);
+    expect(find.text('Vis notes'), findsOneWidget);
+    expect(find.text('Current'), findsNothing);
+  });
+
+  testWidgets('arrow keys and Enter commit a highlighted key suggestion', (
+    tester,
+  ) async {
+    DiveCustomField? changed;
+    await tester.pumpWidget(
+      _host(
+        field: const DiveCustomField(id: 'f1', key: '', value: ''),
+        keySuggestions: const ['Visibility', 'Vis notes', 'Current'],
+        onChanged: (field) => changed = field,
+      ),
+    );
+
+    await tester.enterText(find.byType(TextFormField).first, 'Vis');
+    await tester.pumpAndSettle();
+
+    // Move off the first option, then commit with Enter. Without the field
+    // forwarding onFieldSubmitted this leaves the typed text in place.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    expect(changed, isNotNull);
+    expect(changed!.key, 'Vis notes');
+  });
+}

--- a/test/features/dive_log/presentation/widgets/custom_field_input_row_test.dart
+++ b/test/features/dive_log/presentation/widgets/custom_field_input_row_test.dart
@@ -12,6 +12,7 @@ Widget _host({
   required ValueChanged<DiveCustomField> onChanged,
 }) {
   return MaterialApp(
+    locale: const Locale('en'),
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
     home: Scaffold(

--- a/test/features/import_wizard/presentation/widgets/import_tags_field_test.dart
+++ b/test/features/import_wizard/presentation/widgets/import_tags_field_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/import_wizard/domain/models/tag_selection.dart';
 import 'package:submersion/features/import_wizard/presentation/widgets/import_tags_field.dart';
@@ -391,6 +392,126 @@ void main() {
       expect(addedTag, isNotNull);
       expect(addedTag!.existingTagId, equals('tag-1'));
       expect(addedTag!.name, equals('Vacation'));
+    });
+
+    testWidgets('arrow keys move the suggestion highlight', (tester) async {
+      final existingTags = [
+        Tag(
+          id: 'tag-1',
+          name: 'Vacation',
+          createdAt: DateTime(2026),
+          updatedAt: DateTime(2026),
+        ),
+        Tag(
+          id: 'tag-2',
+          name: 'Vacuum test',
+          createdAt: DateTime(2026),
+          updatedAt: DateTime(2026),
+        ),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ImportTagsField(
+              tags: const [],
+              existingTags: existingTags,
+              onAdd: (_) {},
+              onRemove: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'Vac');
+      await tester.pumpAndSettle();
+
+      expect(
+        tester
+            .widget<ListTile>(find.widgetWithText(ListTile, 'Vacation'))
+            .selected,
+        isTrue,
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+
+      expect(
+        tester
+            .widget<ListTile>(find.widgetWithText(ListTile, 'Vacuum test'))
+            .selected,
+        isTrue,
+      );
+    });
+
+    testWidgets('submitting with suggestions open adds only the highlighted '
+        'tag', (tester) async {
+      final added = <TagSelection>[];
+      final existingTags = [
+        Tag(
+          id: 'tag-1',
+          name: 'Vacation',
+          createdAt: DateTime(2026),
+          updatedAt: DateTime(2026),
+        ),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ImportTagsField(
+              tags: const [],
+              existingTags: existingTags,
+              onAdd: added.add,
+              onRemove: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'Vac');
+      await tester.pumpAndSettle();
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      // Without the open-list guard this also adds a free-text 'Vac' tag.
+      expect(added, hasLength(1));
+      expect(added.single.existingTagId, equals('tag-1'));
+      expect(added.single.name, equals('Vacation'));
+    });
+
+    testWidgets('submitting with no suggestions still adds the typed tag', (
+      tester,
+    ) async {
+      final added = <TagSelection>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ImportTagsField(
+              tags: const [],
+              existingTags: const [],
+              onAdd: added.add,
+              onRemove: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'Night dives');
+      await tester.pumpAndSettle();
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(added, hasLength(1));
+      expect(added.single.existingTagId, isNull);
+      expect(added.single.name, equals('Night dives'));
     });
   });
 }

--- a/test/features/import_wizard/presentation/widgets/import_tags_field_test.dart
+++ b/test/features/import_wizard/presentation/widgets/import_tags_field_test.dart
@@ -513,5 +513,50 @@ void main() {
       expect(added.single.existingTagId, isNull);
       expect(added.single.name, equals('Night dives'));
     });
+
+    testWidgets('submitting after dismissing the suggestions adds the typed '
+        'tag', (tester) async {
+      final added = <TagSelection>[];
+      final existingTags = [
+        Tag(
+          id: 'tag-1',
+          name: 'Vacation',
+          createdAt: DateTime(2026),
+          updatedAt: DateTime(2026),
+        ),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ImportTagsField(
+              tags: const [],
+              existingTags: existingTags,
+              onAdd: added.add,
+              onRemove: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'Vac');
+      await tester.pumpAndSettle();
+      expect(find.widgetWithText(ListTile, 'Vacation'), findsOneWidget);
+
+      // Escape closes the overlay, so RawAutocomplete will not commit a
+      // suggestion; the typed text must still be added.
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+      expect(find.widgetWithText(ListTile, 'Vacation'), findsNothing);
+
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(added, hasLength(1));
+      expect(added.single.name, equals('Vac'));
+      expect(added.single.existingTagId, isNull);
+    });
   });
 }

--- a/test/shared/widgets/forms/autocomplete_options_list_test.dart
+++ b/test/shared/widgets/forms/autocomplete_options_list_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
+
+import 'package:submersion/shared/widgets/forms/autocomplete_options_list.dart';
+
+/// Minimal RawAutocomplete host so the options list sees the framework's
+/// AutocompleteHighlightedOption notifier, exactly as it does in the app.
+Widget _host({
+  required List<String> suggestions,
+  required void Function(String) onSelected,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: RawAutocomplete<String>(
+        optionsBuilder: (value) => value.text.isEmpty
+            ? const Iterable<String>.empty()
+            : suggestions.where(
+                (s) => s.toLowerCase().contains(value.text.toLowerCase()),
+              ),
+        onSelected: onSelected,
+        fieldViewBuilder: (context, controller, focusNode, onFieldSubmitted) =>
+            TextField(
+              controller: controller,
+              focusNode: focusNode,
+              onSubmitted: (_) => onFieldSubmitted(),
+            ),
+        optionsViewBuilder: (context, onSelect, options) =>
+            AutocompleteOptionsList<String>(
+              options: options,
+              onSelected: onSelect,
+              labelFor: (option) => option,
+            ),
+      ),
+    ),
+  );
+}
+
+bool _isSelected(WidgetTester tester, String label) =>
+    tester.widget<ListTile>(find.widgetWithText(ListTile, label)).selected;
+
+void main() {
+  testWidgets('first option starts highlighted', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        suggestions: const ['Diving', 'Dining', 'Medical'],
+        onSelected: (_) {},
+      ),
+    );
+    await tester.enterText(find.byType(TextField), 'di');
+    await tester.pumpAndSettle();
+
+    expect(_isSelected(tester, 'Diving'), isTrue);
+    expect(_isSelected(tester, 'Dining'), isFalse);
+  });
+
+  testWidgets('arrow down moves the highlight to the next option', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _host(
+        suggestions: const ['Diving', 'Dining', 'Medical'],
+        onSelected: (_) {},
+      ),
+    );
+    await tester.enterText(find.byType(TextField), 'di');
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+
+    expect(_isSelected(tester, 'Diving'), isFalse);
+    expect(_isSelected(tester, 'Dining'), isTrue);
+  });
+
+  testWidgets('arrow up moves the highlight back', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        suggestions: const ['Diving', 'Dining', 'Medical'],
+        onSelected: (_) {},
+      ),
+    );
+    await tester.enterText(find.byType(TextField), 'di');
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+
+    expect(_isSelected(tester, 'Diving'), isTrue);
+  });
+
+  testWidgets('submitting commits the highlighted option', (tester) async {
+    String? selected;
+    await tester.pumpWidget(
+      _host(
+        suggestions: const ['Diving', 'Dining', 'Medical'],
+        onSelected: (value) => selected = value,
+      ),
+    );
+    await tester.enterText(find.byType(TextField), 'di');
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    expect(selected, 'Dining');
+  });
+
+  testWidgets('tapping an option still selects it', (tester) async {
+    String? selected;
+    await tester.pumpWidget(
+      _host(
+        suggestions: const ['Diving', 'Dining', 'Medical'],
+        onSelected: (value) => selected = value,
+      ),
+    );
+    await tester.enterText(find.byType(TextField), 'di');
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Medical'));
+    await tester.pumpAndSettle();
+
+    expect(selected, 'Medical');
+  });
+
+  testWidgets('leadingFor renders a leading widget per option', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: RawAutocomplete<String>(
+            optionsBuilder: (value) =>
+                value.text.isEmpty ? const <String>[] : const ['Diving'],
+            fieldViewBuilder:
+                (context, controller, focusNode, onFieldSubmitted) => TextField(
+                  controller: controller,
+                  focusNode: focusNode,
+                  onSubmitted: (_) => onFieldSubmitted(),
+                ),
+            optionsViewBuilder: (context, onSelect, options) =>
+                AutocompleteOptionsList<String>(
+                  options: options,
+                  onSelected: onSelect,
+                  labelFor: (option) => option,
+                  leadingFor: (context, option) => const Icon(Icons.label),
+                ),
+          ),
+        ),
+      ),
+    );
+    await tester.enterText(find.byType(TextField), 'di');
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.label), findsOneWidget);
+  });
+}

--- a/test/shared/widgets/forms/autocomplete_options_list_test.dart
+++ b/test/shared/widgets/forms/autocomplete_options_list_test.dart
@@ -156,4 +156,59 @@ void main() {
 
     expect(find.byIcon(Icons.label), findsOneWidget);
   });
+
+  testWidgets('jumping to an option outside the built range scrolls to it', (
+    tester,
+  ) async {
+    final many = List<String>.generate(
+      40,
+      (i) => 'Option ${i.toString().padLeft(2, '0')}',
+    );
+    await tester.pumpWidget(_host(suggestions: many, onSelected: (_) {}));
+    await tester.enterText(find.byType(TextField), 'Option');
+    await tester.pumpAndSettle();
+
+    // Ctrl+ArrowDown highlights the last option, which is far outside the
+    // rows the ListView has built.
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pumpAndSettle();
+
+    final row = find.widgetWithText(ListTile, 'Option 39');
+    expect(row, findsOneWidget);
+    expect(tester.widget<ListTile>(row).selected, isTrue);
+
+    // It must actually be on screen, not merely built in the cache extent.
+    final listRect = tester.getRect(find.byType(ListView));
+    final rowRect = tester.getRect(row);
+    expect(rowRect.top, greaterThanOrEqualTo(listRect.top - 0.5));
+    expect(rowRect.bottom, lessThanOrEqualTo(listRect.bottom + 0.5));
+  });
+
+  testWidgets('stepping down a long list keeps the highlight on screen', (
+    tester,
+  ) async {
+    final many = List<String>.generate(
+      40,
+      (i) => 'Option ${i.toString().padLeft(2, '0')}',
+    );
+    await tester.pumpWidget(_host(suggestions: many, onSelected: (_) {}));
+    await tester.enterText(find.byType(TextField), 'Option');
+    await tester.pumpAndSettle();
+
+    for (var i = 0; i < 12; i++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+    }
+
+    final row = find.widgetWithText(ListTile, 'Option 12');
+    expect(row, findsOneWidget);
+    expect(tester.widget<ListTile>(row).selected, isTrue);
+
+    final listRect = tester.getRect(find.byType(ListView));
+    final rowRect = tester.getRect(row);
+    expect(rowRect.top, greaterThanOrEqualTo(listRect.top - 0.5));
+    expect(rowRect.bottom, lessThanOrEqualTo(listRect.bottom + 0.5));
+  });
 }

--- a/test/shared/widgets/forms/autocomplete_options_list_test.dart
+++ b/test/shared/widgets/forms/autocomplete_options_list_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'package:submersion/shared/widgets/forms/autocomplete_options_list.dart';
 

--- a/test/shared/widgets/forms/suggestion_form_row_test.dart
+++ b/test/shared/widgets/forms/suggestion_form_row_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:submersion/shared/widgets/forms/suggestion_form_row.dart';
@@ -61,5 +62,46 @@ void main() {
     formKey.currentState!.validate();
     await tester.pump();
     expect(find.text('Name required'), findsOneWidget);
+  });
+
+  testWidgets('arrow keys move the highlight and Enter commits it', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Material(
+            child: SuggestionFormRow(
+              label: 'Country',
+              controller: controller,
+              suggestions: const ['Mexico', 'Mexico City', 'USA'],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.enterText(find.byType(TextFormField), 'Mex');
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<ListTile>(find.widgetWithText(ListTile, 'Mexico')).selected,
+      isTrue,
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      tester
+          .widget<ListTile>(find.widgetWithText(ListTile, 'Mexico City'))
+          .selected,
+      isTrue,
+    );
+
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    expect(controller.text, 'Mexico City');
   });
 }


### PR DESCRIPTION
Fixes #1659.

## Keyboard navigation in find-as-you-type dropdowns

`RawAutocomplete` already binds the arrow keys to its own intents and tracks
the highlighted option in an `AutocompleteHighlightedOption` notifier, but
every hand-rolled `optionsViewBuilder` in the app ignored that notifier. The
keys were moving a highlight nobody could see, and two of the fields never
forwarded `onFieldSubmitted`, so Enter had nothing to commit. The reported
case (trip checklist item category) was one of both.

- New shared `AutocompleteOptionsList<T>` renders the dropdown, paints the row
  the framework has highlighted, and keeps it scrolled into view.
- Adopted at every custom options view: checklist item category, the shared
  `SuggestionFormRow`, the import wizard tag field, and the dive filter buddy
  field.
- Wired the missing `onFieldSubmitted` on the checklist category field and the
  dive custom-field key field, so Enter commits the highlighted suggestion.
- The import wizard tag field submitted the typed text *and* the highlighted
  suggestion, adding two tags for one Enter. It now adds the typed text only
  when no suggestion list is open.

Arrow keys, Home/End (cmd or ctrl + arrow), PageUp/PageDown and Escape all
come from the framework once the highlight is visible.

## Case-sensitive checklist categories

From the issue's additional context: `diving` and `Diving` were separate
categories.

- Category suggestions are de-duplicated case-insensitively, so a category is
  offered once rather than once per casing.
- The checklist groups categories case-insensitively, labelled with the casing
  that appeared first.
- A category typed in a different case is folded onto the matching existing
  one on save, so the two converge instead of drifting apart. Input with no
  case-insensitive match keeps exactly what was typed.

No migration: existing mixed-case rows group together on display and converge
as they are edited.

## Tests

- `autocomplete_options_list_test.dart`: initial highlight, arrow down/up,
  submit commits the highlight, tap still selects, leading widgets render.
- Checklist item sheet: arrow-key navigation end to end through save, plus
  case folding and the no-match passthrough.
- Trip checklist section: categories differing only in case form one group.
- Import tags field: arrow-key highlight, one tag per Enter with suggestions
  open, typed tag still added with none open.

Each new assertion was mutation-tested against the unfixed code.
