### PR TITLE
fix(ui): make every app bar text action visible on every theme (#1231)

### DIFF
--- a/lib/features/buddies/presentation/pages/buddy_edit_page.dart
+++ b/lib/features/buddies/presentation/pages/buddy_edit_page.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:submersion/features/buddies/data/services/contact_photo_loader.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 import 'package:submersion/shared/widgets/profile_photo/profile_photo_picker.dart';
 import 'package:submersion/shared/widgets/profile_photo/profile_avatar.dart';
 import 'package:submersion/shared/utils/contact_import_support.dart';
@@ -300,22 +301,11 @@ class _BuddyEditPageState extends ConsumerState<BuddyEditPage> {
                 : context.l10n.buddies_title_add,
           ),
           actions: [
-            if (_isSaving)
-              const Center(
-                child: Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 16),
-                  child: SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                ),
-              )
-            else
-              TextButton(
-                onPressed: _saveBuddy,
-                child: Text(context.l10n.common_action_save),
-              ),
+            AppBarTextAction(
+              label: context.l10n.common_action_save,
+              onPressed: _isSaving ? null : _saveBuddy,
+              busy: _isSaving,
+            ),
           ],
         ),
         body: body,

--- a/lib/features/certifications/presentation/pages/certification_edit_page.dart
+++ b/lib/features/certifications/presentation/pages/certification_edit_page.dart
@@ -17,6 +17,7 @@ import 'package:submersion/features/certifications/domain/certification_title.da
 import 'package:submersion/features/certifications/domain/entities/certification.dart';
 import 'package:submersion/features/certifications/presentation/providers/certification_providers.dart';
 import 'package:submersion/features/certifications/presentation/widgets/certification_option.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 import 'package:submersion/features/certifications/presentation/certification_level_display.dart';
 import 'package:submersion/features/certifications/presentation/certification_title_l10n.dart';
@@ -901,22 +902,11 @@ class _CertificationEditPageState extends ConsumerState<CertificationEditPage> {
                 : context.l10n.certifications_edit_appBar_add,
           ),
           actions: [
-            if (_isSaving)
-              const Center(
-                child: Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 16),
-                  child: SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                ),
-              )
-            else
-              TextButton(
-                onPressed: _saveCertification,
-                child: Text(context.l10n.certifications_edit_button_save),
-              ),
+            AppBarTextAction(
+              label: context.l10n.certifications_edit_button_save,
+              onPressed: _isSaving ? null : _saveCertification,
+              busy: _isSaving,
+            ),
           ],
         ),
         body: body,

--- a/lib/features/checklists/presentation/pages/checklist_template_edit_page.dart
+++ b/lib/features/checklists/presentation/pages/checklist_template_edit_page.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/checklists/domain/entities/checklist_templat
 import 'package:submersion/features/checklists/presentation/providers/checklist_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 /// Create/edit page for a checklist template and its items.
 class ChecklistTemplateEditPage extends ConsumerStatefulWidget {
@@ -125,9 +126,9 @@ class _ChecklistTemplateEditPageState
       appBar: AppBar(
         title: Text(context.l10n.checklists_templates_pageTitle),
         actions: [
-          TextButton(
+          AppBarTextAction(
+            label: context.l10n.common_action_save,
             onPressed: _loading ? null : _save,
-            child: Text(context.l10n.common_action_save),
           ),
         ],
       ),

--- a/lib/features/courses/presentation/pages/course_edit_page.dart
+++ b/lib/features/courses/presentation/pages/course_edit_page.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/certifications/domain/entities/certification
 import 'package:submersion/features/certifications/presentation/providers/certification_providers.dart';
 import 'package:submersion/features/certifications/presentation/widgets/certification_picker.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 import 'package:submersion/features/certifications/presentation/certification_agency_display.dart';
 
@@ -349,9 +350,9 @@ class _CourseEditPageState extends ConsumerState<CourseEditPage> {
           Semantics(
             button: true,
             label: context.l10n.courses_action_saveSemantic,
-            child: TextButton(
+            child: AppBarTextAction(
+              label: context.l10n.common_action_save,
               onPressed: _isLoading ? null : () => _save(existingCourse),
-              child: Text(context.l10n.common_action_save),
             ),
           ),
         ],

--- a/lib/features/cylinder_configs/presentation/pages/cylinder_config_edit_page.dart
+++ b/lib/features/cylinder_configs/presentation/pages/cylinder_config_edit_page.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/equipment/presentation/providers/equipment_p
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/core/utils/log_failure.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 /// Creates or edits one configuration. Cylinders are a reorderable list;
 /// their sortOrder is derived from list position on save.
@@ -142,9 +143,9 @@ class _CylinderConfigEditPageState
               : l10n.cylinderConfigs_title,
         ),
         actions: [
-          TextButton(
+          AppBarTextAction(
+            label: MaterialLocalizations.of(context).saveButtonLabel,
             onPressed: _saving ? null : _save,
-            child: Text(MaterialLocalizations.of(context).saveButtonLabel),
           ),
         ],
       ),

--- a/lib/features/deco_calculator/presentation/pages/deco_calculator_page.dart
+++ b/lib/features/deco_calculator/presentation/pages/deco_calculator_page.dart
@@ -15,6 +15,7 @@ import 'package:submersion/features/deco_calculator/presentation/widgets/gas_mix
 import 'package:submersion/features/deco_calculator/presentation/widgets/gas_warnings_display.dart';
 import 'package:submersion/features/deco_calculator/presentation/widgets/time_slider.dart';
 import 'package:submersion/features/planning/presentation/widgets/planning_tool_pane.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 /// Interactive deco calculator page with real-time calculations.
 ///
@@ -39,10 +40,10 @@ class DecoCalculatorPage extends ConsumerWidget {
       ),
       Tooltip(
         message: context.l10n.decoCalculator_createPlanTooltip,
-        child: TextButton.icon(
-          icon: const Icon(Icons.edit_calendar),
-          label: Text(context.l10n.decoCalculator_addToPlanner),
+        child: AppBarTextAction(
+          label: context.l10n.decoCalculator_addToPlanner,
           onPressed: () => _addToPlan(context, ref),
+          icon: const Icon(Icons.edit_calendar),
         ),
       ),
     ];

--- a/lib/features/dive_centers/presentation/pages/dive_center_edit_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_edit_page.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/dive_centers/presentation/providers/dive_cen
 import 'package:submersion/features/dive_sites/presentation/widgets/location_picker_map.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 import 'package:submersion/shared/widgets/forms/coordinate_field_group.dart';
 import 'package:submersion/core/utils/log_failure.dart';
 
@@ -618,15 +619,10 @@ class _DiveCenterEditPageState extends ConsumerState<DiveCenterEditPage> {
               : context.l10n.diveCenters_title_add,
         ),
         actions: [
-          TextButton(
+          AppBarTextAction(
+            label: context.l10n.common_action_save,
             onPressed: _isLoading ? null : _save,
-            child: _isLoading
-                ? const SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : Text(context.l10n.common_action_save),
+            busy: _isLoading,
           ),
         ],
       ),

--- a/lib/features/dive_log/presentation/pages/dive_search_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_search_page.dart
@@ -17,6 +17,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/dive_log/presentation/widgets/weekday_filter_selector.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 
 /// Advanced search page with all filter options in collapsible sections.
@@ -201,9 +202,9 @@ class _DiveSearchPageState extends ConsumerState<DiveSearchPage> {
       appBar: AppBar(
         title: Text(context.l10n.diveLog_search_appBar),
         actions: [
-          TextButton(
+          AppBarTextAction(
+            label: context.l10n.diveLog_search_clearAll,
             onPressed: _clearAll,
-            child: Text(context.l10n.diveLog_search_clearAll),
           ),
         ],
       ),

--- a/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/maps/presentation/providers/map_tile_provide
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 /// Result from the location picker
 class PickedLocation {
@@ -145,12 +146,10 @@ class _LocationPickerMapState extends ConsumerState<LocationPickerMap> {
           if (_selectedLocation != null)
             Tooltip(
               message: context.l10n.diveSites_locationPicker_confirmTooltip,
-              child: TextButton.icon(
+              child: AppBarTextAction(
+                label: context.l10n.diveSites_locationPicker_confirmButton,
                 onPressed: _confirmSelection,
                 icon: const Icon(Icons.check),
-                label: Text(
-                  context.l10n.diveSites_locationPicker_confirmButton,
-                ),
               ),
             ),
         ],

--- a/lib/features/equipment/presentation/pages/equipment_edit_page.dart
+++ b/lib/features/equipment/presentation/pages/equipment_edit_page.dart
@@ -15,6 +15,7 @@ import 'package:submersion/features/equipment/domain/entities/equipment_item.dar
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
 import 'package:submersion/features/equipment/presentation/widgets/equipment_attribute_form_section.dart';
 import 'package:submersion/features/equipment/presentation/widgets/equipment_custom_fields_section.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 import 'package:submersion/features/equipment/presentation/utils/equipment_enum_display.dart';
 
@@ -429,25 +430,16 @@ class _EquipmentEditPageState extends ConsumerState<EquipmentEditPage> {
                 : context.l10n.equipment_edit_appBar_newTitle,
           ),
           actions: [
-            if (_isLoading)
-              const Center(
-                child: Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 16),
-                  child: SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                ),
-              )
-            else
-              Tooltip(
-                message: context.l10n.equipment_edit_appBar_saveTooltip,
-                child: TextButton(
-                  onPressed: () => _saveEquipment(existingEquipment),
-                  child: Text(context.l10n.equipment_edit_appBar_saveButton),
-                ),
+            Tooltip(
+              message: context.l10n.equipment_edit_appBar_saveTooltip,
+              child: AppBarTextAction(
+                label: context.l10n.equipment_edit_appBar_saveButton,
+                onPressed: _isLoading
+                    ? null
+                    : () => _saveEquipment(existingEquipment),
+                busy: _isLoading,
               ),
+            ),
           ],
         ),
         body: body,

--- a/lib/features/marine_life/presentation/pages/species_edit_page.dart
+++ b/lib/features/marine_life/presentation/pages/species_edit_page.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/marine_life/domain/entities/species_lookup.d
 import 'package:submersion/features/marine_life/presentation/species_display.dart';
 import 'package:submersion/features/marine_life/presentation/widgets/species_lookup_sheet.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 class SpeciesEditPage extends ConsumerStatefulWidget {
   final String? speciesId;
@@ -104,15 +105,10 @@ class _SpeciesEditPageState extends ConsumerState<SpeciesEditPage> {
           onPressed: () => context.pop(),
         ),
         actions: [
-          TextButton(
+          AppBarTextAction(
+            label: context.l10n.marineLife_speciesEdit_saveButton,
             onPressed: _isSaving ? null : _save,
-            child: _isSaving
-                ? const SizedBox(
-                    width: 16,
-                    height: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : Text(context.l10n.marineLife_speciesEdit_saveButton),
+            busy: _isSaving,
           ),
         ],
       ),

--- a/lib/features/media/presentation/pages/species_tag_picker_page.dart
+++ b/lib/features/media/presentation/pages/species_tag_picker_page.dart
@@ -10,6 +10,7 @@ import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/selection/selection_controller.dart';
 import 'package:submersion/shared/selection/selection_state.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 /// Picks photos to tag with one species, from the dives where the diver
 /// logged it. Pops with the [TagPhotosResult] after tagging, or null.
@@ -66,10 +67,10 @@ class _SpeciesTagPickerPageState extends ConsumerState<SpeciesTagPickerPage> {
             title: Text(l10n.marineLife_tagPicker_title),
             actions: [
               if (allIds.isNotEmpty)
-                TextButton(
+                AppBarTextAction(
                   key: const ValueKey('tag_picker_select_all'),
+                  label: l10n.marineLife_tagPicker_selectAll,
                   onPressed: () => _selection.selectAll(allIds),
-                  child: Text(l10n.marineLife_tagPicker_selectAll),
                 ),
             ],
           ),

--- a/lib/features/pre_dive/presentation/pages/pre_dive_template_edit_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_template_edit_page.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/divers/presentation/providers/diver_provider
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_checklist_template.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 /// Create/edit page for a pre-dive checklist template and its items.
 class PreDiveTemplateEditPage extends ConsumerStatefulWidget {
@@ -169,7 +170,7 @@ class _PreDiveTemplateEditPageState
         ),
         actions: [
           if (_editable)
-            TextButton(onPressed: _save, child: Text(l10n.common_action_save)),
+            AppBarTextAction(label: l10n.common_action_save, onPressed: _save),
         ],
       ),
       body: _loading

--- a/lib/features/settings/presentation/pages/fix_dive_times_page.dart
+++ b/lib/features/settings/presentation/pages/fix_dive_times_page.dart
@@ -7,6 +7,7 @@ import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/settings/data/services/dive_time_migration_service.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 
 class FixDiveTimesPage extends ConsumerStatefulWidget {
@@ -250,13 +251,11 @@ class _FixDiveTimesPageState extends ConsumerState<FixDiveTimesPage> {
         title: Text(context.l10n.settings_fixDiveTimes_title),
         actions: [
           if (_dives.isNotEmpty)
-            TextButton(
+            AppBarTextAction(
+              label: allSelected
+                  ? context.l10n.settings_fixDiveTimes_deselectAll
+                  : context.l10n.settings_fixDiveTimes_selectAll,
               onPressed: _toggleSelectAll,
-              child: Text(
-                allSelected
-                    ? context.l10n.settings_fixDiveTimes_deselectAll
-                    : context.l10n.settings_fixDiveTimes_selectAll,
-              ),
             ),
         ],
       ),

--- a/lib/features/tank_presets/presentation/pages/tank_preset_edit_page.dart
+++ b/lib/features/tank_presets/presentation/pages/tank_preset_edit_page.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/tank_presets/domain/entities/tank_preset_ent
 import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/tank_enum_display.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 class TankPresetEditPage extends ConsumerStatefulWidget {
   final String? presetId;
@@ -132,9 +133,9 @@ class _TankPresetEditPageState extends ConsumerState<TankPresetEditPage> {
           tooltip: context.l10n.common_action_close,
         ),
         actions: [
-          TextButton(
+          AppBarTextAction(
+            label: context.l10n.common_action_save,
             onPressed: _isLoading ? null : _savePreset,
-            child: Text(context.l10n.common_action_save),
           ),
         ],
       ),

--- a/lib/features/trips/presentation/pages/trip_edit_page.dart
+++ b/lib/features/trips/presentation/pages/trip_edit_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
 import 'package:submersion/features/trips/presentation/widgets/dive_assignment_dialog.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
 
 class TripEditPage extends ConsumerStatefulWidget {
@@ -626,26 +627,15 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
                 : context.l10n.trips_edit_appBar_add,
           ),
           actions: [
-            if (_isSaving)
-              const Center(
-                child: Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 16),
-                  child: SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                ),
-              )
-            else
-              Semantics(
-                button: true,
-                label: context.l10n.trips_edit_semanticLabel_save,
-                child: TextButton(
-                  onPressed: _saveTrip,
-                  child: Text(context.l10n.trips_edit_button_save),
-                ),
+            Semantics(
+              button: true,
+              label: context.l10n.trips_edit_semanticLabel_save,
+              child: AppBarTextAction(
+                label: context.l10n.trips_edit_button_save,
+                onPressed: _isSaving ? null : _saveTrip,
+                busy: _isSaving,
               ),
+            ),
           ],
         ),
         body: body,

--- a/lib/features/weight_presets/presentation/pages/weight_preset_editor_page.dart
+++ b/lib/features/weight_presets/presentation/pages/weight_preset_editor_page.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/weight_presets/domain/entities/weight_preset
 import 'package:submersion/features/weight_presets/presentation/providers/weight_preset_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 /// Create or edit a weighting rig from Settings → Management → Weight Presets
 /// (issue #1663). Editing a preset never touches dives that already used it --
@@ -178,9 +179,9 @@ class _WeightPresetEditorPageState
           tooltip: l10n.common_action_cancel,
         ),
         actions: [
-          TextButton(
+          AppBarTextAction(
+            label: l10n.common_action_save,
             onPressed: _saving ? null : _save,
-            child: Text(l10n.common_action_save),
           ),
         ],
       ),

--- a/lib/shared/widgets/app_bar_text_action.dart
+++ b/lib/shared/widgets/app_bar_text_action.dart
@@ -4,17 +4,40 @@ import 'package:flutter/material.dart';
 ///
 /// A bare [TextButton] takes its foreground from `colorScheme.primary`,
 /// which some full themes (Tropical, Console) set to the same color as the
-/// app bar background, rendering the label invisible (#736). This widget
-/// pins the foreground to the app bar's own foreground color instead.
+/// app bar background, rendering the label invisible (#736, and again #1231
+/// on the checklist editors). This widget pins the foreground to the app
+/// bar's own foreground color instead.
+///
+/// `test/shared/widgets/app_bar_text_action_adoption_test.dart` keeps every
+/// app bar text action on this widget, so the defect cannot come back on a
+/// page nobody thought to check.
 class AppBarTextAction extends StatelessWidget {
   const AppBarTextAction({
     super.key,
     required this.label,
     required this.onPressed,
+    this.icon,
+    this.busy = false,
   });
 
   final String label;
-  final VoidCallback onPressed;
+
+  /// Null disables the action. The disabled label is pinned to the same app
+  /// bar foreground at Material's disabled opacity rather than left to the
+  /// theme's `onSurface`-based default, which is what turns a saving-in-
+  /// progress Save into dark-on-dark under the Console app bar.
+  final VoidCallback? onPressed;
+
+  /// Optional leading icon, for actions that carry one (a confirm check, say).
+  final Widget? icon;
+
+  /// Swaps the label for a progress indicator in the same foreground color,
+  /// for pages that report an in-flight save on the action itself. [label]
+  /// still names the action for assistive technology.
+  final bool busy;
+
+  /// Material's disabled foreground opacity for text buttons.
+  static const double _disabledOpacity = 0.38;
 
   @override
   Widget build(BuildContext context) {
@@ -31,10 +54,36 @@ class AppBarTextAction extends StatelessWidget {
         DefaultTextStyle.of(context).style.color ??
         theme.appBarTheme.foregroundColor ??
         theme.colorScheme.onSurface;
-    return TextButton(
-      onPressed: onPressed,
-      style: TextButton.styleFrom(foregroundColor: foreground),
-      child: Text(label),
+
+    final style = TextButton.styleFrom(
+      foregroundColor: foreground,
+      disabledForegroundColor: foreground.withValues(alpha: _disabledOpacity),
     );
+
+    if (busy) {
+      return TextButton(
+        onPressed: onPressed,
+        style: style,
+        child: Semantics(
+          label: label,
+          child: SizedBox(
+            width: 20,
+            height: 20,
+            child: CircularProgressIndicator(strokeWidth: 2, color: foreground),
+          ),
+        ),
+      );
+    }
+
+    if (icon != null) {
+      return TextButton.icon(
+        onPressed: onPressed,
+        style: style,
+        icon: icon,
+        label: Text(label),
+      );
+    }
+
+    return TextButton(onPressed: onPressed, style: style, child: Text(label));
   }
 }

--- a/test/features/checklists/presentation/pages/checklist_template_edit_page_test.dart
+++ b/test/features/checklists/presentation/pages/checklist_template_edit_page_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/theme/full_themes/tropical_theme.dart';
 import 'package:submersion/features/checklists/data/repositories/checklist_template_repository.dart';
 import 'package:submersion/features/checklists/domain/entities/checklist_template.dart';
 import 'package:submersion/features/checklists/presentation/pages/checklist_template_edit_page.dart';
@@ -353,4 +355,37 @@ void main() {
     await tester.pumpAndSettle();
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets(
+    'the Save action stays visible on the tropical app bar when creating a '
+    'new template (#1231)',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            theme: tropicalLight,
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const ChecklistTemplateEditPage(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final style = tester
+          .renderObject<RenderParagraph>(find.text('Save'))
+          .text
+          .style;
+      expect(style?.color, isNotNull);
+      expect(
+        style!.color,
+        isNot(tropicalLight.appBarTheme.backgroundColor),
+        reason:
+            'a bare TextButton paints colorScheme.primary, which this theme '
+            'sets to its own app bar background, so the diver sees no Save '
+            'button at all',
+      );
+    },
+  );
 }

--- a/test/features/pre_dive/presentation/pages/pre_dive_template_edit_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_template_edit_page_test.dart
@@ -1,7 +1,11 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/theme/full_themes/tropical_theme.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/pre_dive/data/repositories/pre_dive_template_repository.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_checklist_template.dart';
@@ -655,4 +659,37 @@ void main() {
       expect(find.text('Save'), findsOneWidget);
     });
   });
+
+  testWidgets(
+    'the Save action stays visible on the tropical app bar when creating a '
+    'new template (#1231)',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            theme: tropicalLight,
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const PreDiveTemplateEditPage(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final style = tester
+          .renderObject<RenderParagraph>(find.text('Save'))
+          .text
+          .style;
+      expect(style?.color, isNotNull);
+      expect(
+        style!.color,
+        isNot(tropicalLight.appBarTheme.backgroundColor),
+        reason:
+            'a bare TextButton paints colorScheme.primary, which this theme '
+            'sets to its own app bar background, so the diver sees no Save '
+            'button at all',
+      );
+    },
+  );
 }

--- a/test/shared/widgets/app_bar_text_action_adoption_test.dart
+++ b/test/shared/widgets/app_bar_text_action_adoption_test.dart
@@ -79,6 +79,39 @@ class Foo {
     );
   });
 
+  // A `${...}` interpolation can hold string literals of the SAME quote as the
+  // string enclosing it, and they do not end it. Terminating at the first
+  // matching quote hands the inner literal's CONTENT to the scan as code; when
+  // that content is a bracket, the span matcher closes the app bar early and
+  // the actions list falls outside it, so a real offender goes unreported.
+  // 103 files under lib/ interpolate an expression holding a bracketed
+  // literal, `readableTextSql('tank_id')` and friends among them.
+  test(
+    'interpolation holding a same-quote literal does not blind the scan',
+    () {
+      const source = r'''
+class Foo {
+  PreferredSizeWidget build(BuildContext context) {
+    return AppBar(
+      title: Text('${name.replaceAll(')', '')} trip'),
+      actions: [
+        TextButton(onPressed: () {}, child: const Text('Save')),
+      ],
+    );
+  }
+}
+''';
+
+      expect(
+        _bareAppBarTextButtons(_withoutCommentsAndStrings(source)),
+        hasLength(1),
+        reason:
+            'quotes inside an interpolation must not close the string that '
+            'contains them, or its bracket leaks into the scanned code',
+      );
+    },
+  );
+
   // The other half of the same branch: a NON-raw literal does process
   // escapes, so an escaped quote must not be mistaken for the terminator.
   test('an escaped quote inside a normal string does not blind the scan', () {
@@ -208,53 +241,96 @@ String _withoutCommentsAndStrings(String source) {
       }
       continue;
     }
-
-    // A leading `r` makes the literal raw, and raw strings have no escape
-    // processing. The backslash in `r'\'` therefore does NOT protect the
-    // quote after it: reading it as an escape swallows the terminator and
-    // inverts the parity of every literal further down the file, blanking
-    // real code and hiding offenders inside it.
-    final raw =
-        source[i] == 'r' &&
-        i + 1 < source.length &&
-        (source[i + 1] == "'" || source[i + 1] == '"') &&
-        (i == 0 || !_isIdentifierPart(source[i - 1]));
-    final quoteAt = raw ? i + 1 : i;
-    final quote = source[quoteAt];
-
-    if (quote == "'" || quote == '"') {
-      final triple = source.startsWith(quote * 3, quoteAt);
-      final terminator = triple ? quote * 3 : quote;
-      // The blanked width covers the `r` prefix as well as the opening quote.
-      out.write(' ' * (quoteAt - i + terminator.length));
-      i = quoteAt + terminator.length;
-      while (i < source.length && !source.startsWith(terminator, i)) {
-        if (!raw && source[i] == r'\' && i + 1 < source.length) {
-          out.write('  ');
-          i += 2;
-          continue;
-        }
-        out.write(source[i] == '\n' ? '\n' : ' ');
-        i++;
-      }
-      // An unterminated literal runs to end of file; there is nothing left
-      // to blank in that case.
-      if (i < source.length) {
-        out.write(' ' * terminator.length);
-        i += terminator.length;
-      }
+    if (_literalBeginsAt(source, i)) {
+      i = _blankLiteral(source, i, out);
       continue;
     }
-
     out.write(source[i]);
     i++;
   }
   return out.toString();
 }
 
-/// Whether [char] can appear inside a Dart identifier.
+/// Whether a string literal begins at [i], counting an `r` prefix as part of
+/// it.
 ///
-/// This is what tells the `r` prefix of a raw string from the last letter of
-/// a name, so a variable such as `ctr` followed by a string cannot be read as
-/// a raw literal.
+/// The character before an `r` is checked so that the tail of a name such as
+/// `ctr` cannot be read as a raw prefix.
+bool _literalBeginsAt(String source, int i) {
+  final char = source[i];
+  if (char == "'" || char == '"') return true;
+  return char == 'r' &&
+      i + 1 < source.length &&
+      (source[i + 1] == "'" || source[i + 1] == '"') &&
+      (i == 0 || !_isIdentifierPart(source[i - 1]));
+}
+
+/// Blanks the string literal starting at [start] into [out], returning the
+/// index just past it. Newlines are preserved so reported line numbers stay
+/// true to the file.
+///
+/// Two Dart rules make this more than a scan to the next quote:
+///
+/// - A raw literal has no escape processing, so the backslash in `r'\'` does
+///   not protect the quote after it.
+/// - A `${...}` interpolation may contain literals quoted the SAME way as the
+///   string enclosing it, and they do not end it. Those nest arbitrarily, so
+///   the interpolation is walked with this function recursing on each literal
+///   it holds.
+///
+/// Getting either wrong does not merely mis-blank one string: it inverts the
+/// parity of the literals that follow, or leaks their content into the scanned
+/// code, where a stray bracket moves where the enclosing widget appears to
+/// end.
+int _blankLiteral(String source, int start, StringBuffer out) {
+  var i = start;
+  final raw = source[i] == 'r';
+  if (raw) {
+    out.write(' ');
+    i++;
+  }
+
+  final quote = source[i];
+  final triple = source.startsWith(quote * 3, i);
+  final terminator = triple ? quote * 3 : quote;
+  out.write(' ' * terminator.length);
+  i += terminator.length;
+
+  while (i < source.length && !source.startsWith(terminator, i)) {
+    if (!raw && source[i] == r'\' && i + 1 < source.length) {
+      out.write('  ');
+      i += 2;
+      continue;
+    }
+    if (!raw && source.startsWith(r'${', i)) {
+      out.write('  ');
+      i += 2;
+      var depth = 1;
+      while (i < source.length && depth > 0) {
+        if (_literalBeginsAt(source, i)) {
+          i = _blankLiteral(source, i, out);
+          continue;
+        }
+        final char = source[i];
+        if (char == '{') depth++;
+        if (char == '}') depth--;
+        out.write(char == '\n' ? '\n' : ' ');
+        i++;
+      }
+      continue;
+    }
+    out.write(source[i] == '\n' ? '\n' : ' ');
+    i++;
+  }
+
+  // An unterminated literal runs to end of file; there is nothing left to
+  // blank in that case.
+  if (i < source.length) {
+    out.write(' ' * terminator.length);
+    i += terminator.length;
+  }
+  return i;
+}
+
+/// Whether [char] can appear inside a Dart identifier.
 bool _isIdentifierPart(String char) => RegExp(r'[A-Za-z0-9_$]').hasMatch(char);

--- a/test/shared/widgets/app_bar_text_action_adoption_test.dart
+++ b/test/shared/widgets/app_bar_text_action_adoption_test.dart
@@ -48,6 +48,59 @@ void main() {
           'themes whose primary color matches their app bar background.',
     );
   });
+
+  // A raw string has no escape processing, so the backslash in `r'\'` does
+  // NOT protect the quote that follows it. Treating it as an escape swallows
+  // the terminator, and every string literal after it in the file is read
+  // with inverted parity: real code gets blanked, and an offender inside it
+  // becomes invisible to the scan. `lib/features/universal_import/domain/
+  // services/import_media_resolver.dart` writes exactly this literal.
+  test('a raw string holding a backslash does not blind the scan', () {
+    const source = r'''
+class Foo {
+  String normalize(String path) => path.replaceAll(r'\', '/');
+
+  PreferredSizeWidget build(BuildContext context) {
+    return AppBar(
+      actions: [
+        TextButton(onPressed: () {}, child: const Text('Save')),
+      ],
+    );
+  }
+}
+''';
+
+    expect(
+      _bareAppBarTextButtons(_withoutCommentsAndStrings(source)),
+      hasLength(1),
+      reason:
+          'the bare TextButton sits after a raw string with a trailing '
+          'backslash, which must not be read as an escape',
+    );
+  });
+
+  // The other half of the same branch: a NON-raw literal does process
+  // escapes, so an escaped quote must not be mistaken for the terminator.
+  test('an escaped quote inside a normal string does not blind the scan', () {
+    const source = '''
+class Foo {
+  String get label => 'it\\'s here';
+
+  PreferredSizeWidget build(BuildContext context) {
+    return AppBar(
+      actions: [
+        TextButton(onPressed: () {}, child: const Text('Save')),
+      ],
+    );
+  }
+}
+''';
+
+    expect(
+      _bareAppBarTextButtons(_withoutCommentsAndStrings(source)),
+      hasLength(1),
+    );
+  });
 }
 
 /// Offsets of every `TextButton(` / `TextButton.icon(` that sits inside the
@@ -137,15 +190,14 @@ String _withoutCommentsAndStrings(String source) {
   final out = StringBuffer();
   var i = 0;
   while (i < source.length) {
-    final rest = source.length - i;
-    if (rest >= 2 && source.startsWith('//', i)) {
+    if (source.startsWith('//', i)) {
       while (i < source.length && source[i] != '\n') {
         out.write(' ');
         i++;
       }
       continue;
     }
-    if (rest >= 2 && source.startsWith('/*', i)) {
+    if (source.startsWith('/*', i)) {
       while (i < source.length && !source.startsWith('*/', i)) {
         out.write(source[i] == '\n' ? '\n' : ' ');
         i++;
@@ -156,14 +208,28 @@ String _withoutCommentsAndStrings(String source) {
       }
       continue;
     }
-    final quote = source[i];
+
+    // A leading `r` makes the literal raw, and raw strings have no escape
+    // processing. The backslash in `r'\'` therefore does NOT protect the
+    // quote after it: reading it as an escape swallows the terminator and
+    // inverts the parity of every literal further down the file, blanking
+    // real code and hiding offenders inside it.
+    final raw =
+        source[i] == 'r' &&
+        i + 1 < source.length &&
+        (source[i + 1] == "'" || source[i + 1] == '"') &&
+        (i == 0 || !_isIdentifierPart(source[i - 1]));
+    final quoteAt = raw ? i + 1 : i;
+    final quote = source[quoteAt];
+
     if (quote == "'" || quote == '"') {
-      final triple = rest >= 3 && source.startsWith(quote * 3, i);
+      final triple = source.startsWith(quote * 3, quoteAt);
       final terminator = triple ? quote * 3 : quote;
-      out.write(' ' * terminator.length);
-      i += terminator.length;
+      // The blanked width covers the `r` prefix as well as the opening quote.
+      out.write(' ' * (quoteAt - i + terminator.length));
+      i = quoteAt + terminator.length;
       while (i < source.length && !source.startsWith(terminator, i)) {
-        if (source[i] == r'\' && i + 1 < source.length) {
+        if (!raw && source[i] == r'\' && i + 1 < source.length) {
           out.write('  ');
           i += 2;
           continue;
@@ -179,8 +245,16 @@ String _withoutCommentsAndStrings(String source) {
       }
       continue;
     }
+
     out.write(source[i]);
     i++;
   }
   return out.toString();
 }
+
+/// Whether [char] can appear inside a Dart identifier.
+///
+/// This is what tells the `r` prefix of a raw string from the last letter of
+/// a name, so a variable such as `ctr` followed by a string cannot be read as
+/// a raw literal.
+bool _isIdentifierPart(String char) => RegExp(r'[A-Za-z0-9_$]').hasMatch(char);

--- a/test/shared/widgets/app_bar_text_action_adoption_test.dart
+++ b/test/shared/widgets/app_bar_text_action_adoption_test.dart
@@ -30,7 +30,10 @@ void main() {
       if (p.equals(entity.path, wrapper)) continue;
 
       final source = _withoutCommentsAndStrings(entity.readAsStringSync());
-      for (final offset in _bareAppBarTextButtons(source)) {
+      for (final offset in [
+        ..._bareAppBarTextButtons(source),
+        ..._bareTextButtonsInHoistedActions(source),
+      ]) {
         final line = '\n'.allMatches(source.substring(0, offset)).length + 1;
         offenders.add('${entity.path}:$line');
       }
@@ -57,7 +60,9 @@ void main() {
 List<int> _bareAppBarTextButtons(String source) {
   final found = <int>[];
   final appBars = RegExp(r'\b(?:Sliver)?AppBar\s*\(');
-  final actions = RegExp(r'\bactions:\s*(?:\.\.\.)?\[');
+  // `const` and a generic type argument are both common in this tree, and
+  // either one silently ended the match before this was widened.
+  final actions = RegExp(r'\bactions:\s*(?:const\s*)?(?:<[^>]*>\s*)?\[');
   final textButtons = RegExp(r'\bTextButton\s*(?:\.\s*icon\s*)?\(');
 
   for (final appBar in appBars.allMatches(source)) {
@@ -72,6 +77,35 @@ List<int> _bareAppBarTextButtons(String source) {
       for (final button in textButtons.allMatches(list)) {
         found.add(open + listOpen + button.start);
       }
+    }
+  }
+  return found;
+}
+
+/// Offsets of every `TextButton(` / `TextButton.icon(` inside a list literal
+/// assigned to a local named `actions`, in a file that builds an app bar.
+///
+/// [_bareAppBarTextButtons] only sees actions written inline, so a page that
+/// hoists its list into a local to share it between an app bar and an embedded
+/// pane slips straight past it. The deco calculator did exactly that, and its
+/// invisible "Add to planner" button survived the first sweep of this bug
+/// because of it.
+///
+/// The `AppBar` requirement is what keeps this from flagging an unrelated
+/// local that happens to be called `actions`, such as a dialog's button list.
+List<int> _bareTextButtonsInHoistedActions(String source) {
+  if (!RegExp(r'\b(?:Sliver)?AppBar\s*\(').hasMatch(source)) return const [];
+
+  final found = <int>[];
+  final hoisted = RegExp(r'\bactions\s*=\s*(?:const\s*)?(?:<[^>]*>\s*)?\[');
+  final textButtons = RegExp(r'\bTextButton\s*(?:\.\s*icon\s*)?\(');
+
+  for (final match in hoisted.allMatches(source)) {
+    final open = match.end - 1;
+    final close = _matchingBracket(source, open);
+    final list = source.substring(open, close);
+    for (final button in textButtons.allMatches(list)) {
+      found.add(open + button.start);
     }
   }
   return found;
@@ -137,8 +171,12 @@ String _withoutCommentsAndStrings(String source) {
         out.write(source[i] == '\n' ? '\n' : ' ');
         i++;
       }
-      out.write(' ' * (i < source.length ? terminator.length : 0));
-      i += i < source.length ? terminator.length : 0;
+      // An unterminated literal runs to end of file; there is nothing left
+      // to blank in that case.
+      if (i < source.length) {
+        out.write(' ' * terminator.length);
+        i += terminator.length;
+      }
       continue;
     }
     out.write(source[i]);

--- a/test/shared/widgets/app_bar_text_action_adoption_test.dart
+++ b/test/shared/widgets/app_bar_text_action_adoption_test.dart
@@ -1,0 +1,148 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+/// A bare [TextButton] takes its foreground from `colorScheme.primary`, which
+/// the Tropical theme sets to the very color of its app bar background and
+/// Console sets to a near neighbour of it. An app bar action written that way
+/// paints its label onto an identical ground and disappears: #736 reported it
+/// on the diver profile pages, #1231 reported the same invisible Save on the
+/// checklist editors after only those six pages were migrated.
+///
+/// Guard the whole tree rather than the pages that regressed, because the next
+/// one will be somewhere new. [AppBarTextAction] pins the label to the app
+/// bar's own foreground color and is the only sanctioned way to put a text
+/// action in an app bar.
+void main() {
+  final wrapper = p.join(
+    'lib',
+    'shared',
+    'widgets',
+    'app_bar_text_action.dart',
+  );
+
+  test('every app bar text action goes through AppBarTextAction', () {
+    final offenders = <String>[];
+
+    for (final entity in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      if (p.equals(entity.path, wrapper)) continue;
+
+      final source = _withoutCommentsAndStrings(entity.readAsStringSync());
+      for (final offset in _bareAppBarTextButtons(source)) {
+        final line = '\n'.allMatches(source.substring(0, offset)).length + 1;
+        offenders.add('${entity.path}:$line');
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'Use AppBarTextAction from lib/shared/widgets/app_bar_text_action.dart '
+          'for AppBar.actions text buttons, so the label stays visible on the '
+          'themes whose primary color matches their app bar background.',
+    );
+  });
+}
+
+/// Offsets of every `TextButton(` / `TextButton.icon(` that sits inside the
+/// `actions:` list of an `AppBar(` or `SliverAppBar(`.
+///
+/// Both enclosures are matched by balancing brackets rather than by line
+/// proximity: a `TextButton` in a dialog's `actions:` is legitimate (a dialog
+/// surface renders `primary` legibly) and lives only a few lines away from an
+/// app bar in the same build method.
+List<int> _bareAppBarTextButtons(String source) {
+  final found = <int>[];
+  final appBars = RegExp(r'\b(?:Sliver)?AppBar\s*\(');
+  final actions = RegExp(r'\bactions:\s*(?:\.\.\.)?\[');
+  final textButtons = RegExp(r'\bTextButton\s*(?:\.\s*icon\s*)?\(');
+
+  for (final appBar in appBars.allMatches(source)) {
+    final open = appBar.end - 1;
+    final close = _matchingBracket(source, open);
+    final arguments = source.substring(open, close);
+
+    for (final action in actions.allMatches(arguments)) {
+      final listOpen = action.end - 1;
+      final listClose = _matchingBracket(arguments, listOpen);
+      final list = arguments.substring(listOpen, listClose);
+      for (final button in textButtons.allMatches(list)) {
+        found.add(open + listOpen + button.start);
+      }
+    }
+  }
+  return found;
+}
+
+/// Index of the bracket closing the one at [open], counting `(` and `[`
+/// together so an argument list and a widget list nest correctly.
+int _matchingBracket(String source, int open) {
+  var depth = 0;
+  for (var i = open; i < source.length; i++) {
+    final char = source[i];
+    if (char == '(' || char == '[') {
+      depth++;
+    } else if (char == ')' || char == ']') {
+      depth--;
+      if (depth == 0) return i;
+    }
+  }
+  return source.length;
+}
+
+/// Blanks out comments and string literals, preserving every offset so the
+/// reported line numbers still point at the real source.
+///
+/// Without this a doc comment naming `TextButton` inside an app bar's build
+/// method, or a string holding a bracket, would either invent an offender or
+/// throw the bracket balance off.
+String _withoutCommentsAndStrings(String source) {
+  final out = StringBuffer();
+  var i = 0;
+  while (i < source.length) {
+    final rest = source.length - i;
+    if (rest >= 2 && source.startsWith('//', i)) {
+      while (i < source.length && source[i] != '\n') {
+        out.write(' ');
+        i++;
+      }
+      continue;
+    }
+    if (rest >= 2 && source.startsWith('/*', i)) {
+      while (i < source.length && !source.startsWith('*/', i)) {
+        out.write(source[i] == '\n' ? '\n' : ' ');
+        i++;
+      }
+      // Blank the terminator too, when the comment is closed at all.
+      for (var k = 0; k < 2 && i < source.length; k++, i++) {
+        out.write(' ');
+      }
+      continue;
+    }
+    final quote = source[i];
+    if (quote == "'" || quote == '"') {
+      final triple = rest >= 3 && source.startsWith(quote * 3, i);
+      final terminator = triple ? quote * 3 : quote;
+      out.write(' ' * terminator.length);
+      i += terminator.length;
+      while (i < source.length && !source.startsWith(terminator, i)) {
+        if (source[i] == r'\' && i + 1 < source.length) {
+          out.write('  ');
+          i += 2;
+          continue;
+        }
+        out.write(source[i] == '\n' ? '\n' : ' ');
+        i++;
+      }
+      out.write(' ' * (i < source.length ? terminator.length : 0));
+      i += i < source.length ? terminator.length : 0;
+      continue;
+    }
+    out.write(source[i]);
+    i++;
+  }
+  return out.toString();
+}

--- a/test/shared/widgets/app_bar_text_action_test.dart
+++ b/test/shared/widgets/app_bar_text_action_test.dart
@@ -124,4 +124,68 @@ void main() {
     await tester.tap(find.text('Save'));
     expect(tapped, isTrue);
   });
+
+  testWidgets('a disabled AppBarTextAction dims the app bar foreground '
+      'rather than falling back to onSurface', (tester) async {
+    await pump(
+      tester,
+      tropicalLight,
+      const AppBarTextAction(label: 'Save', onPressed: null),
+    );
+    final foreground = tropicalLight.appBarTheme.foregroundColor!;
+    expect(
+      renderedColor(tester, 'Save'),
+      foreground.withValues(alpha: 0.38),
+      reason:
+          'styleFrom(foregroundColor:) only colors the enabled state, so a '
+          'Save disabled mid-write would otherwise revert to the theme '
+          'default and disappear again on a dark app bar',
+    );
+  });
+
+  testWidgets('a busy AppBarTextAction shows a progress indicator in the app '
+      'bar foreground and keeps the label for assistive technology', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      tropicalLight,
+      const AppBarTextAction(label: 'Save', onPressed: null, busy: true),
+    );
+
+    expect(find.text('Save'), findsNothing);
+    final indicator = tester.widget<CircularProgressIndicator>(
+      find.byType(CircularProgressIndicator),
+    );
+    expect(
+      indicator.color,
+      tropicalLight.appBarTheme.foregroundColor,
+      reason:
+          'an uncolored indicator paints colorScheme.primary, which is the '
+          'app bar background on this theme',
+    );
+    expect(
+      tester.getSemantics(find.byType(CircularProgressIndicator)).label,
+      'Save',
+    );
+  });
+
+  testWidgets('an icon AppBarTextAction still colors its label', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      tropicalLight,
+      AppBarTextAction(
+        label: 'Confirm',
+        onPressed: () {},
+        icon: const Icon(Icons.check),
+      ),
+    );
+    expect(find.byIcon(Icons.check), findsOneWidget);
+    expect(
+      renderedColor(tester, 'Confirm'),
+      tropicalLight.appBarTheme.foregroundColor,
+    );
+  });
 }


### PR DESCRIPTION
## Summary

Fixes #1231. Creating a checklist appeared to offer no way to save it.

The Save action was there all along. It is a bare `TextButton` in
`AppBar.actions`, which takes its foreground from `colorScheme.primary`, and
the Tropical theme sets `primary` to the very color of its app bar background
(`#00B4A0`). The label was painted teal on teal. Console sets `primary` to a
near neighbour of its app bar background (`#1A2230` on `#2A3444`, roughly
1.3:1) and is barely better.

This is the same defect as #736, which produced `AppBarTextAction` to pin the
label to the app bar's own foreground color. Only the six diver profile pages
adopted it, so sixteen other actions across the app were still invisible on
those themes, the two checklist template editors among them.

The failing test in this branch pins the mechanism: on `tropicalLight` the
rendered Save label resolved to `Color(0.0000, 0.7059, 0.6275)`, which is
exactly `appBarTheme.backgroundColor`.

## Changes

- Migrate all sixteen remaining `AppBar.actions` text buttons to
  `AppBarTextAction`: both checklist template editors, plus buddy,
  certification, course, cylinder config, dive center, dive search, equipment,
  location picker, species, species tag picker, fix dive times, tank preset,
  trip and weight preset.
- Widen `AppBarTextAction` so it can cover those call sites: a nullable
  `onPressed` (several pages disable Save while a write is in flight), an
  optional `icon`, and a `busy` flag that swaps the label for a progress
  indicator while keeping the label for assistive technology.
- Pin the disabled label to the app bar foreground at Material's 38% opacity.
  `TextButton.styleFrom(foregroundColor:)` only colors the enabled state, so a
  Save disabled mid-write would otherwise revert to the theme's
  `onSurface` default and disappear again on a dark app bar.
- Collapse the four hand-rolled app bar spinners onto `busy`. An uncolored
  `CircularProgressIndicator` also paints `colorScheme.primary`, so those were
  invisible mid-save for exactly the same reason.
- Add `test/shared/widgets/app_bar_text_action_adoption_test.dart`, a repo-wide
  guard that fails on any bare `TextButton` inside an `AppBar`'s `actions`
  list. It matches both enclosures by balancing brackets rather than by line
  proximity, so a dialog's own `actions` (legible on a dialog surface) stay
  allowed. This follows the existing `app_date_picker_adoption_test` pattern,
  on the reasoning that the next regression will be on a page nobody thought
  to check.

## Test Plan

- [x] `flutter test` passes (25586 passed, 21 skipped, 0 failures)
- [x] `flutter analyze` passes (no issues)
- [x] New page-level regression test on each checklist editor asserting the
      Save label does not resolve to the app bar background, red before the
      fix and green after
- [x] New coverage for the disabled, busy and icon paths of
      `AppBarTextAction`
- [x] Manual testing on: not run. The defect and the fix are both pinned by
      color assertions against `tropicalLight`, so a visual pass is a
      confirmation rather than the evidence.

## Notes for review

`AppBarTextAction` still renders a `TextButton` internally, so existing tests
that locate actions with `find.widgetWithText(TextButton, 'Save')` keep
working. That is why a sixteen-page migration produced no test churn.

Two behavioural details worth a look:

- The species editor's busy indicator grows from 16 to 20 logical pixels, now
  sharing the size the other pages already used.
- The four collapsed spinner branches previously rendered no button at all
  while saving. They now render a disabled, busy button, so the action keeps
  its place in the app bar instead of the row reflowing mid-save.


## Update after review

Copilot flagged that the guard's `actions:` matcher required a bare `[`, so
`actions: const [...]` never reached it. That was correct, and 11 such sites
exist in `lib/`.

Chasing it found a wider blind spot and one more real defect. A page that
hoists its actions into a local, to share the list between an app bar and an
embedded pane, never writes `actions:` adjacent to a `[` at all. The deco
calculator does that, and its "Add to planner" action was a bare
`TextButton.icon`, invisible on Tropical exactly like the rest. It is migrated
now, so this PR covers seventeen call sites rather than sixteen.

The guard gained a companion scan for list literals assigned to a local named
`actions` in a file that builds an app bar, verified by mutation: it reports
`deco_calculator_page.dart:42` against the unfixed page and stays silent once
fixed.

Copilot's other point, that the guard uses Python-style string operations and
an invalid raw string literal, is a false positive. `String` declares
`operator *(int)` in `dart:core`, and `r'\'` is a valid Dart raw string holding
one backslash. The file analyzes clean and its tests pass. The flagged branch
was simplified anyway, since it evaluated the same condition twice.

Full suite re-run after these changes: 25586 passed, 21 skipped, 0 failures.
`flutter analyze` clean.


## Second review round: the guard had a real hole

Copilot's follow-up review raised a suppressed comment with no thread, and it
was correct. The guard's comment and string stripper treated a backslash as an
escape in every literal, but a raw string has no escape processing: the
backslash in `r'\'` does not protect the quote after it. Reading it as an
escape swallowed the terminator, so every string literal further down that file
was blanked with inverted parity, taking real code with it and hiding any
offender inside.

That literal is live in this tree:
`lib/features/universal_import/domain/services/import_media_resolver.dart:141`
writes `replaceAll(r'\', '/')`.

The stripper now recognises an `r` prefix, checking the preceding character so
a name ending in `r` cannot be mistaken for one, and skips escape handling for
raw literals. Two tests pin both halves of that branch: a bare `TextButton`
placed after a raw string with a trailing backslash, and one placed after a
normal string with an escaped quote. The first fails against the old stripper,
reporting no offenders where there is one.

Worth knowing if you touch these tests: the sample sources have to be raw
(`r'''`) themselves. Inside an ordinary `'''` literal Dart's own escape
processing removes the backslash before the stripper ever sees it, and the test
passes while proving nothing. The first version of this test did exactly that.

Full suite after this round: 25588 passed, 21 skipped, 0 failures.
`flutter analyze` clean.


## Third review round: interpolation

Also correct, and a wider hole than the raw string. The stripper ended a
literal at the first matching quote, but a `${...}` interpolation may hold
literals quoted the same way as the string enclosing it, and those do not end
it. The inner literal's content was therefore handed to the scan as code, and
when that content is a bracket the span matcher closes the app bar early, the
actions list falls outside it, and a real offender goes unreported.

141 files under `lib/` carry the same-quote shape; 103 interpolate an
expression holding a bracketed literal, `readableTextSql('tank_id')` among
them.

The stripper is now a small lexer. `_literalBeginsAt` finds a literal with or
without its raw prefix, and `_blankLiteral` walks one, recursing on every
literal inside an interpolation so nesting of any depth is handled. Raw
literals skip both escape and interpolation handling, since raw strings do
neither.

The new test fails against the old stripper by finding no offender where one is
planted, which is the dangerous direction for a guard. The repo-wide scan still
reports zero offenders under the corrected parse, so the sharper reading did
not unmask anything that had been hiding behind the old one.

Full suite after this round: 25589 passed, 21 skipped, 0 failures.
`flutter analyze` clean.
