### PR TITLE
fix(media): file scanned logbook pages under the Submersion folder (#1645)

### DIFF
--- a/lib/core/constants/app_directories.dart
+++ b/lib/core/constants/app_directories.dart
@@ -1,9 +1,10 @@
-/// The folder under the platform documents directory that holds everything
-/// the app owns there: the database and its sidecars, pre-reset backups,
+/// The folder under the platform documents directory that holds the app's
+/// own persistent data: the database and its sidecars, pre-reset backups,
 /// and the scanned-page copies written by the OCR import flow.
 ///
 /// On Windows and Linux `getApplicationDocumentsDirectory()` is the user's
-/// own Documents folder, so a file written directly under it sits among
-/// their personal files (issue #1645). Every documents-directory path the
-/// app builds must go through this one name.
+/// own Documents folder, so app-owned data written directly under it sits
+/// among their personal files (issue #1645). Files the user asked for, such
+/// as exports, deliberately land in the Documents root where they can find
+/// them; everything the app keeps for itself goes under this name.
 const String kAppDocumentsFolder = 'Submersion';

--- a/lib/core/constants/app_directories.dart
+++ b/lib/core/constants/app_directories.dart
@@ -1,0 +1,9 @@
+/// The folder under the platform documents directory that holds everything
+/// the app owns there: the database and its sidecars, pre-reset backups,
+/// and the scanned-page copies written by the OCR import flow.
+///
+/// On Windows and Linux `getApplicationDocumentsDirectory()` is the user's
+/// own Documents folder, so a file written directly under it sits among
+/// their personal files (issue #1645). Every documents-directory path the
+/// app builds must go through this one name.
+const String kAppDocumentsFolder = 'Submersion';

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -58,6 +58,7 @@ import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
 import 'package:submersion/features/marine_life/data/services/builtin_species_seed_version_store.dart';
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/scanned_logs_migration.dart';
 import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
 import 'package:submersion/features/media_store/data/media_orphan_backlog_sweep.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
@@ -749,6 +750,28 @@ class _StartupWrapperState extends State<StartupWrapper>
       } catch (e, stackTrace) {
         debugPrint(
           'Orphaned-media backlog sweep failed (will retry): $e\n$stackTrace',
+        );
+      }
+    }());
+
+    // Scanned-page folder migration (issue #1645), every launch. The common
+    // case is one directory stat that finds nothing; on an install that
+    // still has `<documents>/scanned_logs/` it moves the pages under
+    // `Submersion` and relinks their rows. Same fire-and-forget shape as the
+    // media sweep above: a scan or a read must never wait on, or fail with,
+    // this housekeeping, and the report is the only diagnostic.
+    unawaited(() async {
+      try {
+        final report = await ScannedLogsMigration(
+          relocateRows: (from, to) =>
+              mediaRepository.relocateLocalFile(from: from, to: to),
+        ).run();
+        if (report.outcome != ScannedLogsMigrationOutcome.noLegacyData) {
+          debugPrint('Scanned logs migration: $report');
+        }
+      } catch (e, stackTrace) {
+        debugPrint(
+          'Scanned logs migration failed (will retry): $e\n$stackTrace',
         );
       }
     }());

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -757,22 +757,16 @@ class _StartupWrapperState extends State<StartupWrapper>
     // Scanned-page folder migration (issue #1645), every launch. The common
     // case is one directory stat that finds nothing; on an install that
     // still has `<documents>/scanned_logs/` it moves the pages under
-    // `Submersion` and relinks their rows. Same fire-and-forget shape as the
-    // media sweep above: a scan or a read must never wait on, or fail with,
-    // this housekeeping, and the report is the only diagnostic.
+    // `Submersion` and relinks their rows. Fire-and-forget like the media
+    // sweep above, but with no try/catch: run() folds every failure into
+    // its report by contract, so the report is the only diagnostic.
     unawaited(() async {
-      try {
-        final report = await ScannedLogsMigration(
-          relocateRows: (from, to) =>
-              mediaRepository.relocateLocalFile(from: from, to: to),
-        ).run();
-        if (report.outcome != ScannedLogsMigrationOutcome.noLegacyData) {
-          debugPrint('Scanned logs migration: $report');
-        }
-      } catch (e, stackTrace) {
-        debugPrint(
-          'Scanned logs migration failed (will retry): $e\n$stackTrace',
-        );
+      final report = await ScannedLogsMigration(
+        relocateRows: (from, to) =>
+            mediaRepository.relocateLocalFile(from: from, to: to),
+      ).run();
+      if (report.outcome != ScannedLogsMigrationOutcome.noLegacyData) {
+        debugPrint('Scanned logs migration: $report');
       }
     }());
 

--- a/lib/core/services/database_location_service.dart
+++ b/lib/core/services/database_location_service.dart
@@ -7,6 +7,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:submersion/core/constants/app_directories.dart';
 import 'package:submersion/core/domain/entities/storage_config.dart';
 import 'package:submersion/core/services/security_scoped_bookmark_service.dart';
 
@@ -131,13 +132,13 @@ class DatabaseLocationService {
   /// Get the default database path (app documents directory)
   Future<String> getDefaultDatabasePath() async {
     final dbFolder = await getApplicationDocumentsDirectory();
-    return p.join(dbFolder.path, 'Submersion', databaseFilename);
+    return p.join(dbFolder.path, kAppDocumentsFolder, databaseFilename);
   }
 
   /// Get the default database directory
   Future<String> getDefaultDatabaseDirectory() async {
     final dbFolder = await getApplicationDocumentsDirectory();
-    return p.join(dbFolder.path, 'Submersion');
+    return p.join(dbFolder.path, kAppDocumentsFolder);
   }
 
   /// Check if custom folder mode is supported on this platform
@@ -479,7 +480,7 @@ Future<String?> resolveAndroidDbDir(
     // primary internal volume.
     chosen = options.first;
   }
-  final dbDir = p.join(chosen.path, 'Submersion');
+  final dbDir = p.join(chosen.path, kAppDocumentsFolder);
   await Directory(dbDir).create(recursive: true);
   return dbDir;
 }

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -7,6 +7,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart' as sqlite3;
 
+import 'package:submersion/core/constants/app_directories.dart';
 import 'package:submersion/core/database/background_database_connection.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/database_connection_setup.dart';
@@ -745,7 +746,7 @@ class DatabaseService {
   /// Get the default database path
   Future<String> _getDefaultPath() async {
     final dbFolder = await getApplicationDocumentsDirectory();
-    return p.join(dbFolder.path, 'Submersion', 'submersion.db');
+    return p.join(dbFolder.path, kAppDocumentsFolder, 'submersion.db');
   }
 
   /// Get the current database path (async version for external use)

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -909,6 +909,60 @@ class MediaRepository {
     }
   }
 
+  /// Points every row that references the local file at [from] at [to]
+  /// instead, in `file_path` and, where it mirrors the same path, in
+  /// `local_path`.
+  ///
+  /// The row half of a file move (the scanned-logs folder migration, issue
+  /// #1645). Rows are marked pending like any other edit: a peer that later
+  /// touches the row would otherwise sync the stale path back over this one.
+  ///
+  /// Returns the number of rows rewritten. Zero is not an error: a file with
+  /// no row behind it is simply moved.
+  Future<int> relocateLocalFile({
+    required String from,
+    required String to,
+  }) async {
+    try {
+      final rows =
+          await (_db.select(_db.media)..where(
+                (t) => t.filePath.equals(from) | t.localPath.equals(from),
+              ))
+              .get();
+      if (rows.isEmpty) return 0;
+
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await _db.transaction(() async {
+        for (final row in rows) {
+          await (_db.update(
+            _db.media,
+          )..where((t) => t.id.equals(row.id))).write(
+            MediaCompanion(
+              filePath: Value(row.filePath == from ? to : row.filePath),
+              localPath: Value(row.localPath == from ? to : row.localPath),
+              updatedAt: Value(now),
+            ),
+          );
+          await _syncRepository.markRecordPending(
+            entityType: 'media',
+            recordId: row.id,
+            localUpdatedAt: now,
+          );
+        }
+      });
+      SyncEventBus.notifyLocalChange();
+      _log.info('Relocated ${rows.length} media rows from $from to $to');
+      return rows.length;
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to relocate media rows from $from',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   /// Get all orphaned media
   /// Includes enrichment data (depth, temperature) if available
   Future<List<domain.MediaItem>> getOrphanedMedia() async {

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -909,7 +909,7 @@ class MediaRepository {
     }
   }
 
-  /// Points every row that references the local file at [from] at [to]
+  /// Points every row that references the local file at [from] to [to]
   /// instead, in `file_path` and, where it mirrors the same path, in
   /// `local_path`.
   ///

--- a/lib/features/media/data/services/media_import_service.dart
+++ b/lib/features/media/data/services/media_import_service.dart
@@ -37,6 +37,20 @@ class ImportResult {
   bool get allSucceeded => failures.isEmpty;
 }
 
+/// The folder under the platform documents directory that holds everything
+/// the app owns there: the database, its backups, and the scanned-page
+/// copies written by [MediaImportService.importLocalFileForDive].
+///
+/// On Windows and Linux `getApplicationDocumentsDirectory()` is the user's
+/// own Documents folder, so a file written directly under it sits among
+/// their personal files (issue #1645). Keep this in step with the literal in
+/// `DatabaseLocationService.getDefaultDatabaseDirectory`.
+const String kAppDocumentsFolder = 'Submersion';
+
+/// Where the OCR scan flow files its logbook-page copies, relative to
+/// [kAppDocumentsFolder].
+const String kScannedLogsSubdirectory = 'scanned_logs';
+
 /// Service for importing photos from the device gallery into the app.
 ///
 /// Handles the full import flow:
@@ -64,12 +78,23 @@ class MediaImportService {
   /// enqueue an upload. Null when no store is configured.
   final void Function(String mediaId)? onMediaCreated;
 
-  /// Copies [sourceFile] into the app documents directory (subdir
-  /// [subdirectory]) and creates a localFile media row linked to [diveId].
+  /// The directory [importLocalFileForDive] writes into for [subdirectory]:
+  /// `<documents>/Submersion/<subdirectory>`.
   ///
-  /// [subdirectory] defaults to 'scanned_logs' for the OCR scan flow that
-  /// introduced this method; file imports pass their own so an imported
-  /// logbook's photos are not filed as scanned pages.
+  /// Public so the one-time folder migration can name the same destination
+  /// without a second copy of the layout.
+  static Directory destinationDirectory(
+    Directory documents,
+    String subdirectory,
+  ) => Directory(p.join(documents.path, kAppDocumentsFolder, subdirectory));
+
+  /// Copies [sourceFile] into the app's own folder under the documents
+  /// directory (see [destinationDirectory]) and creates a localFile media
+  /// row linked to [diveId].
+  ///
+  /// [subdirectory] defaults to [kScannedLogsSubdirectory] for the OCR scan
+  /// flow that introduced this method; file imports pass their own so an
+  /// imported logbook's photos are not filed as scanned pages.
   ///
   /// [latitude] and [longitude] are the photo's own coordinates when the
   /// source recorded them, which is not the same as the dive site's.
@@ -79,10 +104,10 @@ class MediaImportService {
     DateTime? takenAt,
     double? latitude,
     double? longitude,
-    String subdirectory = 'scanned_logs',
+    String subdirectory = kScannedLogsSubdirectory,
   }) async {
     final docs = await _documentsDirectory();
-    final dir = Directory(p.join(docs.path, subdirectory));
+    final dir = destinationDirectory(docs, subdirectory);
     await dir.create(recursive: true);
     final sourceExt = p.extension(sourceFile.path);
     final ext = sourceExt.isEmpty ? '.jpg' : sourceExt;

--- a/lib/features/media/data/services/media_import_service.dart
+++ b/lib/features/media/data/services/media_import_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
+import 'package:submersion/core/constants/app_directories.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
@@ -37,16 +38,6 @@ class ImportResult {
   bool get allSucceeded => failures.isEmpty;
 }
 
-/// The folder under the platform documents directory that holds everything
-/// the app owns there: the database, its backups, and the scanned-page
-/// copies written by [MediaImportService.importLocalFileForDive].
-///
-/// On Windows and Linux `getApplicationDocumentsDirectory()` is the user's
-/// own Documents folder, so a file written directly under it sits among
-/// their personal files (issue #1645). Keep this in step with the literal in
-/// `DatabaseLocationService.getDefaultDatabaseDirectory`.
-const String kAppDocumentsFolder = 'Submersion';
-
 /// Where the OCR scan flow files its logbook-page copies, relative to
 /// [kAppDocumentsFolder].
 const String kScannedLogsSubdirectory = 'scanned_logs';
@@ -79,7 +70,8 @@ class MediaImportService {
   final void Function(String mediaId)? onMediaCreated;
 
   /// The directory [importLocalFileForDive] writes into for [subdirectory]:
-  /// `<documents>/Submersion/<subdirectory>`.
+  /// `<documents>/Submersion/<subdirectory>`, the same [kAppDocumentsFolder]
+  /// the database lives in.
   ///
   /// Public so the one-time folder migration can name the same destination
   /// without a second copy of the layout.

--- a/lib/features/media/data/services/scanned_logs_migration.dart
+++ b/lib/features/media/data/services/scanned_logs_migration.dart
@@ -1,0 +1,233 @@
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/media/data/services/media_import_service.dart';
+
+/// What one run of [ScannedLogsMigration] did.
+enum ScannedLogsMigrationOutcome {
+  /// No legacy folder on disk. The common case: a fresh install, a mobile
+  /// platform, or a machine that already migrated on an earlier launch.
+  noLegacyData,
+
+  /// The legacy folder was found and at least one page was moved, skipped,
+  /// or left for a retry. Look at the counts for the detail.
+  migrated,
+
+  /// Nothing was moved: the documents directory could not be resolved, the
+  /// destination could not be created, or every page failed. The legacy
+  /// folder is untouched.
+  failed,
+}
+
+/// The result of one migration run, with the paths involved so a debug log
+/// can show exactly which directories were considered.
+class ScannedLogsMigrationReport {
+  const ScannedLogsMigrationReport({
+    required this.outcome,
+    this.moved = 0,
+    this.skipped = 0,
+    this.failed = 0,
+    this.legacyPath,
+    this.targetPath,
+    this.error,
+  });
+
+  final ScannedLogsMigrationOutcome outcome;
+
+  /// Pages now at the destination with their rows relinked and the legacy
+  /// copy gone.
+  final int moved;
+
+  /// Pages left in the legacy folder because a DIFFERENT file already sits
+  /// at their destination name. Neither copy is touched.
+  final int skipped;
+
+  /// Pages left in the legacy folder because the copy or the row relink
+  /// threw. The next launch retries them.
+  final int failed;
+
+  final String? legacyPath;
+  final String? targetPath;
+  final Object? error;
+
+  @override
+  String toString() =>
+      'ScannedLogsMigrationReport(${outcome.name}, moved: $moved, '
+      'skipped: $skipped, failed: $failed, legacy: $legacyPath, '
+      'target: $targetPath${error == null ? '' : ', error: $error'})';
+}
+
+/// One-time move of scanned logbook pages from `<documents>/scanned_logs/`
+/// into `<documents>/Submersion/scanned_logs/` (issue #1645).
+///
+/// Through the release that introduced OCR import, scans were copied
+/// directly under the platform documents directory. On Windows and Linux
+/// that is the user's own Documents folder, so the app left a
+/// `scanned_logs` folder among their personal files. Every other file the
+/// app owns there sits one level down in `Submersion`; new scans now go
+/// there too, and this pass brings the existing ones along.
+///
+/// Each page is copied, its media rows are relinked through [relocateRows],
+/// and only then is the legacy copy deleted, so an interruption at any point
+/// leaves the page readable from wherever its rows still point. A page whose
+/// destination name is already taken by a different file is skipped rather
+/// than clobbered; an identical file there is a resumed move.
+///
+/// Never throws. This runs fire-and-forget at startup and a failure here
+/// must not break a scan or a read, so every problem is folded into the
+/// report and logged.
+class ScannedLogsMigration {
+  ScannedLogsMigration({
+    required Future<int> Function(String from, String to) relocateRows,
+    Future<Directory> Function()? documentsDirectory,
+    String subdirectory = kScannedLogsSubdirectory,
+  }) : _relocateRows = relocateRows,
+       _documentsDirectory =
+           documentsDirectory ?? getApplicationDocumentsDirectory,
+       _subdirectory = subdirectory;
+
+  /// Rewrites every media row referencing the file at `from` to `to` and
+  /// returns how many it touched. `MediaRepository.relocateLocalFile` in
+  /// production; a recorder in tests.
+  final Future<int> Function(String from, String to) _relocateRows;
+  final Future<Directory> Function() _documentsDirectory;
+  final String _subdirectory;
+  final _log = LoggerService.forClass(ScannedLogsMigration);
+
+  Future<ScannedLogsMigrationReport> run() async {
+    String? legacyPath;
+    String? targetPath;
+    try {
+      final docs = await _documentsDirectory();
+      final legacy = Directory(p.join(docs.path, _subdirectory));
+      final target = MediaImportService.destinationDirectory(
+        docs,
+        _subdirectory,
+      );
+      legacyPath = legacy.path;
+      targetPath = target.path;
+
+      if (!await legacy.exists()) {
+        return ScannedLogsMigrationReport(
+          outcome: ScannedLogsMigrationOutcome.noLegacyData,
+          legacyPath: legacyPath,
+          targetPath: targetPath,
+        );
+      }
+
+      await target.create(recursive: true);
+
+      var moved = 0;
+      var skipped = 0;
+      var failed = 0;
+      await for (final entity in legacy.list(followLinks: false)) {
+        // Only the flat page copies the import wrote. Anything else under
+        // the legacy folder was not put there by the app.
+        if (entity is! File) continue;
+        switch (await _movePage(entity, target)) {
+          case _PageResult.moved:
+            moved++;
+          case _PageResult.skipped:
+            skipped++;
+          case _PageResult.failed:
+            failed++;
+        }
+      }
+
+      if (await legacy.list(followLinks: false).isEmpty) {
+        await _deleteQuietly(legacy);
+      }
+
+      final report = ScannedLogsMigrationReport(
+        outcome: moved == 0 && skipped == 0 && failed > 0
+            ? ScannedLogsMigrationOutcome.failed
+            : ScannedLogsMigrationOutcome.migrated,
+        moved: moved,
+        skipped: skipped,
+        failed: failed,
+        legacyPath: legacyPath,
+        targetPath: targetPath,
+      );
+      _log.info('Scanned logs migration: $report');
+      return report;
+    } catch (e, stackTrace) {
+      _log.error(
+        'Scanned logs migration failed',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return ScannedLogsMigrationReport(
+        outcome: ScannedLogsMigrationOutcome.failed,
+        legacyPath: legacyPath,
+        targetPath: targetPath,
+        error: e,
+      );
+    }
+  }
+
+  Future<_PageResult> _movePage(File page, Directory target) async {
+    final from = page.path;
+    final to = p.join(target.path, p.basename(from));
+    final dest = File(to);
+    var copiedNow = false;
+    try {
+      if (await dest.exists()) {
+        if (!await _sameBytes(page, dest)) {
+          _log.warning(
+            'Scanned page $from skipped: a different file is already at $to',
+          );
+          return _PageResult.skipped;
+        }
+        // An earlier launch copied this page and was interrupted before it
+        // deleted the source. Finish that move rather than stranding the
+        // legacy folder forever.
+      } else {
+        await page.copy(to);
+        copiedNow = true;
+      }
+
+      try {
+        await _relocateRows(from, to);
+      } catch (_) {
+        // The rows still point at the legacy copy, which is intact, so the
+        // page stays readable. Drop the half-made destination so the next
+        // launch starts this page clean.
+        if (copiedNow) await _deleteQuietly(dest);
+        rethrow;
+      }
+
+      await page.delete();
+      return _PageResult.moved;
+    } catch (e, stackTrace) {
+      _log.error(
+        'Scanned page $from could not be moved to $to',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return _PageResult.failed;
+    }
+  }
+
+  /// Byte-for-byte comparison. Pages are a handful of camera JPEGs and this
+  /// runs once per install, so reading both fully is cheaper than being
+  /// clever about it.
+  Future<bool> _sameBytes(File a, File b) async {
+    if (await a.length() != await b.length()) return false;
+    const eq = ListEquality<int>();
+    return eq.equals(await a.readAsBytes(), await b.readAsBytes());
+  }
+
+  Future<void> _deleteQuietly(FileSystemEntity entity) async {
+    try {
+      if (await entity.exists()) await entity.delete();
+    } catch (_) {
+      // A leftover is harmless; the next launch sees it again.
+    }
+  }
+}
+
+enum _PageResult { moved, skipped, failed }

--- a/lib/features/media/data/services/scanned_logs_migration.dart
+++ b/lib/features/media/data/services/scanned_logs_migration.dart
@@ -13,8 +13,9 @@ enum ScannedLogsMigrationOutcome {
   /// platform, or a machine that already migrated on an earlier launch.
   noLegacyData,
 
-  /// The legacy folder was found and at least one page was moved, skipped,
-  /// or left for a retry. Look at the counts for the detail.
+  /// The legacy folder was found and processed. The counts say what
+  /// happened to each page; all zero means the folder held no pages and has
+  /// simply been removed.
   migrated,
 
   /// Nothing was moved: the documents directory could not be resolved, the

--- a/lib/features/settings/presentation/pages/storage_settings_page.dart
+++ b/lib/features/settings/presentation/pages/storage_settings_page.dart
@@ -3,6 +3,7 @@ import 'package:intl/intl.dart';
 import 'package:go_router/go_router.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:submersion/core/constants/app_directories.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/core/domain/entities/storage_config.dart';
@@ -454,7 +455,7 @@ class _StorageSettingsPageState extends ConsumerState<StorageSettingsPage> {
 
     // Generate a timestamped backup path
     final appDir = await getApplicationDocumentsDirectory();
-    final backupDir = p.join(appDir.path, 'Submersion', 'Backups');
+    final backupDir = p.join(appDir.path, kAppDocumentsFolder, 'Backups');
     final timestamp = DateFormat('yyyy-MM-dd_HHmmss').format(DateTime.now());
     final backupPath = p.join(backupDir, 'pre_reset_$timestamp.db');
 

--- a/test/features/media/data/media_repository_relocate_local_file_test.dart
+++ b/test/features/media/data/media_repository_relocate_local_file_test.dart
@@ -116,6 +116,23 @@ void main() {
     },
   );
 
+  test(
+    'rethrows a database failure so the migration can leave the file',
+    () async {
+      // The migration copies the page first and only deletes the legacy copy
+      // after the rows are relinked, so a swallowed error here would strand a
+      // row on a path that is about to disappear. The error must surface.
+      // Dropping the table rather than closing the database: a closed
+      // in-memory database quietly answers a select with no rows.
+      await db.customStatement('DROP TABLE media');
+
+      await expectLater(
+        repo.relocateLocalFile(from: from, to: to),
+        throwsA(isA<Exception>()),
+      );
+    },
+  );
+
   test('returns zero and marks nothing when no row matches', () async {
     await insertDive('d1');
     await repo.createMedia(scan(filePath: '/elsewhere/1.jpg'));

--- a/test/features/media/data/media_repository_relocate_local_file_test.dart
+++ b/test/features/media/data/media_repository_relocate_local_file_test.dart
@@ -1,0 +1,129 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Coverage for [MediaRepository.relocateLocalFile], the row half of the
+/// scanned-logs folder migration (issue #1645).
+///
+/// A scan's media row carries the copy's absolute path in `file_path` (and,
+/// for rows the v72 backfill touched, in `local_path` too), so moving the file
+/// on disk without rewriting the row would strand it as "File not found".
+void main() {
+  late AppDatabase db;
+  late MediaRepository repo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = MediaRepository();
+  });
+  tearDown(tearDownTestDatabase);
+
+  final epoch = DateTime(2026, 1, 1).millisecondsSinceEpoch;
+
+  Future<void> insertDive(String id) => db
+      .into(db.dives)
+      .insert(
+        DivesCompanion(
+          id: Value(id),
+          diveDateTime: Value(epoch),
+          createdAt: Value(epoch),
+          updatedAt: Value(epoch),
+        ),
+      );
+
+  MediaItem scan({
+    required String filePath,
+    String? localPath,
+    String diveId = 'd1',
+  }) => MediaItem(
+    id: '',
+    mediaType: MediaType.photo,
+    sourceType: MediaSourceType.localFile,
+    filePath: filePath,
+    localPath: localPath,
+    originalFilename: 'page.jpg',
+    diveId: diveId,
+    takenAt: DateTime(2026, 1, 1),
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  const from = '/docs/scanned_logs/1.jpg';
+  const to = '/docs/Submersion/scanned_logs/1.jpg';
+
+  test('rewrites file_path on a row that only carries file_path', () async {
+    await insertDive('d1');
+    final created = await repo.createMedia(scan(filePath: from));
+
+    final count = await repo.relocateLocalFile(from: from, to: to);
+
+    expect(count, 1);
+    final row = await repo.getMediaById(created.id);
+    expect(row!.filePath, to);
+    expect(row.localPath, isNull);
+  });
+
+  test('rewrites both columns when local_path mirrors file_path', () async {
+    await insertDive('d1');
+    final created = await repo.createMedia(
+      scan(filePath: from, localPath: from),
+    );
+
+    await repo.relocateLocalFile(from: from, to: to);
+
+    final row = await repo.getMediaById(created.id);
+    expect(row!.filePath, to);
+    expect(row.localPath, to);
+  });
+
+  test('leaves rows at other paths alone', () async {
+    await insertDive('d1');
+    const other = '/docs/scanned_logs/2.jpg';
+    final untouched = await repo.createMedia(scan(filePath: other));
+    await repo.createMedia(scan(filePath: from));
+
+    final count = await repo.relocateLocalFile(from: from, to: to);
+
+    expect(count, 1);
+    final row = await repo.getMediaById(untouched.id);
+    expect(row!.filePath, other);
+  });
+
+  test(
+    'marks every relocated row pending so peers learn the new path',
+    () async {
+      await insertDive('d1');
+      final a = await repo.createMedia(scan(filePath: from));
+      final b = await repo.createMedia(scan(filePath: from, localPath: from));
+      final untouched = await repo.createMedia(
+        scan(filePath: '/docs/scanned_logs/2.jpg'),
+      );
+      // createMedia already marks rows pending; clear the slate so the
+      // assertion below is about relocateLocalFile alone.
+      await db.delete(db.syncRecords).go();
+
+      await repo.relocateLocalFile(from: from, to: to);
+
+      final pending = await SyncRepository().getPendingRecords();
+      expect(pending.map((r) => r.recordId).toSet(), {a.id, b.id});
+      expect(pending.map((r) => r.recordId), isNot(contains(untouched.id)));
+    },
+  );
+
+  test('returns zero and marks nothing when no row matches', () async {
+    await insertDive('d1');
+    await repo.createMedia(scan(filePath: '/elsewhere/1.jpg'));
+    await db.delete(db.syncRecords).go();
+
+    final count = await repo.relocateLocalFile(from: from, to: to);
+
+    expect(count, 0);
+    expect(await SyncRepository().getPendingRecords(), isEmpty);
+  });
+}

--- a/test/features/media/data/services/media_import_local_file_test.dart
+++ b/test/features/media/data/services/media_import_local_file_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:path/path.dart' as p;
 import 'package:submersion/features/media/data/services/media_import_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
@@ -35,26 +36,35 @@ void main() {
     await sourceDir.delete(recursive: true);
   });
 
-  test(
-    'copies file into scanned_logs and creates localFile media row',
-    () async {
-      final source = File('${sourceDir.path}/page.jpg')
-        ..writeAsBytesSync([0xFF, 0xD8, 0xFF, 0xE0]); // JPEG magic bytes
+  test('copies file into <documents>/Submersion/scanned_logs and creates '
+      'localFile media row', () async {
+    final source = File('${sourceDir.path}/page.jpg')
+      ..writeAsBytesSync([0xFF, 0xD8, 0xFF, 0xE0]); // JPEG magic bytes
 
-      final item = await service.importLocalFileForDive(
-        sourceFile: source,
-        diveId: 'dive-1',
-      );
+    final item = await service.importLocalFileForDive(
+      sourceFile: source,
+      diveId: 'dive-1',
+    );
 
-      expect(item.sourceType, MediaSourceType.localFile);
-      expect(item.diveId, 'dive-1');
-      expect(item.mediaType, MediaType.photo);
-      expect(item.filePath, contains('scanned_logs'));
-      expect(item.originalFilename, 'page.jpg');
-      expect(File(item.filePath!).existsSync(), isTrue);
-      verify(mockMediaRepository.createMedia(any)).called(1);
-    },
-  );
+    expect(item.sourceType, MediaSourceType.localFile);
+    expect(item.diveId, 'dive-1');
+    expect(item.mediaType, MediaType.photo);
+    // Issue #1645: on Windows and Linux the documents directory is the
+    // user's own Documents folder, so anything written directly under it
+    // lands among their personal files. Every other file the app owns
+    // sits one level down in `Submersion`, and scans must too.
+    expect(
+      p.dirname(item.filePath!),
+      p.join(docsDir.path, 'Submersion', 'scanned_logs'),
+    );
+    expect(
+      Directory(p.join(docsDir.path, 'scanned_logs')).existsSync(),
+      isFalse,
+    );
+    expect(item.originalFilename, 'page.jpg');
+    expect(File(item.filePath!).existsSync(), isTrue);
+    verify(mockMediaRepository.createMedia(any)).called(1);
+  });
 
   test('extensionless source defaults to .jpg', () async {
     final source = File('${sourceDir.path}/scan')
@@ -86,8 +96,10 @@ void main() {
         expect(item.latitude, closeTo(18.465562, 1e-6));
         expect(item.longitude, closeTo(-66.084902, 1e-6));
         expect(item.takenAt, DateTime.utc(2025, 1, 15, 10, 3, 20));
-        expect(item.filePath, contains('imported_photos'));
-        expect(item.filePath, isNot(contains('scanned_logs')));
+        expect(
+          p.dirname(item.filePath!),
+          p.join(docsDir.path, 'Submersion', 'imported_photos'),
+        );
       },
     );
 

--- a/test/features/media/data/services/scanned_logs_migration_test.dart
+++ b/test/features/media/data/services/scanned_logs_migration_test.dart
@@ -1,0 +1,181 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:submersion/features/media/data/services/scanned_logs_migration.dart';
+
+/// Coverage for [ScannedLogsMigration], the one-time move of scanned logbook
+/// pages from `<documents>/scanned_logs/` into
+/// `<documents>/Submersion/scanned_logs/` (issue #1645).
+///
+/// The filesystem half runs against a real temp tree so the behaviour is
+/// covered on the POSIX CI matrix; the row half is a recording callback so
+/// these tests need no database.
+void main() {
+  late Directory docs;
+  late List<(String from, String to)> relinked;
+  late Future<int> Function(String from, String to) relocateRows;
+
+  setUp(() {
+    docs = Directory.systemTemp.createTempSync('scanned_logs_migration_');
+    relinked = [];
+    relocateRows = (from, to) async {
+      relinked.add((from, to));
+      return 1;
+    };
+  });
+
+  tearDown(() {
+    if (!Platform.isWindows) {
+      Process.runSync('chmod', ['-R', 'u+rwX', docs.path]);
+    }
+    if (docs.existsSync()) docs.deleteSync(recursive: true);
+  });
+
+  String legacyPath() => p.join(docs.path, 'scanned_logs');
+  String targetPath() => p.join(docs.path, 'Submersion', 'scanned_logs');
+
+  File seedLegacy(String name, List<int> bytes) =>
+      File(p.join(legacyPath(), name))
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(bytes);
+
+  ScannedLogsMigration migration({
+    Future<Directory> Function()? documentsDirectory,
+    Future<int> Function(String from, String to)? relocate,
+  }) => ScannedLogsMigration(
+    documentsDirectory: documentsDirectory ?? () async => docs,
+    relocateRows: relocate ?? relocateRows,
+  );
+
+  test('no legacy folder is a no-op that creates nothing', () async {
+    final report = await migration().run();
+
+    expect(report.outcome, ScannedLogsMigrationOutcome.noLegacyData);
+    expect(report.moved, 0);
+    expect(Directory(targetPath()).existsSync(), isFalse);
+  });
+
+  test(
+    'moves every page, relinks its rows, and removes the legacy folder',
+    () async {
+      seedLegacy('1.jpg', [1, 2, 3]);
+      seedLegacy('2.jpg', [4, 5, 6]);
+
+      final report = await migration().run();
+
+      expect(report.outcome, ScannedLogsMigrationOutcome.migrated);
+      expect(report.moved, 2);
+      expect(report.skipped, 0);
+      expect(report.failed, 0);
+      expect(File(p.join(targetPath(), '1.jpg')).readAsBytesSync(), [1, 2, 3]);
+      expect(File(p.join(targetPath(), '2.jpg')).readAsBytesSync(), [4, 5, 6]);
+      expect(Directory(legacyPath()).existsSync(), isFalse);
+      expect(relinked.toSet(), {
+        (p.join(legacyPath(), '1.jpg'), p.join(targetPath(), '1.jpg')),
+        (p.join(legacyPath(), '2.jpg'), p.join(targetPath(), '2.jpg')),
+      });
+    },
+  );
+
+  test(
+    'a page already at the destination with different bytes is skipped',
+    () async {
+      seedLegacy('1.jpg', [1, 2, 3]);
+      File(p.join(targetPath(), '1.jpg'))
+        ..createSync(recursive: true)
+        ..writeAsBytesSync([9, 9, 9]);
+
+      final report = await migration().run();
+
+      expect(report.moved, 0);
+      expect(report.skipped, 1);
+      // Neither copy is touched and no row is pointed at the wrong bytes.
+      expect(File(p.join(targetPath(), '1.jpg')).readAsBytesSync(), [9, 9, 9]);
+      expect(File(p.join(legacyPath(), '1.jpg')).readAsBytesSync(), [1, 2, 3]);
+      expect(relinked, isEmpty);
+      // The legacy folder still holds a page, so it stays.
+      expect(Directory(legacyPath()).existsSync(), isTrue);
+    },
+  );
+
+  test('an identical page already at the destination is a resumed move: rows '
+      'are relinked and the legacy copy is removed', () async {
+    // A previous launch copied the file and was interrupted before it
+    // deleted the source. Treating that as "skip" would strand the legacy
+    // folder forever.
+    seedLegacy('1.jpg', [1, 2, 3]);
+    File(p.join(targetPath(), '1.jpg'))
+      ..createSync(recursive: true)
+      ..writeAsBytesSync([1, 2, 3]);
+
+    final report = await migration().run();
+
+    expect(report.moved, 1);
+    expect(report.skipped, 0);
+    expect(File(p.join(legacyPath(), '1.jpg')).existsSync(), isFalse);
+    expect(Directory(legacyPath()).existsSync(), isFalse);
+    expect(relinked, [
+      (p.join(legacyPath(), '1.jpg'), p.join(targetPath(), '1.jpg')),
+    ]);
+  });
+
+  test(
+    'a row relink failure leaves that page in place and moves the rest',
+    () async {
+      seedLegacy('bad.jpg', [1]);
+      seedLegacy('good.jpg', [2]);
+
+      final report = await migration(
+        relocate: (from, to) async {
+          if (p.basename(from) == 'bad.jpg') throw StateError('db closed');
+          relinked.add((from, to));
+          return 1;
+        },
+      ).run();
+
+      expect(report.outcome, ScannedLogsMigrationOutcome.migrated);
+      expect(report.moved, 1);
+      expect(report.failed, 1);
+      // The failed page is exactly where it was, so the next launch retries it
+      // and its rows still resolve meanwhile.
+      expect(File(p.join(legacyPath(), 'bad.jpg')).readAsBytesSync(), [1]);
+      expect(File(p.join(targetPath(), 'bad.jpg')).existsSync(), isFalse);
+      expect(File(p.join(targetPath(), 'good.jpg')).readAsBytesSync(), [2]);
+      expect(Directory(legacyPath()).existsSync(), isTrue);
+    },
+  );
+
+  test('subdirectories inside the legacy folder are left alone', () async {
+    seedLegacy('1.jpg', [1]);
+    Directory(p.join(legacyPath(), 'nested')).createSync();
+
+    final report = await migration().run();
+
+    expect(report.moved, 1);
+    expect(Directory(p.join(legacyPath(), 'nested')).existsSync(), isTrue);
+    expect(Directory(legacyPath()).existsSync(), isTrue);
+  });
+
+  test('never throws: a documents lookup failure is reported', () async {
+    final report = await migration(
+      documentsDirectory: () async => throw StateError('no path provider'),
+    ).run();
+
+    expect(report.outcome, ScannedLogsMigrationOutcome.failed);
+    expect(report.error, isA<StateError>());
+  });
+
+  test('never throws: an unwritable destination is reported', () async {
+    seedLegacy('1.jpg', [1]);
+    Directory(p.join(docs.path, 'Submersion')).createSync();
+    Process.runSync('chmod', ['555', p.join(docs.path, 'Submersion')]);
+
+    final report = await migration().run();
+
+    expect(report.outcome, ScannedLogsMigrationOutcome.failed);
+    expect(report.moved, 0);
+    expect(File(p.join(legacyPath(), '1.jpg')).existsSync(), isTrue);
+    expect(relinked, isEmpty);
+  }, skip: Platform.isWindows ? 'chmod is POSIX only' : false);
+}


### PR DESCRIPTION
## Summary

Fixes #1645.

Scanned logbook pages were copied to `<documents>/scanned_logs/`. On Windows and Linux `getApplicationDocumentsDirectory()` is the user's own Documents folder, so the app left a `scanned_logs` folder among their personal files. Everything else the app owns there sits one level down in `Submersion`, next to the database.

New scans now go to `<documents>/Submersion/scanned_logs/`, and a one-time migration at startup brings existing pages along. The imported-file store the issue names as a reference is not on `main` yet (#478 is still open), so the migration here is written fresh, modelled on the Windows app-data migration's report shape.

## Changes

- `MediaImportService.importLocalFileForDive` writes into `<documents>/Submersion/<subdirectory>` through a public static `destinationDirectory` helper, with named constants for the folder names.
- `MediaRepository.relocateLocalFile` rewrites `file_path`, and a mirroring `local_path`, for every row at the old path in one transaction, and marks each row pending for sync so a peer's later edit cannot sync the stale path back over the fix.
- New `ScannedLogsMigration` copies each page, relinks its rows, then deletes the legacy copy, so an interruption at any point leaves the page readable from wherever its rows still point. A different file already at the destination name is skipped untouched; an identical one is a resumed move. Subfolders are left alone and the legacy folder is removed once empty. The pass never throws.
- `StartupWrapper` runs the migration fire-and-forget after the databases open, next to the orphaned-media sweep. The common case is one directory stat.

## Test Plan

- [x] `flutter test` passes (new: 8 migration tests, 5 repository relink tests; the import service test now asserts the exact `Submersion` path and that no top-level `scanned_logs` folder is created)
- [x] `flutter analyze` passes
- [x] Manual testing on: Windows install with an existing `Documents\scanned_logs\` folder
