### PR TITLE
feat(backup): reclaim backup files the history has lost track of

### DIFF
--- a/docs/superpowers/specs/2026-08-29-storage-reclamation-design.md
+++ b/docs/superpowers/specs/2026-08-29-storage-reclamation-design.md
@@ -452,11 +452,23 @@ Three decisions differ from the sketch above, all made while building it:
   slice A, for the same reason: an Android SAF location has no `Directory`
   behind it, and an empty list would tell that user their backup folder holds
   nothing forgotten when it was never read.
-- **The lease wraps `reclaim` as well as `find`.** `BackupsDirectoryAccess`
-  holds `resolveBackupsDirectoryLeased` open across the whole operation and
-  releases in a `finally`. Deleting outside the lease would fail on exactly the
-  Apple custom-location configuration the lease exists for, and a mid-delete
+- **The lease wraps `reclaim` as well as `find`, and it is a read-only lease.**
+  `BackupsDirectoryAccess` holds the directory open across the whole operation
+  and releases in a `finally`. Deleting outside the lease would fail on exactly
+  the Apple custom-location configuration the lease exists for, and a mid-delete
   throw would otherwise leak a scoped resource for the life of the process.
+
+  It does NOT use `BackupService.resolveBackupsDirectoryLeased`, which mutates
+  on three paths that are all correct for a writer and all wrong for a scan that
+  runs whenever the Storage usage page is opened: it creates the directory it
+  returns, creates a missing custom directory, and self-heals an unreachable
+  custom location by clearing it. The clearing is the one that bites. An
+  unmounted share is unreachable for as long as it is unmounted, so opening a
+  settings page in that window would point every future backup at the sandbox
+  instead of the folder the diver chose, silently and permanently. This is the
+  same trap slice A hit when `resolveDefaultBackupsDirectory()` was passed by
+  value and a measurement page minted a Backups folder; sharing a resolver with
+  a writer imports the writer's willingness to change things.
 
 `BackupsDirectoryAccess` also declines to inherit one behaviour of
 `resolveBackupsDirectoryLeased`: that resolver substitutes the sandbox default

--- a/docs/superpowers/specs/2026-08-29-storage-reclamation-design.md
+++ b/docs/superpowers/specs/2026-08-29-storage-reclamation-design.md
@@ -432,6 +432,46 @@ security-scoped bookmark lease (`resolveBackupsDirectoryLeased`, `:1166`).
 
 Backup retention counts are out of scope here; they belong to issue #1376.
 
+#### What shipped, and where it deviates
+
+Slice D landed in two parts. Part 1 (PR #1415) put the attribution in the
+filename, since an orphan is by definition a file whose record is gone and a
+device id stored in the record is the information already missing. Part 2 is
+`OrphanedBackupScan` plus `UnrecognizedBackupService`, the page, and the notice.
+
+Three decisions differ from the sketch above, all made while building it:
+
+- **The prune action is a page, not a control on the Storage usage page.** The
+  sketch put it inline. A delete button beside a size row is one tap away from
+  destroying what may be a diver's only logbook copy, and the row has no space
+  to say why two of the three files listed cannot be removed at all. The notice
+  under the backups group states the count and the bytes; the page behind it
+  carries the explanation, the per-file ownership, and the confirmation.
+- **`find()` returns null, not an empty list, when the folder cannot be
+  enumerated.** This is the same distinction `StorageCategory.measure` draws in
+  slice A, for the same reason: an Android SAF location has no `Directory`
+  behind it, and an empty list would tell that user their backup folder holds
+  nothing forgotten when it was never read.
+- **The lease wraps `reclaim` as well as `find`.** `BackupsDirectoryAccess`
+  holds `resolveBackupsDirectoryLeased` open across the whole operation and
+  releases in a `finally`. Deleting outside the lease would fail on exactly the
+  Apple custom-location configuration the lease exists for, and a mid-delete
+  throw would otherwise leak a scoped resource for the life of the process.
+
+`BackupsDirectoryAccess` also declines to inherit one behaviour of
+`resolveBackupsDirectoryLeased`: that resolver substitutes the sandbox default
+for a `content://` location because its callers need somewhere writable
+(issue #505). A scan that inherited the substitution would list the sandbox
+directory's files under a heading describing the user's Dropbox folder, and
+offer them for deletion.
+
+Pre-migration safety copies are excluded by the scan's `submersion_backup_`
+prefix gate: `LiveDatabaseCopier` names them `<timestamp>-v<from>-v<to>.db`.
+That gate is load-bearing rather than incidental, because the pre-migration
+writer logs "registration failed; .db is on disk" on its own error path, so an
+unrecorded safety copy is a state the app produces deliberately. A regression
+test pins it.
+
 ### Slice E: tombstone GC for local-only libraries
 
 Reach `clearAcknowledgedDeletions` when sync is not configured, using the

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -115,6 +115,7 @@ import 'package:submersion/features/settings/presentation/pages/language_setting
 import 'package:submersion/features/settings/presentation/pages/nav_customization_page.dart';
 import 'package:submersion/features/settings/presentation/pages/theme_gallery_page.dart';
 import 'package:submersion/features/settings/presentation/pages/storage_settings_page.dart';
+import 'package:submersion/features/backup/presentation/pages/unrecognized_backups_page.dart';
 import 'package:submersion/features/settings/presentation/pages/storage_usage_page.dart';
 import 'package:submersion/features/settings/presentation/pages/diver_profile_hub_page.dart';
 import 'package:submersion/features/settings/presentation/pages/personal_info_edit_page.dart';
@@ -1033,6 +1034,14 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                 path: 'storage-usage',
                 name: 'storageUsage',
                 builder: (context, state) => const StorageUsagePage(),
+                routes: [
+                  GoRoute(
+                    path: 'unrecognized-backups',
+                    name: 'unrecognizedBackups',
+                    builder: (context, state) =>
+                        const UnrecognizedBackupsPage(),
+                  ),
+                ],
               ),
               GoRoute(
                 path: 'data-quality',

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -1146,13 +1146,28 @@ class BackupService {
   /// PreMigrationBackupService. Unlike [resolveBackupsDirectory] this ignores
   /// any configured custom location by design.
   static Future<String> resolveDefaultBackupsDirectory() async {
-    final appDir = await getApplicationDocumentsDirectory();
-    final backupDir = Directory(p.join(appDir.path, _localBackupFolder));
+    final backupDir = Directory(await defaultBackupsDirectoryPath());
     if (!await backupDir.exists()) {
       await backupDir.create(recursive: true);
     }
     return backupDir.path;
   }
+
+  /// Where the sandbox backups directory would be, without creating it.
+  ///
+  /// [resolveDefaultBackupsDirectory] creates it, which is right for a caller
+  /// about to write a backup and wrong for one that only wants to look. Both
+  /// read the folder name from the same constant so a reader cannot end up
+  /// looking somewhere the writer does not use.
+  static Future<String> defaultBackupsDirectoryPath() async {
+    final appDir = await getApplicationDocumentsDirectory();
+    return p.join(appDir.path, _localBackupFolder);
+  }
+
+  /// The bookmark port production uses. Exposed so a read-only resolver can
+  /// arm the same security-scoped access without reaching for a private type.
+  static const BackupBookmarkPort defaultBookmarkPort =
+      _DefaultBackupBookmarkPort();
 
   /// Resolves the backups directory and arms any security-scoped access needed
   /// to write into it, returning a [BackupDirLease]. Callers MUST call

--- a/lib/features/backup/data/services/backups_directory_access.dart
+++ b/lib/features/backup/data/services/backups_directory_access.dart
@@ -1,3 +1,4 @@
+import 'package:submersion/core/services/backup_bookmark_service.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/data/services/backup_target.dart';
@@ -21,7 +22,7 @@ class BackupsDirectoryAccess {
   }) : _configuredLocation = configuredLocation,
        _acquireLease = acquireLease;
 
-  /// Wired to the live preferences and the leased resolver.
+  /// Wired to the live preferences and a resolver that only reads.
   ///
   /// [bookmarks] exists only so a test can exercise the Apple branch without a
   /// native channel, mirroring the seam `resolveBackupsDirectoryLeased` already
@@ -31,10 +32,7 @@ class BackupsDirectoryAccess {
     BackupBookmarkPort? bookmarks,
   }) => BackupsDirectoryAccess(
     configuredLocation: () async => preferences.getSettings().backupLocation,
-    acquireLease: () => BackupService.resolveBackupsDirectoryLeased(
-      preferences,
-      bookmarks: bookmarks,
-    ),
+    acquireLease: () => _leaseForReading(preferences, bookmarks: bookmarks),
   );
 
   final Future<String?> Function() _configuredLocation;
@@ -62,4 +60,52 @@ class BackupsDirectoryAccess {
       await lease.release();
     }
   }
+
+  /// Resolves the backups directory for reading, changing nothing.
+  ///
+  /// Deliberately NOT `BackupService.resolveBackupsDirectoryLeased`, which
+  /// mutates on three paths that are all correct for a writer and all wrong
+  /// here. It creates the directory it returns, it creates a missing custom
+  /// directory, and it self-heals an unreachable custom location by clearing
+  /// it. A backup has to land somewhere, so a writer is right to insist; a scan
+  /// that runs whenever the Storage usage page is opened is not.
+  ///
+  /// The clearing is the one that bites. An unmounted share is unreachable for
+  /// as long as it is unmounted, and opening a settings page in that window
+  /// would point every future backup at the sandbox instead of the folder the
+  /// diver chose, silently and permanently.
+  ///
+  /// A SAF location never reaches here: [use] returns before taking a lease.
+  static Future<BackupDirLease> _leaseForReading(
+    BackupPreferences preferences, {
+    BackupBookmarkPort? bookmarks,
+  }) async {
+    final custom = preferences.getSettings().backupLocation;
+    if (custom == null || custom.isEmpty) {
+      return BackupDirLease(
+        await BackupService.defaultBackupsDirectoryPath(),
+        _noRelease,
+      );
+    }
+    if (!BackupBookmarkService.isSupported) {
+      return BackupDirLease(custom, _noRelease);
+    }
+
+    // Apple: the folder is reachable only while its bookmark is armed. A
+    // missing or unresolvable bookmark yields the bare path rather than a
+    // reset; the listing then finds nothing, which is the honest outcome for a
+    // folder this process cannot open.
+    final bytes = preferences.getBackupLocationBookmark();
+    if (bytes == null) return BackupDirLease(custom, _noRelease);
+
+    final port = bookmarks ?? BackupService.defaultBookmarkPort;
+    final lease = await port.resolve(bytes);
+    if (lease == null) return BackupDirLease(custom, _noRelease);
+
+    // A stale bookmark is used as resolved and not re-minted: re-minting is a
+    // write, and the writer already re-mints it on its own next run.
+    return BackupDirLease(lease.path, () => port.release(lease.ref));
+  }
+
+  static Future<void> _noRelease() async {}
 }

--- a/lib/features/backup/data/services/backups_directory_access.dart
+++ b/lib/features/backup/data/services/backups_directory_access.dart
@@ -1,0 +1,58 @@
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/data/services/backup_target.dart';
+
+/// Holds the backups directory open for the length of one operation.
+///
+/// Slice A's [backupsPathToMeasure] answers a narrower question: which path to
+/// measure, once. Listing files and then deleting some of them needs the
+/// directory reachable for the whole sequence, and on Apple platforms a custom
+/// location is reachable only while its security-scoped bookmark lease is held.
+/// A lease that outlives the work leaks a scoped resource, so the release is in
+/// a `finally` rather than after the body.
+///
+/// The two callbacks are injected because the alternative is a test that needs
+/// SharedPreferences and a native bookmark channel to assert something as small
+/// as "a content:// location takes no lease".
+class BackupsDirectoryAccess {
+  BackupsDirectoryAccess({
+    required Future<String?> Function() configuredLocation,
+    required Future<BackupDirLease> Function() acquireLease,
+  }) : _configuredLocation = configuredLocation,
+       _acquireLease = acquireLease;
+
+  /// Wired to the live preferences and the leased resolver.
+  factory BackupsDirectoryAccess.live(BackupPreferences preferences) =>
+      BackupsDirectoryAccess(
+        configuredLocation: () async =>
+            preferences.getSettings().backupLocation,
+        acquireLease: () =>
+            BackupService.resolveBackupsDirectoryLeased(preferences),
+      );
+
+  final Future<String?> Function() _configuredLocation;
+  final Future<BackupDirLease> Function() _acquireLease;
+
+  /// Runs [body] with a directory `dart:io` can list, or null when there is
+  /// none.
+  ///
+  /// Null rather than the sandbox default for a SAF location, deliberately.
+  /// `resolveBackupsDirectoryLeased` substitutes the default there because its
+  /// caller needs somewhere writable, but this caller is looking for files the
+  /// backup history has lost track of, and the sandbox default is not where a
+  /// SAF-configured device keeps its backups. Scanning it would offer a
+  /// different directory's files for deletion under a heading about this one.
+  Future<T> use<T>(Future<T> Function(String? directoryPath) body) async {
+    final configured = await _configuredLocation();
+    if (configured != null && configured.isNotEmpty && isSafRef(configured)) {
+      return body(null);
+    }
+
+    final lease = await _acquireLease();
+    try {
+      return await body(lease.path);
+    } finally {
+      await lease.release();
+    }
+  }
+}

--- a/lib/features/backup/data/services/backups_directory_access.dart
+++ b/lib/features/backup/data/services/backups_directory_access.dart
@@ -22,13 +22,20 @@ class BackupsDirectoryAccess {
        _acquireLease = acquireLease;
 
   /// Wired to the live preferences and the leased resolver.
-  factory BackupsDirectoryAccess.live(BackupPreferences preferences) =>
-      BackupsDirectoryAccess(
-        configuredLocation: () async =>
-            preferences.getSettings().backupLocation,
-        acquireLease: () =>
-            BackupService.resolveBackupsDirectoryLeased(preferences),
-      );
+  ///
+  /// [bookmarks] exists only so a test can exercise the Apple branch without a
+  /// native channel, mirroring the seam `resolveBackupsDirectoryLeased` already
+  /// offers. Production passes nothing and gets the real port.
+  factory BackupsDirectoryAccess.live(
+    BackupPreferences preferences, {
+    BackupBookmarkPort? bookmarks,
+  }) => BackupsDirectoryAccess(
+    configuredLocation: () async => preferences.getSettings().backupLocation,
+    acquireLease: () => BackupService.resolveBackupsDirectoryLeased(
+      preferences,
+      bookmarks: bookmarks,
+    ),
+  );
 
   final Future<String?> Function() _configuredLocation;
   final Future<BackupDirLease> Function() _acquireLease;

--- a/lib/features/backup/data/services/orphaned_backup_scan.dart
+++ b/lib/features/backup/data/services/orphaned_backup_scan.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/backup/data/services/backup_attribution.dart';
+import 'package:submersion/features/backup/data/services/backup_crypto.dart';
+
+/// A backup file on disk with no record in this device's history.
+class UnrecognizedBackup {
+  const UnrecognizedBackup({
+    required this.path,
+    required this.sizeBytes,
+    required this.modified,
+    required this.ownership,
+  });
+
+  final String path;
+  final int sizeBytes;
+  final DateTime modified;
+  final BackupOwnership ownership;
+
+  String get filename => p.basename(path);
+
+  /// Only a file this device provably wrote may be deleted.
+  ///
+  /// A file from another device may be its only copy, and an unattributed one
+  /// predates attribution entirely, so neither can be told apart from a
+  /// forgotten local backup by anything but its name.
+  bool get isReclaimable => ownership == BackupOwnership.thisDevice;
+}
+
+/// Finds backup files the history has lost track of, and reclaims the ones
+/// that are provably this device's.
+///
+/// `pruneOldBackups` and the pre-migration prune both work off the
+/// SharedPreferences history, and `getValidatedBackupHistory` drops records
+/// whose file has vanished. Nothing removes a file whose record vanished, so a
+/// prefs reset, a reinstall over a preserved Documents directory, or a crash
+/// between writing the file and recording it leaves a full copy of the
+/// database that is invisible to every existing path.
+///
+/// Listing them is always safe. Deleting them is not: the app tells users to
+/// put the backup folder in Dropbox, Nextcloud or Google Drive, where every
+/// other device's backups are equally absent from this device's history. That
+/// is what [BackupOwnership] is for, and why [reclaim] re-checks rather than
+/// trusting its caller.
+class OrphanedBackupScan {
+  OrphanedBackupScan({
+    required Future<String?> Function() backupsDirectory,
+    required Future<Set<String>> Function() knownPaths,
+    required Future<String> Function() thisDeviceId,
+  }) : _backupsDirectory = backupsDirectory,
+       _knownPaths = knownPaths,
+       _thisDeviceId = thisDeviceId;
+
+  /// Null when the location cannot be enumerated: an Android SAF location is a
+  /// content:// tree URI with no Directory behind it.
+  final Future<String?> Function() _backupsDirectory;
+  final Future<Set<String>> Function() _knownPaths;
+  final Future<String> Function() _thisDeviceId;
+  final _log = LoggerService.forClass(OrphanedBackupScan);
+
+  static const String _prefix = 'submersion_backup_';
+
+  Future<List<UnrecognizedBackup>> find() async {
+    final directoryPath = await _backupsDirectory();
+    if (directoryPath == null) return const [];
+
+    final directory = Directory(directoryPath);
+    if (!await directory.exists()) return const [];
+
+    final known = await _knownPaths();
+    final deviceId = await _thisDeviceId();
+    final found = <UnrecognizedBackup>[];
+
+    await for (final entity in directory.list(followLinks: false)) {
+      if (entity is! File) continue;
+      final name = p.basename(entity.path);
+      if (!_isBackupFile(name)) continue;
+      if (known.contains(entity.path)) continue;
+
+      try {
+        final stat = await entity.stat();
+        found.add(
+          UnrecognizedBackup(
+            path: entity.path,
+            sizeBytes: stat.size,
+            modified: stat.modified,
+            ownership: classifyBackupFile(
+              filename: name,
+              thisDeviceId: deviceId,
+            ),
+          ),
+        );
+      } on FileSystemException {
+        continue;
+      }
+    }
+
+    found.sort((a, b) => b.modified.compareTo(a.modified));
+    return found;
+  }
+
+  /// Deletes the reclaimable entries in [candidates], returning bytes freed.
+  ///
+  /// Re-checks [UnrecognizedBackup.isReclaimable] rather than trusting the
+  /// caller. This is the last gate before an irreversible delete of what may
+  /// be another device's only backup, and a UI bug upstream must not be able
+  /// to reach past it.
+  Future<int> reclaim(Iterable<UnrecognizedBackup> candidates) async {
+    var bytes = 0;
+    for (final candidate in candidates) {
+      if (!candidate.isReclaimable) continue;
+      try {
+        final file = File(candidate.path);
+        if (!await file.exists()) continue;
+        await file.delete();
+        bytes += candidate.sizeBytes;
+      } on FileSystemException catch (e) {
+        _log.warning('Could not reclaim ${candidate.filename}: $e');
+        continue;
+      }
+    }
+    if (bytes > 0) _log.info('Reclaimed $bytes bytes of forgotten backups');
+    return bytes;
+  }
+
+  /// A backup this app wrote: our prefix, and a plaintext or encrypted
+  /// extension. The hidden `.db.tmp` in-progress files are already swept by
+  /// the pre-migration service and must not be double-handled here.
+  static bool _isBackupFile(String name) {
+    if (!name.startsWith(_prefix)) return false;
+    if (name.startsWith('.')) return false;
+    final extension = p.extension(name);
+    return extension == '.db' || extension == BackupCrypto.fileExtension;
+  }
+}

--- a/lib/features/backup/data/services/orphaned_backup_scan.dart
+++ b/lib/features/backup/data/services/orphaned_backup_scan.dart
@@ -108,6 +108,12 @@ class OrphanedBackupScan {
   /// caller. This is the last gate before an irreversible delete of what may
   /// be another device's only backup, and a UI bug upstream must not be able
   /// to reach past it.
+  ///
+  /// The freed total is measured immediately before each delete rather than
+  /// summed from [UnrecognizedBackup.sizeBytes]. That field is whatever the
+  /// listing saw, and the page it feeds can sit open for as long as the user
+  /// reads it; a cloud client rewriting a file in that window would turn the
+  /// reported figure into a number the app made up rather than one it measured.
   Future<int> reclaim(Iterable<UnrecognizedBackup> candidates) async {
     var bytes = 0;
     for (final candidate in candidates) {
@@ -115,8 +121,9 @@ class OrphanedBackupScan {
       try {
         final file = File(candidate.path);
         if (!await file.exists()) continue;
+        final size = await file.length();
         await file.delete();
-        bytes += candidate.sizeBytes;
+        bytes += size;
       } on FileSystemException catch (e) {
         _log.warning('Could not reclaim ${candidate.filename}: $e');
         continue;

--- a/lib/features/backup/data/services/orphaned_backup_scan.dart
+++ b/lib/features/backup/data/services/orphaned_backup_scan.dart
@@ -127,11 +127,15 @@ class OrphanedBackupScan {
   }
 
   /// A backup this app wrote: our prefix, and a plaintext or encrypted
-  /// extension. The hidden `.db.tmp` in-progress files are already swept by
-  /// the pre-migration service and must not be double-handled here.
+  /// extension.
+  ///
+  /// The prefix must be at the START of the name, which is also what excludes
+  /// an in-progress write. `LiveDatabaseCopier` writes to `.<filename>.tmp`, so
+  /// a partial backup carries the real prefix one character in; the pre-migration
+  /// service sweeps those, and claiming one here would offer a file that is
+  /// still being written. The `.tmp` extension excludes it a second time.
   static bool _isBackupFile(String name) {
     if (!name.startsWith(_prefix)) return false;
-    if (name.startsWith('.')) return false;
     final extension = p.extension(name);
     return extension == '.db' || extension == BackupCrypto.fileExtension;
   }

--- a/lib/features/backup/data/services/orphaned_backup_scan.dart
+++ b/lib/features/backup/data/services/orphaned_backup_scan.dart
@@ -104,10 +104,21 @@ class OrphanedBackupScan {
 
   /// Deletes the reclaimable entries in [candidates], returning bytes freed.
   ///
-  /// Re-checks [UnrecognizedBackup.isReclaimable] rather than trusting the
-  /// caller. This is the last gate before an irreversible delete of what may
-  /// be another device's only backup, and a UI bug upstream must not be able
-  /// to reach past it.
+  /// Decides for itself which entries it may delete, from the filename and the
+  /// live device id, rather than reading [UnrecognizedBackup.isReclaimable].
+  /// That field was computed when the directory was listed, so re-reading it
+  /// would only re-consult this class's own earlier answer: it cannot catch a
+  /// caller that built an entry some other way, and it cannot notice the device
+  /// identity changing between the listing and the tap. This is the last gate
+  /// before an irreversible delete of what may be another device's only backup,
+  /// so it derives the answer again.
+  ///
+  /// Deletes are also confined to the backups directory. Nothing in the app
+  /// produces an entry from anywhere else, which is exactly why the constraint
+  /// belongs here rather than in the caller: it makes the guarantee a property
+  /// of this method instead of a property of where its arguments came from. The
+  /// comparison normalizes both paths but does not resolve symlinks, so it
+  /// constrains honest callers rather than defeating a hostile one.
   ///
   /// The freed total is measured immediately before each delete rather than
   /// summed from [UnrecognizedBackup.sizeBytes]. That field is whatever the
@@ -115,9 +126,18 @@ class OrphanedBackupScan {
   /// reads it; a cloud client rewriting a file in that window would turn the
   /// reported figure into a number the app made up rather than one it measured.
   Future<int> reclaim(Iterable<UnrecognizedBackup> candidates) async {
+    // No directory to be inside means nothing here can be shown to be ours.
+    final directoryPath = await _backupsDirectory();
+    if (directoryPath == null) return 0;
+    final directory = p.canonicalize(directoryPath);
+    final deviceId = await _thisDeviceId();
+
     var bytes = 0;
     for (final candidate in candidates) {
-      if (!candidate.isReclaimable) continue;
+      if (!_mayDelete(candidate.path, directory, deviceId)) {
+        _log.warning('Refused to reclaim ${candidate.filename}');
+        continue;
+      }
       try {
         final file = File(candidate.path);
         if (!await file.exists()) continue;
@@ -131,6 +151,15 @@ class OrphanedBackupScan {
     }
     if (bytes > 0) _log.info('Reclaimed $bytes bytes of forgotten backups');
     return bytes;
+  }
+
+  /// Whether [path] is a backup in [directory] that this device wrote.
+  static bool _mayDelete(String path, String directory, String deviceId) {
+    final name = p.basename(path);
+    if (!_isBackupFile(name)) return false;
+    if (p.canonicalize(p.dirname(path)) != directory) return false;
+    return classifyBackupFile(filename: name, thisDeviceId: deviceId) ==
+        BackupOwnership.thisDevice;
   }
 
   /// A backup this app wrote: our prefix, and a plaintext or encrypted

--- a/lib/features/backup/data/services/unrecognized_backup_service.dart
+++ b/lib/features/backup/data/services/unrecognized_backup_service.dart
@@ -1,0 +1,82 @@
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backups_directory_access.dart';
+import 'package:submersion/features/backup/data/services/orphaned_backup_scan.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+
+/// The paths the scan must treat as accounted for.
+///
+/// Reads the RAW history, deliberately, not
+/// `BackupService.getValidatedBackupHistory`. That method drops records whose
+/// file is missing and rewrites preferences to match, which is two problems
+/// here. A measurement surface must not mutate stored state as a side effect of
+/// being opened, the lesson slice A learned when a directory resolver passed by
+/// value silently created a Backups folder. And a backups folder on an
+/// unmounted share or an unsynced cloud folder is momentarily "missing": pruned
+/// there, its files come back with no record, attributable to this device, and
+/// this page would offer them for deletion.
+///
+/// The raw history is a superset of the validated one, so every difference
+/// between them can only mean fewer files offered for deletion.
+Future<Set<String>> knownPathsFromPreferences(
+  BackupPreferences preferences,
+) async => knownBackupPaths(preferences.getHistory());
+
+/// The local files [history] still accounts for.
+///
+/// Everything the scan does hangs off this set being complete: a live backup
+/// whose path is missing here is reported as forgotten, and if this device
+/// wrote it, offered for deletion. Cloud-only records contribute nothing
+/// because they have no file in this directory to account for.
+Set<String> knownBackupPaths(Iterable<BackupRecord> history) => {
+  for (final record in history) ?record.localPath,
+};
+
+/// Runs [OrphanedBackupScan] against the directory the app is actually using.
+///
+/// The scan takes its inputs as callbacks so it can be tested without
+/// SharedPreferences or a sync database. This is where those callbacks are
+/// bound to the real sources, and where both operations are wrapped in the
+/// directory lease.
+///
+/// [reclaim] takes the lease even though it deletes by absolute path and has no
+/// use for the directory: on Apple platforms a custom location is only
+/// reachable while its security-scoped bookmark is held, so deleting outside
+/// the lease would fail on exactly the configuration the lease exists for.
+class UnrecognizedBackupService {
+  UnrecognizedBackupService({
+    required BackupsDirectoryAccess access,
+    required Future<Set<String>> Function() knownPaths,
+    required Future<String> Function() thisDeviceId,
+  }) : _access = access,
+       _knownPaths = knownPaths,
+       _thisDeviceId = thisDeviceId;
+
+  final BackupsDirectoryAccess _access;
+  final Future<Set<String>> Function() _knownPaths;
+  final Future<String> Function() _thisDeviceId;
+
+  /// The forgotten files, or null when the directory cannot be enumerated.
+  ///
+  /// Null is not an empty list, the same distinction `StorageCategory.measure`
+  /// draws for the same reason: an Android SAF location is a content:// tree
+  /// URI with no directory behind it, and reporting it as clean would tell the
+  /// user there is nothing to reclaim when nothing was ever looked at.
+  Future<List<UnrecognizedBackup>?> find() => _access.use((path) async {
+    if (path == null) return null;
+    return _scanIn(path).find();
+  });
+
+  /// Deletes the reclaimable entries in [selection], returning bytes freed.
+  ///
+  /// The scan re-checks every entry, so a selection that has gone stale (the
+  /// user leaving the page open while a backup runs) cannot delete anything it
+  /// was not entitled to delete when it was built.
+  Future<int> reclaim(Iterable<UnrecognizedBackup> selection) =>
+      _access.use((path) => _scanIn(path).reclaim(selection));
+
+  OrphanedBackupScan _scanIn(String? directoryPath) => OrphanedBackupScan(
+    backupsDirectory: () async => directoryPath,
+    knownPaths: _knownPaths,
+    thisDeviceId: _thisDeviceId,
+  );
+}

--- a/lib/features/backup/presentation/pages/unrecognized_backups_page.dart
+++ b/lib/features/backup/presentation/pages/unrecognized_backups_page.dart
@@ -39,11 +39,19 @@ class _UnrecognizedBackupsPageState
     final l10n = context.l10n;
     final scan = ref.watch(unrecognizedBackupsProvider);
 
-    // A rescan can remove a file that was ticked, so drop selections the list
-    // no longer offers before anything reads them.
+    // Drop ticks the list no longer offers, before anything reads them. That
+    // means gone, and it also means still listed but no longer this device's:
+    // a sync reset changes the device id, so the next scan classifies the same
+    // file as another device's. Pruning on presence alone would leave it ticked
+    // behind a tile that shows "Another device" and no checkbox, with the bar
+    // still counting it and a confirm reporting "Freed 0 B" once the service
+    // refused it.
     if (scan.valueOrNull case final entries?) {
-      final present = {for (final entry in entries) entry.path};
-      _selected.removeWhere((path) => !present.contains(path));
+      final selectable = {
+        for (final entry in entries)
+          if (entry.isReclaimable) entry.path,
+      };
+      _selected.removeWhere((path) => !selectable.contains(path));
     }
 
     return Scaffold(

--- a/lib/features/backup/presentation/pages/unrecognized_backups_page.dart
+++ b/lib/features/backup/presentation/pages/unrecognized_backups_page.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/byte_format.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/backup/data/services/backup_attribution.dart';
+import 'package:submersion/features/backup/data/services/orphaned_backup_scan.dart';
+import 'package:submersion/features/backup/presentation/providers/unrecognized_backup_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Backup files sitting in the backups folder that the history has lost track
+/// of, and the one place in the app that offers to delete them.
+///
+/// Reached from the Storage usage page rather than shown inline there, because
+/// that page is a measurement surface and this is an irreversible action on
+/// what may be the only copy of someone's dive log. The navigation step buys
+/// room to say which files are safe to remove and why the rest are not.
+///
+/// Only [BackupOwnership.thisDevice] entries are selectable. The service
+/// re-checks that on the way through, so this widget's job is to avoid
+/// offering the choice at all, not to be the thing that enforces it.
+class UnrecognizedBackupsPage extends ConsumerStatefulWidget {
+  const UnrecognizedBackupsPage({super.key});
+
+  @override
+  ConsumerState<UnrecognizedBackupsPage> createState() =>
+      _UnrecognizedBackupsPageState();
+}
+
+class _UnrecognizedBackupsPageState
+    extends ConsumerState<UnrecognizedBackupsPage> {
+  /// Selected paths rather than selected entries, so a refresh that returns
+  /// equal-but-not-identical entries keeps the user's ticks.
+  final _selected = <String>{};
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final scan = ref.watch(unrecognizedBackupsProvider);
+
+    // A rescan can remove a file that was ticked, so drop selections the list
+    // no longer offers before anything reads them.
+    if (scan.valueOrNull case final entries?) {
+      final present = {for (final entry in entries) entry.path};
+      _selected.removeWhere((path) => !present.contains(path));
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.backup_unrecognized_appBar_title)),
+      body: switch (scan) {
+        AsyncData(:final value?) when value.isEmpty => _Message(
+          l10n.backup_unrecognized_empty,
+        ),
+        AsyncData(:final value?) => _List(
+          entries: value,
+          selected: _selected,
+          onToggle: (entry, selected) => setState(() {
+            if (selected) {
+              _selected.add(entry.path);
+            } else {
+              _selected.remove(entry.path);
+            }
+          }),
+        ),
+        // Null, not empty: the folder was never readable.
+        AsyncData() => _Message(l10n.backup_unrecognized_unavailable),
+        AsyncError() => _Message(l10n.backup_unrecognized_loadFailed),
+        _ => const Center(child: CircularProgressIndicator()),
+      },
+      bottomNavigationBar: switch (scan) {
+        AsyncData(:final value?) when value.isNotEmpty => _DeleteBar(
+          selection: [
+            for (final entry in value)
+              if (_selected.contains(entry.path)) entry,
+          ],
+          onDelete: _confirmAndReclaim,
+        ),
+        _ => null,
+      },
+    );
+  }
+
+  Future<void> _confirmAndReclaim(List<UnrecognizedBackup> selection) async {
+    final l10n = context.l10n;
+    final messenger = ScaffoldMessenger.of(context);
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.backup_unrecognized_confirm_title),
+        content: Text(
+          l10n.backup_unrecognized_confirm_message(selection.length),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l10n.common_action_cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(l10n.common_action_delete),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    final int freed;
+    try {
+      freed = await ref
+          .read(unrecognizedBackupServiceProvider)
+          .reclaim(selection);
+    } catch (_) {
+      // Reported rather than swallowed: the page would otherwise redraw with
+      // the files still listed and no explanation, which reads as the tap
+      // having done nothing.
+      if (mounted) {
+        messenger.showSnackBar(
+          SnackBar(content: Text(l10n.backup_unrecognized_deleteFailed)),
+        );
+      }
+      return;
+    }
+
+    if (!mounted) return;
+    setState(_selected.clear);
+    ref.invalidate(unrecognizedBackupsProvider);
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(l10n.backup_unrecognized_freed(formatBytes(freed))),
+      ),
+    );
+  }
+}
+
+class _Message extends StatelessWidget {
+  const _Message(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) => Center(
+    child: Padding(
+      padding: const EdgeInsets.all(24),
+      child: Text(text, textAlign: TextAlign.center),
+    ),
+  );
+}
+
+class _List extends StatelessWidget {
+  const _List({
+    required this.entries,
+    required this.selected,
+    required this.onToggle,
+  });
+
+  final List<UnrecognizedBackup> entries;
+  final Set<String> selected;
+  final void Function(UnrecognizedBackup entry, bool selected) onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ListView.builder(
+      itemCount: entries.length + 1,
+      itemBuilder: (context, index) {
+        if (index == 0) {
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              context.l10n.backup_unrecognized_explanation,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          );
+        }
+        final entry = entries[index - 1];
+        return _BackupTile(
+          entry: entry,
+          selected: selected.contains(entry.path),
+          onToggle: (value) => onToggle(entry, value),
+        );
+      },
+    );
+  }
+}
+
+class _BackupTile extends ConsumerWidget {
+  const _BackupTile({
+    required this.entry,
+    required this.selected,
+    required this.onToggle,
+  });
+
+  final UnrecognizedBackup entry;
+  final bool selected;
+  final ValueChanged<bool> onToggle;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    final units = UnitFormatter(ref.watch(settingsProvider));
+
+    return ListTile(
+      title: Text(entry.filename, overflow: TextOverflow.ellipsis),
+      subtitle: Text(
+        l10n.backup_unrecognized_fileDetail(
+          formatBytes(entry.sizeBytes),
+          units.formatDateTime(entry.modified, l10n: l10n),
+        ),
+      ),
+      trailing: entry.isReclaimable
+          ? Checkbox(
+              value: selected,
+              onChanged: (value) => onToggle(value ?? false),
+            )
+          : Text(
+              switch (entry.ownership) {
+                BackupOwnership.otherDevice =>
+                  l10n.backup_unrecognized_ownership_otherDevice,
+                _ => l10n.backup_unrecognized_ownership_unattributed,
+              },
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+      onTap: entry.isReclaimable ? () => onToggle(!selected) : null,
+    );
+  }
+}
+
+class _DeleteBar extends StatelessWidget {
+  const _DeleteBar({required this.selection, required this.onDelete});
+
+  final List<UnrecognizedBackup> selection;
+  final Future<void> Function(List<UnrecognizedBackup> selection) onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final bytes = selection.fold(0, (sum, entry) => sum + entry.sizeBytes);
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SizedBox(
+          width: double.infinity,
+          child: FilledButton(
+            onPressed: selection.isEmpty ? null : () => onDelete(selection),
+            child: Text(
+              context.l10n.backup_unrecognized_deleteSelected(
+                selection.length,
+                formatBytes(bytes),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/backup/presentation/pages/unrecognized_backups_page.dart
+++ b/lib/features/backup/presentation/pages/unrecognized_backups_page.dart
@@ -92,6 +92,12 @@ class _UnrecognizedBackupsPageState
   Future<void> _confirmAndReclaim(List<UnrecognizedBackup> selection) async {
     final l10n = context.l10n;
     final messenger = ScaffoldMessenger.of(context);
+    // Read before the dialog, alongside the other two. showDialog defaults to
+    // the ROOT navigator, so the dialog outlives this page being torn down
+    // underneath it, and `ref` on an unmounted element throws StateError. The
+    // service is a plain object once resolved, so holding it costs nothing and
+    // removes the gap entirely rather than guarding it.
+    final service = ref.read(unrecognizedBackupServiceProvider);
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -112,13 +118,12 @@ class _UnrecognizedBackupsPageState
         ],
       ),
     );
-    if (confirmed != true) return;
+    // Both checked: the user may have said no, and the page may be gone.
+    if (confirmed != true || !mounted) return;
 
     final int freed;
     try {
-      freed = await ref
-          .read(unrecognizedBackupServiceProvider)
-          .reclaim(selection);
+      freed = await service.reclaim(selection);
     } catch (_) {
       // Reported rather than swallowed: the page would otherwise redraw with
       // the files still listed and no explanation, which reads as the tap

--- a/lib/features/backup/presentation/providers/unrecognized_backup_providers.dart
+++ b/lib/features/backup/presentation/providers/unrecognized_backup_providers.dart
@@ -1,0 +1,26 @@
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/backup/data/services/backups_directory_access.dart';
+import 'package:submersion/features/backup/data/services/orphaned_backup_scan.dart';
+import 'package:submersion/features/backup/data/services/unrecognized_backup_service.dart';
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+/// Scan and reclaim over the active backups directory.
+final unrecognizedBackupServiceProvider = Provider<UnrecognizedBackupService>((
+  ref,
+) {
+  final preferences = ref.watch(backupPreferencesProvider);
+  final syncRepository = ref.watch(syncRepositoryProvider);
+
+  return UnrecognizedBackupService(
+    access: BackupsDirectoryAccess.live(preferences),
+    knownPaths: () => knownPathsFromPreferences(preferences),
+    thisDeviceId: syncRepository.getDeviceId,
+  );
+});
+
+/// Backup files on disk that this device's history does not account for, or
+/// null when the configured location cannot be enumerated.
+final unrecognizedBackupsProvider = FutureProvider<List<UnrecognizedBackup>?>(
+  (ref) => ref.watch(unrecognizedBackupServiceProvider).find(),
+);

--- a/lib/features/settings/presentation/pages/storage_usage_page.dart
+++ b/lib/features/settings/presentation/pages/storage_usage_page.dart
@@ -4,16 +4,23 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/storage/storage_category.dart';
 import 'package:submersion/core/utils/byte_format.dart';
 import 'package:submersion/features/settings/presentation/providers/storage_usage_providers.dart';
+import 'package:submersion/features/settings/presentation/widgets/unrecognized_backups_notice.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Reports how many bytes the app holds on this device, by category.
 ///
-/// Read-only by design. Nothing on this page deletes anything: the categories
-/// that can be reclaimed today are reclaimed from the pages that already own
-/// that action, and the ones that cannot be reclaimed safely at all (exports
-/// live beside the database and are user-visible in the Files app; every backup
-/// is a full copy of the database) are shown here precisely so the user can
-/// decide for themselves.
+/// Measurement only. Nothing here deletes anything: the categories that can be
+/// reclaimed today are reclaimed from the pages that already own that action,
+/// and the ones that cannot be reclaimed safely at all (exports live beside the
+/// database and are user-visible in the Files app; every backup is a full copy
+/// of the database) are shown here precisely so the user can decide for
+/// themselves.
+///
+/// The one exception is [UnrecognizedBackupsNotice], which appears under the
+/// backups group when the history has lost track of a file. It still deletes
+/// nothing itself: it links to a page that explains which files are safe to
+/// remove, because a delete button beside a size row would be a one-tap
+/// irreversible action on what may be someone's only copy.
 class StorageUsagePage extends ConsumerWidget {
   const StorageUsagePage({super.key});
 
@@ -48,6 +55,8 @@ class StorageUsagePage extends ConsumerWidget {
               _GroupHeader(group: group),
               for (final category in grouped[group]!)
                 StorageUsageRow(category: category),
+              if (group == StorageGroup.backups)
+                const UnrecognizedBackupsNotice(),
             ],
           const SizedBox(height: 32),
         ],

--- a/lib/features/settings/presentation/widgets/unrecognized_backups_notice.dart
+++ b/lib/features/settings/presentation/widgets/unrecognized_backups_notice.dart
@@ -13,10 +13,16 @@ import 'package:submersion/l10n/l10n_extension.dart';
 ///
 /// Renders nothing at all unless the scan came back with something. A row that
 /// said "0 forgotten files" would be noise on every launch for every user whose
-/// backups are in order, which is nearly all of them, and the states that are
-/// not a clean folder (still scanning, failed, or a location this device cannot
-/// list) have no honest one-line summary here. The page behind the button says
-/// which of those happened.
+/// backups are in order, which is nearly all of them.
+///
+/// It also hides while the scan is still running, when it failed, and when the
+/// location cannot be listed. Hiding is the whole behaviour in those cases:
+/// there is no button, so the page is not reachable and says nothing to the
+/// user about them. What makes that acceptable is the backups size row directly
+/// above, which measures the same directory and already reports "Not available"
+/// for a location with no directory behind it and "Could not measure" when the
+/// walk fails. A second line here would restate what that row just said, and
+/// only for the one category that has a scan.
 class UnrecognizedBackupsNotice extends ConsumerWidget {
   const UnrecognizedBackupsNotice({super.key});
 

--- a/lib/features/settings/presentation/widgets/unrecognized_backups_notice.dart
+++ b/lib/features/settings/presentation/widgets/unrecognized_backups_notice.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/storage/storage_category.dart';
+import 'package:submersion/core/utils/byte_format.dart';
+import 'package:submersion/features/backup/presentation/providers/unrecognized_backup_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/storage_usage_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Points at backup files the history has lost track of, from the backups
+/// group of the Storage usage page.
+///
+/// Renders nothing at all unless the scan came back with something. A row that
+/// said "0 forgotten files" would be noise on every launch for every user whose
+/// backups are in order, which is nearly all of them, and the states that are
+/// not a clean folder (still scanning, failed, or a location this device cannot
+/// list) have no honest one-line summary here. The page behind the button says
+/// which of those happened.
+class UnrecognizedBackupsNotice extends ConsumerWidget {
+  const UnrecognizedBackupsNotice({super.key});
+
+  /// Where [_review] navigates. Pinned against the route tree by a test in
+  /// `app_router_test.dart`, since go_router resolves an absolute location at
+  /// push time and a rename on either side is a runtime failure otherwise.
+  static const routeLocation = '/settings/storage-usage/unrecognized-backups';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final entries = ref.watch(unrecognizedBackupsProvider).valueOrNull;
+    if (entries == null || entries.isEmpty) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    final bytes = entries.fold(0, (sum, entry) => sum + entry.sizeBytes);
+
+    return ListTile(
+      leading: Icon(Icons.help_outline, color: theme.colorScheme.primary),
+      title: Text(
+        context.l10n.settings_storageUsage_unrecognized_title(entries.length),
+      ),
+      subtitle: Text(formatBytes(bytes)),
+      trailing: TextButton(
+        onPressed: () => _review(context, ref),
+        child: Text(context.l10n.settings_storageUsage_unrecognized_action),
+      ),
+      onTap: () => _review(context, ref),
+    );
+  }
+
+  /// Re-measures on the way back rather than having the sub-page reach into
+  /// this feature's providers: a reclaim changes what the backups row should
+  /// say, and this side of the navigation is where that row lives.
+  Future<void> _review(BuildContext context, WidgetRef ref) async {
+    await context.push(routeLocation);
+    ref.invalidate(unrecognizedBackupsProvider);
+    ref.invalidate(storageCategorySizeProvider(StorageCategoryId.backups));
+  }
+}

--- a/lib/features/settings/presentation/widgets/unrecognized_backups_notice.dart
+++ b/lib/features/settings/presentation/widgets/unrecognized_backups_notice.dart
@@ -52,7 +52,26 @@ class UnrecognizedBackupsNotice extends ConsumerWidget {
   /// say, and this side of the navigation is where that row lives.
   Future<void> _review(BuildContext context, WidgetRef ref) async {
     await context.push(routeLocation);
-    ref.invalidate(unrecognizedBackupsProvider);
-    ref.invalidate(storageCategorySizeProvider(StorageCategoryId.backups));
+    // Checked here as well as inside the callee: the analyzer cannot see a
+    // guard on the far side of a call, and use_build_context_synchronously is
+    // fatal in CI. The tested guard is the one in the callee.
+    if (!context.mounted) return;
+    refreshAfterUnrecognizedReview(context, ref);
   }
+}
+
+/// Refreshes the rows a reclaim can change, if this notice is still on screen.
+///
+/// Separate from the push so the guard is reachable from a test. The await on
+/// `context.push` has no bound: the sub-page stays open as long as the user
+/// reads it, and the Storage usage page underneath can be torn down in that
+/// window by a deep link or a shell navigation. A `WidgetRef` whose element has
+/// been unmounted throws `StateError` on invalidate, so without this check a
+/// tap the user made on a page they have already left surfaces as an unhandled
+/// error. There is nothing to refresh in that case either: the rows are gone.
+@visibleForTesting
+void refreshAfterUnrecognizedReview(BuildContext context, WidgetRef ref) {
+  if (!context.mounted) return;
+  ref.invalidate(unrecognizedBackupsProvider);
+  ref.invalidate(storageCategorySizeProvider(StorageCategoryId.backups));
 }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -10890,5 +10890,20 @@
   "startup_versionMismatch_restore_warning": "كل ما سجّلته بعد الترقية موجود في الملف الأحدث فقط. يُحتفظ بذلك الملف كنسخة احتياطية مثبّتة، لذا فإن إعادة تثبيت الإصدار الأحدث تستعيده.",
   "backup_history_preDowngradeSubtitle": "قاعدة بيانات أحدث، محفوظة عند الرجوع - {size}",
   "backup_history_manualSubtitle": "{diveCount, plural, =1{غوصة واحدة} other{{diveCount} غوصات}}, {siteCount, plural, =1{موقع غوص واحد} other{{siteCount} مواقع غوص}} - {size}",
-  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{غوصة واحدة} other{{diveCount} غوصات}}, {siteCount, plural, =1{موقع غوص واحد} other{{siteCount} مواقع غوص}} - {size} (تلقائي)"
+  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{غوصة واحدة} other{{diveCount} غوصات}}, {siteCount, plural, =1{موقع غوص واحد} other{{siteCount} مواقع غوص}} - {size} (تلقائي)",
+  "backup_unrecognized_appBar_title": "نسخ احتياطية غير معروفة",
+  "backup_unrecognized_explanation": "هذه الملفات موجودة في مجلد النسخ الاحتياطي لديك لكنها ليست في سجل النسخ الاحتياطي لهذا الجهاز. لا يمكن حذف سوى ملف كتبه هذا الجهاز هنا: أي ملف آخر قد يكون النسخة الوحيدة لجهاز آخر.",
+  "backup_unrecognized_empty": "لا توجد ملفات نسخ احتياطي غير معروفة.",
+  "backup_unrecognized_loadFailed": "تعذّرت قراءة مجلد النسخ الاحتياطي.",
+  "backup_unrecognized_unavailable": "لا يستطيع هذا الجهاز سرد مجلد النسخ الاحتياطي الذي اخترته، لذا لا يمكن العثور على الملفات غير المعروفة.",
+  "backup_unrecognized_ownership_otherDevice": "جهاز آخر",
+  "backup_unrecognized_ownership_unattributed": "جهاز غير معروف",
+  "backup_unrecognized_fileDetail": "{size} • {date}",
+  "backup_unrecognized_deleteSelected": "{count, plural, =1{حذف ملف واحد ({size})} other{حذف {count} ملفات ({size})}}",
+  "backup_unrecognized_confirm_title": "حذف ملفات النسخ الاحتياطي هذه؟",
+  "backup_unrecognized_confirm_message": "{count, plural, =1{سيُحذف ملف نسخ احتياطي واحد نهائيًا. لا يمكن التراجع عن ذلك.} other{ستُحذف {count} من ملفات النسخ الاحتياطي نهائيًا. لا يمكن التراجع عن ذلك.}}",
+  "backup_unrecognized_deleteFailed": "تعذّر حذف الملفات المحددة.",
+  "backup_unrecognized_freed": "تم تحرير {size}",
+  "settings_storageUsage_unrecognized_title": "{count, plural, =1{ملف واحد غير موجود في سجل النسخ الاحتياطي} other{{count} ملفات غير موجودة في سجل النسخ الاحتياطي}}",
+  "settings_storageUsage_unrecognized_action": "مراجعة"
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -10890,5 +10890,20 @@
   "startup_versionMismatch_restore_warning": "Alles, was du nach dem Upgrade eingetragen hast, liegt nur in der neueren Datei. Diese Datei wird als angeheftete Sicherung behalten; installiere die neuere Version erneut, um sie zurückzuholen.",
   "backup_history_preDowngradeSubtitle": "Neuere Datenbank, beim Zurückwechseln behalten - {size}",
   "backup_history_manualSubtitle": "{diveCount, plural, =1{1 Tauchgang} other{{diveCount} Tauchgänge}}, {siteCount, plural, =1{1 Tauchplatz} other{{siteCount} Tauchplätze}} - {size}",
-  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 Tauchgang} other{{diveCount} Tauchgänge}}, {siteCount, plural, =1{1 Tauchplatz} other{{siteCount} Tauchplätze}} - {size} (automatisch)"
+  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 Tauchgang} other{{diveCount} Tauchgänge}}, {siteCount, plural, =1{1 Tauchplatz} other{{siteCount} Tauchplätze}} - {size} (automatisch)",
+  "backup_unrecognized_appBar_title": "Nicht erkannte Sicherungen",
+  "backup_unrecognized_explanation": "Diese Dateien liegen in Ihrem Sicherungsordner, stehen aber nicht im Sicherungsverlauf dieses Geräts. Hier kann nur eine von diesem Gerät geschriebene Datei gelöscht werden: alles andere könnte die einzige Kopie eines anderen Geräts sein.",
+  "backup_unrecognized_empty": "Keine nicht erkannten Sicherungsdateien.",
+  "backup_unrecognized_loadFailed": "Der Sicherungsordner konnte nicht gelesen werden.",
+  "backup_unrecognized_unavailable": "Dieses Gerät kann den gewählten Sicherungsordner nicht auflisten, daher können nicht erkannte Dateien nicht gefunden werden.",
+  "backup_unrecognized_ownership_otherDevice": "Anderes Gerät",
+  "backup_unrecognized_ownership_unattributed": "Unbekanntes Gerät",
+  "backup_unrecognized_fileDetail": "{size} • {date}",
+  "backup_unrecognized_deleteSelected": "{count, plural, =1{1 Datei löschen ({size})} other{{count} Dateien löschen ({size})}}",
+  "backup_unrecognized_confirm_title": "Diese Sicherungsdateien löschen?",
+  "backup_unrecognized_confirm_message": "{count, plural, =1{1 Sicherungsdatei wird endgültig gelöscht. Dies kann nicht rückgängig gemacht werden.} other{{count} Sicherungsdateien werden endgültig gelöscht. Dies kann nicht rückgängig gemacht werden.}}",
+  "backup_unrecognized_deleteFailed": "Die ausgewählten Dateien konnten nicht gelöscht werden.",
+  "backup_unrecognized_freed": "{size} freigegeben",
+  "settings_storageUsage_unrecognized_title": "{count, plural, =1{1 Datei fehlt im Sicherungsverlauf} other{{count} Dateien fehlen im Sicherungsverlauf}}",
+  "settings_storageUsage_unrecognized_action": "Prüfen"
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -22557,5 +22557,25 @@
         "type": "String"
       }
     }
-  }
+  },
+  "backup_unrecognized_appBar_title": "Unrecognized Backups",
+  "backup_unrecognized_explanation": "These files are in your backups folder but not in this device's backup history. Only a file this device wrote can be deleted here: anything else may be another device's only copy.",
+  "backup_unrecognized_empty": "No unrecognized backup files.",
+  "backup_unrecognized_loadFailed": "Could not read the backups folder.",
+  "backup_unrecognized_unavailable": "This device cannot list the backup folder you chose, so unrecognized files cannot be found.",
+  "backup_unrecognized_ownership_otherDevice": "Another device",
+  "backup_unrecognized_ownership_unattributed": "Unknown device",
+  "backup_unrecognized_fileDetail": "{size} \u2022 {date}",
+  "@backup_unrecognized_fileDetail": { "placeholders": { "size": { "type": "String" }, "date": { "type": "String" } } },
+  "backup_unrecognized_deleteSelected": "{count, plural, =1{Delete 1 file ({size})} other{Delete {count} files ({size})}}",
+  "@backup_unrecognized_deleteSelected": { "placeholders": { "count": { "type": "int" }, "size": { "type": "String" } } },
+  "backup_unrecognized_confirm_title": "Delete these backup files?",
+  "backup_unrecognized_confirm_message": "{count, plural, =1{1 backup file will be permanently deleted. This cannot be undone.} other{{count} backup files will be permanently deleted. This cannot be undone.}}",
+  "@backup_unrecognized_confirm_message": { "placeholders": { "count": { "type": "int" } } },
+  "backup_unrecognized_deleteFailed": "Could not delete the selected files.",
+  "backup_unrecognized_freed": "Freed {size}",
+  "@backup_unrecognized_freed": { "placeholders": { "size": { "type": "String" } } },
+  "settings_storageUsage_unrecognized_title": "{count, plural, =1{1 file not in your backup history} other{{count} files not in your backup history}}",
+  "@settings_storageUsage_unrecognized_title": { "placeholders": { "count": { "type": "int" } } },
+  "settings_storageUsage_unrecognized_action": "Review"
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -10890,5 +10890,20 @@
   "startup_versionMismatch_restore_warning": "Todo lo que registraste después de la actualización solo existe en el archivo más reciente. Ese archivo se conserva como copia fijada, así que volver a instalar la versión más reciente lo recupera.",
   "backup_history_preDowngradeSubtitle": "Base de datos más reciente, conservada al volver atrás - {size}",
   "backup_history_manualSubtitle": "{diveCount, plural, =1{1 inmersión} other{{diveCount} inmersiones}}, {siteCount, plural, =1{1 punto de buceo} other{{siteCount} puntos de buceo}} - {size}",
-  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 inmersión} other{{diveCount} inmersiones}}, {siteCount, plural, =1{1 punto de buceo} other{{siteCount} puntos de buceo}} - {size} (automática)"
+  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 inmersión} other{{diveCount} inmersiones}}, {siteCount, plural, =1{1 punto de buceo} other{{siteCount} puntos de buceo}} - {size} (automática)",
+  "backup_unrecognized_appBar_title": "Copias de seguridad no reconocidas",
+  "backup_unrecognized_explanation": "Estos archivos están en tu carpeta de copias de seguridad pero no en el historial de este dispositivo. Aquí solo se puede eliminar un archivo escrito por este dispositivo: cualquier otro podría ser la única copia de otro dispositivo.",
+  "backup_unrecognized_empty": "No hay archivos de copia de seguridad no reconocidos.",
+  "backup_unrecognized_loadFailed": "No se pudo leer la carpeta de copias de seguridad.",
+  "backup_unrecognized_unavailable": "Este dispositivo no puede enumerar la carpeta de copias de seguridad que elegiste, así que no se pueden encontrar archivos no reconocidos.",
+  "backup_unrecognized_ownership_otherDevice": "Otro dispositivo",
+  "backup_unrecognized_ownership_unattributed": "Dispositivo desconocido",
+  "backup_unrecognized_fileDetail": "{size} • {date}",
+  "backup_unrecognized_deleteSelected": "{count, plural, =1{Eliminar 1 archivo ({size})} other{Eliminar {count} archivos ({size})}}",
+  "backup_unrecognized_confirm_title": "¿Eliminar estos archivos de copia de seguridad?",
+  "backup_unrecognized_confirm_message": "{count, plural, =1{Se eliminará permanentemente 1 archivo de copia de seguridad. Esta acción no se puede deshacer.} other{Se eliminarán permanentemente {count} archivos de copia de seguridad. Esta acción no se puede deshacer.}}",
+  "backup_unrecognized_deleteFailed": "No se pudieron eliminar los archivos seleccionados.",
+  "backup_unrecognized_freed": "Se liberaron {size}",
+  "settings_storageUsage_unrecognized_title": "{count, plural, =1{1 archivo que no está en tu historial de copias de seguridad} other{{count} archivos que no están en tu historial de copias de seguridad}}",
+  "settings_storageUsage_unrecognized_action": "Revisar"
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -10890,5 +10890,20 @@
   "startup_versionMismatch_restore_warning": "Tout ce que vous avez enregistré après la mise à jour n'existe que dans le fichier le plus récent. Ce fichier est conservé comme sauvegarde épinglée : réinstallez la version plus récente pour le retrouver.",
   "backup_history_preDowngradeSubtitle": "Base plus récente, conservée lors du retour en arrière - {size}",
   "backup_history_manualSubtitle": "{diveCount, plural, =1{1 plongée} other{{diveCount} plongées}}, {siteCount, plural, =1{1 site} other{{siteCount} sites}} - {size}",
-  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 plongée} other{{diveCount} plongées}}, {siteCount, plural, =1{1 site} other{{siteCount} sites}} - {size} (auto)"
+  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 plongée} other{{diveCount} plongées}}, {siteCount, plural, =1{1 site} other{{siteCount} sites}} - {size} (auto)",
+  "backup_unrecognized_appBar_title": "Sauvegardes non reconnues",
+  "backup_unrecognized_explanation": "Ces fichiers se trouvent dans votre dossier de sauvegardes mais pas dans l'historique de sauvegarde de cet appareil. Seul un fichier écrit par cet appareil peut être supprimé ici : tout autre fichier peut être l'unique copie d'un autre appareil.",
+  "backup_unrecognized_empty": "Aucun fichier de sauvegarde non reconnu.",
+  "backup_unrecognized_loadFailed": "Impossible de lire le dossier de sauvegardes.",
+  "backup_unrecognized_unavailable": "Cet appareil ne peut pas lister le dossier de sauvegardes que vous avez choisi ; les fichiers non reconnus ne peuvent donc pas être trouvés.",
+  "backup_unrecognized_ownership_otherDevice": "Un autre appareil",
+  "backup_unrecognized_ownership_unattributed": "Appareil inconnu",
+  "backup_unrecognized_fileDetail": "{size} • {date}",
+  "backup_unrecognized_deleteSelected": "{count, plural, =1{Supprimer 1 fichier ({size})} other{Supprimer {count} fichiers ({size})}}",
+  "backup_unrecognized_confirm_title": "Supprimer ces fichiers de sauvegarde ?",
+  "backup_unrecognized_confirm_message": "{count, plural, =1{1 fichier de sauvegarde sera définitivement supprimé. Cette action est irréversible.} other{{count} fichiers de sauvegarde seront définitivement supprimés. Cette action est irréversible.}}",
+  "backup_unrecognized_deleteFailed": "Impossible de supprimer les fichiers sélectionnés.",
+  "backup_unrecognized_freed": "{size} libéré",
+  "settings_storageUsage_unrecognized_title": "{count, plural, =1{1 fichier absent de votre historique de sauvegarde} other{{count} fichiers absents de votre historique de sauvegarde}}",
+  "settings_storageUsage_unrecognized_action": "Examiner"
 }

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -10890,5 +10890,20 @@
   "startup_versionMismatch_restore_warning": "כל מה שתיעדת אחרי העדכון קיים רק בקובץ החדש יותר. הקובץ הזה נשמר כגיבוי מוצמד, כך שהתקנה מחדש של הגרסה החדשה תחזיר אותו.",
   "backup_history_preDowngradeSubtitle": "מסד נתונים חדש יותר, נשמר בעת החזרה - {size}",
   "backup_history_manualSubtitle": "{diveCount, plural, =1{צלילה אחת} other{{diveCount} צלילות}}, {siteCount, plural, =1{אתר אחד} other{{siteCount} אתרים}} - {size}",
-  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{צלילה אחת} other{{diveCount} צלילות}}, {siteCount, plural, =1{אתר אחד} other{{siteCount} אתרים}} - {size} (אוטומטי)"
+  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{צלילה אחת} other{{diveCount} צלילות}}, {siteCount, plural, =1{אתר אחד} other{{siteCount} אתרים}} - {size} (אוטומטי)",
+  "backup_unrecognized_appBar_title": "גיבויים לא מזוהים",
+  "backup_unrecognized_explanation": "הקבצים האלה נמצאים בתיקיית הגיבויים שלך אך לא בהיסטוריית הגיבויים של המכשיר הזה. אפשר למחוק כאן רק קובץ שהמכשיר הזה כתב: כל קובץ אחר עלול להיות העותק היחיד של מכשיר אחר.",
+  "backup_unrecognized_empty": "אין קובצי גיבוי לא מזוהים.",
+  "backup_unrecognized_loadFailed": "לא ניתן לקרוא את תיקיית הגיבויים.",
+  "backup_unrecognized_unavailable": "המכשיר הזה אינו יכול להציג את תוכן תיקיית הגיבויים שבחרת, ולכן לא ניתן לאתר קבצים לא מזוהים.",
+  "backup_unrecognized_ownership_otherDevice": "מכשיר אחר",
+  "backup_unrecognized_ownership_unattributed": "מכשיר לא ידוע",
+  "backup_unrecognized_fileDetail": "{size} • {date}",
+  "backup_unrecognized_deleteSelected": "{count, plural, =1{מחיקת קובץ אחד ({size})} other{מחיקת {count} קבצים ({size})}}",
+  "backup_unrecognized_confirm_title": "למחוק את קובצי הגיבוי האלה?",
+  "backup_unrecognized_confirm_message": "{count, plural, =1{קובץ גיבוי אחד יימחק לצמיתות. לא ניתן לבטל את הפעולה.} other{{count} קובצי גיבוי יימחקו לצמיתות. לא ניתן לבטל את הפעולה.}}",
+  "backup_unrecognized_deleteFailed": "לא ניתן היה למחוק את הקבצים שנבחרו.",
+  "backup_unrecognized_freed": "{size} פונו",
+  "settings_storageUsage_unrecognized_title": "{count, plural, =1{קובץ אחד שאינו בהיסטוריית הגיבויים שלך} other{{count} קבצים שאינם בהיסטוריית הגיבויים שלך}}",
+  "settings_storageUsage_unrecognized_action": "בדיקה"
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -10890,5 +10890,20 @@
   "startup_versionMismatch_restore_warning": "Minden, amit a frissítés után rögzítettél, csak az újabb fájlban létezik. Azt a fájlt rögzített biztonsági mentésként megőrizzük, így az újabb verzió ismételt telepítésével visszakapod.",
   "backup_history_preDowngradeSubtitle": "Újabb adatbázis, visszalépéskor megőrizve - {size}",
   "backup_history_manualSubtitle": "{diveCount, plural, =1{1 merülés} other{{diveCount} merülés}}, {siteCount, plural, =1{1 merülőhely} other{{siteCount} merülőhely}} - {size}",
-  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 merülés} other{{diveCount} merülés}}, {siteCount, plural, =1{1 merülőhely} other{{siteCount} merülőhely}} - {size} (automatikus)"
+  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 merülés} other{{diveCount} merülés}}, {siteCount, plural, =1{1 merülőhely} other{{siteCount} merülőhely}} - {size} (automatikus)",
+  "backup_unrecognized_appBar_title": "Ismeretlen biztonsági mentések",
+  "backup_unrecognized_explanation": "Ezek a fájlok a biztonsági mentések mappájában vannak, de nem szerepelnek ennek az eszköznek a mentési előzményeiben. Itt csak olyan fájl törölhető, amelyet ez az eszköz írt: bármi más lehet egy másik eszköz egyetlen másolata.",
+  "backup_unrecognized_empty": "Nincs ismeretlen biztonsági mentési fájl.",
+  "backup_unrecognized_loadFailed": "A biztonsági mentések mappája nem olvasható.",
+  "backup_unrecognized_unavailable": "Ez az eszköz nem tudja kilistázni a kiválasztott mentési mappát, ezért az ismeretlen fájlok nem találhatók meg.",
+  "backup_unrecognized_ownership_otherDevice": "Másik eszköz",
+  "backup_unrecognized_ownership_unattributed": "Ismeretlen eszköz",
+  "backup_unrecognized_fileDetail": "{size} • {date}",
+  "backup_unrecognized_deleteSelected": "{count, plural, =1{1 fájl törlése ({size})} other{{count} fájl törlése ({size})}}",
+  "backup_unrecognized_confirm_title": "Törli ezeket a biztonsági mentési fájlokat?",
+  "backup_unrecognized_confirm_message": "{count, plural, =1{1 biztonsági mentési fájl véglegesen törlődik. A művelet nem vonható vissza.} other{{count} biztonsági mentési fájl véglegesen törlődik. A művelet nem vonható vissza.}}",
+  "backup_unrecognized_deleteFailed": "A kiválasztott fájlok törlése nem sikerült.",
+  "backup_unrecognized_freed": "{size} felszabadítva",
+  "settings_storageUsage_unrecognized_title": "{count, plural, =1{1 fájl hiányzik a mentési előzményekből} other{{count} fájl hiányzik a mentési előzményekből}}",
+  "settings_storageUsage_unrecognized_action": "Áttekintés"
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -10890,5 +10890,20 @@
   "startup_versionMismatch_restore_warning": "Tutto ciò che hai registrato dopo l'aggiornamento esiste solo nel file più recente. Quel file viene conservato come backup bloccato: reinstallando la versione più recente lo recuperi.",
   "backup_history_preDowngradeSubtitle": "Database più recente, conservato tornando indietro - {size}",
   "backup_history_manualSubtitle": "{diveCount, plural, =1{1 immersione} other{{diveCount} immersioni}}, {siteCount, plural, =1{1 sito} other{{siteCount} siti}} - {size}",
-  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 immersione} other{{diveCount} immersioni}}, {siteCount, plural, =1{1 sito} other{{siteCount} siti}} - {size} (auto)"
+  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 immersione} other{{diveCount} immersioni}}, {siteCount, plural, =1{1 sito} other{{siteCount} siti}} - {size} (auto)",
+  "backup_unrecognized_appBar_title": "Backup non riconosciuti",
+  "backup_unrecognized_explanation": "Questi file si trovano nella cartella dei backup ma non nella cronologia dei backup di questo dispositivo. Qui può essere eliminato solo un file scritto da questo dispositivo: qualsiasi altro potrebbe essere l'unica copia di un altro dispositivo.",
+  "backup_unrecognized_empty": "Nessun file di backup non riconosciuto.",
+  "backup_unrecognized_loadFailed": "Impossibile leggere la cartella dei backup.",
+  "backup_unrecognized_unavailable": "Questo dispositivo non può elencare la cartella dei backup che hai scelto, quindi i file non riconosciuti non possono essere trovati.",
+  "backup_unrecognized_ownership_otherDevice": "Un altro dispositivo",
+  "backup_unrecognized_ownership_unattributed": "Dispositivo sconosciuto",
+  "backup_unrecognized_fileDetail": "{size} • {date}",
+  "backup_unrecognized_deleteSelected": "{count, plural, =1{Elimina 1 file ({size})} other{Elimina {count} file ({size})}}",
+  "backup_unrecognized_confirm_title": "Eliminare questi file di backup?",
+  "backup_unrecognized_confirm_message": "{count, plural, =1{1 file di backup sarà eliminato definitivamente. L'operazione non può essere annullata.} other{{count} file di backup saranno eliminati definitivamente. L'operazione non può essere annullata.}}",
+  "backup_unrecognized_deleteFailed": "Impossibile eliminare i file selezionati.",
+  "backup_unrecognized_freed": "Liberati {size}",
+  "settings_storageUsage_unrecognized_title": "{count, plural, =1{1 file non presente nella cronologia dei backup} other{{count} file non presenti nella cronologia dei backup}}",
+  "settings_storageUsage_unrecognized_action": "Esamina"
 }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -61115,6 +61115,96 @@ abstract class AppLocalizations {
     int siteCount,
     String size,
   );
+
+  /// No description provided for @backup_unrecognized_appBar_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Unrecognized Backups'**
+  String get backup_unrecognized_appBar_title;
+
+  /// No description provided for @backup_unrecognized_explanation.
+  ///
+  /// In en, this message translates to:
+  /// **'These files are in your backups folder but not in this device\'s backup history. Only a file this device wrote can be deleted here: anything else may be another device\'s only copy.'**
+  String get backup_unrecognized_explanation;
+
+  /// No description provided for @backup_unrecognized_empty.
+  ///
+  /// In en, this message translates to:
+  /// **'No unrecognized backup files.'**
+  String get backup_unrecognized_empty;
+
+  /// No description provided for @backup_unrecognized_loadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not read the backups folder.'**
+  String get backup_unrecognized_loadFailed;
+
+  /// No description provided for @backup_unrecognized_unavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'This device cannot list the backup folder you chose, so unrecognized files cannot be found.'**
+  String get backup_unrecognized_unavailable;
+
+  /// No description provided for @backup_unrecognized_ownership_otherDevice.
+  ///
+  /// In en, this message translates to:
+  /// **'Another device'**
+  String get backup_unrecognized_ownership_otherDevice;
+
+  /// No description provided for @backup_unrecognized_ownership_unattributed.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown device'**
+  String get backup_unrecognized_ownership_unattributed;
+
+  /// No description provided for @backup_unrecognized_fileDetail.
+  ///
+  /// In en, this message translates to:
+  /// **'{size} • {date}'**
+  String backup_unrecognized_fileDetail(String size, String date);
+
+  /// No description provided for @backup_unrecognized_deleteSelected.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Delete 1 file ({size})} other{Delete {count} files ({size})}}'**
+  String backup_unrecognized_deleteSelected(int count, String size);
+
+  /// No description provided for @backup_unrecognized_confirm_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete these backup files?'**
+  String get backup_unrecognized_confirm_title;
+
+  /// No description provided for @backup_unrecognized_confirm_message.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 backup file will be permanently deleted. This cannot be undone.} other{{count} backup files will be permanently deleted. This cannot be undone.}}'**
+  String backup_unrecognized_confirm_message(int count);
+
+  /// No description provided for @backup_unrecognized_deleteFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not delete the selected files.'**
+  String get backup_unrecognized_deleteFailed;
+
+  /// No description provided for @backup_unrecognized_freed.
+  ///
+  /// In en, this message translates to:
+  /// **'Freed {size}'**
+  String backup_unrecognized_freed(String size);
+
+  /// No description provided for @settings_storageUsage_unrecognized_title.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 file not in your backup history} other{{count} files not in your backup history}}'**
+  String settings_storageUsage_unrecognized_title(int count);
+
+  /// No description provided for @settings_storageUsage_unrecognized_action.
+  ///
+  /// In en, this message translates to:
+  /// **'Review'**
+  String get settings_storageUsage_unrecognized_action;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -36896,4 +36896,83 @@ class AppLocalizationsAr extends AppLocalizations {
     );
     return '$_temp0, $_temp1 - $size (تلقائي)';
   }
+
+  @override
+  String get backup_unrecognized_appBar_title => 'نسخ احتياطية غير معروفة';
+
+  @override
+  String get backup_unrecognized_explanation =>
+      'هذه الملفات موجودة في مجلد النسخ الاحتياطي لديك لكنها ليست في سجل النسخ الاحتياطي لهذا الجهاز. لا يمكن حذف سوى ملف كتبه هذا الجهاز هنا: أي ملف آخر قد يكون النسخة الوحيدة لجهاز آخر.';
+
+  @override
+  String get backup_unrecognized_empty =>
+      'لا توجد ملفات نسخ احتياطي غير معروفة.';
+
+  @override
+  String get backup_unrecognized_loadFailed =>
+      'تعذّرت قراءة مجلد النسخ الاحتياطي.';
+
+  @override
+  String get backup_unrecognized_unavailable =>
+      'لا يستطيع هذا الجهاز سرد مجلد النسخ الاحتياطي الذي اخترته، لذا لا يمكن العثور على الملفات غير المعروفة.';
+
+  @override
+  String get backup_unrecognized_ownership_otherDevice => 'جهاز آخر';
+
+  @override
+  String get backup_unrecognized_ownership_unattributed => 'جهاز غير معروف';
+
+  @override
+  String backup_unrecognized_fileDetail(String size, String date) {
+    return '$size • $date';
+  }
+
+  @override
+  String backup_unrecognized_deleteSelected(int count, String size) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'حذف $count ملفات ($size)',
+      one: 'حذف ملف واحد ($size)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_confirm_title =>
+      'حذف ملفات النسخ الاحتياطي هذه؟';
+
+  @override
+  String backup_unrecognized_confirm_message(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'ستُحذف $count من ملفات النسخ الاحتياطي نهائيًا. لا يمكن التراجع عن ذلك.',
+      one: 'سيُحذف ملف نسخ احتياطي واحد نهائيًا. لا يمكن التراجع عن ذلك.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_deleteFailed => 'تعذّر حذف الملفات المحددة.';
+
+  @override
+  String backup_unrecognized_freed(String size) {
+    return 'تم تحرير $size';
+  }
+
+  @override
+  String settings_storageUsage_unrecognized_title(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ملفات غير موجودة في سجل النسخ الاحتياطي',
+      one: 'ملف واحد غير موجود في سجل النسخ الاحتياطي',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settings_storageUsage_unrecognized_action => 'مراجعة';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -37201,4 +37201,85 @@ class AppLocalizationsDe extends AppLocalizations {
     );
     return '$_temp0, $_temp1 - $size (automatisch)';
   }
+
+  @override
+  String get backup_unrecognized_appBar_title => 'Nicht erkannte Sicherungen';
+
+  @override
+  String get backup_unrecognized_explanation =>
+      'Diese Dateien liegen in Ihrem Sicherungsordner, stehen aber nicht im Sicherungsverlauf dieses Geräts. Hier kann nur eine von diesem Gerät geschriebene Datei gelöscht werden: alles andere könnte die einzige Kopie eines anderen Geräts sein.';
+
+  @override
+  String get backup_unrecognized_empty =>
+      'Keine nicht erkannten Sicherungsdateien.';
+
+  @override
+  String get backup_unrecognized_loadFailed =>
+      'Der Sicherungsordner konnte nicht gelesen werden.';
+
+  @override
+  String get backup_unrecognized_unavailable =>
+      'Dieses Gerät kann den gewählten Sicherungsordner nicht auflisten, daher können nicht erkannte Dateien nicht gefunden werden.';
+
+  @override
+  String get backup_unrecognized_ownership_otherDevice => 'Anderes Gerät';
+
+  @override
+  String get backup_unrecognized_ownership_unattributed => 'Unbekanntes Gerät';
+
+  @override
+  String backup_unrecognized_fileDetail(String size, String date) {
+    return '$size • $date';
+  }
+
+  @override
+  String backup_unrecognized_deleteSelected(int count, String size) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Dateien löschen ($size)',
+      one: '1 Datei löschen ($size)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_confirm_title =>
+      'Diese Sicherungsdateien löschen?';
+
+  @override
+  String backup_unrecognized_confirm_message(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count Sicherungsdateien werden endgültig gelöscht. Dies kann nicht rückgängig gemacht werden.',
+      one:
+          '1 Sicherungsdatei wird endgültig gelöscht. Dies kann nicht rückgängig gemacht werden.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_deleteFailed =>
+      'Die ausgewählten Dateien konnten nicht gelöscht werden.';
+
+  @override
+  String backup_unrecognized_freed(String size) {
+    return '$size freigegeben';
+  }
+
+  @override
+  String settings_storageUsage_unrecognized_title(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Dateien fehlen im Sicherungsverlauf',
+      one: '1 Datei fehlt im Sicherungsverlauf',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settings_storageUsage_unrecognized_action => 'Prüfen';
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -36700,4 +36700,82 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0, $_temp1 - $size (auto)';
   }
+
+  @override
+  String get backup_unrecognized_appBar_title => 'Unrecognized Backups';
+
+  @override
+  String get backup_unrecognized_explanation =>
+      'These files are in your backups folder but not in this device\'s backup history. Only a file this device wrote can be deleted here: anything else may be another device\'s only copy.';
+
+  @override
+  String get backup_unrecognized_empty => 'No unrecognized backup files.';
+
+  @override
+  String get backup_unrecognized_loadFailed =>
+      'Could not read the backups folder.';
+
+  @override
+  String get backup_unrecognized_unavailable =>
+      'This device cannot list the backup folder you chose, so unrecognized files cannot be found.';
+
+  @override
+  String get backup_unrecognized_ownership_otherDevice => 'Another device';
+
+  @override
+  String get backup_unrecognized_ownership_unattributed => 'Unknown device';
+
+  @override
+  String backup_unrecognized_fileDetail(String size, String date) {
+    return '$size • $date';
+  }
+
+  @override
+  String backup_unrecognized_deleteSelected(int count, String size) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Delete $count files ($size)',
+      one: 'Delete 1 file ($size)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_confirm_title => 'Delete these backup files?';
+
+  @override
+  String backup_unrecognized_confirm_message(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count backup files will be permanently deleted. This cannot be undone.',
+      one: '1 backup file will be permanently deleted. This cannot be undone.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_deleteFailed =>
+      'Could not delete the selected files.';
+
+  @override
+  String backup_unrecognized_freed(String size) {
+    return 'Freed $size';
+  }
+
+  @override
+  String settings_storageUsage_unrecognized_title(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count files not in your backup history',
+      one: '1 file not in your backup history',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settings_storageUsage_unrecognized_action => 'Review';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -37317,4 +37317,88 @@ class AppLocalizationsEs extends AppLocalizations {
     );
     return '$_temp0, $_temp1 - $size (automática)';
   }
+
+  @override
+  String get backup_unrecognized_appBar_title =>
+      'Copias de seguridad no reconocidas';
+
+  @override
+  String get backup_unrecognized_explanation =>
+      'Estos archivos están en tu carpeta de copias de seguridad pero no en el historial de este dispositivo. Aquí solo se puede eliminar un archivo escrito por este dispositivo: cualquier otro podría ser la única copia de otro dispositivo.';
+
+  @override
+  String get backup_unrecognized_empty =>
+      'No hay archivos de copia de seguridad no reconocidos.';
+
+  @override
+  String get backup_unrecognized_loadFailed =>
+      'No se pudo leer la carpeta de copias de seguridad.';
+
+  @override
+  String get backup_unrecognized_unavailable =>
+      'Este dispositivo no puede enumerar la carpeta de copias de seguridad que elegiste, así que no se pueden encontrar archivos no reconocidos.';
+
+  @override
+  String get backup_unrecognized_ownership_otherDevice => 'Otro dispositivo';
+
+  @override
+  String get backup_unrecognized_ownership_unattributed =>
+      'Dispositivo desconocido';
+
+  @override
+  String backup_unrecognized_fileDetail(String size, String date) {
+    return '$size • $date';
+  }
+
+  @override
+  String backup_unrecognized_deleteSelected(int count, String size) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Eliminar $count archivos ($size)',
+      one: 'Eliminar 1 archivo ($size)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_confirm_title =>
+      '¿Eliminar estos archivos de copia de seguridad?';
+
+  @override
+  String backup_unrecognized_confirm_message(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'Se eliminarán permanentemente $count archivos de copia de seguridad. Esta acción no se puede deshacer.',
+      one:
+          'Se eliminará permanentemente 1 archivo de copia de seguridad. Esta acción no se puede deshacer.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_deleteFailed =>
+      'No se pudieron eliminar los archivos seleccionados.';
+
+  @override
+  String backup_unrecognized_freed(String size) {
+    return 'Se liberaron $size';
+  }
+
+  @override
+  String settings_storageUsage_unrecognized_title(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count archivos que no están en tu historial de copias de seguridad',
+      one: '1 archivo que no está en tu historial de copias de seguridad',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settings_storageUsage_unrecognized_action => 'Revisar';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -37373,4 +37373,85 @@ class AppLocalizationsFr extends AppLocalizations {
     );
     return '$_temp0, $_temp1 - $size (auto)';
   }
+
+  @override
+  String get backup_unrecognized_appBar_title => 'Sauvegardes non reconnues';
+
+  @override
+  String get backup_unrecognized_explanation =>
+      'Ces fichiers se trouvent dans votre dossier de sauvegardes mais pas dans l\'historique de sauvegarde de cet appareil. Seul un fichier écrit par cet appareil peut être supprimé ici : tout autre fichier peut être l\'unique copie d\'un autre appareil.';
+
+  @override
+  String get backup_unrecognized_empty =>
+      'Aucun fichier de sauvegarde non reconnu.';
+
+  @override
+  String get backup_unrecognized_loadFailed =>
+      'Impossible de lire le dossier de sauvegardes.';
+
+  @override
+  String get backup_unrecognized_unavailable =>
+      'Cet appareil ne peut pas lister le dossier de sauvegardes que vous avez choisi ; les fichiers non reconnus ne peuvent donc pas être trouvés.';
+
+  @override
+  String get backup_unrecognized_ownership_otherDevice => 'Un autre appareil';
+
+  @override
+  String get backup_unrecognized_ownership_unattributed => 'Appareil inconnu';
+
+  @override
+  String backup_unrecognized_fileDetail(String size, String date) {
+    return '$size • $date';
+  }
+
+  @override
+  String backup_unrecognized_deleteSelected(int count, String size) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Supprimer $count fichiers ($size)',
+      one: 'Supprimer 1 fichier ($size)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_confirm_title =>
+      'Supprimer ces fichiers de sauvegarde ?';
+
+  @override
+  String backup_unrecognized_confirm_message(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count fichiers de sauvegarde seront définitivement supprimés. Cette action est irréversible.',
+      one:
+          '1 fichier de sauvegarde sera définitivement supprimé. Cette action est irréversible.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_deleteFailed =>
+      'Impossible de supprimer les fichiers sélectionnés.';
+
+  @override
+  String backup_unrecognized_freed(String size) {
+    return '$size libéré';
+  }
+
+  @override
+  String settings_storageUsage_unrecognized_title(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count fichiers absents de votre historique de sauvegarde',
+      one: '1 fichier absent de votre historique de sauvegarde',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settings_storageUsage_unrecognized_action => 'Examiner';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -36532,4 +36532,81 @@ class AppLocalizationsHe extends AppLocalizations {
     );
     return '$_temp0, $_temp1 - $size (אוטומטי)';
   }
+
+  @override
+  String get backup_unrecognized_appBar_title => 'גיבויים לא מזוהים';
+
+  @override
+  String get backup_unrecognized_explanation =>
+      'הקבצים האלה נמצאים בתיקיית הגיבויים שלך אך לא בהיסטוריית הגיבויים של המכשיר הזה. אפשר למחוק כאן רק קובץ שהמכשיר הזה כתב: כל קובץ אחר עלול להיות העותק היחיד של מכשיר אחר.';
+
+  @override
+  String get backup_unrecognized_empty => 'אין קובצי גיבוי לא מזוהים.';
+
+  @override
+  String get backup_unrecognized_loadFailed =>
+      'לא ניתן לקרוא את תיקיית הגיבויים.';
+
+  @override
+  String get backup_unrecognized_unavailable =>
+      'המכשיר הזה אינו יכול להציג את תוכן תיקיית הגיבויים שבחרת, ולכן לא ניתן לאתר קבצים לא מזוהים.';
+
+  @override
+  String get backup_unrecognized_ownership_otherDevice => 'מכשיר אחר';
+
+  @override
+  String get backup_unrecognized_ownership_unattributed => 'מכשיר לא ידוע';
+
+  @override
+  String backup_unrecognized_fileDetail(String size, String date) {
+    return '$size • $date';
+  }
+
+  @override
+  String backup_unrecognized_deleteSelected(int count, String size) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'מחיקת $count קבצים ($size)',
+      one: 'מחיקת קובץ אחד ($size)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_confirm_title => 'למחוק את קובצי הגיבוי האלה?';
+
+  @override
+  String backup_unrecognized_confirm_message(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count קובצי גיבוי יימחקו לצמיתות. לא ניתן לבטל את הפעולה.',
+      one: 'קובץ גיבוי אחד יימחק לצמיתות. לא ניתן לבטל את הפעולה.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_deleteFailed =>
+      'לא ניתן היה למחוק את הקבצים שנבחרו.';
+
+  @override
+  String backup_unrecognized_freed(String size) {
+    return '$size פונו';
+  }
+
+  @override
+  String settings_storageUsage_unrecognized_title(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count קבצים שאינם בהיסטוריית הגיבויים שלך',
+      one: 'קובץ אחד שאינו בהיסטוריית הגיבויים שלך',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settings_storageUsage_unrecognized_action => 'בדיקה';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -37116,4 +37116,86 @@ class AppLocalizationsHu extends AppLocalizations {
     );
     return '$_temp0, $_temp1 - $size (automatikus)';
   }
+
+  @override
+  String get backup_unrecognized_appBar_title =>
+      'Ismeretlen biztonsági mentések';
+
+  @override
+  String get backup_unrecognized_explanation =>
+      'Ezek a fájlok a biztonsági mentések mappájában vannak, de nem szerepelnek ennek az eszköznek a mentési előzményeiben. Itt csak olyan fájl törölhető, amelyet ez az eszköz írt: bármi más lehet egy másik eszköz egyetlen másolata.';
+
+  @override
+  String get backup_unrecognized_empty =>
+      'Nincs ismeretlen biztonsági mentési fájl.';
+
+  @override
+  String get backup_unrecognized_loadFailed =>
+      'A biztonsági mentések mappája nem olvasható.';
+
+  @override
+  String get backup_unrecognized_unavailable =>
+      'Ez az eszköz nem tudja kilistázni a kiválasztott mentési mappát, ezért az ismeretlen fájlok nem találhatók meg.';
+
+  @override
+  String get backup_unrecognized_ownership_otherDevice => 'Másik eszköz';
+
+  @override
+  String get backup_unrecognized_ownership_unattributed => 'Ismeretlen eszköz';
+
+  @override
+  String backup_unrecognized_fileDetail(String size, String date) {
+    return '$size • $date';
+  }
+
+  @override
+  String backup_unrecognized_deleteSelected(int count, String size) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count fájl törlése ($size)',
+      one: '1 fájl törlése ($size)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_confirm_title =>
+      'Törli ezeket a biztonsági mentési fájlokat?';
+
+  @override
+  String backup_unrecognized_confirm_message(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count biztonsági mentési fájl véglegesen törlődik. A művelet nem vonható vissza.',
+      one:
+          '1 biztonsági mentési fájl véglegesen törlődik. A művelet nem vonható vissza.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_deleteFailed =>
+      'A kiválasztott fájlok törlése nem sikerült.';
+
+  @override
+  String backup_unrecognized_freed(String size) {
+    return '$size felszabadítva';
+  }
+
+  @override
+  String settings_storageUsage_unrecognized_title(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count fájl hiányzik a mentési előzményekből',
+      one: '1 fájl hiányzik a mentési előzményekből',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settings_storageUsage_unrecognized_action => 'Áttekintés';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -37269,4 +37269,87 @@ class AppLocalizationsIt extends AppLocalizations {
     );
     return '$_temp0, $_temp1 - $size (auto)';
   }
+
+  @override
+  String get backup_unrecognized_appBar_title => 'Backup non riconosciuti';
+
+  @override
+  String get backup_unrecognized_explanation =>
+      'Questi file si trovano nella cartella dei backup ma non nella cronologia dei backup di questo dispositivo. Qui può essere eliminato solo un file scritto da questo dispositivo: qualsiasi altro potrebbe essere l\'unica copia di un altro dispositivo.';
+
+  @override
+  String get backup_unrecognized_empty =>
+      'Nessun file di backup non riconosciuto.';
+
+  @override
+  String get backup_unrecognized_loadFailed =>
+      'Impossibile leggere la cartella dei backup.';
+
+  @override
+  String get backup_unrecognized_unavailable =>
+      'Questo dispositivo non può elencare la cartella dei backup che hai scelto, quindi i file non riconosciuti non possono essere trovati.';
+
+  @override
+  String get backup_unrecognized_ownership_otherDevice =>
+      'Un altro dispositivo';
+
+  @override
+  String get backup_unrecognized_ownership_unattributed =>
+      'Dispositivo sconosciuto';
+
+  @override
+  String backup_unrecognized_fileDetail(String size, String date) {
+    return '$size • $date';
+  }
+
+  @override
+  String backup_unrecognized_deleteSelected(int count, String size) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Elimina $count file ($size)',
+      one: 'Elimina 1 file ($size)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_confirm_title =>
+      'Eliminare questi file di backup?';
+
+  @override
+  String backup_unrecognized_confirm_message(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count file di backup saranno eliminati definitivamente. L\'operazione non può essere annullata.',
+      one:
+          '1 file di backup sarà eliminato definitivamente. L\'operazione non può essere annullata.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_deleteFailed =>
+      'Impossibile eliminare i file selezionati.';
+
+  @override
+  String backup_unrecognized_freed(String size) {
+    return 'Liberati $size';
+  }
+
+  @override
+  String settings_storageUsage_unrecognized_title(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count file non presenti nella cronologia dei backup',
+      one: '1 file non presente nella cronologia dei backup',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settings_storageUsage_unrecognized_action => 'Esamina';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -37018,4 +37018,84 @@ class AppLocalizationsNl extends AppLocalizations {
     );
     return '$_temp0, $_temp1 - $size (automatisch)';
   }
+
+  @override
+  String get backup_unrecognized_appBar_title => 'Niet-herkende back-ups';
+
+  @override
+  String get backup_unrecognized_explanation =>
+      'Deze bestanden staan in je back-upmap maar niet in de back-upgeschiedenis van dit apparaat. Alleen een bestand dat dit apparaat heeft geschreven kan hier worden verwijderd: al het andere kan de enige kopie van een ander apparaat zijn.';
+
+  @override
+  String get backup_unrecognized_empty =>
+      'Geen niet-herkende back-upbestanden.';
+
+  @override
+  String get backup_unrecognized_loadFailed => 'Kon de back-upmap niet lezen.';
+
+  @override
+  String get backup_unrecognized_unavailable =>
+      'Dit apparaat kan de gekozen back-upmap niet uitlezen, dus niet-herkende bestanden kunnen niet worden gevonden.';
+
+  @override
+  String get backup_unrecognized_ownership_otherDevice => 'Ander apparaat';
+
+  @override
+  String get backup_unrecognized_ownership_unattributed => 'Onbekend apparaat';
+
+  @override
+  String backup_unrecognized_fileDetail(String size, String date) {
+    return '$size • $date';
+  }
+
+  @override
+  String backup_unrecognized_deleteSelected(int count, String size) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count bestanden verwijderen ($size)',
+      one: '1 bestand verwijderen ($size)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_confirm_title =>
+      'Deze back-upbestanden verwijderen?';
+
+  @override
+  String backup_unrecognized_confirm_message(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count back-upbestanden worden permanent verwijderd. Dit kan niet ongedaan worden gemaakt.',
+      one:
+          '1 back-upbestand wordt permanent verwijderd. Dit kan niet ongedaan worden gemaakt.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_deleteFailed =>
+      'Kon de geselecteerde bestanden niet verwijderen.';
+
+  @override
+  String backup_unrecognized_freed(String size) {
+    return '$size vrijgemaakt';
+  }
+
+  @override
+  String settings_storageUsage_unrecognized_title(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count bestanden ontbreken in je back-upgeschiedenis',
+      one: '1 bestand ontbreekt in je back-upgeschiedenis',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settings_storageUsage_unrecognized_action => 'Bekijken';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -37282,4 +37282,88 @@ class AppLocalizationsPt extends AppLocalizations {
     );
     return '$_temp0, $_temp1 - $size (automático)';
   }
+
+  @override
+  String get backup_unrecognized_appBar_title =>
+      'Cópias de segurança não reconhecidas';
+
+  @override
+  String get backup_unrecognized_explanation =>
+      'Estes ficheiros estão na sua pasta de cópias de segurança mas não no histórico deste dispositivo. Só pode ser excluído aqui um ficheiro escrito por este dispositivo: qualquer outro pode ser a única cópia de outro dispositivo.';
+
+  @override
+  String get backup_unrecognized_empty =>
+      'Não há ficheiros de cópia de segurança não reconhecidos.';
+
+  @override
+  String get backup_unrecognized_loadFailed =>
+      'Não foi possível ler a pasta de cópias de segurança.';
+
+  @override
+  String get backup_unrecognized_unavailable =>
+      'Este dispositivo não consegue listar a pasta de cópias de segurança que escolheu, por isso não é possível encontrar ficheiros não reconhecidos.';
+
+  @override
+  String get backup_unrecognized_ownership_otherDevice => 'Outro dispositivo';
+
+  @override
+  String get backup_unrecognized_ownership_unattributed =>
+      'Dispositivo desconhecido';
+
+  @override
+  String backup_unrecognized_fileDetail(String size, String date) {
+    return '$size • $date';
+  }
+
+  @override
+  String backup_unrecognized_deleteSelected(int count, String size) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Excluir $count ficheiros ($size)',
+      one: 'Excluir 1 ficheiro ($size)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_confirm_title =>
+      'Excluir estes ficheiros de cópia de segurança?';
+
+  @override
+  String backup_unrecognized_confirm_message(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count ficheiros de cópia de segurança serão excluídos permanentemente. Não é possível anular.',
+      one:
+          '1 ficheiro de cópia de segurança será excluído permanentemente. Não é possível anular.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_deleteFailed =>
+      'Não foi possível excluir os ficheiros selecionados.';
+
+  @override
+  String backup_unrecognized_freed(String size) {
+    return '$size libertados';
+  }
+
+  @override
+  String settings_storageUsage_unrecognized_title(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count ficheiros que não estão no seu histórico de cópias de segurança',
+      one: '1 ficheiro que não está no seu histórico de cópias de segurança',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settings_storageUsage_unrecognized_action => 'Rever';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -35085,4 +35085,79 @@ class AppLocalizationsZh extends AppLocalizations {
     );
     return '$_temp0, $_temp1 - $size（自动）';
   }
+
+  @override
+  String get backup_unrecognized_appBar_title => '无法识别的备份';
+
+  @override
+  String get backup_unrecognized_explanation =>
+      '这些文件位于您的备份文件夹中，但不在本设备的备份历史记录内。此处只能删除本设备写入的文件：其他文件可能是另一台设备的唯一副本。';
+
+  @override
+  String get backup_unrecognized_empty => '没有无法识别的备份文件。';
+
+  @override
+  String get backup_unrecognized_loadFailed => '无法读取备份文件夹。';
+
+  @override
+  String get backup_unrecognized_unavailable =>
+      '本设备无法列出您选择的备份文件夹，因此找不到无法识别的文件。';
+
+  @override
+  String get backup_unrecognized_ownership_otherDevice => '其他设备';
+
+  @override
+  String get backup_unrecognized_ownership_unattributed => '未知设备';
+
+  @override
+  String backup_unrecognized_fileDetail(String size, String date) {
+    return '$size • $date';
+  }
+
+  @override
+  String backup_unrecognized_deleteSelected(int count, String size) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '删除 $count 个文件（$size）',
+      one: '删除 1 个文件（$size）',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_confirm_title => '删除这些备份文件？';
+
+  @override
+  String backup_unrecognized_confirm_message(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '将永久删除 $count 个备份文件。此操作无法撤销。',
+      one: '将永久删除 1 个备份文件。此操作无法撤销。',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get backup_unrecognized_deleteFailed => '无法删除所选文件。';
+
+  @override
+  String backup_unrecognized_freed(String size) {
+    return '已释放 $size';
+  }
+
+  @override
+  String settings_storageUsage_unrecognized_title(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 个文件不在您的备份历史记录中',
+      one: '1 个文件不在您的备份历史记录中',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settings_storageUsage_unrecognized_action => '查看';
 }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -10890,5 +10890,20 @@
   "startup_versionMismatch_restore_warning": "Alles wat je na de upgrade hebt gelogd, bestaat alleen in het nieuwere bestand. Dat bestand wordt bewaard als vastgezette back-up, dus je krijgt het terug door de nieuwere versie opnieuw te installeren.",
   "backup_history_preDowngradeSubtitle": "Nieuwere database, bewaard bij het teruggaan - {size}",
   "backup_history_manualSubtitle": "{diveCount, plural, =1{1 duik} other{{diveCount} duiken}}, {siteCount, plural, =1{1 duikstek} other{{siteCount} duikstekken}} - {size}",
-  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 duik} other{{diveCount} duiken}}, {siteCount, plural, =1{1 duikstek} other{{siteCount} duikstekken}} - {size} (automatisch)"
+  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 duik} other{{diveCount} duiken}}, {siteCount, plural, =1{1 duikstek} other{{siteCount} duikstekken}} - {size} (automatisch)",
+  "backup_unrecognized_appBar_title": "Niet-herkende back-ups",
+  "backup_unrecognized_explanation": "Deze bestanden staan in je back-upmap maar niet in de back-upgeschiedenis van dit apparaat. Alleen een bestand dat dit apparaat heeft geschreven kan hier worden verwijderd: al het andere kan de enige kopie van een ander apparaat zijn.",
+  "backup_unrecognized_empty": "Geen niet-herkende back-upbestanden.",
+  "backup_unrecognized_loadFailed": "Kon de back-upmap niet lezen.",
+  "backup_unrecognized_unavailable": "Dit apparaat kan de gekozen back-upmap niet uitlezen, dus niet-herkende bestanden kunnen niet worden gevonden.",
+  "backup_unrecognized_ownership_otherDevice": "Ander apparaat",
+  "backup_unrecognized_ownership_unattributed": "Onbekend apparaat",
+  "backup_unrecognized_fileDetail": "{size} • {date}",
+  "backup_unrecognized_deleteSelected": "{count, plural, =1{1 bestand verwijderen ({size})} other{{count} bestanden verwijderen ({size})}}",
+  "backup_unrecognized_confirm_title": "Deze back-upbestanden verwijderen?",
+  "backup_unrecognized_confirm_message": "{count, plural, =1{1 back-upbestand wordt permanent verwijderd. Dit kan niet ongedaan worden gemaakt.} other{{count} back-upbestanden worden permanent verwijderd. Dit kan niet ongedaan worden gemaakt.}}",
+  "backup_unrecognized_deleteFailed": "Kon de geselecteerde bestanden niet verwijderen.",
+  "backup_unrecognized_freed": "{size} vrijgemaakt",
+  "settings_storageUsage_unrecognized_title": "{count, plural, =1{1 bestand ontbreekt in je back-upgeschiedenis} other{{count} bestanden ontbreken in je back-upgeschiedenis}}",
+  "settings_storageUsage_unrecognized_action": "Bekijken"
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -10890,5 +10890,20 @@
   "startup_versionMismatch_restore_warning": "Tudo o que registaste depois da atualização existe apenas no ficheiro mais recente. Esse ficheiro fica guardado como cópia fixada, por isso instalar de novo a versão mais recente recupera-o.",
   "backup_history_preDowngradeSubtitle": "Base de dados mais recente, guardada ao recuar - {size}",
   "backup_history_manualSubtitle": "{diveCount, plural, =1{1 mergulho} other{{diveCount} mergulhos}}, {siteCount, plural, =1{1 local} other{{siteCount} locais}} - {size}",
-  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 mergulho} other{{diveCount} mergulhos}}, {siteCount, plural, =1{1 local} other{{siteCount} locais}} - {size} (automático)"
+  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{1 mergulho} other{{diveCount} mergulhos}}, {siteCount, plural, =1{1 local} other{{siteCount} locais}} - {size} (automático)",
+  "backup_unrecognized_appBar_title": "Cópias de segurança não reconhecidas",
+  "backup_unrecognized_explanation": "Estes ficheiros estão na sua pasta de cópias de segurança mas não no histórico deste dispositivo. Só pode ser excluído aqui um ficheiro escrito por este dispositivo: qualquer outro pode ser a única cópia de outro dispositivo.",
+  "backup_unrecognized_empty": "Não há ficheiros de cópia de segurança não reconhecidos.",
+  "backup_unrecognized_loadFailed": "Não foi possível ler a pasta de cópias de segurança.",
+  "backup_unrecognized_unavailable": "Este dispositivo não consegue listar a pasta de cópias de segurança que escolheu, por isso não é possível encontrar ficheiros não reconhecidos.",
+  "backup_unrecognized_ownership_otherDevice": "Outro dispositivo",
+  "backup_unrecognized_ownership_unattributed": "Dispositivo desconhecido",
+  "backup_unrecognized_fileDetail": "{size} • {date}",
+  "backup_unrecognized_deleteSelected": "{count, plural, =1{Excluir 1 ficheiro ({size})} other{Excluir {count} ficheiros ({size})}}",
+  "backup_unrecognized_confirm_title": "Excluir estes ficheiros de cópia de segurança?",
+  "backup_unrecognized_confirm_message": "{count, plural, =1{1 ficheiro de cópia de segurança será excluído permanentemente. Não é possível anular.} other{{count} ficheiros de cópia de segurança serão excluídos permanentemente. Não é possível anular.}}",
+  "backup_unrecognized_deleteFailed": "Não foi possível excluir os ficheiros selecionados.",
+  "backup_unrecognized_freed": "{size} libertados",
+  "settings_storageUsage_unrecognized_title": "{count, plural, =1{1 ficheiro que não está no seu histórico de cópias de segurança} other{{count} ficheiros que não estão no seu histórico de cópias de segurança}}",
+  "settings_storageUsage_unrecognized_action": "Rever"
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -10890,5 +10890,20 @@
   "startup_versionMismatch_restore_warning": "升级之后记录的内容只存在于较新的文件中。该文件会作为已固定的备份保留，重新安装较新版本即可取回。",
   "backup_history_preDowngradeSubtitle": "较新的数据库，回退时保留 - {size}",
   "backup_history_manualSubtitle": "{diveCount, plural, =1{{diveCount} 次潜水} other{{diveCount} 次潜水}}, {siteCount, plural, =1{{siteCount} 个潜点} other{{siteCount} 个潜点}} - {size}",
-  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{{diveCount} 次潜水} other{{diveCount} 次潜水}}, {siteCount, plural, =1{{siteCount} 个潜点} other{{siteCount} 个潜点}} - {size}（自动）"
+  "backup_history_manualSubtitleAuto": "{diveCount, plural, =1{{diveCount} 次潜水} other{{diveCount} 次潜水}}, {siteCount, plural, =1{{siteCount} 个潜点} other{{siteCount} 个潜点}} - {size}（自动）",
+  "backup_unrecognized_appBar_title": "无法识别的备份",
+  "backup_unrecognized_explanation": "这些文件位于您的备份文件夹中，但不在本设备的备份历史记录内。此处只能删除本设备写入的文件：其他文件可能是另一台设备的唯一副本。",
+  "backup_unrecognized_empty": "没有无法识别的备份文件。",
+  "backup_unrecognized_loadFailed": "无法读取备份文件夹。",
+  "backup_unrecognized_unavailable": "本设备无法列出您选择的备份文件夹，因此找不到无法识别的文件。",
+  "backup_unrecognized_ownership_otherDevice": "其他设备",
+  "backup_unrecognized_ownership_unattributed": "未知设备",
+  "backup_unrecognized_fileDetail": "{size} • {date}",
+  "backup_unrecognized_deleteSelected": "{count, plural, =1{删除 1 个文件（{size}）} other{删除 {count} 个文件（{size}）}}",
+  "backup_unrecognized_confirm_title": "删除这些备份文件？",
+  "backup_unrecognized_confirm_message": "{count, plural, =1{将永久删除 1 个备份文件。此操作无法撤销。} other{将永久删除 {count} 个备份文件。此操作无法撤销。}}",
+  "backup_unrecognized_deleteFailed": "无法删除所选文件。",
+  "backup_unrecognized_freed": "已释放 {size}",
+  "settings_storageUsage_unrecognized_title": "{count, plural, =1{1 个文件不在您的备份历史记录中} other{{count} 个文件不在您的备份历史记录中}}",
+  "settings_storageUsage_unrecognized_action": "查看"
 }

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -17,6 +17,7 @@ import 'package:submersion/features/safety/presentation/pages/no_fly_page.dart';
 import 'package:submersion/features/settings/presentation/pages/section_appearance_page.dart';
 import 'package:submersion/features/statistics/presentation/providers/statistics_filter_provider.dart';
 import 'package:submersion/features/settings/presentation/pages/settings_page.dart';
+import 'package:submersion/features/settings/presentation/widgets/unrecognized_backups_notice.dart';
 import 'package:submersion/features/settings/presentation/pages/column_config_page.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
@@ -75,6 +76,33 @@ List<String> _orderedRoutePaths(List<RouteBase> routes) => [
     ..._orderedRoutePaths(route.routes),
   ],
 ];
+
+/// The location a named route resolves to, assembled from its ancestors.
+///
+/// A nested GoRoute stores only its own segment, so a widget that pushes a
+/// hand-written absolute path can drift from the tree without any test
+/// noticing until the push fails at runtime.
+String? _locationOfRoute(
+  List<RouteBase> routes,
+  String name, [
+  String prefix = '',
+]) {
+  for (final route in routes) {
+    if (route is GoRoute) {
+      final here = route.path.startsWith('/')
+          ? route.path
+          : '${prefix == '/' ? '' : prefix}/${route.path}';
+      if (route.name == name) return here;
+      final found = _locationOfRoute(route.routes, name, here);
+      if (found != null) return found;
+    }
+    if (route is ShellRoute) {
+      final found = _locationOfRoute(route.routes, name, prefix);
+      if (found != null) return found;
+    }
+  }
+  return null;
+}
 
 void main() {
   late GoRouter router;
@@ -1189,6 +1217,18 @@ void main() {
             'it must not animate the way a pushed page does.',
       );
       expect((page as NoTransitionPage).child, isA<SpeciesPage>());
+    });
+  });
+
+  group('storage usage', () {
+    test('the unrecognized backups page is reachable at the pushed path', () {
+      // UnrecognizedBackupsNotice pushes an absolute location. Nothing else
+      // ties that string to the route tree, so a rename on either side is a
+      // runtime "no routes for location" and nothing before that.
+      expect(
+        _locationOfRoute(router.configuration.routes, 'unrecognizedBackups'),
+        UnrecognizedBackupsNotice.routeLocation,
+      );
     });
   });
 }

--- a/test/features/backup/data/services/backups_directory_access_test.dart
+++ b/test/features/backup/data/services/backups_directory_access_test.dart
@@ -85,9 +85,16 @@ void main() {
       SharedPreferences.setMockInitialValues({});
       documents = await Directory.systemTemp.createTemp('live_access_test');
       PathProviderPlatform.instance = _FakePathProvider(documents.path);
+      // Pinned rather than inherited. isSupported is
+      // `Platform.isIOS || Platform.isMacOS`, so a test that leaves it to the
+      // host exercises the Apple branch on a developer's Mac and the non-Apple
+      // branch on a Linux CI runner, which is how the bookmark assertion below
+      // passed locally and failed on shard 4.
+      BackupBookmarkService.debugSupportedOverride = false;
     });
 
     tearDown(() async {
+      BackupBookmarkService.debugSupportedOverride = null;
       if (documents.existsSync()) await documents.delete(recursive: true);
     });
 
@@ -106,9 +113,31 @@ void main() {
       },
     );
 
+    test('a custom location without bookmark support is used as-is', () async {
+      // Linux and Windows desktop, and Android with a plain filesystem path.
+      // Left to the host this branch never runs on a developer's Mac.
+      final custom = await Directory.systemTemp.createTemp('plain_backups');
+      addTearDown(() async {
+        if (custom.existsSync()) await custom.delete(recursive: true);
+      });
+      final prefs = await preferences();
+      await prefs.setBackupLocation(custom.path);
+      await prefs.setBackupLocationBookmark([1, 2, 3]);
+      final port = _FakeBookmarkPort(null);
+
+      final seen = await BackupsDirectoryAccess.live(
+        prefs,
+        bookmarks: port,
+      ).use((path) async => path);
+
+      expect(seen, custom.path);
+      expect(port.resolveCalls, 0);
+    });
+
     test(
       'a custom Apple location is armed and released as a scoped resource',
       () async {
+        BackupBookmarkService.debugSupportedOverride = true;
         // The reason this factory exists rather than a plain path callback. On
         // Apple platforms a custom location is only reachable while its
         // security-scoped bookmark is held, so a factory wired to the unleased

--- a/test/features/backup/data/services/backups_directory_access_test.dart
+++ b/test/features/backup/data/services/backups_directory_access_test.dart
@@ -79,11 +79,16 @@ void main() {
     // that arms an Apple security-scoped bookmark, and nothing else asserts
     // that binding.
     late Directory documents;
+    late PathProviderPlatform realPathProvider;
 
     setUp(() async {
       TestWidgetsFlutterBinding.ensureInitialized();
       SharedPreferences.setMockInitialValues({});
       documents = await Directory.systemTemp.createTemp('live_access_test');
+      // Restored in tearDown: the instance is a global, and the fake points at
+      // a temp directory this group deletes. Leaving it installed hands any
+      // later test in this isolate a documents path that no longer exists.
+      realPathProvider = PathProviderPlatform.instance;
       PathProviderPlatform.instance = _FakePathProvider(documents.path);
       // Pinned rather than inherited. isSupported is
       // `Platform.isIOS || Platform.isMacOS`, so a test that leaves it to the
@@ -95,6 +100,7 @@ void main() {
 
     tearDown(() async {
       BackupBookmarkService.debugSupportedOverride = null;
+      PathProviderPlatform.instance = realPathProvider;
       if (documents.existsSync()) await documents.delete(recursive: true);
     });
 

--- a/test/features/backup/data/services/backups_directory_access_test.dart
+++ b/test/features/backup/data/services/backups_directory_access_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/data/services/backups_directory_access.dart';
+
+/// The scan and the reclaim both need the backups directory held open for the
+/// whole operation, which is a different requirement from slice A's
+/// measurement: on Apple platforms a custom location is only reachable while
+/// its security-scoped bookmark lease is held, and a lease that outlives the
+/// work leaks a scoped resource.
+void main() {
+  BackupDirLease countingLease(String path, void Function() onRelease) =>
+      BackupDirLease(path, () async => onRelease());
+
+  test('a SAF location has no directory to enumerate', () async {
+    final access = BackupsDirectoryAccess(
+      configuredLocation: () async =>
+          'content://com.android.externalstorage.documents/tree/primary%3ABackups',
+      acquireLease: () async =>
+          fail('a content:// tree URI must not resolve to a filesystem lease'),
+    );
+
+    expect(await access.use((path) async => path), isNull);
+  });
+
+  test(
+    'a filesystem location is handed to the body as its leased path',
+    () async {
+      final access = BackupsDirectoryAccess(
+        configuredLocation: () async => null,
+        acquireLease: () async => countingLease('/backups', () {}),
+      );
+
+      expect(await access.use((path) async => path), '/backups');
+    },
+  );
+
+  test('the lease is released once the body completes', () async {
+    var released = 0;
+    final access = BackupsDirectoryAccess(
+      configuredLocation: () async => null,
+      acquireLease: () async => countingLease('/backups', () => released++),
+    );
+
+    await access.use((path) async => null);
+
+    expect(released, 1);
+  });
+
+  test('the lease is released when the body throws', () async {
+    var released = 0;
+    final access = BackupsDirectoryAccess(
+      configuredLocation: () async => null,
+      acquireLease: () async => countingLease('/backups', () => released++),
+    );
+
+    await expectLater(
+      access.use((path) async => throw const FileSystemException('boom')),
+      throwsA(isA<FileSystemException>()),
+    );
+
+    expect(released, 1);
+  });
+}

--- a/test/features/backup/data/services/backups_directory_access_test.dart
+++ b/test/features/backup/data/services/backups_directory_access_test.dart
@@ -1,6 +1,14 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/services/backup_bookmark_service.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 
 import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/data/services/backups_directory_access.dart';
@@ -63,4 +71,113 @@ void main() {
 
     expect(released, 1);
   });
+
+  group('the live factory', () {
+    // Every test above injects both callbacks, which exercises the policy and
+    // none of the wiring. This is the seam where a mistake is invisible: the
+    // production path binds to resolveBackupsDirectoryLeased, the only call
+    // that arms an Apple security-scoped bookmark, and nothing else asserts
+    // that binding.
+    late Directory documents;
+
+    setUp(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      SharedPreferences.setMockInitialValues({});
+      documents = await Directory.systemTemp.createTemp('live_access_test');
+      PathProviderPlatform.instance = _FakePathProvider(documents.path);
+    });
+
+    tearDown(() async {
+      if (documents.existsSync()) await documents.delete(recursive: true);
+    });
+
+    Future<BackupPreferences> preferences() async =>
+        BackupPreferences(await SharedPreferences.getInstance());
+
+    test(
+      'an unconfigured location resolves the leased sandbox default',
+      () async {
+        final access = BackupsDirectoryAccess.live(await preferences());
+
+        expect(
+          await access.use((path) async => path),
+          p.join(documents.path, 'Submersion', 'Backups'),
+        );
+      },
+    );
+
+    test(
+      'a custom Apple location is armed and released as a scoped resource',
+      () async {
+        // The reason this factory exists rather than a plain path callback. On
+        // Apple platforms a custom location is only reachable while its
+        // security-scoped bookmark is held, so a factory wired to the unleased
+        // resolver would list nothing and delete nothing on exactly the
+        // configuration a diver is most likely to have chosen deliberately.
+        final custom = await Directory.systemTemp.createTemp('custom_backups');
+        addTearDown(() async {
+          if (custom.existsSync()) await custom.delete(recursive: true);
+        });
+        final prefs = await preferences();
+        await prefs.setBackupLocation(custom.path);
+        await prefs.setBackupLocationBookmark([1, 2, 3]);
+        final port = _FakeBookmarkPort(
+          BackupBookmarkLease(
+            ref: 'scoped-ref',
+            path: custom.path,
+            isStale: false,
+          ),
+        );
+
+        final seen = await BackupsDirectoryAccess.live(
+          prefs,
+          bookmarks: port,
+        ).use((path) async => path);
+
+        expect(seen, custom.path);
+        expect(port.resolveCalls, 1);
+        expect(port.released, ['scoped-ref']);
+      },
+    );
+
+    test('a SAF location resolves to no directory', () async {
+      final prefs = await preferences();
+      await prefs.setBackupLocation('content://com.android.providers/tree/x');
+
+      expect(
+        await BackupsDirectoryAccess.live(prefs).use((path) async => path),
+        isNull,
+      );
+    });
+  });
+}
+
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.documentsPath);
+
+  final String documentsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+}
+
+class _FakeBookmarkPort implements BackupBookmarkPort {
+  _FakeBookmarkPort(this.resolveResult);
+
+  final BackupBookmarkLease? resolveResult;
+  final List<String> released = [];
+  int resolveCalls = 0;
+
+  @override
+  Future<BackupBookmarkLease?> resolve(Uint8List data) async {
+    resolveCalls++;
+    return resolveResult;
+  }
+
+  @override
+  Future<void> release(String ref) async => released.add(ref);
+
+  @override
+  Future<Uint8List?> createBookmark(String path) async => null;
 }

--- a/test/features/backup/data/services/backups_directory_access_test.dart
+++ b/test/features/backup/data/services/backups_directory_access_test.dart
@@ -140,6 +140,35 @@ void main() {
       },
     );
 
+    test('scanning does not create the sandbox backups folder', () async {
+      // The scan runs whenever the Storage usage page is opened. Slice A
+      // already learned this one: resolveDefaultBackupsDirectory CREATES the
+      // directory, so a measurement surface that resolves it by value mints a
+      // Submersion/Backups folder for users whose backups live elsewhere.
+      await BackupsDirectoryAccess.live(await preferences()).use((_) async {});
+
+      expect(
+        Directory(p.join(documents.path, 'Submersion', 'Backups')).existsSync(),
+        isFalse,
+      );
+    });
+
+    test('an unreachable custom location is not cleared', () async {
+      // resolveBackupsDirectoryLeased self-heals a dead location by clearing
+      // it, which is right for the write path: a backup has to land somewhere.
+      // Reading must not do it. An unmounted share is unreachable for as long
+      // as it is unmounted, and opening a settings page in that window would
+      // silently point every future backup at the sandbox instead of the
+      // folder the diver chose.
+      final prefs = await preferences();
+      final unreachable = p.join(documents.path, 'unmounted-share', 'Backups');
+      await prefs.setBackupLocation(unreachable);
+
+      await BackupsDirectoryAccess.live(prefs).use((_) async {});
+
+      expect(prefs.getSettings().backupLocation, unreachable);
+    });
+
     test('a SAF location resolves to no directory', () async {
       final prefs = await preferences();
       await prefs.setBackupLocation('content://com.android.providers/tree/x');

--- a/test/features/backup/data/services/orphaned_backup_scan_test.dart
+++ b/test/features/backup/data/services/orphaned_backup_scan_test.dart
@@ -1,0 +1,195 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:submersion/features/backup/data/services/backup_attribution.dart';
+import 'package:submersion/features/backup/data/services/orphaned_backup_scan.dart';
+
+void main() {
+  const thisDevice = '9f8e7d6c-1111-2222-3333-444455556666';
+  const otherDevice = '0a1b2c3d-1111-2222-3333-444455556666';
+
+  late Directory backups;
+
+  setUp(() async {
+    backups = await Directory.systemTemp.createTemp('orphan_backup_test');
+  });
+
+  tearDown(() async {
+    if (backups.existsSync()) await backups.delete(recursive: true);
+  });
+
+  Future<String> writeBackup({
+    required String deviceId,
+    required String timestamp,
+    int bytes = 100,
+    String extension = '.db',
+  }) async {
+    final name = buildBackupFilename(
+      timestamp: timestamp,
+      deviceId: deviceId,
+      extension: extension,
+    );
+    final file = File(p.join(backups.path, name));
+    await file.writeAsBytes(List<int>.filled(bytes, 0));
+    return file.path;
+  }
+
+  Future<String> writeRaw(String name, {int bytes = 100}) async {
+    final file = File(p.join(backups.path, name));
+    await file.writeAsBytes(List<int>.filled(bytes, 0));
+    return file.path;
+  }
+
+  OrphanedBackupScan build({Set<String> known = const {}}) =>
+      OrphanedBackupScan(
+        backupsDirectory: () async => backups.path,
+        knownPaths: () async => known,
+        thisDeviceId: () async => thisDevice,
+      );
+
+  test('a backup still in the history is not unrecognized', () async {
+    final path = await writeBackup(
+      deviceId: thisDevice,
+      timestamp: '2026-08-31_120000',
+    );
+
+    final found = await build(known: {path}).find();
+
+    expect(found, isEmpty);
+  });
+
+  test('this device\'s forgotten backup is reclaimable', () async {
+    final path = await writeBackup(
+      deviceId: thisDevice,
+      timestamp: '2026-08-31_120000',
+      bytes: 512,
+    );
+
+    final found = await build().find();
+
+    expect(found, hasLength(1));
+    expect(found.single.path, path);
+    expect(found.single.sizeBytes, 512);
+    expect(found.single.ownership, BackupOwnership.thisDevice);
+    expect(found.single.isReclaimable, isTrue);
+  });
+
+  test('another device\'s backup is listed but never reclaimable', () async {
+    // The hazard: in a shared Dropbox or Drive folder this file is absent from
+    // our history because it was never ours, not because it was forgotten.
+    await writeBackup(deviceId: otherDevice, timestamp: '2026-08-31_120000');
+
+    final found = await build().find();
+
+    expect(found, hasLength(1));
+    expect(found.single.ownership, BackupOwnership.otherDevice);
+    expect(found.single.isReclaimable, isFalse);
+  });
+
+  test('a legacy backup is listed but never reclaimable', () async {
+    await writeRaw('submersion_backup_2026-08-31_120000.db');
+
+    final found = await build().find();
+
+    expect(found.single.ownership, BackupOwnership.unattributed);
+    expect(found.single.isReclaimable, isFalse);
+  });
+
+  test('encrypted backups are scanned too', () async {
+    await writeBackup(
+      deviceId: thisDevice,
+      timestamp: '2026-08-31_120000',
+      extension: '.sbe',
+    );
+
+    final found = await build().find();
+
+    expect(found.single.isReclaimable, isTrue);
+  });
+
+  test('non-backup files in the folder are ignored entirely', () async {
+    await writeRaw('holiday_photos.zip');
+    await writeRaw('notes.txt');
+    await writeRaw('.hidden_backup.db.tmp');
+
+    final found = await build().find();
+
+    expect(found, isEmpty);
+  });
+
+  test('a directory that cannot be enumerated yields nothing', () async {
+    final scan = OrphanedBackupScan(
+      backupsDirectory: () async => null,
+      knownPaths: () async => const {},
+      thisDeviceId: () async => thisDevice,
+    );
+
+    expect(await scan.find(), isEmpty);
+  });
+
+  group('reclaim', () {
+    test('deletes this device\'s files and reports the bytes', () async {
+      final path = await writeBackup(
+        deviceId: thisDevice,
+        timestamp: '2026-08-31_120000',
+        bytes: 700,
+      );
+      final scan = build();
+      final found = await scan.find();
+
+      final bytes = await scan.reclaim(found);
+
+      expect(bytes, 700);
+      expect(File(path).existsSync(), isFalse);
+    });
+
+    test('refuses another device\'s file even when handed one', () async {
+      // Defence in depth. The UI never offers these, but reclaim is the last
+      // gate before an irreversible delete, so it re-checks rather than
+      // trusting its caller.
+      final path = await writeBackup(
+        deviceId: otherDevice,
+        timestamp: '2026-08-31_120000',
+      );
+      final scan = build();
+      final found = await scan.find();
+
+      final bytes = await scan.reclaim(found);
+
+      expect(bytes, 0);
+      expect(File(path).existsSync(), isTrue);
+    });
+
+    test('refuses a legacy file even when handed one', () async {
+      final path = await writeRaw('submersion_backup_2026-08-31_120000.db');
+      final scan = build();
+      final found = await scan.find();
+
+      final bytes = await scan.reclaim(found);
+
+      expect(bytes, 0);
+      expect(File(path).existsSync(), isTrue);
+    });
+
+    test('reclaims only the safe files from a mixed selection', () async {
+      final mine = await writeBackup(
+        deviceId: thisDevice,
+        timestamp: '2026-08-31_120000',
+        bytes: 300,
+      );
+      final theirs = await writeBackup(
+        deviceId: otherDevice,
+        timestamp: '2026-08-31_130000',
+        bytes: 900,
+      );
+      final scan = build();
+
+      final bytes = await scan.reclaim(await scan.find());
+
+      expect(bytes, 300);
+      expect(File(mine).existsSync(), isFalse);
+      expect(File(theirs).existsSync(), isTrue);
+    });
+  });
+}

--- a/test/features/backup/data/services/orphaned_backup_scan_test.dart
+++ b/test/features/backup/data/services/orphaned_backup_scan_test.dart
@@ -154,6 +154,66 @@ void main() {
     expect(await scan.reclaim(found), 4096);
   });
 
+  group('reclaim re-derives its own permission to delete', () {
+    // isReclaimable reads a field computed when the directory was listed.
+    // Re-reading it is not a re-check, so these three cases hand reclaim an
+    // entry that claims to be reclaimable and confirm it decides for itself.
+    UnrecognizedBackup claiming(String path) => UnrecognizedBackup(
+      path: path,
+      sizeBytes: 100,
+      modified: DateTime(2026, 9, 1),
+      ownership: BackupOwnership.thisDevice,
+    );
+
+    test('a file outside the backups directory is refused', () async {
+      final elsewhere = await Directory.systemTemp.createTemp('not_backups');
+      addTearDown(() async {
+        if (elsewhere.existsSync()) await elsewhere.delete(recursive: true);
+      });
+      final outsider = File(
+        p.join(
+          elsewhere.path,
+          buildBackupFilename(
+            timestamp: '2026-09-01_1200',
+            deviceId: thisDevice,
+          ),
+        ),
+      );
+      await outsider.writeAsBytes(List<int>.filled(100, 0));
+
+      expect(await build().reclaim([claiming(outsider.path)]), 0);
+      expect(outsider.existsSync(), isTrue);
+    });
+
+    test('a name tagged for another device is refused', () async {
+      final path = await writeBackup(
+        deviceId: otherDevice,
+        timestamp: '2026-09-01_1200',
+      );
+
+      expect(await build().reclaim([claiming(path)]), 0);
+      expect(File(path).existsSync(), isTrue);
+    });
+
+    test(
+      'nothing is deleted when the directory cannot be enumerated',
+      () async {
+        final path = await writeBackup(
+          deviceId: thisDevice,
+          timestamp: '2026-09-01_1200',
+        );
+        final scan = OrphanedBackupScan(
+          backupsDirectory: () async => null,
+          knownPaths: () async => const {},
+          thisDeviceId: () async => thisDevice,
+        );
+
+        expect(await scan.reclaim([claiming(path)]), 0);
+        expect(File(path).existsSync(), isTrue);
+      },
+    );
+  });
+
   test('a directory that cannot be enumerated yields nothing', () async {
     final scan = OrphanedBackupScan(
       backupsDirectory: () async => null,

--- a/test/features/backup/data/services/orphaned_backup_scan_test.dart
+++ b/test/features/backup/data/services/orphaned_backup_scan_test.dart
@@ -136,6 +136,24 @@ void main() {
     expect(await build().find(), isEmpty);
   });
 
+  test('bytes freed are measured at delete time, not at scan time', () async {
+    // The size on an UnrecognizedBackup is whatever the listing saw, and the
+    // page it feeds can sit open for as long as the user reads it. A cloud
+    // client rewriting the file in that window would make the freed figure a
+    // number the app made up rather than one it measured.
+    final path = await writeBackup(
+      deviceId: thisDevice,
+      timestamp: '2026-09-01_1200',
+      bytes: 100,
+    );
+    final scan = build();
+    final found = await scan.find();
+
+    await File(path).writeAsBytes(List<int>.filled(4096, 0));
+
+    expect(await scan.reclaim(found), 4096);
+  });
+
   test('a directory that cannot be enumerated yields nothing', () async {
     final scan = OrphanedBackupScan(
       backupsDirectory: () async => null,

--- a/test/features/backup/data/services/orphaned_backup_scan_test.dart
+++ b/test/features/backup/data/services/orphaned_backup_scan_test.dart
@@ -123,6 +123,19 @@ void main() {
     expect(found, isEmpty);
   });
 
+  test('an in-progress write is not mistaken for a finished backup', () async {
+    // LiveDatabaseCopier writes to `.<filename>.tmp` beside the target, so a
+    // partially written backup carries the real prefix one character in. The
+    // name must not start with the prefix for the scan to claim it, and the
+    // extension is `.tmp` rather than `.db`, so two independent gates exclude
+    // it. Listing one would offer a backup that is still being written.
+    await writeRaw(
+      '.${buildBackupFilename(timestamp: '2026-09-01_1200', deviceId: thisDevice)}.tmp',
+    );
+
+    expect(await build().find(), isEmpty);
+  });
+
   test('a directory that cannot be enumerated yields nothing', () async {
     final scan = OrphanedBackupScan(
       backupsDirectory: () async => null,

--- a/test/features/backup/data/services/orphaned_backup_scan_test.dart
+++ b/test/features/backup/data/services/orphaned_backup_scan_test.dart
@@ -25,11 +25,16 @@ void main() {
     int bytes = 100,
     String extension = '.db',
   }) async {
-    final name = buildBackupFilename(
+    // buildBackupFilename always yields `.db`; BackupService names the
+    // encrypted artifact by swapping the extension on the same stem, so the
+    // fixture does the same rather than asking the generator for it.
+    final plaintext = buildBackupFilename(
       timestamp: timestamp,
       deviceId: deviceId,
-      extension: extension,
     );
+    final name = extension == '.db'
+        ? plaintext
+        : '${p.basenameWithoutExtension(plaintext)}$extension';
     final file = File(p.join(backups.path, name));
     await file.writeAsBytes(List<int>.filled(bytes, 0));
     return file.path;

--- a/test/features/backup/data/services/unrecognized_backup_service_test.dart
+++ b/test/features/backup/data/services/unrecognized_backup_service_test.dart
@@ -1,0 +1,206 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/data/services/backup_attribution.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/data/services/backups_directory_access.dart';
+import 'package:submersion/features/backup/data/services/unrecognized_backup_service.dart';
+
+/// Composition, not scanning. `OrphanedBackupScan` already has its own tests
+/// for classification and for the reclaim refusal; what is untested until here
+/// is that the scan is pointed at the leased directory, told what this device's
+/// history actually knows, and given this device's real sync identity.
+void main() {
+  const thisDevice = 'device-a';
+  const otherDevice = 'device-b';
+
+  late Directory backups;
+  late int leasesReleased;
+
+  setUp(() async {
+    backups = await Directory.systemTemp.createTemp('unrecognized_backups');
+    leasesReleased = 0;
+  });
+
+  tearDown(() async {
+    if (backups.existsSync()) await backups.delete(recursive: true);
+  });
+
+  Future<String> writeBackup({
+    required String timestamp,
+    required String deviceId,
+    int bytes = 1024,
+  }) async {
+    final path = p.join(
+      backups.path,
+      buildBackupFilename(timestamp: timestamp, deviceId: deviceId),
+    );
+    await File(path).writeAsBytes(List.filled(bytes, 0));
+    return path;
+  }
+
+  UnrecognizedBackupService serviceFor({
+    Set<String> knownPaths = const {},
+    String? configuredLocation,
+  }) => UnrecognizedBackupService(
+    access: BackupsDirectoryAccess(
+      configuredLocation: () async => configuredLocation,
+      acquireLease: () async =>
+          BackupDirLease(backups.path, () async => leasesReleased++),
+    ),
+    knownPaths: () async => knownPaths,
+    thisDeviceId: () async => thisDevice,
+  );
+
+  test('lists a backup file the history has no record of', () async {
+    await writeBackup(timestamp: '2026-09-01_1200', deviceId: thisDevice);
+
+    final found = (await serviceFor().find())!;
+
+    expect(found, hasLength(1));
+    expect(found.single.ownership, BackupOwnership.thisDevice);
+  });
+
+  test('a file the history still knows about is not listed', () async {
+    final known = await writeBackup(
+      timestamp: '2026-09-01_1200',
+      deviceId: thisDevice,
+    );
+
+    final found = (await serviceFor(knownPaths: {known}).find())!;
+
+    expect(found, isEmpty);
+  });
+
+  test(
+    'this device is read from the live sync identity, not the file',
+    () async {
+      await writeBackup(timestamp: '2026-09-01_1200', deviceId: otherDevice);
+
+      final found = (await serviceFor().find())!;
+
+      expect(found.single.ownership, BackupOwnership.otherDevice);
+      expect(found.single.isReclaimable, isFalse);
+    },
+  );
+
+  test('a location that cannot be enumerated reports null, not empty', () async {
+    // Null is not zero, the same distinction slice A's StorageCategory.measure
+    // draws. An empty list here would tell an Android SAF user their backup
+    // folder holds nothing forgotten, when it was never readable at all.
+    await writeBackup(timestamp: '2026-09-01_1200', deviceId: thisDevice);
+
+    final found = await serviceFor(
+      configuredLocation: 'content://com.android.providers/tree/primary%3AB',
+    ).find();
+
+    expect(found, isNull);
+  });
+
+  test('reclaiming deletes the file and reports the bytes freed', () async {
+    final path = await writeBackup(
+      timestamp: '2026-09-01_1200',
+      deviceId: thisDevice,
+      bytes: 2048,
+    );
+    final service = serviceFor();
+
+    final freed = await service.reclaim((await service.find())!);
+
+    expect(freed, 2048);
+    expect(File(path).existsSync(), isFalse);
+  });
+
+  test('reclaiming runs inside a directory lease and releases it', () async {
+    await writeBackup(timestamp: '2026-09-01_1200', deviceId: thisDevice);
+    final service = serviceFor();
+    final found = (await service.find())!;
+    leasesReleased = 0;
+
+    await service.reclaim(found);
+
+    expect(leasesReleased, 1);
+  });
+
+  test('a pre-migration safety copy is never listed', () async {
+    // Named by LiveDatabaseCopier as `<timestamp>-v<from>-v<to>.db`, with no
+    // `submersion_backup_` prefix, so the scan's prefix gate excludes it. That
+    // gate is the only thing standing between this page and offering to delete
+    // the copy taken immediately before a schema migration, which is the one
+    // file a failed migration needs. Pinned here because the pre-migration
+    // writer logs "registration failed; .db is on disk" on its own error path,
+    // so an unrecorded safety copy is a state the app produces deliberately.
+    await File(
+      p.join(backups.path, '20260901-120000000-v114-v115.db'),
+    ).writeAsBytes(List.filled(1024, 0));
+
+    expect(await serviceFor().find(), isEmpty);
+  });
+
+  group('knownBackupPaths', () {
+    BackupRecord recordWith({String? localPath, String? cloudFileId}) =>
+        BackupRecord(
+          id: 'id',
+          filename: 'submersion_backup_2026-09-01_1200__d0123456789abcdef.db',
+          timestamp: DateTime.utc(2026, 9, 1),
+          sizeBytes: 1024,
+          location: cloudFileId == null
+              ? BackupLocation.local
+              : BackupLocation.cloud,
+          localPath: localPath,
+          cloudFileId: cloudFileId,
+        );
+
+    test('a record with a local file marks that path known', () {
+      expect(knownBackupPaths([recordWith(localPath: '/backups/a.db')]), {
+        '/backups/a.db',
+      });
+    });
+
+    test('a cloud-only record contributes no local path', () {
+      expect(knownBackupPaths([recordWith(cloudFileId: 'drive-1')]), isEmpty);
+    });
+  });
+
+  group('knownPathsFromPreferences', () {
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test(
+      'a record whose file is unreachable still marks its path known',
+      () async {
+        // The distinction between the raw history and getValidatedBackupHistory,
+        // which drops records whose file is missing and rewrites preferences to
+        // match. A backups folder on an unmounted share or an unsynced cloud
+        // folder is momentarily "missing" and would lose its records; when the
+        // files came back they would be unattributed to any history, this
+        // device's by name, and offered for deletion. The raw history is a
+        // superset, which errs in the only safe direction.
+        final preferences = BackupPreferences(
+          await SharedPreferences.getInstance(),
+        );
+        await preferences.setHistory([
+          BackupRecord(
+            id: 'unreachable',
+            filename: 'submersion_backup_2026-09-01_1200__d0123456789abcdef.db',
+            timestamp: DateTime.utc(2026, 9, 1),
+            sizeBytes: 1024,
+            location: BackupLocation.local,
+            localPath: '/volumes/unmounted/submersion_backup.db',
+          ),
+        ]);
+
+        expect(await knownPathsFromPreferences(preferences), {
+          '/volumes/unmounted/submersion_backup.db',
+        });
+      },
+    );
+  });
+}

--- a/test/features/backup/presentation/pages/unrecognized_backups_page_test.dart
+++ b/test/features/backup/presentation/pages/unrecognized_backups_page_test.dart
@@ -1,0 +1,217 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/backup/data/services/backup_attribution.dart';
+import 'package:submersion/features/backup/data/services/backups_directory_access.dart';
+import 'package:submersion/features/backup/data/services/orphaned_backup_scan.dart';
+import 'package:submersion/features/backup/data/services/unrecognized_backup_service.dart';
+import 'package:submersion/features/backup/presentation/pages/unrecognized_backups_page.dart';
+import 'package:submersion/features/backup/presentation/providers/unrecognized_backup_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Stands in for the filesystem.
+///
+/// Both real methods do `dart:io` work, and an await on real I/O inside
+/// `testWidgets` never completes under FakeAsync, so the run would hang with no
+/// output rather than fail. The real service has its own tests against a temp
+/// directory.
+class _FakeService extends UnrecognizedBackupService {
+  _FakeService({this.freed = 0, this.onReclaim})
+    : super(
+        access: BackupsDirectoryAccess(
+          configuredLocation: () async => null,
+          acquireLease: () async =>
+              throw StateError('the fake never reaches the filesystem'),
+        ),
+        knownPaths: () async => const {},
+        thisDeviceId: () async => '',
+      );
+
+  final int freed;
+  final void Function()? onReclaim;
+  final reclaimed = <UnrecognizedBackup>[];
+
+  @override
+  Future<int> reclaim(Iterable<UnrecognizedBackup> selection) async {
+    reclaimed.addAll(selection);
+    onReclaim?.call();
+    return freed;
+  }
+}
+
+void main() {
+  UnrecognizedBackup entry({
+    required String name,
+    int bytes = 1024,
+    BackupOwnership ownership = BackupOwnership.thisDevice,
+  }) => UnrecognizedBackup(
+    path: '/backups/$name',
+    sizeBytes: bytes,
+    modified: DateTime(2026, 9, 1, 12),
+    ownership: ownership,
+  );
+
+  Widget harness({
+    required Future<List<UnrecognizedBackup>?> Function() entries,
+    UnrecognizedBackupService? service,
+  }) => ProviderScope(
+    overrides: [
+      // The page reads settingsProvider for the diver's date format; the real
+      // notifier reaches for a DatabaseService this harness never starts.
+      settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+      unrecognizedBackupsProvider.overrideWith((ref) => entries()),
+      if (service != null)
+        unrecognizedBackupServiceProvider.overrideWithValue(service),
+    ],
+    child: const MaterialApp(
+      // Pinned: flutter_test forwards the host machine's locale list, and the
+      // English assertions below would find nothing on a translated build.
+      locale: Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: UnrecognizedBackupsPage(),
+    ),
+  );
+
+  testWidgets('lists every unrecognized file with its size', (tester) async {
+    await tester.pumpWidget(
+      harness(
+        entries: () async => [
+          entry(name: 'a.db', bytes: 2048),
+          entry(name: 'b.db', bytes: 1024),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('a.db'), findsOneWidget);
+    expect(find.text('b.db'), findsOneWidget);
+    expect(find.textContaining('2.0 KB'), findsWidgets);
+  });
+
+  testWidgets('only a file this device wrote can be selected', (tester) async {
+    await tester.pumpWidget(
+      harness(
+        entries: () async => [
+          entry(name: 'mine.db'),
+          entry(name: 'theirs.db', ownership: BackupOwnership.otherDevice),
+          entry(name: 'legacy.db', ownership: BackupOwnership.unattributed),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Checkbox), findsOneWidget);
+    expect(find.text('Another device'), findsOneWidget);
+    expect(find.text('Unknown device'), findsOneWidget);
+  });
+
+  testWidgets('the delete action stays disabled until something is selected', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      harness(entries: () async => [entry(name: 'a.db')]),
+    );
+    await tester.pumpAndSettle();
+
+    final button = tester.widget<FilledButton>(find.byType(FilledButton));
+    expect(button.onPressed, isNull);
+  });
+
+  testWidgets('confirming deletes the selected files and reports bytes freed', (
+    tester,
+  ) async {
+    var listed = [
+      entry(name: 'mine.db', bytes: 2048),
+      entry(name: 'theirs.db', ownership: BackupOwnership.otherDevice),
+    ];
+    final service = _FakeService(
+      freed: 2048,
+      onReclaim: () => listed = [
+        entry(name: 'theirs.db', ownership: BackupOwnership.otherDevice),
+      ],
+    );
+
+    await tester.pumpWidget(
+      harness(entries: () async => listed, service: service),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(Checkbox));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(FilledButton));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    expect(service.reclaimed.map((e) => e.filename), ['mine.db']);
+    expect(find.textContaining('2.0 KB'), findsWidgets);
+    expect(find.text('mine.db'), findsNothing);
+  });
+
+  testWidgets('cancelling the confirmation deletes nothing', (tester) async {
+    final service = _FakeService();
+
+    await tester.pumpWidget(
+      harness(
+        entries: () async => [entry(name: 'mine.db')],
+        service: service,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(Checkbox));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(FilledButton));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(service.reclaimed, isEmpty);
+    expect(find.text('mine.db'), findsOneWidget);
+  });
+
+  testWidgets('an empty scan says so rather than showing a bare list', (
+    tester,
+  ) async {
+    await tester.pumpWidget(harness(entries: () async => []));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('No unrecognized'), findsOneWidget);
+    expect(find.byType(FilledButton), findsNothing);
+  });
+
+  testWidgets('a failed scan reports the failure, not an empty folder', (
+    tester,
+  ) async {
+    // The difference matters: "nothing to clean up" and "the folder could not
+    // be read" look identical on an empty list, and only one of them means the
+    // user has nothing left to do.
+    await tester.pumpWidget(
+      harness(entries: () async => throw const FileSystemException('denied')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Could not read'), findsOneWidget);
+    expect(find.textContaining('No unrecognized'), findsNothing);
+  });
+
+  testWidgets('a folder that cannot be listed is not reported as clean', (
+    tester,
+  ) async {
+    // An Android SAF location is a content:// tree URI with no directory to
+    // enumerate. Rendering that as the empty state would tell the user there
+    // is nothing to reclaim when nothing was ever looked at.
+    await tester.pumpWidget(harness(entries: () async => null));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('cannot list'), findsOneWidget);
+    expect(find.textContaining('No unrecognized'), findsNothing);
+  });
+}

--- a/test/features/backup/presentation/pages/unrecognized_backups_page_test.dart
+++ b/test/features/backup/presentation/pages/unrecognized_backups_page_test.dart
@@ -214,4 +214,37 @@ void main() {
     expect(find.textContaining('cannot list'), findsOneWidget);
     expect(find.textContaining('No unrecognized'), findsNothing);
   });
+
+  testWidgets('a tick is dropped when the file stops being this device\'s', (
+    tester,
+  ) async {
+    // A sync reset changes the device id, so the next scan classifies the same
+    // file as another device's. Pruning only paths that VANISHED leaves this
+    // one ticked: the bar counts a file whose tile now shows "Another device"
+    // and no checkbox, and confirming would report "Freed 0 B" after the
+    // service correctly refused it.
+    var listed = [entry(name: 'mine.db')];
+
+    await tester.pumpWidget(harness(entries: () async => listed));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(Checkbox));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<FilledButton>(find.byType(FilledButton)).onPressed,
+      isNotNull,
+    );
+
+    listed = [entry(name: 'mine.db', ownership: BackupOwnership.otherDevice)];
+    ProviderScope.containerOf(
+      tester.element(find.byType(UnrecognizedBackupsPage)),
+    ).invalidate(unrecognizedBackupsProvider);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Checkbox), findsNothing);
+    expect(
+      tester.widget<FilledButton>(find.byType(FilledButton)).onPressed,
+      isNull,
+    );
+  });
 }

--- a/test/features/backup/presentation/providers/unrecognized_backup_providers_test.dart
+++ b/test/features/backup/presentation/providers/unrecognized_backup_providers_test.dart
@@ -1,0 +1,118 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_attribution.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/presentation/providers/unrecognized_backup_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+/// Exercises the real providers rather than an injected service.
+///
+/// Every other test builds `UnrecognizedBackupService` with callbacks, which
+/// covers the behaviour and none of the binding. The binding is where this
+/// feature has already been bitten once: part 1's review found
+/// `_generateFilename` constructing its own `SyncRepository` instead of using
+/// the injected one, which no test could see because the replacement worked
+/// whenever the database singleton happened to be up.
+class _FakeSyncRepository extends SyncRepository {
+  _FakeSyncRepository(this.id);
+
+  final String id;
+
+  @override
+  Future<String> getDeviceId() async => id;
+}
+
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.documentsPath);
+
+  final String documentsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+}
+
+void main() {
+  const thisDevice = 'device-a';
+
+  late Directory documents;
+  late Directory backups;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    documents = await Directory.systemTemp.createTemp('unrecognized_wiring');
+    PathProviderPlatform.instance = _FakePathProvider(documents.path);
+    backups = await Directory(
+      p.join(documents.path, 'Submersion', 'Backups'),
+    ).create(recursive: true);
+  });
+
+  tearDown(() async {
+    if (documents.existsSync()) await documents.delete(recursive: true);
+  });
+
+  Future<File> writeBackup(String timestamp) async {
+    final file = File(
+      p.join(
+        backups.path,
+        buildBackupFilename(timestamp: timestamp, deviceId: thisDevice),
+      ),
+    );
+    await file.writeAsBytes(List<int>.filled(1024, 0));
+    return file;
+  }
+
+  test(
+    'the scan reads the live history and this device\'s sync identity',
+    () async {
+      final forgotten = await writeBackup('2026-09-01_1200');
+      final recorded = await writeBackup('2026-09-02_1200');
+
+      final preferences = BackupPreferences(
+        await SharedPreferences.getInstance(),
+      );
+      await preferences.setHistory([
+        BackupRecord(
+          id: 'kept',
+          filename: p.basename(recorded.path),
+          timestamp: DateTime.utc(2026, 9, 2),
+          sizeBytes: 1024,
+          location: BackupLocation.local,
+          localPath: recorded.path,
+        ),
+      ]);
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(
+            await SharedPreferences.getInstance(),
+          ),
+          syncRepositoryProvider.overrideWithValue(
+            _FakeSyncRepository(thisDevice),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final found = await container.read(unrecognizedBackupsProvider.future);
+
+      // One assertion per binding: the default location came from preferences,
+      // the recorded file was excluded because the history was actually read,
+      // and the ownership resolved because the device id came from the provider.
+      expect(found, isNotNull);
+      expect(found!.map((e) => e.filename), [p.basename(forgotten.path)]);
+      expect(found.single.ownership, BackupOwnership.thisDevice);
+    },
+  );
+}

--- a/test/features/backup/presentation/providers/unrecognized_backup_providers_test.dart
+++ b/test/features/backup/presentation/providers/unrecognized_backup_providers_test.dart
@@ -47,11 +47,14 @@ void main() {
 
   late Directory documents;
   late Directory backups;
+  late PathProviderPlatform realPathProvider;
 
   setUp(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
     SharedPreferences.setMockInitialValues({});
     documents = await Directory.systemTemp.createTemp('unrecognized_wiring');
+    // Restored in tearDown: see the note in backups_directory_access_test.
+    realPathProvider = PathProviderPlatform.instance;
     PathProviderPlatform.instance = _FakePathProvider(documents.path);
     backups = await Directory(
       p.join(documents.path, 'Submersion', 'Backups'),
@@ -59,6 +62,7 @@ void main() {
   });
 
   tearDown(() async {
+    PathProviderPlatform.instance = realPathProvider;
     if (documents.existsSync()) await documents.delete(recursive: true);
   });
 

--- a/test/features/settings/presentation/pages/storage_usage_page_test.dart
+++ b/test/features/settings/presentation/pages/storage_usage_page_test.dart
@@ -1,9 +1,14 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/storage/storage_category.dart';
+import 'package:submersion/features/backup/data/services/backup_attribution.dart';
+import 'package:submersion/features/backup/data/services/orphaned_backup_scan.dart';
+import 'package:submersion/features/backup/presentation/providers/unrecognized_backup_providers.dart';
+import 'package:submersion/features/settings/presentation/widgets/unrecognized_backups_notice.dart';
 import 'package:submersion/features/settings/presentation/pages/storage_usage_page.dart';
 import 'package:submersion/features/settings/presentation/providers/storage_usage_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
@@ -23,11 +28,20 @@ void main() {
   /// once the provider is listening. A `Future.error` built eagerly in a map
   /// literal has no listener yet and the zone reports it as unhandled, failing
   /// the test before the page ever renders it.
-  Widget harness({required Map<String, Future<int?> Function()> sizes}) {
+  Widget harness({
+    required Map<String, Future<int?> Function()> sizes,
+    Future<List<UnrecognizedBackup>?> Function()? unrecognized,
+  }) {
     return ProviderScope(
       overrides: [
         storageCategorySizeProvider.overrideWith(
           (ref, id) => sizes[id]?.call() ?? Future<int?>.value(0),
+        ),
+        // The backups group carries a notice fed by a filesystem scan. Left
+        // live it would reach SharedPreferences and the sync database, so
+        // every test here states what the scan found, defaulting to nothing.
+        unrecognizedBackupsProvider.overrideWith(
+          (ref) => unrecognized?.call() ?? Future.value(const []),
         ),
       ],
       child: const MaterialApp(
@@ -208,5 +222,78 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
+  });
+
+  group('unrecognized backups notice', () {
+    UnrecognizedBackup forgotten({int bytes = 1024}) => UnrecognizedBackup(
+      path: '/backups/submersion_backup_2026-09-01_1200__d$bytes.db',
+      sizeBytes: bytes,
+      modified: DateTime(2026, 9, 1),
+      ownership: BackupOwnership.thisDevice,
+    );
+
+    testWidgets('surfaces files the backup history has lost track of', (
+      tester,
+    ) async {
+      useTallSurface(tester);
+      await tester.pumpWidget(
+        harness(
+          sizes: {},
+          unrecognized: () async => [
+            forgotten(bytes: 1024),
+            forgotten(bytes: 3072),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('2 files not in your backup history'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(UnrecognizedBackupsNotice),
+          matching: find.text('4.0 KB'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('stays out of the way when the scan finds nothing', (
+      tester,
+    ) async {
+      useTallSurface(tester);
+      await tester.pumpWidget(harness(sizes: {}, unrecognized: () async => []));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(UnrecognizedBackupsNotice), findsOneWidget);
+      expect(find.textContaining('not in your backup history'), findsNothing);
+    });
+
+    testWidgets('says nothing while the scan is still running', (tester) async {
+      useTallSurface(tester);
+      await tester.pumpWidget(
+        harness(
+          sizes: {},
+          unrecognized: () => Completer<List<UnrecognizedBackup>?>().future,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('not in your backup history'), findsNothing);
+    });
+
+    testWidgets('a failed scan does not claim the folder is clean', (
+      tester,
+    ) async {
+      useTallSurface(tester);
+      await tester.pumpWidget(
+        harness(
+          sizes: {},
+          unrecognized: () async => throw const FileSystemException('denied'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('not in your backup history'), findsNothing);
+    });
   });
 }

--- a/test/features/settings/presentation/widgets/unrecognized_backups_notice_test.dart
+++ b/test/features/settings/presentation/widgets/unrecognized_backups_notice_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/settings/presentation/widgets/unrecognized_backups_notice.dart';
+
+class _Holder extends ConsumerWidget {
+  const _Holder({required this.capture});
+
+  final void Function(BuildContext context, WidgetRef ref) capture;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    capture(context, ref);
+    return const SizedBox.shrink();
+  }
+}
+
+void main() {
+  testWidgets('the refresh is a no-op once the page it belongs to is gone', (
+    tester,
+  ) async {
+    // The notice awaits a push, so the refresh runs an unbounded time later.
+    // A WidgetRef whose element has been unmounted throws StateError on
+    // invalidate, which would surface as an unhandled error from a tap the
+    // user made on a page they have already left.
+    late BuildContext context;
+    late WidgetRef ref;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: _Holder(
+            capture: (c, r) {
+              context = c;
+              ref = r;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: SizedBox.shrink())),
+    );
+    expect(context.mounted, isFalse);
+
+    expect(() => refreshAfterUnrecognizedReview(context, ref), returnsNormally);
+  });
+}


### PR DESCRIPTION
## Summary

Slice D part 2 of #1375, the surface. Part 1 (#1415) put the writing device in the
backup filename and landed the scan alongside it, but nothing ever called the scan.

A backup file whose SharedPreferences record is gone is invisible to every prune path
in the app and permanent, and each one is a full copy of the database. A prefs reset,
a reinstall over a preserved Documents directory, or a crash between writing the file
and recording it all produce one.

The Storage usage page now shows a notice under the backups group when the scan finds
any, leading to a page that lists them with the device that wrote each one. Only a file
this device provably wrote is selectable; the scan re-checks that on the way through, so
a UI bug cannot reach past it.

## Changes

- `BackupsDirectoryAccess`: holds the backups directory lease across the whole
  operation and releases it in a `finally`. `reclaim` takes the lease even though it
  deletes by absolute path, because on Apple platforms a custom location is reachable
  only while its security-scoped bookmark is held.
- `UnrecognizedBackupService`: binds the existing `OrphanedBackupScan` to the live
  history and sync identity, and reports `null` rather than an empty list when the
  location cannot be enumerated.
- `UnrecognizedBackupsPage`: per-file size, date and ownership, selection limited to
  this device's files, a confirmation, and a report of the bytes freed.
- `UnrecognizedBackupsNotice`: the entry point under the backups group, rendered only
  when the scan actually found something.
- Route `/settings/storage-usage/unrecognized-backups`, pinned to the widget's own
  constant by a router test.
- 15 new strings, translated across all 11 locales.
- Design spec updated with what shipped and where it deviates from the sketch.

## Three decisions worth reviewing

**The prune is a page, not a control on the Storage usage page.** The spec put it
inline. A delete button beside a size row is one tap from destroying what may be a
diver's only logbook copy, and the row has no space to say why two of the three files
listed cannot be removed at all.

**A SAF location yields `null`, not the sandbox default and not an empty list.**
`resolveBackupsDirectoryLeased` substitutes the sandbox default for a `content://`
location because its callers need somewhere writable (#505). A scan that inherited that
substitution would list the sandbox directory's files under a heading describing the
user's Dropbox folder and offer them for deletion. Reporting an empty list would instead
tell that user their folder holds nothing forgotten when it was never read, so `find()`
returns `null`, the same distinction `StorageCategory.measure` draws.

**Known paths come from the raw history, not `getValidatedBackupHistory`.** That method
drops records whose file is missing and rewrites preferences to match, so a measurement
surface would mutate stored state just by being opened. Worse, a backups folder on an
unmounted share or an unsynced cloud folder is momentarily "missing": pruned there, its
files come back with no record, attributable to this device, and this page would offer
them for deletion. The raw history is a superset, so every difference between the two
can only mean fewer files offered.

## Safety property pinned by a test

Pre-migration safety copies stay invisible. `LiveDatabaseCopier` names them
`<timestamp>-v<from>-v<to>.db`, with no `submersion_backup_` prefix, so the scan's prefix
gate excludes them. That gate is load-bearing rather than incidental, because the
pre-migration writer logs "registration failed; .db is on disk" on its own error path, so
an unrecorded safety copy is a state the app produces deliberately. The regression test
was mutation-tested: removing the prefix check makes it fail.

## Note on the inherited commit

The first commit here is the scan from the abandoned part-2 branch. Its test called
`buildBackupFilename` with an `extension:` argument that #1415 removed during review the
day after that commit was written, so the branch no longer compiled against `main`. The
fixture now swaps the extension the way `BackupService` does.

## Test Plan

- [x] `flutter test` passes (25603 passed, 21 skipped, 0 failed)
- [x] `flutter analyze` passes (no issues, whole project)
- [x] Manual testing on: not yet exercised on a device; the reclaim path is covered by
      widget tests against a fake service and by service tests against a temp directory
