### PR TITLE
fix(dive-log): clamp bottom time to the dive's total duration (#1642)

### DIFF
--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -491,7 +491,10 @@ class ReparseService {
   }) async {
     final diveDateTimeMs = _parsedEntryTime(parsed).millisecondsSinceEpoch;
     final exitTimeMs = diveDateTimeMs + (parsed.durationSeconds * 1000);
-    final bottomTimeSeconds = _calculateBottomTimeFromSamples(parsed.samples);
+    final bottomTimeSeconds = _calculateBottomTimeFromSamples(
+      parsed.samples,
+      totalDurationSeconds: parsed.durationSeconds,
+    );
     final waterTemp = _minWaterTemp(parsed);
 
     await (db.update(db.dives)..where((t) => t.id.equals(diveId))).write(
@@ -854,14 +857,16 @@ class ReparseService {
   /// Delegates to [BottomTimeCalculator], mirroring
   /// DiveComputerRepositoryImpl._calculateBottomTimeFromPoints: bottom time
   /// runs from surface departure to the start of the final ascent, so
-  /// multilevel dives count their shallower segments. Returns null if
-  /// insufficient data.
+  /// multilevel dives count their shallower segments, and never exceeds
+  /// [totalDurationSeconds], the computer's own reported runtime. Returns
+  /// null if insufficient data.
   static int? _calculateBottomTimeFromSamples(
-    List<pigeon.ProfileSample> samples,
-  ) {
+    List<pigeon.ProfileSample> samples, {
+    required int totalDurationSeconds,
+  }) {
     return BottomTimeCalculator.secondsFromSamples([
       for (final s in samples) (timestamp: s.timeSeconds, depth: s.depthMeters),
-    ]);
+    ], totalDurationSeconds: totalDurationSeconds);
   }
 
   /// Minimum water temperature for this parse, in Celsius.

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -855,7 +855,7 @@ class ReparseService {
   /// Calculate bottom time from profile samples.
   ///
   /// Delegates to [BottomTimeCalculator], mirroring
-  /// DiveComputerRepositoryImpl._calculateBottomTimeFromPoints: bottom time
+  /// DiveComputerRepository._calculateBottomTimeFromPoints: bottom time
   /// runs from surface departure to the start of the final ascent, so
   /// multilevel dives count their shallower segments, and never exceeds
   /// [totalDurationSeconds], the computer's own reported runtime. Returns

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -1165,8 +1165,13 @@ class DiveComputerRepository {
                 : null);
 
         // durationSeconds from the dive computer is total runtime,
-        // not bottom time. Calculate bottom time from the profile.
-        final bottomTimeSeconds = _calculateBottomTimeFromPoints(points);
+        // not bottom time. Calculate bottom time from the profile, bounded
+        // by that runtime so a sample stream that outlasts the dive cannot
+        // produce a bottom time longer than the dive (issue #1642).
+        final bottomTimeSeconds = _calculateBottomTimeFromPoints(
+          points,
+          totalDurationSeconds: durationSeconds,
+        );
 
         // Downloaded profiles carry no dive type, so every dive used to land
         // on 'recreational', including dives whose samples show mandatory
@@ -2034,14 +2039,18 @@ class DiveComputerRepository {
   ///
   /// Delegates to [BottomTimeCalculator]: bottom time runs from surface
   /// departure to the start of the final ascent, so multilevel dives
-  /// count their shallower segments.
+  /// count their shallower segments. The result never exceeds
+  /// [totalDurationSeconds], the computer's own reported runtime.
   ///
   /// Returns null if profile data is insufficient for calculation.
-  int? _calculateBottomTimeFromPoints(List<ProfilePointData> points) {
+  int? _calculateBottomTimeFromPoints(
+    List<ProfilePointData> points, {
+    required int totalDurationSeconds,
+  }) {
     return BottomTimeCalculator.secondsFromSamples([
       for (final point in points)
         (timestamp: point.timestamp, depth: point.depth),
-    ]);
+    ], totalDurationSeconds: totalDurationSeconds);
   }
 
   /// Raw libdivecomputer event types that [_mapEventTypeString] folds into a

--- a/lib/features/dive_log/domain/entities/dive.dart
+++ b/lib/features/dive_log/domain/entities/dive.dart
@@ -508,14 +508,16 @@ class Dive extends Equatable {
   /// ascent (US Navy convention): the descent counts; stops shallower
   /// than the depth threshold (safety stops, shallow deco) do not, while
   /// deeper stops still count. See [BottomTimeCalculator] for the
-  /// threshold rule.
+  /// threshold rule. The result is bounded by [runtime] when one is set,
+  /// so a profile that outlasts the dive cannot report a bottom time longer
+  /// than the dive itself.
   ///
   /// Returns null if profile data is insufficient for calculation.
   Duration? calculateBottomTimeFromProfile() {
     final seconds = BottomTimeCalculator.secondsFromSamples([
       for (final point in profile)
         (timestamp: point.timestamp, depth: point.depth),
-    ]);
+    ], totalDurationSeconds: runtime?.inSeconds);
     return seconds == null ? null : Duration(seconds: seconds);
   }
 

--- a/lib/features/dive_log/domain/services/bottom_time_calculator.dart
+++ b/lib/features/dive_log/domain/services/bottom_time_calculator.dart
@@ -29,11 +29,20 @@ class BottomTimeCalculator {
   /// Bottom time in seconds from (timestamp, depth) samples, or null when
   /// the profile is too small or degenerate. Samples need not be sorted;
   /// timestamps are seconds from dive start, depths are meters.
+  ///
+  /// [totalDurationSeconds] is the dive's own reported total duration. When
+  /// given, the result never exceeds it: bottom time is a strict subset of
+  /// total dive time by definition, so a larger number is always wrong. The
+  /// case that motivated the bound (issue #1642) is a sample stream that
+  /// keeps logging at the surface after the dive ended; on a shallow dive the
+  /// threshold sits so close to the surface that wave action or sensor noise
+  /// in that tail can register as the start of the final ascent.
   static int? secondsFromSamples(
     List<({int timestamp, double depth})> samples, {
     double absoluteFloorMeters = defaultAbsoluteFloorMeters,
     double maxDepthFraction = defaultMaxDepthFraction,
     double thresholdCapFraction = defaultThresholdCapFraction,
+    int? totalDurationSeconds,
   }) {
     if (samples.length < 3) return null;
 
@@ -60,7 +69,10 @@ class BottomTimeCalculator {
     }
     if (ascentStart == null) return null;
 
-    final bottomSeconds = ascentStart - sorted.first.timestamp;
+    var bottomSeconds = ascentStart - sorted.first.timestamp;
+    if (totalDurationSeconds != null && bottomSeconds > totalDurationSeconds) {
+      bottomSeconds = totalDurationSeconds;
+    }
     return bottomSeconds > 0 ? bottomSeconds : null;
   }
 }

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -2611,6 +2611,52 @@ void main() {
       expect(dive.bottomTime, 1800);
     });
 
+    test('bottomTime never exceeds durationSeconds when the sample stream '
+        'outlasts the dive (issue #1642)', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      // 13 s dive to 1.77 m; surface logging continues and a 1.55 m noise
+      // sample at t=368 clears the 1.50 m threshold. Unclamped, bottom time
+      // would be 368 s.
+      final parsed = makeParsedDive(
+        durationSeconds: 13,
+        maxDepthMeters: 1.77,
+        avgDepthMeters: 0.5,
+        samples: [
+          pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+          pigeon.ProfileSample(timeSeconds: 5, depthMeters: 1.77),
+          pigeon.ProfileSample(timeSeconds: 10, depthMeters: 1.6),
+          pigeon.ProfileSample(timeSeconds: 13, depthMeters: 0.3),
+          pigeon.ProfileSample(timeSeconds: 60, depthMeters: 0.2),
+          pigeon.ProfileSample(timeSeconds: 120, depthMeters: 0.4),
+          pigeon.ProfileSample(timeSeconds: 240, depthMeters: 0.9),
+          pigeon.ProfileSample(timeSeconds: 368, depthMeters: 1.55),
+          pigeon.ProfileSample(timeSeconds: 400, depthMeters: 0.0),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final dive = await getDive('dive-1');
+      expect(dive.runtime, 13);
+      expect(dive.bottomTime, 13);
+    });
+
     test(
       'bottomTime falls back to durationSeconds when maxDepth is 0',
       () async {

--- a/test/features/dive_log/data/repositories/dive_computer_bottom_time_clamp_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_bottom_time_clamp_test.dart
@@ -1,0 +1,89 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Issue #1642: the live-download path must never store a bottom time longer
+/// than the computer's own reported duration, even when the sample stream
+/// keeps logging at the surface after the dive ended.
+void main() {
+  late AppDatabase db;
+  late DiveComputerRepository computers;
+
+  Future<void> insertComputer(String id) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion(
+            id: Value(id),
+            name: Value('Computer $id'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<Dive> getDive(String id) =>
+      (db.select(db.dives)..where((t) => t.id.equals(id))).getSingle();
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    computers = DiveComputerRepository();
+    await insertComputer('comp-1');
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  // 13 s dive to 1.77 m. Threshold = min(max(6, 0.58), 0.85 * 1.77) = 1.50 m,
+  // so the 1.55 m surface-noise sample at t=368 would otherwise mark the
+  // ascent start and yield a 368 s bottom time.
+  const shallowWithSurfaceTail = [
+    ProfilePointData(timestamp: 0, depth: 0.0),
+    ProfilePointData(timestamp: 5, depth: 1.77),
+    ProfilePointData(timestamp: 10, depth: 1.6),
+    ProfilePointData(timestamp: 13, depth: 0.3),
+    ProfilePointData(timestamp: 60, depth: 0.2),
+    ProfilePointData(timestamp: 120, depth: 0.4),
+    ProfilePointData(timestamp: 240, depth: 0.9),
+    ProfilePointData(timestamp: 368, depth: 1.55),
+    ProfilePointData(timestamp: 400, depth: 0.0),
+  ];
+
+  test('imported bottom time never exceeds durationSeconds', () async {
+    final diveId = await computers.importProfile(
+      computerId: 'comp-1',
+      profileStartTime: DateTime(2026, 1, 1, 10),
+      points: shallowWithSurfaceTail,
+      durationSeconds: 13,
+      maxDepth: 1.77,
+    );
+
+    final dive = await getDive(diveId);
+    expect(dive.runtime, 13);
+    expect(dive.bottomTime, 13);
+  });
+
+  test('a bottom time already within the duration is left alone', () async {
+    final diveId = await computers.importProfile(
+      computerId: 'comp-1',
+      profileStartTime: DateTime(2026, 1, 1, 10),
+      points: const [
+        ProfilePointData(timestamp: 0, depth: 0.0),
+        ProfilePointData(timestamp: 60, depth: 30.0),
+        ProfilePointData(timestamp: 1200, depth: 30.0),
+        ProfilePointData(timestamp: 1260, depth: 5.0),
+        ProfilePointData(timestamp: 1320, depth: 0.0),
+      ],
+      durationSeconds: 1320,
+      maxDepth: 30.0,
+    );
+
+    final dive = await getDive(diveId);
+    expect(dive.bottomTime, 1200);
+  });
+}

--- a/test/features/dive_log/domain/entities/dive_bottom_time_test.dart
+++ b/test/features/dive_log/domain/entities/dive_bottom_time_test.dart
@@ -31,5 +31,45 @@ void main() {
       final dive = Dive(id: 'bt-empty', dateTime: DateTime(2024, 1, 1));
       expect(dive.calculateBottomTimeFromProfile(), isNull);
     });
+    group('clamps to the dive\'s runtime (issue #1642)', () {
+      // 13 s dive to 1.77 m; the profile keeps logging surface noise and a
+      // 1.55 m sample at t=368 sits above the 1.50 m threshold.
+      const profile = [
+        DiveProfilePoint(timestamp: 0, depth: 0.0),
+        DiveProfilePoint(timestamp: 5, depth: 1.77),
+        DiveProfilePoint(timestamp: 10, depth: 1.6),
+        DiveProfilePoint(timestamp: 13, depth: 0.3),
+        DiveProfilePoint(timestamp: 60, depth: 0.2),
+        DiveProfilePoint(timestamp: 120, depth: 0.4),
+        DiveProfilePoint(timestamp: 240, depth: 0.9),
+        DiveProfilePoint(timestamp: 368, depth: 1.55),
+        DiveProfilePoint(timestamp: 400, depth: 0.0),
+      ];
+
+      test('bottom time never exceeds runtime', () {
+        final dive = Dive(
+          id: 'bt-clamp',
+          dateTime: DateTime(2024, 1, 1),
+          runtime: const Duration(seconds: 13),
+          profile: profile,
+        );
+        expect(
+          dive.calculateBottomTimeFromProfile(),
+          const Duration(seconds: 13),
+        );
+      });
+
+      test('without a runtime there is nothing to clamp against', () {
+        final dive = Dive(
+          id: 'bt-unbounded',
+          dateTime: DateTime(2024, 1, 1),
+          profile: profile,
+        );
+        expect(
+          dive.calculateBottomTimeFromProfile(),
+          const Duration(seconds: 368),
+        );
+      });
+    });
   });
 }

--- a/test/features/dive_log/domain/services/bottom_time_calculator_test.dart
+++ b/test/features/dive_log/domain/services/bottom_time_calculator_test.dart
@@ -130,5 +130,59 @@ void main() {
         isNull,
       );
     });
+    group('totalDurationSeconds clamp', () {
+      // Issue #1642: a 13 s dive to 1.77 m whose sample stream keeps logging
+      // at the surface. Threshold = min(max(6, 0.58), 0.85 * 1.77 = 1.50) =
+      // 1.50 m, so the 1.55 m noise sample at t=368 becomes the ascent start
+      // and the unbounded answer is 368 s, longer than the whole dive.
+      const shallowWithSurfaceTail = [
+        (timestamp: 0, depth: 0.0),
+        (timestamp: 5, depth: 1.77),
+        (timestamp: 10, depth: 1.6),
+        (timestamp: 13, depth: 0.3),
+        (timestamp: 60, depth: 0.2),
+        (timestamp: 120, depth: 0.4),
+        (timestamp: 240, depth: 0.9),
+        (timestamp: 368, depth: 1.55),
+        (timestamp: 400, depth: 0.0),
+      ];
+
+      test('without a total duration the surface tail is counted', () {
+        expect(
+          BottomTimeCalculator.secondsFromSamples(shallowWithSurfaceTail),
+          368,
+        );
+      });
+
+      test('never exceeds the dive\'s own total duration', () {
+        expect(
+          BottomTimeCalculator.secondsFromSamples(
+            shallowWithSurfaceTail,
+            totalDurationSeconds: 13,
+          ),
+          13,
+        );
+      });
+
+      test('is a no-op when the result is already within bounds', () {
+        expect(
+          BottomTimeCalculator.secondsFromSamples(
+            multilevel,
+            totalDurationSeconds: 3600,
+          ),
+          3060,
+        );
+      });
+
+      test('a zero total duration yields null rather than zero', () {
+        expect(
+          BottomTimeCalculator.secondsFromSamples(
+            shallowWithSurfaceTail,
+            totalDurationSeconds: 0,
+          ),
+          isNull,
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

Closes #1642.

`BottomTimeCalculator.secondsFromSamples()` finds the last sample at or deeper than the depth threshold and measures back to the first sample. Nothing ties that result to the dive's own reported duration. On a very shallow dive the threshold sits within centimetres of the surface (about 1.5 m for a 1.77 m dive), so when the sample stream keeps logging after the dive ended, a surface-noise sample in that tail becomes the ascent start and bottom time spans the whole tail. The reported case was a 13 second dive with a 368 second bottom time.

Bottom time is a strict subset of total dive time by definition, so the calculator now accepts an optional `totalDurationSeconds` and never returns a larger number. The bound holds regardless of what produces the oversized result.

## Changes

- `BottomTimeCalculator.secondsFromSamples()` gains an optional `totalDurationSeconds` and clamps the result to it. A zero duration yields null via the existing non-positive guard rather than a zero bottom time.
- Live download path (`DiveComputerRepository.importProfile`) passes the computer's `durationSeconds`. The private helper takes the bound as a required parameter so a new caller cannot forget it.
- `ReparseService` passes `parsed.durationSeconds` the same way.
- `Dive.calculateBottomTimeFromProfile()` passes the dive's `runtime`. It uses `runtime` and not `effectiveRuntime` on purpose: that getter falls back to the stored bottom time, which would pin every recalculation to the old answer.
- The uncombine service call site is left unchanged. Its samples define the segment, so there is no independent duration to clamp against.

## Test Plan

- [x] `flutter test` passes (new coverage at all four layers: calculator, `Dive` entity, `ReparseService`, and the download path, each with the 13 s / 368 s scenario, plus a no-op check when the answer is already within bounds and an unbounded check when no duration is available)
- [x] `flutter analyze` passes
- [ ] Manual testing on: not applicable, pure calculation change
