### PR TITLE
fix(startup): theme the splash so its error screens read in dark mode

### DIFF
--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -26,6 +26,7 @@ import 'package:submersion/core/presentation/pages/lock_escape_dialogs.dart';
 import 'package:submersion/core/presentation/pages/lock_screen_view.dart';
 import 'package:submersion/core/presentation/startup_brightness.dart';
 import 'package:submersion/core/presentation/startup_failure.dart';
+import 'package:submersion/core/presentation/startup_theme.dart';
 import 'package:submersion/core/presentation/widgets/backup_status_views.dart';
 import 'package:submersion/core/presentation/widgets/ocean_background.dart';
 import 'package:submersion/core/presentation/widgets/startup_failure_view.dart';
@@ -43,6 +44,7 @@ import 'package:submersion/core/services/security/database_security_sidecar.dart
 import 'package:submersion/core/services/security/locked_database_escape.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/core/services/notification_service.dart';
+import 'package:submersion/core/theme/app_theme_registry.dart';
 import 'package:submersion/core/utils/app_version.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/data/services/backup_service.dart';
@@ -1313,6 +1315,21 @@ class _StartupWrapperState extends State<StartupWrapper>
     final textColor = isDark ? Colors.white : Colors.black87;
     final subtitleColor = isDark ? Colors.white70 : Colors.black54;
 
+    // The splash paints its plain text from the palette above, but every
+    // themed descendant (the restore Card, the buttons, the progress
+    // indicators, the escape-hatch dialogs) reads Theme.of instead. A
+    // MaterialApp with no theme gets Flutter's default, which is always
+    // LIGHT: in dark mode that put a near-white card surface under white
+    // text and made the restore offer unreadable. The theme therefore has to
+    // follow the same brightness the palette does.
+    //
+    // The preset comes from the same pre-database mirror the brightness does,
+    // so a diver on Console or Deep is not handed an ocean-blue error screen.
+    final splashTheme = AppThemeRegistry.resolveTheme(
+      resolveStartupThemePreset(widget.prefs),
+      brightness,
+    );
+
     final isReady = _state == _StartupState.ready;
 
     // Splash layer: stays at full opacity while initializing/migrating/error,
@@ -1331,6 +1348,7 @@ class _StartupWrapperState extends State<StartupWrapper>
               child: MaterialApp(
                 debugShowCheckedModeBanner: false,
                 navigatorKey: _splashNavigatorKey,
+                theme: splashTheme,
                 // The splash runs before the database (and therefore the
                 // diver's saved locale preference) is readable, so it can
                 // only resolve the system locale. Without these delegates

--- a/lib/core/presentation/startup_theme.dart
+++ b/lib/core/presentation/startup_theme.dart
@@ -18,6 +18,10 @@ const String cachedThemePresetKey = 'cached_theme_preset';
 /// Resolves the theme preset for surfaces that render before the database
 /// opens. A missing key, or one naming a preset this build no longer ships,
 /// falls back to the default preset.
+///
+/// Resolution deliberately happens here rather than at the write, so the
+/// mirror keeps the diver's actual choice even while a build that cannot
+/// honour it is running.
 AppThemePreset resolveStartupThemePreset(SharedPreferences prefs) {
   final id = prefs.getString(cachedThemePresetKey);
   return id == null

--- a/lib/core/presentation/startup_theme.dart
+++ b/lib/core/presentation/startup_theme.dart
@@ -1,0 +1,26 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/theme/app_theme_preset.dart';
+import 'package:submersion/core/theme/app_theme_registry.dart';
+
+/// SharedPreferences key mirroring the active diver's theme preset.
+///
+/// The companion of `cachedThemeModeKey`, and it exists for the same reason:
+/// the authoritative setting lives in the per-diver settings table, which the
+/// startup splash cannot read because the database is not open yet. Without
+/// the mirror the splash could only guess a preset, and a diver on Console or
+/// Deep would meet an ocean-blue error screen.
+///
+/// The settings notifier writes it on every change and every hydration, so it
+/// is stale for at most one launch.
+const String cachedThemePresetKey = 'cached_theme_preset';
+
+/// Resolves the theme preset for surfaces that render before the database
+/// opens. A missing key, or one naming a preset this build no longer ships,
+/// falls back to the default preset.
+AppThemePreset resolveStartupThemePreset(SharedPreferences prefs) {
+  final id = prefs.getString(cachedThemePresetKey);
+  return id == null
+      ? AppThemeRegistry.presets.first
+      : AppThemeRegistry.findById(id);
+}

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -1314,6 +1314,12 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
       cachedThemeModeKey,
       cachedThemeModeValue(state.themeMode),
     );
+    // Mirrored raw, not normalised through AppThemeRegistry. Normalising on
+    // write would be lossy in the one case that matters: a database written
+    // by a beta build can name a preset this build does not ship, and the
+    // splash renders before hydration, so a build that ships that preset
+    // again would meet a default already burned into the mirror. Reading is
+    // where an unknown id is resolved; see [resolveStartupThemePreset].
     await prefs.setString(cachedThemePresetKey, state.themePresetId);
   }
 

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -24,6 +24,7 @@ import 'package:submersion/core/constants/gas_consumption_display.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/deco/entities/cns_calculation_method.dart';
 import 'package:submersion/core/presentation/startup_brightness.dart';
+import 'package:submersion/core/presentation/startup_theme.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/notifications/data/services/notification_scheduler.dart';
@@ -1172,7 +1173,7 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
           perdixOverlayY: perdixOverlayY,
           seascapeAppearance: seascapeAppearance,
         );
-        await _writeCachedThemeMode(prefs);
+        await _writeCachedTheme(prefs);
         return;
       }
 
@@ -1213,7 +1214,7 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
         await prefs.remove(SettingsKeys.seascapeAppearance);
       }
 
-      await _writeCachedThemeMode(prefs);
+      await _writeCachedTheme(prefs);
 
       // Schedule notifications with the loaded settings
       _scheduleNotificationsIfNeeded();
@@ -1288,7 +1289,7 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
     if (perdixY != null) {
       await prefs.setDouble(SettingsKeys.perdixOverlayY, perdixY);
     }
-    await _writeCachedThemeMode(prefs);
+    await _writeCachedTheme(prefs);
 
     final diverId = _validatedDiverId;
     if (diverId == null) {
@@ -1304,14 +1305,16 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
     await _repository.updateSettingsForDiver(diverId, state);
   }
 
-  /// Mirrors the effective theme mode into SharedPreferences so the startup
-  /// splash and setup wizard (which render before the database opens) can
-  /// resolve dark mode. See [resolveStartupBrightness].
-  Future<void> _writeCachedThemeMode(SharedPreferences prefs) async {
+  /// Mirrors the effective theme into SharedPreferences so the startup splash
+  /// and setup wizard (which render before the database opens) can resolve
+  /// both halves of it. See [resolveStartupBrightness] for the mode and
+  /// [resolveStartupThemePreset] for the preset.
+  Future<void> _writeCachedTheme(SharedPreferences prefs) async {
     await prefs.setString(
       cachedThemeModeKey,
       cachedThemeModeValue(state.themeMode),
     );
+    await prefs.setString(cachedThemePresetKey, state.themePresetId);
   }
 
   Future<void> setDepthUnit(DepthUnit unit) async {

--- a/test/core/presentation/pages/startup_page_test.dart
+++ b/test/core/presentation/pages/startup_page_test.dart
@@ -13,9 +13,12 @@ import 'package:submersion/core/domain/entities/migration_progress.dart';
 import 'package:submersion/core/presentation/pages/startup_page.dart';
 import 'package:submersion/core/presentation/startup_brightness.dart';
 import 'package:submersion/core/presentation/startup_failure.dart';
+import 'package:submersion/core/presentation/startup_theme.dart';
 import 'package:submersion/core/presentation/widgets/ocean_background.dart';
 import 'package:submersion/core/presentation/widgets/startup_failure_view.dart';
+import 'package:submersion/core/presentation/widgets/startup_restore_card.dart';
 import 'package:submersion/core/presentation/widgets/version_mismatch_view.dart';
+import 'package:submersion/core/theme/app_theme_registry.dart';
 import 'package:submersion/core/services/database_location_service.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
@@ -2228,6 +2231,99 @@ void main() {
       expect(find.text('Your Data Is Newer Than This App'), findsOneWidget);
       expect(find.text('Restore your pre-upgrade backup'), findsOneWidget);
       expect(find.textContaining('v170'), findsOneWidget);
+    });
+
+    testWidgets('restore card stays readable in dark mode', (tester) async {
+      // The splash paints its own dark palette from the cached theme mode,
+      // but the Card behind the restore offer takes its surface from the
+      // theme. When the splash MaterialApp carried no theme, that surface
+      // came from Flutter's default LIGHT ThemeData while the text stayed
+      // white, and the whole offer washed out (#1595).
+      SharedPreferences.setMockInitialValues({cachedThemeModeKey: 'dark'});
+      prefs = await SharedPreferences.getInstance();
+      locationService = _FakeLocationService(prefs);
+      tester.platformDispatcher.platformBrightnessTestValue = Brightness.light;
+      addTearDown(tester.platformDispatcher.clearPlatformBrightnessTestValue);
+
+      final dir = Directory.systemTemp.createTempSync('startup-downgrade-d-');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      await seedCopy(
+        dir,
+        id: 'old',
+        fromSchemaVersion: 170,
+        toSchemaVersion: 175,
+        timestamp: DateTime.utc(2026, 8, 1, 9),
+      );
+
+      await tester.pumpWidget(
+        wrapper(
+          storedSchemaVersion: 191,
+          supportedSchemaVersion: 175,
+          probe: (_) => 170,
+        ),
+      );
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(StartupRestoreCard), findsOneWidget);
+
+      // The colour the card actually paints, not the colour it was asked for.
+      final surface = tester
+          .widget<Material>(
+            find
+                .descendant(
+                  of: find.byType(StartupRestoreCard),
+                  matching: find.byType(Material),
+                )
+                .first,
+          )
+          .color;
+      expect(surface, isNotNull);
+      expect(
+        ThemeData.estimateBrightnessForColor(surface!),
+        Brightness.dark,
+        reason: 'white card text needs a dark surface behind it',
+      );
+    });
+
+    testWidgets('the splash wears the diver\'s cached theme preset', (
+      tester,
+    ) async {
+      // The preset lives in the unopened database, so the settings notifier
+      // mirrors it into SharedPreferences for exactly this screen.
+      SharedPreferences.setMockInitialValues({
+        cachedThemeModeKey: 'dark',
+        cachedThemePresetKey: 'console',
+      });
+      prefs = await SharedPreferences.getInstance();
+      locationService = _FakeLocationService(prefs);
+
+      final dir = Directory.systemTemp.createTempSync('startup-downgrade-p-');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      await seedCopy(
+        dir,
+        id: 'old',
+        fromSchemaVersion: 170,
+        toSchemaVersion: 175,
+        timestamp: DateTime.utc(2026, 8, 1, 9),
+      );
+
+      await tester.pumpWidget(
+        wrapper(
+          storedSchemaVersion: 191,
+          supportedSchemaVersion: 175,
+          probe: (_) => 170,
+        ),
+      );
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+
+      final theme = Theme.of(tester.element(find.byType(StartupRestoreCard)));
+      final console = AppThemeRegistry.resolveTheme(
+        AppThemeRegistry.findById('console'),
+        Brightness.dark,
+      );
+      expect(theme.colorScheme.primary, console.colorScheme.primary);
     });
 
     testWidgets('shows no restore when every copy is itself too new', (

--- a/test/core/presentation/startup_theme_test.dart
+++ b/test/core/presentation/startup_theme_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/presentation/startup_theme.dart';
+import 'package:submersion/core/theme/app_theme_registry.dart';
+
+Future<SharedPreferences> _prefsWith(Map<String, Object> values) async {
+  SharedPreferences.setMockInitialValues(values);
+  return SharedPreferences.getInstance();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('resolveStartupThemePreset', () {
+    test('returns the cached preset', () async {
+      final prefs = await _prefsWith({cachedThemePresetKey: 'console'});
+      expect(resolveStartupThemePreset(prefs).id, 'console');
+    });
+
+    test('falls back to the default when the key is missing', () async {
+      final prefs = await _prefsWith({});
+      expect(
+        resolveStartupThemePreset(prefs).id,
+        AppThemeRegistry.presets.first.id,
+      );
+    });
+
+    test('falls back to the default for a retired preset id', () async {
+      // A preset removed from the registry must not strand the splash: the
+      // mirror can outlive the preset that wrote it.
+      final prefs = await _prefsWith({cachedThemePresetKey: 'kelp'});
+      expect(
+        resolveStartupThemePreset(prefs).id,
+        AppThemeRegistry.presets.first.id,
+      );
+    });
+  });
+}

--- a/test/features/settings/presentation/providers/settings_notifier_real_test.dart
+++ b/test/features/settings/presentation/providers/settings_notifier_real_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/deco/entities/cns_calculation_method.dart';
 import 'package:submersion/core/presentation/startup_brightness.dart';
+import 'package:submersion/core/presentation/startup_theme.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
@@ -852,6 +853,24 @@ void main() {
 
       await notifier.setThemeMode(ThemeMode.system);
       expect(prefs.getString(cachedThemeModeKey), 'system');
+    });
+
+    test('hydration writes the default theme preset into prefs', () {
+      final prefs = container.read(sharedPreferencesProvider);
+      expect(prefs.getString(cachedThemePresetKey), 'submersion');
+    });
+
+    test('setThemePresetId mirrors the new preset into prefs', () async {
+      // The splash reads this mirror to theme its error screens, so a diver
+      // who switched presets must not meet the previous one on next launch.
+      final notifier = container.read(settingsProvider.notifier);
+      final prefs = container.read(sharedPreferencesProvider);
+
+      await notifier.setThemePresetId('console');
+      expect(prefs.getString(cachedThemePresetKey), 'console');
+
+      await notifier.setThemePresetId('deep');
+      expect(prefs.getString(cachedThemePresetKey), 'deep');
     });
   });
 }

--- a/test/features/settings/presentation/providers/settings_notifier_real_test.dart
+++ b/test/features/settings/presentation/providers/settings_notifier_real_test.dart
@@ -872,6 +872,19 @@ void main() {
       await notifier.setThemePresetId('deep');
       expect(prefs.getString(cachedThemePresetKey), 'deep');
     });
+
+    test('a preset this build cannot resolve is mirrored unchanged', () async {
+      // A database written by a beta build can name a preset the running
+      // build does not ship. The mirror keeps the diver's actual choice, so
+      // a build that ships it again honours it on its first launch; the
+      // splash resolves the fallback at read time instead.
+      final notifier = container.read(settingsProvider.notifier);
+      final prefs = container.read(sharedPreferencesProvider);
+
+      await notifier.setThemePresetId('kelp');
+
+      expect(prefs.getString(cachedThemePresetKey), 'kelp');
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

The startup splash builds its own `MaterialApp`, and that `MaterialApp` carried no `theme`. Flutter substitutes its default `ThemeData`, which is always light, so the screen had two disagreeing sources of colour: a hand-rolled dark palette passed down as props, and a light Material theme driving every themed descendant.

Plain `Text` looked right; the `Card` behind the restore offer did not. On the schema-mismatch screen ("Your Data Is Newer Than This App") that put white text on a near-white M3 card surface and made the whole "Restore your pre-upgrade backup" block unreadable, which is the one route that works without leaving the app. The buttons, progress indicators and escape-hatch dialogs were light-themed for the same reason.

## Changes

- Resolve a real theme at the brightness the splash already computes, and hand it to the splash `MaterialApp`
- Mirror the diver's theme preset into SharedPreferences under `cached_theme_preset`, exactly as the theme mode is already mirrored: the preset lives in the per-diver settings table, which is not readable before the database opens
- The settings notifier now writes both halves of the theme on every save and every hydration; a preset id this build no longer ships falls back to the default
- Tests assert the colour the restore card actually paints, not that a theme was passed, so a light card colour inside a dark theme would still fail

## Test Plan

- [x] `flutter test` passes (25587 passed, 21 pre-existing skips)
- [x] `flutter analyze` passes
- [x] `dart format .` clean
- [x] New regression tests written failing first, against the unfixed code

## Visual result

Verified by rendering the real widget under the splash host in dark mode. Before, the restore card painted a near-white surface under white text; after, the card follows the resolved brightness and the accent follows the diver's preset.

