### PR TITLE
fix(sync): keep the retired identity's cloud files when it owns the only library (#1551)

### DIFF
--- a/lib/core/services/sync/sync_initializer.dart
+++ b/lib/core/services/sync/sync_initializer.dart
@@ -426,6 +426,45 @@ class SyncInitializer {
     CloudStorageProvider provider,
   ) async => classifyPeerFiles(await peerLogFiles(provider));
 
+  /// Whether some device OTHER than [deviceId] publishes a pullable library on
+  /// [provider]. The licence for deleting [deviceId]'s cloud files when this
+  /// install retires that identity (Reset Sync State, and the Repair Sync that
+  /// wraps it): those files are only redundant while a second copy exists.
+  ///
+  /// Without this check the retirement cleanup is destructive exactly where
+  /// the user is most likely to reach for it. An install that inherited an
+  /// earlier install's device id owns the whole cloud library under that id
+  /// (issue #1541, routine on macOS where replacing the .app leaves the
+  /// device-id anchor in ~/Library/Preferences), and the screen it lands on --
+  /// "No library found" -- is the one that points at Repair Sync. The same
+  /// exposure covers any single-device user whose local library is empty or
+  /// damaged. Leaving the files behind instead costs one stale peer log, which
+  /// the freshly minted identity simply pulls; deleting them costs the library
+  /// (issue #1551).
+  ///
+  /// Only a manifest counts. A half-finished publish (base parts, no manifest)
+  /// is not a library anyone can pull, and a retirement marker is a tombstone,
+  /// so [classifyPeerFiles] rules both out. A listing we could not read is not
+  /// evidence of a second copy either, so a failure answers false.
+  Future<bool> anotherDevicePublishesLibrary(
+    String deviceId,
+    CloudStorageProvider provider,
+  ) async {
+    try {
+      final files = await _changesetLogFiles(provider);
+      final others = files
+          .where((f) => ChangesetLogLayout.deviceIdOf(f.name) != deviceId)
+          .toList();
+      return classifyPeerFiles(others) == PeerLibraryState.pullable;
+    } catch (e) {
+      _log.warning(
+        'Could not list the account while retiring $deviceId; keeping its '
+        'cloud files: $e',
+      );
+      return false;
+    }
+  }
+
   /// What the account holds, from the point of view of an install that has no
   /// library of its own yet, i.e. the setup wizard's Connect step.
   ///

--- a/lib/core/services/sync/sync_initializer.dart
+++ b/lib/core/services/sync/sync_initializer.dart
@@ -442,19 +442,29 @@ class SyncInitializer {
   /// the freshly minted identity simply pulls; deleting them costs the library
   /// (issue #1551).
   ///
-  /// Only a manifest counts. A half-finished publish (base parts, no manifest)
-  /// is not a library anyone can pull, and a retirement marker is a tombstone,
-  /// so [classifyPeerFiles] rules both out. A listing we could not read is not
-  /// evidence of a second copy either, so a failure answers false.
+  /// Only a manifest counts, and only one filed under a device id that parses.
+  /// A half-finished publish (base parts, no manifest) is not a library anyone
+  /// can pull, and a retirement marker is a tombstone, so [classifyPeerFiles]
+  /// rules both out. A listing we could not read is not evidence of a second
+  /// copy either, so a failure answers false -- as does one that stalls past
+  /// [timeout], which also keeps reset from hanging behind its non-dismissible
+  /// progress dialog.
   Future<bool> anotherDevicePublishesLibrary(
     String deviceId,
-    CloudStorageProvider provider,
-  ) async {
+    CloudStorageProvider provider, {
+    @visibleForTesting Duration timeout = const Duration(seconds: 8),
+  }) async {
     try {
-      final files = await _changesetLogFiles(provider);
-      final others = files
-          .where((f) => ChangesetLogLayout.deviceIdOf(f.name) != deviceId)
-          .toList();
+      final files = await _changesetLogFiles(provider).timeout(timeout);
+      final others = files.where((f) {
+        final id = ChangesetLogLayout.deviceIdOf(f.name);
+        // A name that parses to no device id was published by no device.
+        // isManifest matches on prefix and suffix alone, so "ssv1..manifest
+        // .json" would otherwise pass as a peer's library and license the
+        // delete. Elsewhere an unparseable name is merely pulled and ignored;
+        // here it would cost the library, so it is dropped.
+        return id != null && id != deviceId;
+      }).toList();
       return classifyPeerFiles(others) == PeerLibraryState.pullable;
     } catch (e) {
       _log.warning(

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -1485,11 +1485,29 @@ class SyncNotifier extends StateNotifier<SyncState> {
   /// the anchored identity, so a clone survives everything short of this.
   /// The retired identity's cloud file is removed best-effort: after the id
   /// changes it would otherwise be merged back as a stale "peer" forever.
+  ///
+  /// That removal is guarded, because the retired id's files are only
+  /// redundant while another device still publishes the library. When it is
+  /// the account's sole publisher -- an install that inherited an earlier
+  /// install's id (#1541), or any single-device user whose local library is
+  /// empty or damaged -- those files ARE the library, and deleting them would
+  /// destroy it (#1551). They are kept instead: an orphaned peer log that the
+  /// identity just minted can pull, which costs one redundant merge at worst.
   Future<void> resetSyncState() async {
     final oldDeviceId = await _syncRepository.getDeviceId();
     await _syncService.resetSyncState();
-    await _ref.read(syncInitializerProvider).adoptFreshIdentity();
-    await _syncService.deleteDeviceSyncFile(oldDeviceId);
+    final initializer = _ref.read(syncInitializerProvider);
+    await initializer.adoptFreshIdentity();
+    // The question is about the RETIRED id, which is no longer this device's,
+    // so it is passed explicitly rather than inferred from the current one.
+    final provider = _ref.read(cloudStorageProviderProvider);
+    if (provider != null &&
+        await initializer.anotherDevicePublishesLibrary(
+          oldDeviceId,
+          provider,
+        )) {
+      await _syncService.deleteDeviceSyncFile(oldDeviceId);
+    }
     // Reset is the manual escape hatch: drop any stuck replace intent and
     // un-pause an awaiting-adoption state.
     await _ref.read(libraryEpochStoreProvider).clearPendingReplace();
@@ -1500,8 +1518,8 @@ class SyncNotifier extends StateNotifier<SyncState> {
   }
 
   /// Comprehensive local repair: the full [resetSyncState] (fresh identity,
-  /// this device's cloud file removed, pending-replace/awaiting-adoption
-  /// cleared) PLUS the last-accepted epoch marker and leftover base temp files,
+  /// this device's cloud file removed unless it is the account's only library,
+  /// pending-replace/awaiting-adoption cleared) PLUS the last-accepted epoch marker and leftover base temp files,
   /// ending with any error cleared. The guaranteed local escape from a wedged
   /// sync (issue #509); dive data is never touched.
   Future<void> repairSync() async {

--- a/test/core/services/sync/sync_initializer_test.dart
+++ b/test/core/services/sync/sync_initializer_test.dart
@@ -370,6 +370,78 @@ void main() {
     });
   });
 
+  // Reset Sync State retires an identity and then deletes its cloud files.
+  // That is only safe while someone else still holds the library (#1551).
+  group('anotherDevicePublishesLibrary', () {
+    test('is true when a peer publishes a manifest', () async {
+      final ownId = await repository.getDeviceId();
+      await provider.uploadFile(_payload, peerFileName(ownId));
+      await provider.uploadFile(_payload, peerFileName('deviceB'));
+
+      expect(
+        await initializer.anotherDevicePublishesLibrary(ownId, provider),
+        isTrue,
+      );
+    });
+
+    test('is false when the retired id is the only publisher', () async {
+      final ownId = await repository.getDeviceId();
+      await provider.uploadFile(_payload, peerFileName(ownId));
+      await provider.uploadFile(
+        _payload,
+        ChangesetLogLayout.basePartName(ownId, 1, 0),
+      );
+
+      expect(
+        await initializer.anotherDevicePublishesLibrary(ownId, provider),
+        isFalse,
+      );
+    });
+
+    test('is false when the other device has no manifest yet', () async {
+      final ownId = await repository.getDeviceId();
+      await provider.uploadFile(_payload, peerFileName(ownId));
+      await provider.uploadFile(
+        _payload,
+        ChangesetLogLayout.basePartName('deviceB', 1, 0),
+      );
+
+      expect(
+        await initializer.anotherDevicePublishesLibrary(ownId, provider),
+        isFalse,
+      );
+    });
+
+    test('is false when the only other file is a retirement marker', () async {
+      final ownId = await repository.getDeviceId();
+      await provider.uploadFile(_payload, peerFileName(ownId));
+      await provider.uploadFile(
+        _payload,
+        ChangesetLogLayout.retiredMarkerName('deviceB'),
+      );
+
+      expect(
+        await initializer.anotherDevicePublishesLibrary(ownId, provider),
+        isFalse,
+      );
+    });
+
+    test('is false when the listing cannot be read', () async {
+      final ownId = await repository.getDeviceId();
+      await provider.uploadFile(_payload, peerFileName(ownId));
+      await provider.uploadFile(_payload, peerFileName('deviceB'));
+      provider.failLists = true;
+
+      expect(
+        await initializer.anotherDevicePublishesLibrary(ownId, provider),
+        isFalse,
+        reason:
+            'an unreadable listing is not evidence of a second copy, and the '
+            'caller deletes on a true',
+      );
+    });
+  });
+
   group('checkSyncOnLaunch provider persistence', () {
     test('saveProvider then getLastProvider round-trips', () async {
       expect(initializer.getLastProvider(), isNull);

--- a/test/core/services/sync/sync_initializer_test.dart
+++ b/test/core/services/sync/sync_initializer_test.dart
@@ -426,6 +426,43 @@ void main() {
       );
     });
 
+    test('is false when a manifest-shaped name carries no device id', () async {
+      // isManifest() matches on prefix and suffix alone, so a malformed name
+      // passes it while deviceIdOf() yields null. Counting that as a peer
+      // would license deleting the retired id's files -- possibly the only
+      // library -- on the strength of a file no device ever published.
+      final ownId = await repository.getDeviceId();
+      await provider.uploadFile(_payload, peerFileName(ownId));
+      await provider.uploadFile(
+        _payload,
+        '${ChangesetLogLayout.prefix}.manifest.json',
+      );
+
+      expect(
+        await initializer.anotherDevicePublishesLibrary(ownId, provider),
+        isFalse,
+      );
+    });
+
+    test('is false when the listing stalls', () async {
+      // resetSyncState runs behind a non-dismissible progress dialog, so an
+      // unbounded listing would strand the user; and a listing that never
+      // answered is not evidence of a second copy.
+      final ownId = await repository.getDeviceId();
+      await provider.uploadFile(_payload, peerFileName(ownId));
+      await provider.uploadFile(_payload, peerFileName('deviceB'));
+      provider.hangOperations = true;
+
+      expect(
+        await initializer.anotherDevicePublishesLibrary(
+          ownId,
+          provider,
+          timeout: const Duration(milliseconds: 20),
+        ),
+        isFalse,
+      );
+    });
+
     test('is false when the listing cannot be read', () async {
       final ownId = await repository.getDeviceId();
       await provider.uploadFile(_payload, peerFileName(ownId));

--- a/test/core/services/sync/sync_reset_hardening_test.dart
+++ b/test/core/services/sync/sync_reset_hardening_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -6,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/sync_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
@@ -156,10 +158,104 @@ void main() {
       },
     );
 
+    test(
+      'keeps the retired log when no other device publishes a library',
+      () async {
+        // The install that owns the whole cloud library under this id -- the
+        // reinstall of #1541, or any single-device user. Deleting here would
+        // shred the only copy (#1551).
+        final cloud = FakeCloudStorageProvider();
+        final oldId = await repository.getDeviceId();
+        await seedPeerManifest(cloud, oldId);
+
+        final prefs = await SharedPreferences.getInstance();
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            cloudStorageProviderProvider.overrideWithValue(cloud),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(syncStateProvider.notifier).resetSyncState();
+
+        expect(await repository.getDeviceId(), isNot(oldId));
+        expect(
+          await hasPublishedLog(cloud, oldId),
+          isTrue,
+          reason:
+              'the retired id was the account\'s only publisher, so its log '
+              'is the whole library -- kept as an orphaned peer log, which '
+              'the freshly minted identity can now pull',
+        );
+      },
+    );
+
+    test('keeps the retired log when the only other device never finished '
+        'publishing', () async {
+      // Base parts but no manifest: a publish that died partway is not a
+      // library anyone can pull, so it cannot license the delete.
+      final cloud = FakeCloudStorageProvider();
+      final oldId = await repository.getDeviceId();
+      await seedPeerManifest(cloud, oldId);
+      final folder = await cloud.getOrCreateSyncFolder();
+      await cloud.uploadFile(
+        Uint8List.fromList(const [1, 2, 3]),
+        ChangesetLogLayout.basePartName('half-published-peer', 1, 0),
+        folderId: folder,
+      );
+
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          cloudStorageProviderProvider.overrideWithValue(cloud),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(syncStateProvider.notifier).resetSyncState();
+
+      expect(await hasPublishedLog(cloud, oldId), isTrue);
+    });
+
+    test(
+      'keeps the retired log when a retirement marker is the only other file',
+      () async {
+        // A retired peer's tombstone is not a second copy of the library.
+        final cloud = FakeCloudStorageProvider();
+        final oldId = await repository.getDeviceId();
+        await seedPeerManifest(cloud, oldId);
+        final folder = await cloud.getOrCreateSyncFolder();
+        await cloud.uploadFile(
+          Uint8List.fromList(utf8.encode('{}')),
+          ChangesetLogLayout.retiredMarkerName('retired-peer'),
+          folderId: folder,
+        );
+
+        final prefs = await SharedPreferences.getInstance();
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            cloudStorageProviderProvider.overrideWithValue(cloud),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(syncStateProvider.notifier).resetSyncState();
+
+        expect(await hasPublishedLog(cloud, oldId), isTrue);
+      },
+    );
+
     test('reset succeeds even when the cloud delete fails', () async {
       final cloud = FakeCloudStorageProvider()..failDeletes = true;
       final oldId = await repository.getDeviceId();
       await seedPeerManifest(cloud, oldId);
+      // A live peer, so the retirement cleanup is actually attempted: with
+      // no other publisher the guard would skip the delete and the failure
+      // this test is about would never happen.
+      await seedPeerManifest(cloud, 'peer-device');
 
       final prefs = await SharedPreferences.getInstance();
       final container = ProviderContainer(


### PR DESCRIPTION
Closes #1551

## Problem

`SyncNotifier.resetSyncState()` (and `repairSync()`, which wraps it) mints a
fresh device identity and then calls `deleteDeviceSyncFile(oldDeviceId)`, which
deletes **every** changeset-log file filed under the retired id: manifest, base
parts, changesets.

That is correct while the retired id's files are this device's redundant log and
the library also lives on peers. It is destructive when the retired id is the
account's **only** publisher:

- an install that inherited an earlier install's device id owns the whole cloud
  library under that id (#1541, routine on macOS where replacing the `.app`
  leaves the device-id anchor in `~/Library/Preferences`), and the screen it
  lands on, "No library found", is exactly the one that points at Repair Sync;
- any single-device user whose local library is empty or damaged.

The confirmation dialog already promises "Your dive data is safe and is not
deleted", which was untrue in precisely those cases.

## Fix

`SyncInitializer.anotherDevicePublishesLibrary(deviceId, provider)` takes the
changeset-log listing once and asks whether some device **other** than the
retired id publishes a pullable library. `resetSyncState()` deletes only on a
true.

Only a manifest counts as a second copy. `classifyPeerFiles` already rules out
the two look-alikes: a half-finished publish (base parts, no manifest) is not
pullable, and a `.retired.json` marker is a tombstone. A listing that cannot be
read is not evidence of a second copy either, so a failure answers false.

Skipping is cheap: the files stay as an orphaned peer log, which the identity
just minted can pull, costing one redundant merge at worst. Deleting them costs
the library. No new user-facing strings, and the existing dialog copy becomes
true rather than needing a rewrite.

`removeThisDeviceCloudFiles` (#509's "remove this device's files") is
deliberately left unguarded: there the deletion is the user's stated intent,
named on the button. The bug was that a differently-labelled action did the same
thing as a silent side effect.

## Tests

`SyncInitializer.anotherDevicePublishesLibrary`: true with a peer manifest;
false when the retired id is the sole publisher, when the other device has base
parts but no manifest, when the only other file is a retirement marker, and when
the listing throws.

`SyncNotifier.resetSyncState`: the retired log survives when it is the only
library, when the only peer never finished publishing, and when the only other
file is a retirement marker. The pre-existing "retires the old changeset log"
test still covers the delete firing when a peer does publish; "reset succeeds
even when the cloud delete fails" now seeds a peer so the delete is actually
attempted.

Every assertion was mutation-tested (the new method's red was a compile error,
which proves nothing on its own): returning `true` unconditionally breaks the
three sole-copy cases, and turning the `catch` into a `rethrow` breaks the
unreadable-listing case.
