### PR TITLE
fix(selection): return to the normal list after a bulk action (#1262)

### DIFF
--- a/lib/features/buddies/presentation/widgets/buddy_list_content.dart
+++ b/lib/features/buddies/presentation/widgets/buddy_list_content.dart
@@ -231,14 +231,15 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
     _handleItemTap(buddies[index].buddy);
   }
 
-  Future<void> _startMerge() async {
+  Future<BulkActionOutcome> _startMerge() async {
     final selectedCount = _selectedIds.length;
     final result = await context.push<BuddyMergeResult>(
       '/buddies/merge',
       extra: _selectedIds.toList(),
     );
 
-    if (!mounted || result == null) return;
+    if (result == null) return BulkActionOutcome.cancelled;
+    if (!mounted) return BulkActionOutcome.completed;
 
     _mergeSnapshot = result.snapshot;
     final mergedId = result.survivorId;
@@ -282,9 +283,10 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
         ),
       );
     }
+    return BulkActionOutcome.completed;
   }
 
-  Future<void> _confirmAndDelete() async {
+  Future<BulkActionOutcome> _confirmAndDelete() async {
     final count = _selectedIds.length;
     final confirmed = await showDialog<bool>(
       context: context,
@@ -327,7 +329,9 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
           ),
         );
       }
+      return BulkActionOutcome.completed;
     }
+    return BulkActionOutcome.cancelled;
   }
 
   Future<void> _importFromContacts(BuildContext context) async {

--- a/lib/features/certifications/presentation/widgets/certification_list_content.dart
+++ b/lib/features/certifications/presentation/widgets/certification_list_content.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/constants/sort_options_display.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/selection/bulk_action.dart';
 import 'package:submersion/shared/selection/selectable_list_scope.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
 import 'package:submersion/shared/selection/selection_app_bar.dart';
@@ -303,9 +304,9 @@ class _CertificationListContentState
     _handleItemTap(cert);
   }
 
-  Future<void> _confirmAndDelete() async {
+  Future<BulkActionOutcome> _confirmAndDelete() async {
     final ids = _selectedIds.toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -327,7 +328,7 @@ class _CertificationListContentState
         ],
       ),
     );
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !mounted) return BulkActionOutcome.cancelled;
 
     final messenger = ScaffoldMessenger.of(context);
     final notifier = ref.read(certificationListNotifierProvider.notifier);
@@ -335,12 +336,13 @@ class _CertificationListContentState
     for (final id in ids) {
       await notifier.deleteCertification(id);
     }
-    if (!mounted) return;
+    if (!mounted) return BulkActionOutcome.completed;
     messenger.showSnackBar(
       SnackBar(
         content: Text(context.l10n.common_bulkDelete_snackbar(ids.length)),
       ),
     );
+    return BulkActionOutcome.completed;
   }
 
   Widget _buildTableModeScaffold(

--- a/lib/features/courses/presentation/widgets/course_list_content.dart
+++ b/lib/features/courses/presentation/widgets/course_list_content.dart
@@ -266,9 +266,9 @@ class _CourseListContentState extends ConsumerState<CourseListContent> {
   }
 
   /// Mark every checked course complete, mirroring the per-course action.
-  Future<void> _markSelectedComplete() async {
+  Future<BulkActionOutcome> _markSelectedComplete() async {
     final ids = _selectedIds.toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
     final courses = (ref.read(courseListNotifierProvider).value ?? const [])
         .where((c) => ids.contains(c.id))
         .toList();
@@ -279,11 +279,12 @@ class _CourseListContentState extends ConsumerState<CourseListContent> {
     for (final course in courses) {
       await notifier.updateCourse(course.copyWith(completionDate: now));
     }
+    return BulkActionOutcome.completed;
   }
 
-  Future<void> _confirmAndDelete() async {
+  Future<BulkActionOutcome> _confirmAndDelete() async {
     final ids = _selectedIds.toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -305,7 +306,7 @@ class _CourseListContentState extends ConsumerState<CourseListContent> {
         ],
       ),
     );
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !mounted) return BulkActionOutcome.cancelled;
 
     final messenger = ScaffoldMessenger.of(context);
     final notifier = ref.read(courseListNotifierProvider.notifier);
@@ -313,12 +314,13 @@ class _CourseListContentState extends ConsumerState<CourseListContent> {
     for (final id in ids) {
       await notifier.deleteCourse(id);
     }
-    if (!mounted) return;
+    if (!mounted) return BulkActionOutcome.completed;
     messenger.showSnackBar(
       SnackBar(
         content: Text(context.l10n.common_bulkDelete_snackbar(ids.length)),
       ),
     );
+    return BulkActionOutcome.completed;
   }
 
   Widget _buildTableModeScaffold(

--- a/lib/features/cylinder_configs/presentation/pages/cylinder_config_list_page.dart
+++ b/lib/features/cylinder_configs/presentation/pages/cylinder_config_list_page.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/cylinder_configs/presentation/providers/cyli
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/selection/bulk_action.dart';
 import 'package:submersion/shared/selection/selectable_list_scope.dart';
 import 'package:submersion/shared/selection/selection_checkbox_slot.dart';
 import 'package:submersion/shared/selection/selection_app_bar.dart';
@@ -144,9 +145,9 @@ class _CylinderConfigListPageState
     );
   }
 
-  Future<void> _confirmAndDelete() async {
+  Future<BulkActionOutcome> _confirmAndDelete() async {
     final ids = _selectedIds.toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -168,7 +169,7 @@ class _CylinderConfigListPageState
         ],
       ),
     );
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !mounted) return BulkActionOutcome.cancelled;
 
     final messenger = ScaffoldMessenger.of(context);
     final repo = ref.read(cylinderConfigRepositoryProvider);
@@ -176,13 +177,14 @@ class _CylinderConfigListPageState
     for (final id in ids) {
       await repo.deleteConfig(id);
     }
-    if (!mounted) return;
+    if (!mounted) return BulkActionOutcome.completed;
     ref.invalidate(cylinderConfigsProvider);
     messenger.showSnackBar(
       SnackBar(
         content: Text(context.l10n.common_bulkDelete_snackbar(ids.length)),
       ),
     );
+    return BulkActionOutcome.completed;
   }
 }
 

--- a/lib/features/dive_centers/presentation/widgets/dive_center_list_content.dart
+++ b/lib/features/dive_centers/presentation/widgets/dive_center_list_content.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/constants/sort_options_display.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/selection/bulk_action.dart';
 import 'package:submersion/shared/selection/selectable_list_scope.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
 import 'package:submersion/shared/selection/selection_app_bar.dart';
@@ -356,9 +357,9 @@ class _DiveCenterListContentState extends ConsumerState<DiveCenterListContent> {
     _handleItemTap(center);
   }
 
-  Future<void> _confirmAndDelete() async {
+  Future<BulkActionOutcome> _confirmAndDelete() async {
     final ids = _selectedIds.toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -380,7 +381,7 @@ class _DiveCenterListContentState extends ConsumerState<DiveCenterListContent> {
         ],
       ),
     );
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !mounted) return BulkActionOutcome.cancelled;
 
     final messenger = ScaffoldMessenger.of(context);
     final notifier = ref.read(diveCenterListNotifierProvider.notifier);
@@ -388,12 +389,13 @@ class _DiveCenterListContentState extends ConsumerState<DiveCenterListContent> {
     for (final id in ids) {
       await notifier.deleteDiveCenter(id);
     }
-    if (!mounted) return;
+    if (!mounted) return BulkActionOutcome.completed;
     messenger.showSnackBar(
       SnackBar(
         content: Text(context.l10n.common_bulkDelete_snackbar(ids.length)),
       ),
     );
+    return BulkActionOutcome.completed;
   }
 
   Widget _buildTableModeScaffold(

--- a/lib/features/dive_computer/presentation/pages/device_list_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_list_page.dart
@@ -141,18 +141,19 @@ class _DeviceListPageState extends ConsumerState<DeviceListPage> {
 
   /// Folds the checked computers into one (#645). The sheet owns the
   /// confirmation; this only reports the outcome and leaves selection mode.
-  Future<void> _startMerge() async {
+  Future<BulkActionOutcome> _startMerge() async {
     final ids = _selectedIds;
     final computers = [
       for (final computer
           in ref.read(allDiveComputersProvider).value ?? const <DiveComputer>[])
         if (ids.contains(computer.id)) computer,
     ];
-    if (computers.length < 2) return;
+    if (computers.length < 2) return BulkActionOutcome.cancelled;
 
     final messenger = ScaffoldMessenger.of(context);
     final result = await DiveComputerMergeSheet.show(context, computers);
-    if (result == null || !mounted) return;
+    if (result == null) return BulkActionOutcome.cancelled;
+    if (!mounted) return BulkActionOutcome.completed;
 
     _selection.exit();
     final survivor = computers.firstWhere((c) => c.id == result.survivorId);
@@ -166,11 +167,12 @@ class _DeviceListPageState extends ConsumerState<DeviceListPage> {
         ),
       ),
     );
+    return BulkActionOutcome.completed;
   }
 
-  Future<void> _confirmAndDelete() async {
+  Future<BulkActionOutcome> _confirmAndDelete() async {
     final ids = _selectedIds.toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -192,7 +194,7 @@ class _DeviceListPageState extends ConsumerState<DeviceListPage> {
         ],
       ),
     );
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !mounted) return BulkActionOutcome.cancelled;
 
     final messenger = ScaffoldMessenger.of(context);
     final notifier = ref.read(diveComputerNotifierProvider.notifier);
@@ -200,12 +202,13 @@ class _DeviceListPageState extends ConsumerState<DeviceListPage> {
     for (final id in ids) {
       await notifier.delete(id);
     }
-    if (!mounted) return;
+    if (!mounted) return BulkActionOutcome.completed;
     messenger.showSnackBar(
       SnackBar(
         content: Text(context.l10n.common_bulkDelete_snackbar(ids.length)),
       ),
     );
+    return BulkActionOutcome.completed;
   }
 
   Widget _buildEmptyState(BuildContext context, ColorScheme colorScheme) {

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -337,21 +337,22 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
   }
 
   /// Pick a date range and select every dive whose date falls inside it.
-  Future<void> _selectByDateRange(List<DiveSummary> dives) async {
+  Future<BulkActionOutcome> _selectByDateRange(List<DiveSummary> dives) async {
     final range = await showAppDateRangePicker(
       context: context,
       firstDate: DateTime(1970),
       lastDate: DateTime(2100),
     );
-    if (range == null) return;
+    if (range == null) return BulkActionOutcome.cancelled;
     final matching = dives
         .where((d) => inDateRange(d, range))
         .map((d) => d.id)
         .toList();
     _selection.selectAll([..._selectedIds, ...matching]);
+    return BulkActionOutcome.completed;
   }
 
-  Future<void> _confirmAndDelete() async {
+  Future<BulkActionOutcome> _confirmAndDelete() async {
     final count = _selectedIds.length;
     final confirmed = await showDialog<bool>(
       context: context,
@@ -423,7 +424,9 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
           ),
         );
       }
+      return BulkActionOutcome.completed;
     }
+    return BulkActionOutcome.cancelled;
   }
 
   /// Show the combine-dives dialog for the current selection, then refresh
@@ -433,16 +436,17 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
   /// clearing, but the snackbar action is #406-complete: `persist: false` is
   /// required whenever a SnackBar has an action, otherwise it defaults to
   /// persisting until explicitly dismissed.
-  Future<void> _combineSelected() async {
+  Future<BulkActionOutcome> _combineSelected() async {
     final ids = _selectedIds.toList();
-    if (ids.length < 2) return;
+    if (ids.length < 2) return BulkActionOutcome.cancelled;
     final scaffoldMessenger = ScaffoldMessenger.of(context);
 
     final outcome = await showCombineDivesDialog(
       context: context,
       diveIds: ids,
     );
-    if (outcome == null || !mounted) return;
+    if (outcome == null) return BulkActionOutcome.cancelled;
+    if (!mounted) return BulkActionOutcome.completed;
 
     // Select the merged dive the same way a list tap does: highlight its row
     // (highlightedDiveIdProvider) AND open it in the detail pane
@@ -526,6 +530,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
     // first or the row won't exist yet to scroll to.
     await ref.read(paginatedDiveListProvider.notifier).refresh();
     if (mounted) _scrollToSelectedItem(outcome.mergedDive.id);
+    return BulkActionOutcome.completed;
   }
 
   /// Invalidate the merge-derived providers other than the paginated list
@@ -541,10 +546,10 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
     _invalidateStatsAfterMerge();
   }
 
-  void _showExportDialog() {
+  Future<BulkActionOutcome> _showExportDialog() async {
     final count = _selectedIds.length;
 
-    showModalBottomSheet(
+    final format = await showModalBottomSheet<_BulkExportFormat>(
       context: context,
       builder: (sheetContext) => SafeArea(
         child: Column(
@@ -572,46 +577,35 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
               leading: const Icon(Icons.picture_as_pdf),
               title: Text(context.l10n.diveLog_bulkExport_pdf),
               subtitle: Text(context.l10n.diveLog_bulkExport_pdfDescription),
-              onTap: () {
-                Navigator.pop(sheetContext);
-                _exportSelectedAs(
-                  _BulkExportFormat.pdf,
-                  context.l10n.diveLog_bulkExport_pdf,
-                );
-              },
+              onTap: () => Navigator.pop(sheetContext, _BulkExportFormat.pdf),
             ),
             ListTile(
               leading: const Icon(Icons.table_chart),
               title: Text(context.l10n.diveLog_bulkExport_csv),
               subtitle: Text(context.l10n.diveLog_bulkExport_csvDescription),
-              onTap: () {
-                Navigator.pop(sheetContext);
-                _exportSelectedAs(
-                  _BulkExportFormat.csv,
-                  context.l10n.diveLog_bulkExport_csv,
-                );
-              },
+              onTap: () => Navigator.pop(sheetContext, _BulkExportFormat.csv),
             ),
             ListTile(
               leading: const Icon(Icons.code),
               title: Text(context.l10n.diveLog_bulkExport_uddf),
               subtitle: Text(context.l10n.diveLog_bulkExport_uddfDescription),
-              onTap: () {
-                Navigator.pop(sheetContext);
-                _exportSelectedAs(
-                  _BulkExportFormat.uddf,
-                  context.l10n.diveLog_bulkExport_uddf,
-                );
-              },
+              onTap: () => Navigator.pop(sheetContext, _BulkExportFormat.uddf),
             ),
             const SizedBox(height: 8),
           ],
         ),
       ),
     );
+
+    if (format == null || !mounted) return BulkActionOutcome.cancelled;
+    return _exportSelectedAs(format, switch (format) {
+      _BulkExportFormat.pdf => context.l10n.diveLog_bulkExport_pdf,
+      _BulkExportFormat.csv => context.l10n.diveLog_bulkExport_csv,
+      _BulkExportFormat.uddf => context.l10n.diveLog_bulkExport_uddf,
+    });
   }
 
-  Future<void> _exportSelectedAs(
+  Future<BulkActionOutcome> _exportSelectedAs(
     _BulkExportFormat format,
     String formatLabel,
   ) async {
@@ -621,7 +615,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
     if (format == _BulkExportFormat.pdf) {
       pdfOptions = await PdfExportDialog.show(context);
       // A null return means the diver cancelled, not that anything failed.
-      if (pdfOptions == null || !mounted) return;
+      if (pdfOptions == null || !mounted) return BulkActionOutcome.cancelled;
     }
 
     // Only UDDF carries raw dive computer bytes, so only it offers the
@@ -631,7 +625,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
       title: formatLabel,
       showRawDataToggle: format == _BulkExportFormat.uddf,
     );
-    if (choice == null || !mounted) return;
+    if (choice == null || !mounted) return BulkActionOutcome.cancelled;
     final destination = choice.destination;
     final uddfOptions = UddfExportOptions(
       includeRawData: choice.includeRawData,
@@ -715,10 +709,10 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
           // Keep the export going without the personalization.
         }
       }
-      if (!mounted) return;
+      if (!mounted) return BulkActionOutcome.cancelled;
 
       if (!keepDialogForDelivery) {
-        if (!mounted) return;
+        if (!mounted) return BulkActionOutcome.cancelled;
         Navigator.of(context, rootNavigator: true).pop();
         dialogVisible = false;
       }
@@ -771,14 +765,13 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
                 ),
       };
 
-      if (!mounted) return;
+      if (!mounted) return BulkActionOutcome.completed;
       if (dialogVisible) {
         Navigator.of(context, rootNavigator: true).pop();
         dialogVisible = false;
       }
       // A null path means the save panel was dismissed - not a failure.
-      if (path == null) return;
-      _exitSelectionMode();
+      if (path == null) return BulkActionOutcome.cancelled;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
@@ -787,6 +780,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
           backgroundColor: Colors.green,
         ),
       );
+      return BulkActionOutcome.completed;
     } catch (e) {
       if (mounted) {
         if (dialogVisible) {
@@ -799,23 +793,35 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
           ),
         );
       }
+      return BulkActionOutcome.failed;
     }
   }
 
-  /// Open the bulk-edit form for the selected dives, then exit selection mode.
-  Future<void> _openBulkEdit() async {
+  /// Open the bulk edit form for the selected dives.
+  ///
+  /// Reports completed either way. The form leaves itself with
+  /// `context.go('/dives')` rather than popping a result, so a saved edit and
+  /// a cancelled one both complete the pushed route's future with null and are
+  /// indistinguishable from here. Teaching it to pop a result would have to
+  /// keep the `go` fallback for the deep-linked entry, and popping inside the
+  /// shell navigator is what blanks a master-detail pane -- so this keeps the
+  /// behavior it has always had rather than risking that for the cancel case.
+  Future<BulkActionOutcome> _openBulkEdit() async {
     final ids = _selectedIds.toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
     await context.pushNamed('bulkEditDives', extra: ids);
-    if (mounted) _exitSelectionMode();
+    return BulkActionOutcome.completed;
   }
 
-  /// Open the 3D comparison view for the selected dives, then exit selection.
-  Future<void> _compareIn3d() async {
+  /// Open the 3D comparison view for the selected dives.
+  ///
+  /// Opening the comparison IS the action, so it completes as soon as the
+  /// view has been shown; there is nothing to cancel out of.
+  Future<BulkActionOutcome> _compareIn3d() async {
     final ids = _selectedIds.toList();
-    if (ids.length < 2) return;
+    if (ids.length < 2) return BulkActionOutcome.cancelled;
     await context.pushNamed('compareDives3d', extra: ids);
-    if (mounted) _exitSelectionMode();
+    return BulkActionOutcome.completed;
   }
 
   /// One tap policy for every dive row, in every view mode.
@@ -1331,6 +1337,9 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
       ),
       BulkAction(
         id: 'date_range',
+        // Builds the selection instead of acting on it, so it is the one
+        // action that must leave the mode standing.
+        exitsSelectionOnComplete: false,
         icon: Icons.date_range,
         label: context.l10n.diveLog_selection_tooltip_selectDateRange,
         // Operates on the visible list rather than the selection, so it is

--- a/lib/features/dive_sites/presentation/widgets/site_list_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_content.dart
@@ -248,14 +248,15 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
     _handleItemTap(sites[index].site);
   }
 
-  Future<void> _startMerge() async {
+  Future<BulkActionOutcome> _startMerge() async {
     final selectedCount = _selectedIds.length;
     final result = await context.push<SiteMergeResult>(
       '/sites/merge',
       extra: _selectedIds.toList(),
     );
 
-    if (!mounted || result == null) return;
+    if (result == null) return BulkActionOutcome.cancelled;
+    if (!mounted) return BulkActionOutcome.completed;
 
     _mergeSnapshot = result.snapshot;
     final mergedId = result.survivorId;
@@ -300,9 +301,10 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
         ),
       );
     }
+    return BulkActionOutcome.completed;
   }
 
-  Future<void> _confirmAndDelete() async {
+  Future<BulkActionOutcome> _confirmAndDelete() async {
     final count = _selectedIds.length;
     final confirmed = await showDialog<bool>(
       context: context,
@@ -371,7 +373,9 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
           ),
         );
       }
+      return BulkActionOutcome.completed;
     }
+    return BulkActionOutcome.cancelled;
   }
 
   void _showSortSheet(BuildContext context) {

--- a/lib/features/equipment/presentation/pages/service_kind_list_page.dart
+++ b/lib/features/equipment/presentation/pages/service_kind_list_page.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/equipment/domain/entities/service_kind.dart'
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
 import 'package:submersion/features/equipment/presentation/utils/service_category_label.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/selection/bulk_action.dart';
 import 'package:submersion/shared/selection/selectable_list_scope.dart';
 import 'package:submersion/shared/selection/selection_app_bar.dart';
 import 'package:submersion/shared/selection/selection_controller.dart';
@@ -178,9 +179,9 @@ class _ServiceKindListPageState extends ConsumerState<ServiceKindListPage> {
     );
   }
 
-  Future<void> _confirmAndDeleteSelected() async {
+  Future<BulkActionOutcome> _confirmAndDeleteSelected() async {
     final ids = _selectedIds.toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -202,7 +203,7 @@ class _ServiceKindListPageState extends ConsumerState<ServiceKindListPage> {
         ],
       ),
     );
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !mounted) return BulkActionOutcome.cancelled;
 
     final messenger = ScaffoldMessenger.of(context);
     final repo = ref.read(serviceKindRepositoryProvider);
@@ -210,7 +211,7 @@ class _ServiceKindListPageState extends ConsumerState<ServiceKindListPage> {
     for (final id in ids) {
       await repo.deleteKind(id);
     }
-    if (!mounted) return;
+    if (!mounted) return BulkActionOutcome.completed;
     // Mirrors the per-row delete: the kind list and the equipment clocks that
     // reference cascaded schedules both need re-reading.
     ref.invalidate(serviceKindsProvider);
@@ -220,6 +221,7 @@ class _ServiceKindListPageState extends ConsumerState<ServiceKindListPage> {
         content: Text(context.l10n.common_bulkDelete_snackbar(ids.length)),
       ),
     );
+    return BulkActionOutcome.completed;
   }
 
   Future<void> _confirmDelete(

--- a/lib/features/equipment/presentation/widgets/equipment_list_content.dart
+++ b/lib/features/equipment/presentation/widgets/equipment_list_content.dart
@@ -377,9 +377,9 @@ class _EquipmentListContentState extends ConsumerState<EquipmentListContent> {
 
   /// Retire or reactivate every checked item, mirroring the per-item actions
   /// on the detail page.
-  Future<void> _applyRetirement({required bool retire}) async {
+  Future<BulkActionOutcome> _applyRetirement({required bool retire}) async {
     final ids = _selectedIds.toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
 
     final messenger = ScaffoldMessenger.of(context);
     final notifier = ref.read(equipmentListNotifierProvider.notifier);
@@ -393,7 +393,7 @@ class _EquipmentListContentState extends ConsumerState<EquipmentListContent> {
       }
     }
 
-    if (!mounted) return;
+    if (!mounted) return BulkActionOutcome.completed;
     messenger.showSnackBar(
       SnackBar(
         content: Text(
@@ -403,11 +403,12 @@ class _EquipmentListContentState extends ConsumerState<EquipmentListContent> {
         ),
       ),
     );
+    return BulkActionOutcome.completed;
   }
 
-  Future<void> _confirmAndDelete() async {
+  Future<BulkActionOutcome> _confirmAndDelete() async {
     final ids = _selectedIds.toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -429,7 +430,7 @@ class _EquipmentListContentState extends ConsumerState<EquipmentListContent> {
         ],
       ),
     );
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !mounted) return BulkActionOutcome.cancelled;
 
     final messenger = ScaffoldMessenger.of(context);
     final notifier = ref.read(equipmentListNotifierProvider.notifier);
@@ -439,12 +440,13 @@ class _EquipmentListContentState extends ConsumerState<EquipmentListContent> {
       await notifier.deleteEquipment(id);
     }
 
-    if (!mounted) return;
+    if (!mounted) return BulkActionOutcome.completed;
     messenger.showSnackBar(
       SnackBar(
         content: Text(context.l10n.common_bulkDelete_snackbar(ids.length)),
       ),
     );
+    return BulkActionOutcome.completed;
   }
 
   /// One tap policy for every equipment row.

--- a/lib/features/marine_life/presentation/pages/species_manage_page.dart
+++ b/lib/features/marine_life/presentation/pages/species_manage_page.dart
@@ -10,6 +10,7 @@ import 'package:submersion/features/marine_life/presentation/providers/species_p
 import 'package:submersion/features/marine_life/presentation/widgets/species_category_chips.dart';
 import 'package:submersion/features/media/presentation/providers/species_media_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/selection/bulk_action.dart';
 import 'package:submersion/shared/selection/selectable_list_scope.dart';
 import 'package:submersion/shared/selection/selection_app_bar.dart';
 import 'package:submersion/shared/selection/selection_controller.dart';
@@ -315,9 +316,9 @@ class _SpeciesManagePageState extends ConsumerState<SpeciesManagePage> {
     );
   }
 
-  Future<void> _confirmAndDeleteSelected() async {
+  Future<BulkActionOutcome> _confirmAndDeleteSelected() async {
     final ids = _selectedIds.toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -339,7 +340,7 @@ class _SpeciesManagePageState extends ConsumerState<SpeciesManagePage> {
         ],
       ),
     );
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !mounted) return BulkActionOutcome.cancelled;
 
     final messenger = ScaffoldMessenger.of(context);
     final notifier = ref.read(speciesListNotifierProvider.notifier);
@@ -360,7 +361,7 @@ class _SpeciesManagePageState extends ConsumerState<SpeciesManagePage> {
       }
     }
 
-    if (!mounted) return;
+    if (!mounted) return BulkActionOutcome.completed;
     ref.invalidate(speciesSightingCountsProvider);
     ref.invalidate(speciesTagCountsProvider);
     messenger.showSnackBar(
@@ -374,6 +375,7 @@ class _SpeciesManagePageState extends ConsumerState<SpeciesManagePage> {
         ),
       ),
     );
+    return BulkActionOutcome.completed;
   }
 
   Future<void> _confirmDelete(Species species) async {

--- a/lib/features/media/presentation/helpers/media_share_helper.dart
+++ b/lib/features/media/presentation/helpers/media_share_helper.dart
@@ -16,7 +16,14 @@ import 'package:submersion/l10n/l10n_extension.dart';
 ///
 /// [anchor] is the iPad share popover's origin; pass the share button's rect
 /// (see `shareAnchorFrom`). Ignored on every other platform.
-Future<void> shareMediaItems(
+///
+/// Returns whether the sheet was opened with at least one file. The library's
+/// selection bar turns that into a [BulkActionOutcome], which is what makes
+/// Share leave multi-select the way every other bulk action does (#1262).
+/// Opening the sheet counts as done even if the diver then dismisses it:
+/// share_plus only reports a dismissal on mobile, so trusting the status
+/// would make the bar behave differently on desktop for no gain.
+Future<bool> shareMediaItems(
   BuildContext context,
   WidgetRef ref,
   List<MediaItem> items, {
@@ -54,16 +61,18 @@ Future<void> shareMediaItems(
       if (context.mounted) {
         _showError(context, l10n.media_photoViewer_cannotShare);
       }
-      return;
+      return false;
     }
     await SharePlus.instance.share(
       ShareParams(files: files, sharePositionOrigin: sharePositionOrigin),
     );
+    return true;
   } catch (e) {
     if (context.mounted) {
       Navigator.of(context, rootNavigator: true).pop();
       _showError(context, l10n.media_photoViewer_failedToShare(e.toString()));
     }
+    return false;
   }
 }
 

--- a/lib/features/media/presentation/helpers/media_share_helper.dart
+++ b/lib/features/media/presentation/helpers/media_share_helper.dart
@@ -43,6 +43,17 @@ Future<bool> shareMediaItems(
         const Center(child: CircularProgressIndicator(color: Colors.white)),
   );
 
+  // The dialog is popped before the platform call so the share sheet is not
+  // raised behind a modal, which leaves the catch below with nothing of its
+  // own to dismiss. Without this flag a throwing share popped a second time
+  // and took the page the diver shared FROM with it.
+  var dialogVisible = true;
+  void dismissDialog() {
+    if (!dialogVisible || !context.mounted) return;
+    Navigator.of(context, rootNavigator: true).pop();
+    dialogVisible = false;
+  }
+
   try {
     final files = <XFile>[];
     for (final item in items) {
@@ -54,9 +65,7 @@ Future<bool> shareMediaItems(
       files.add(XFile(file.path, mimeType: item.shareMimeType));
     }
 
-    if (context.mounted) {
-      Navigator.of(context, rootNavigator: true).pop();
-    }
+    dismissDialog();
     if (files.isEmpty) {
       if (context.mounted) {
         _showError(context, l10n.media_photoViewer_cannotShare);
@@ -68,8 +77,8 @@ Future<bool> shareMediaItems(
     );
     return true;
   } catch (e) {
+    dismissDialog();
     if (context.mounted) {
-      Navigator.of(context, rootNavigator: true).pop();
       _showError(context, l10n.media_photoViewer_failedToShare(e.toString()));
     }
     return false;

--- a/lib/features/media/presentation/widgets/dive_media_section.dart
+++ b/lib/features/media/presentation/widgets/dive_media_section.dart
@@ -144,8 +144,6 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
   }
   // coverage:ignore-end
 
-  void _exitSelectionMode() => _selection.exit();
-
   /// Grid indices for the checked ids, against the current ordering.
   ///
   /// Derived every build rather than stored: the ids are the truth and the
@@ -161,13 +159,13 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
       .map((i) => media[i].id)
       .toList();
 
-  Future<void> _unlinkSelected(
+  Future<BulkActionOutcome> _unlinkSelected(
     BuildContext context,
     List<MediaItem> media,
   ) async {
     final selectedIds = _selection.value.checkedIds.toList();
 
-    if (selectedIds.isEmpty) return;
+    if (selectedIds.isEmpty) return BulkActionOutcome.cancelled;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -205,8 +203,6 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
             .read(mediaListNotifierProvider(widget.diveId).notifier)
             .unlinkMultipleMedia(selectedIds);
 
-        _exitSelectionMode();
-
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -218,6 +214,7 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
             ),
           );
         }
+        return BulkActionOutcome.completed;
       } catch (e) {
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -227,8 +224,10 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
             ),
           );
         }
+        return BulkActionOutcome.failed;
       }
     }
+    return BulkActionOutcome.cancelled;
   }
 
   // coverage:ignore-start

--- a/lib/features/media/presentation/widgets/media_selection_bar.dart
+++ b/lib/features/media/presentation/widgets/media_selection_bar.dart
@@ -50,9 +50,12 @@ class MediaSelectionBar extends ConsumerWidget {
   ///
   /// Routed through the deletion coordinator so the remote-blob delete
   /// intent is enqueued before the rows die (orphan-prevention spec 5.2).
-  Future<void> _unlinkSelected(BuildContext context, WidgetRef ref) async {
+  Future<BulkActionOutcome> _unlinkSelected(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final ids = _ids;
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
 
     // Everything else an unlink discards is derived and rebuilds from the
     // source file on a re-link. A caption and the favorite flag live only in
@@ -60,7 +63,7 @@ class MediaSelectionBar extends ConsumerWidget {
     final atRisk = await ref
         .read(mediaRepositoryProvider)
         .idsWithUserMetadata(ids);
-    if (!context.mounted) return;
+    if (!context.mounted) return BulkActionOutcome.cancelled;
 
     final l10n = context.l10n;
     final confirmed = await showDialog<bool>(
@@ -85,17 +88,20 @@ class MediaSelectionBar extends ConsumerWidget {
         ],
       ),
     );
-    if (confirmed != true) return;
+    if (confirmed != true) return BulkActionOutcome.cancelled;
 
     await ref.read(mediaDeletionCoordinatorProvider).deleteMultipleMedia(ids);
-    controller.exit();
+    return BulkActionOutcome.completed;
   }
 
-  Future<void> _moveToDive(BuildContext context, WidgetRef ref) async {
+  Future<BulkActionOutcome> _moveToDive(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final diveId = await showDivePickerSheet(context);
-    if (diveId == null) return;
+    if (diveId == null) return BulkActionOutcome.cancelled;
     await ref.read(mediaRepositoryProvider).reassignMediaToDive(_ids, diveId);
-    controller.exit();
+    return BulkActionOutcome.completed;
   }
 
   @override
@@ -120,7 +126,10 @@ class MediaSelectionBar extends ConsumerWidget {
           id: 'share',
           icon: Icons.share,
           label: l10n.common_action_share,
-          onInvoke: () => shareMediaItems(context, ref, selectedItems),
+          onInvoke: () async =>
+              await shareMediaItems(context, ref, selectedItems)
+              ? BulkActionOutcome.completed
+              : BulkActionOutcome.failed,
         ),
         BulkAction(
           id: 'move_to_dive',

--- a/lib/features/media/presentation/widgets/site_media_section.dart
+++ b/lib/features/media/presentation/widgets/site_media_section.dart
@@ -54,8 +54,6 @@ class _SiteMediaSectionState extends ConsumerState<SiteMediaSection> {
     super.dispose();
   }
 
-  void _exitSelectionMode() => _selection.exit();
-
   /// Grid indices for the checked ids, against the current ordering.
   Set<int> _indicesFor(List<MediaItem> media) => {
     for (var i = 0; i < media.length; i++)
@@ -68,13 +66,13 @@ class _SiteMediaSectionState extends ConsumerState<SiteMediaSection> {
       .map((i) => media[i].id)
       .toList();
 
-  Future<void> _unlinkSelected(
+  Future<BulkActionOutcome> _unlinkSelected(
     BuildContext context,
     List<MediaItem> media,
   ) async {
     final selectedIds = _selection.value.checkedIds.toList();
 
-    if (selectedIds.isEmpty) return;
+    if (selectedIds.isEmpty) return BulkActionOutcome.cancelled;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -108,8 +106,6 @@ class _SiteMediaSectionState extends ConsumerState<SiteMediaSection> {
             .read(siteMediaListNotifierProvider(widget.siteId).notifier)
             .unlinkMultipleMedia(selectedIds);
 
-        _exitSelectionMode();
-
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -121,6 +117,7 @@ class _SiteMediaSectionState extends ConsumerState<SiteMediaSection> {
             ),
           );
         }
+        return BulkActionOutcome.completed;
       } catch (e) {
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -130,8 +127,10 @@ class _SiteMediaSectionState extends ConsumerState<SiteMediaSection> {
             ),
           );
         }
+        return BulkActionOutcome.failed;
       }
     }
+    return BulkActionOutcome.cancelled;
   }
 
   void _openItem(BuildContext context, MediaItem item, SiteViewerScope scope) {

--- a/lib/features/media_store/presentation/pages/transfers_page.dart
+++ b/lib/features/media_store/presentation/pages/transfers_page.dart
@@ -153,10 +153,12 @@ class _TransfersPageState extends ConsumerState<TransfersPage> {
   /// Retry every checked entry, lifting the per-row retry wholesale -- the
   /// negative-cache clear included, or the requeue drains straight back into
   /// the same failure.
-  Future<void> _retrySelected(List<MediaTransferQueueEntry> rows) async {
+  Future<BulkActionOutcome> _retrySelected(
+    List<MediaTransferQueueEntry> rows,
+  ) async {
     final ids = _selectedIds.map(int.parse).toSet();
     final checked = rows.where((e) => ids.contains(e.id)).toList();
-    if (checked.isEmpty) return;
+    if (checked.isEmpty) return BulkActionOutcome.cancelled;
 
     final assetCache = ref.read(localAssetCacheRepositoryProvider);
     final queue = ref.read(mediaTransferQueueRepositoryProvider);
@@ -168,11 +170,14 @@ class _TransfersPageState extends ConsumerState<TransfersPage> {
     }
     final runtime = await ref.read(mediaStoreRuntimeProvider.future);
     await runtime?.worker?.drain();
+    return BulkActionOutcome.completed;
   }
 
-  Future<void> _confirmAndDelete(List<MediaTransferQueueEntry> rows) async {
+  Future<BulkActionOutcome> _confirmAndDelete(
+    List<MediaTransferQueueEntry> rows,
+  ) async {
     final ids = _selectedIds.map(int.parse).toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -194,7 +199,7 @@ class _TransfersPageState extends ConsumerState<TransfersPage> {
         ],
       ),
     );
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !mounted) return BulkActionOutcome.cancelled;
 
     final messenger = ScaffoldMessenger.of(context);
     final queue = ref.read(mediaTransferQueueRepositoryProvider);
@@ -202,11 +207,12 @@ class _TransfersPageState extends ConsumerState<TransfersPage> {
     for (final id in ids) {
       await queue.delete(id);
     }
-    if (!mounted) return;
+    if (!mounted) return BulkActionOutcome.completed;
     messenger.showSnackBar(
       SnackBar(
         content: Text(context.l10n.common_bulkDelete_snackbar(ids.length)),
       ),
     );
+    return BulkActionOutcome.completed;
   }
 }

--- a/lib/features/tags/presentation/pages/tag_manage_page.dart
+++ b/lib/features/tags/presentation/pages/tag_manage_page.dart
@@ -339,7 +339,7 @@ class _TagManagePageState extends ConsumerState<TagManagePage> {
     );
   }
 
-  Future<void> _confirmDelete(BuildContext context) async {
+  Future<BulkActionOutcome> _confirmDelete(BuildContext context) async {
     final repository = ref.read(tagRepositoryProvider);
     final statsAsync = ref.read(tagStatisticsProvider);
     final stats = statsAsync.valueOrNull ?? [];
@@ -370,16 +370,15 @@ class _TagManagePageState extends ConsumerState<TagManagePage> {
         ),
       );
 
-      if (confirmed == true) {
-        await ref.read(tagListNotifierProvider.notifier).deleteTag(tagId);
-        _exitSelectionMode();
-      }
+      if (confirmed != true) return BulkActionOutcome.cancelled;
+      await ref.read(tagListNotifierProvider.notifier).deleteTag(tagId);
+      return BulkActionOutcome.completed;
     } else {
       final totalDives = await repository.getMergedDiveCount(
         _selectedIds.toList(),
       );
 
-      if (!context.mounted) return;
+      if (!context.mounted) return BulkActionOutcome.cancelled;
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (ctx) => AlertDialog(
@@ -401,23 +400,22 @@ class _TagManagePageState extends ConsumerState<TagManagePage> {
         ),
       );
 
-      if (confirmed == true) {
-        await ref
-            .read(tagListNotifierProvider.notifier)
-            .deleteTags(_selectedIds.toList());
-        _exitSelectionMode();
-      }
+      if (confirmed != true) return BulkActionOutcome.cancelled;
+      await ref
+          .read(tagListNotifierProvider.notifier)
+          .deleteTags(_selectedIds.toList());
+      return BulkActionOutcome.completed;
     }
   }
 
-  Future<void> _showMergeSheet(BuildContext context) async {
+  Future<BulkActionOutcome> _showMergeSheet(BuildContext context) async {
     final statsAsync = ref.read(tagStatisticsProvider);
     final stats = statsAsync.valueOrNull ?? [];
     final selectedStats = stats
         .where((s) => _selectedIds.contains(s.tag.id))
         .toList();
 
-    if (selectedStats.length < 2) return;
+    if (selectedStats.length < 2) return BulkActionOutcome.cancelled;
 
     final merged = await showModalBottomSheet<bool>(
       context: context,
@@ -425,12 +423,10 @@ class _TagManagePageState extends ConsumerState<TagManagePage> {
       builder: (context) => TagMergeSheet(selectedStats: selectedStats),
     );
 
-    if (merged == true) {
-      _exitSelectionMode();
-    }
+    return merged == true
+        ? BulkActionOutcome.completed
+        : BulkActionOutcome.cancelled;
   }
-
-  void _exitSelectionMode() => _selection.exit();
 
   void _toggleSelection(String id) => _selection.toggle(id);
 }

--- a/lib/features/trips/presentation/widgets/trip_list_content.dart
+++ b/lib/features/trips/presentation/widgets/trip_list_content.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/constants/sort_options_display.dart';
 import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/shared/selection/bulk_action.dart';
 import 'package:submersion/shared/widgets/entity_table/entity_table_view.dart';
 import 'package:submersion/shared/widgets/list_view_mode_toggle.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
@@ -297,9 +298,9 @@ class _TripListContentState extends ConsumerState<TripListContent> {
     );
   }
 
-  Future<void> _confirmAndDelete() async {
+  Future<BulkActionOutcome> _confirmAndDelete() async {
     final ids = _selectedIds.toList();
-    if (ids.isEmpty) return;
+    if (ids.isEmpty) return BulkActionOutcome.cancelled;
 
     final confirmed = await showDialog<bool>(
       context: context,
@@ -321,7 +322,7 @@ class _TripListContentState extends ConsumerState<TripListContent> {
         ],
       ),
     );
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !mounted) return BulkActionOutcome.cancelled;
 
     final messenger = ScaffoldMessenger.of(context);
     final notifier = ref.read(tripListNotifierProvider.notifier);
@@ -331,12 +332,13 @@ class _TripListContentState extends ConsumerState<TripListContent> {
       await notifier.deleteTrip(id);
     }
 
-    if (!mounted) return;
+    if (!mounted) return BulkActionOutcome.completed;
     messenger.showSnackBar(
       SnackBar(
         content: Text(context.l10n.common_bulkDelete_snackbar(ids.length)),
       ),
     );
+    return BulkActionOutcome.completed;
   }
 
   /// One tap policy for every trip row.

--- a/lib/shared/selection/bulk_action.dart
+++ b/lib/shared/selection/bulk_action.dart
@@ -1,4 +1,28 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+
+/// What a bulk action's handler reports once it finishes.
+///
+/// Leaving selection mode afterwards is decided centrally in SelectionAppBar
+/// from this value, not by each handler calling `exit()` for itself. That is
+/// deliberate: the ad-hoc version drifted, and the media library's Share
+/// shipped as the one bulk action that finished and left the diver stranded
+/// in multi-select (#1262), inline beside two siblings that both exited.
+/// Returning an outcome is not optional, so a new action cannot repeat that
+/// omission without failing to compile.
+enum BulkActionOutcome {
+  /// The action ran. The selection has served its purpose and the mode ends.
+  completed,
+
+  /// The diver backed out of a dialog, sheet or page before anything
+  /// happened, so the selection they built is left intact to act on again.
+  cancelled,
+
+  /// The action was attempted and failed. The selection survives so the
+  /// diver can retry after reading the error, rather than rebuilding it.
+  failed,
+}
 
 /// One bulk operation a surface offers on the current selection.
 ///
@@ -38,7 +62,20 @@ class BulkAction {
   /// instead of contorting [maxCount].
   final bool Function(Set<String> checkedIds)? isEnabled;
 
-  final VoidCallback onInvoke;
+  /// Whether completing this action should leave selection mode.
+  ///
+  /// False only for actions that *build* a selection rather than consume one
+  /// -- select-by-date-range feeds the checked set and would be useless if it
+  /// closed the bar it just populated. Every action that acts on the checked
+  /// items leaves the default alone.
+  final bool exitsSelectionOnComplete;
+
+  /// Runs the action and reports what happened.
+  ///
+  /// Awaited by SelectionAppBar, so a handler that shows a dialog must return
+  /// only once the dialog is resolved; returning early would exit the mode
+  /// out from under a modal the diver is still reading.
+  final FutureOr<BulkActionOutcome> Function() onInvoke;
 
   const BulkAction({
     required this.id,
@@ -50,6 +87,7 @@ class BulkAction {
     this.isDestructive = false,
     this.alwaysEnabled = false,
     this.isEnabled,
+    this.exitsSelectionOnComplete = true,
   });
 
   /// Whether this action can run against a selection of [count] items.

--- a/lib/shared/selection/selection_app_bar.dart
+++ b/lib/shared/selection/selection_app_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -31,6 +33,14 @@ enum SelectionBarShell {
 /// are identical in both shells; only the split between inline icons and the
 /// overflow menu depends on [maxInlineActions]. That is what stops the pane
 /// variant from quietly offering fewer actions than the full-width one.
+///
+/// Leaving selection mode after an action is the third property injected
+/// here rather than left to each surface. Every control -- inline icon,
+/// overflow entry and the baseline delete -- routes through
+/// [_runAndMaybeExit], which ends the mode on [BulkActionOutcome.completed]
+/// and leaves it alone otherwise, so a finished action always returns the
+/// diver to the normal list (#1262) while a cancelled or failed one keeps the
+/// selection they built.
 class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// Menu value for the baseline delete entry.
   ///
@@ -49,14 +59,15 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   final SelectionBarShell shell;
 
-  /// Invoked by the baseline delete entry in the overflow menu.
+  /// Invoked by the baseline delete entry in the overflow menu, reporting
+  /// whether the diver went through with it.
   ///
   /// Null only for surfaces that have no true delete -- the dive media section
   /// unlinks media from a dive without destroying files, so a trash entry
   /// there would misdescribe what it does. When null the delete entry is
   /// omitted entirely rather than rendered disabled, so the menu never shows a
   /// dead row. Every surface that can delete must pass this.
-  final VoidCallback? onDelete;
+  final FutureOr<BulkActionOutcome> Function()? onDelete;
 
   /// How many extras render as inline icons before the rest overflow.
   ///
@@ -118,6 +129,30 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 
+  /// Run [handler] and end selection mode if it reports it finished.
+  ///
+  /// The single place the mode ends after an action, for inline icons,
+  /// overflow entries and the baseline delete alike. A handler is free to
+  /// call `exit()` earlier for its own reasons -- the delete paths do, so the
+  /// bar disappears the instant the diver confirms rather than lingering
+  /// through a slow bulk delete -- and this stays a no-op when it does:
+  /// [SelectionState] defines `==`, so re-assigning the inactive state
+  /// notifies nobody.
+  Future<void> _runAndMaybeExit(
+    FutureOr<BulkActionOutcome> Function() handler, {
+    bool exitsOnComplete = true,
+  }) async {
+    final outcome = await handler();
+    if (outcome == BulkActionOutcome.completed && exitsOnComplete) {
+      controller.exit();
+    }
+  }
+
+  Future<void> _invoke(BulkAction action) => _runAndMaybeExit(
+    action.onInvoke,
+    exitsOnComplete: action.exitsSelectionOnComplete,
+  );
+
   /// Baseline controls plus extras, in a fixed order, identical in both
   /// shells.
   List<Widget> _buildControls(
@@ -164,7 +199,7 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
               ? Theme.of(context).colorScheme.error
               : null,
           onPressed: action.isEnabledForSelection(count, checkedIds)
-              ? action.onInvoke
+              ? () => _invoke(action)
               : null,
         ),
       if (overflow.isNotEmpty || _hasDelete)
@@ -191,18 +226,28 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
           ],
           onSelected: (id) {
             if (id == _deleteMenuValue) {
-              onDelete?.call();
+              _invokeDelete();
               return;
             }
             for (final action in overflow) {
               if (action.id == id) {
-                action.onInvoke();
+                _invoke(action);
                 return;
               }
             }
           },
         ),
     ];
+  }
+
+  /// Run the baseline delete under the same exit rule as any other action.
+  ///
+  /// Destroying the checked rows always ends the mode, so there is no opt-out
+  /// to carry here; the decision itself still lives in [_runAndMaybeExit].
+  Future<void> _invokeDelete() async {
+    final handler = onDelete;
+    if (handler == null) return;
+    await _runAndMaybeExit(handler);
   }
 
   /// The baseline delete entry.

--- a/lib/shared/selection/selection_app_bar.dart
+++ b/lib/shared/selection/selection_app_bar.dart
@@ -199,7 +199,7 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
               ? Theme.of(context).colorScheme.error
               : null,
           onPressed: action.isEnabledForSelection(count, checkedIds)
-              ? () => _invoke(action)
+              ? () => unawaited(_invoke(action))
               : null,
         ),
       if (overflow.isNotEmpty || _hasDelete)
@@ -224,14 +224,17 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
               _buildDeleteItem(context, count),
             ],
           ],
+          // onSelected is synchronous, so the dispatch is deliberately
+          // fire-and-forget: the menu closes now and the bar reacts when the
+          // action reports back.
           onSelected: (id) {
             if (id == _deleteMenuValue) {
-              _invokeDelete();
+              unawaited(_invokeDelete());
               return;
             }
             for (final action in overflow) {
               if (action.id == id) {
-                _invoke(action);
+                unawaited(_invoke(action));
                 return;
               }
             }

--- a/lib/shared/selection/selection_app_bar.dart
+++ b/lib/shared/selection/selection_app_bar.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import 'package:submersion/core/utils/log_failure.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/selection/bulk_action.dart';
 import 'package:submersion/shared/selection/selection_controller.dart';
@@ -153,6 +154,21 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
     exitsOnComplete: action.exitsSelectionOnComplete,
   );
 
+  /// Start a dispatch from a synchronous widget callback.
+  ///
+  /// Fire-and-forget by necessity -- onPressed and onSelected cannot await --
+  /// but not unlistened. A handler that throws instead of reporting
+  /// [BulkActionOutcome.failed] would otherwise send its error to the zone,
+  /// where the running app logs it as a bare uncaught error and a test blames
+  /// whichever case happens to be running when it surfaces. [logFailure]
+  /// attaches the listener and names the action in the log.
+  ///
+  /// The contract still holds on that path: the throw aborts
+  /// [_runAndMaybeExit] before it can exit, so a failed action leaves the
+  /// selection standing exactly as a reported failure would.
+  void _start(Future<void> dispatch, String actionId) =>
+      logFailure(dispatch, SelectionAppBar, 'run the $actionId bulk action');
+
   /// Baseline controls plus extras, in a fixed order, identical in both
   /// shells.
   List<Widget> _buildControls(
@@ -199,7 +215,7 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
               ? Theme.of(context).colorScheme.error
               : null,
           onPressed: action.isEnabledForSelection(count, checkedIds)
-              ? () => unawaited(_invoke(action))
+              ? () => _start(_invoke(action), action.id)
               : null,
         ),
       if (overflow.isNotEmpty || _hasDelete)
@@ -229,12 +245,12 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
           // action reports back.
           onSelected: (id) {
             if (id == _deleteMenuValue) {
-              unawaited(_invokeDelete());
+              _start(_invokeDelete(), 'delete');
               return;
             }
             for (final action in overflow) {
               if (action.id == id) {
-                unawaited(_invoke(action));
+                _start(_invoke(action), action.id);
                 return;
               }
             }

--- a/test/features/media/presentation/media_selection_test.dart
+++ b/test/features/media/presentation/media_selection_test.dart
@@ -1,5 +1,11 @@
+import 'dart:io';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
@@ -19,12 +25,38 @@ import 'package:submersion/features/media/presentation/pages/media_viewer_page.d
 import 'package:submersion/features/media/presentation/providers/media_library_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
+import 'package:submersion/features/media/data/services/asset_resolution_service.dart'
+    show ResolutionStatus;
 import 'package:submersion/features/media/presentation/widgets/media_library_grid.dart';
 import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 import 'package:submersion/features/settings/data/repositories/app_settings_repository.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// writeShareTempFile calls getTemporaryDirectory(), a platform channel with
+/// no implementation under flutter_test.
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.tempPath);
+  final String tempPath;
+
+  @override
+  Future<String?> getTemporaryPath() async => tempPath;
+}
+
+/// Records what reached the platform so the share can be asserted without a
+/// real share sheet.
+class _FakeSharePlatform extends SharePlatform {
+  final List<ShareParams> calls = [];
+
+  @override
+  Future<ShareResult> share(ShareParams params) async {
+    calls.add(params);
+    return const ShareResult('ok', ShareResultStatus.success);
+  }
+}
 
 class _UnavailableResolver implements MediaSourceResolver {
   @override
@@ -454,6 +486,146 @@ void main() {
         find.byKey(const ValueKey('selection_exit')),
         findsNothing,
         reason: 'a completed bulk action leaves selection mode',
+      );
+    });
+  });
+
+  group('the library Share leaves selection mode', () {
+    // #1262: Share was the one bulk action in the app that finished and left
+    // the diver stranded in multi-select, inline beside two siblings that both
+    // exited. The bar now decides from the action's outcome, so this is the
+    // regression guard for the whole rule on a real surface.
+    final platform = _FakeSharePlatform();
+    late Directory tempDir;
+
+    setUpAll(() => SharePlatform.instance = platform);
+
+    setUp(() async {
+      platform.calls.clear();
+      tempDir = await Directory.systemTemp.createTemp('library-share-test');
+      PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+    });
+
+    tearDown(() => tempDir.delete(recursive: true));
+
+    Widget host(List<MediaLibraryEntry> entries) => ProviderScope(
+      overrides: [
+        mediaLibraryNotifierProvider.overrideWith(
+          (ref) => _SeededLibraryNotifier(MediaLibraryState(entries: entries)),
+        ),
+        appSettingsRepositoryProvider.overrideWithValue(_FakeSettingsRepo()),
+        mediaDeletionCoordinatorProvider.overrideWithValue(
+          _RecordingDeletionCoordinator(),
+        ),
+        mediaRepositoryProvider.overrideWithValue(_RecordingMediaRepo()),
+        diveRepositoryProvider.overrideWithValue(_FakeDiveRepo()),
+        currentDiverIdProvider.overrideWith((ref) => _FixedDiverIdNotifier()),
+        mediaSourceResolverRegistryProvider.overrideWithValue(
+          MediaSourceResolverRegistry({
+            MediaSourceType.localFile: _UnavailableResolver(),
+          }),
+        ),
+        // The grid's thumbnails stay unresolvable; only the share's
+        // full-resolution read has to succeed.
+        resolvedFullResolutionProvider.overrideWith(
+          (ref, MediaItem arg) async => ResolvedAssetResult(
+            bytes: Uint8List.fromList([1, 2, 3, 4]),
+            status: ResolutionStatus.resolved,
+          ),
+        ),
+      ],
+      child: const MaterialApp(
+        locale: Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: MediaLibraryView()),
+      ),
+    );
+
+    testWidgets('a completed share ends the mode', (tester) async {
+      await tester.pumpWidget(
+        host([entry('a', diveId: 'd1'), entry('b', diveId: 'd1')]),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(MediaLibraryTile).at(0));
+      await tester.pumpAndSettle();
+      expect(find.text('1 selected'), findsOneWidget);
+
+      // Writing the share temp file is real I/O, which deadlocks under the
+      // test zone's fake async unless it runs through runAsync.
+      await tester.runAsync(() async {
+        await tester.tap(find.byKey(const ValueKey('selection_action_share')));
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      });
+      await tester.pump();
+
+      expect(platform.calls, hasLength(1));
+      expect(
+        find.byKey(const ValueKey('selection_exit')),
+        findsNothing,
+        reason: 'a completed share must return the diver to the normal list',
+      );
+    });
+
+    testWidgets('a share that resolves nothing keeps the selection', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            mediaLibraryNotifierProvider.overrideWith(
+              (ref) => _SeededLibraryNotifier(
+                MediaLibraryState(entries: [entry('a', diveId: 'd1')]),
+              ),
+            ),
+            appSettingsRepositoryProvider.overrideWithValue(
+              _FakeSettingsRepo(),
+            ),
+            mediaDeletionCoordinatorProvider.overrideWithValue(
+              _RecordingDeletionCoordinator(),
+            ),
+            mediaRepositoryProvider.overrideWithValue(_RecordingMediaRepo()),
+            diveRepositoryProvider.overrideWithValue(_FakeDiveRepo()),
+            currentDiverIdProvider.overrideWith(
+              (ref) => _FixedDiverIdNotifier(),
+            ),
+            mediaSourceResolverRegistryProvider.overrideWithValue(
+              MediaSourceResolverRegistry({
+                MediaSourceType.localFile: _UnavailableResolver(),
+              }),
+            ),
+            resolvedFullResolutionProvider.overrideWith(
+              (ref, MediaItem arg) async => const ResolvedAssetResult(
+                status: ResolutionStatus.unavailable,
+              ),
+            ),
+          ],
+          child: const MaterialApp(
+            locale: Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: MediaLibraryView()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(MediaLibraryTile).at(0));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('selection_action_share')));
+      await tester.pumpAndSettle();
+
+      expect(platform.calls, isEmpty);
+      expect(
+        find.text('1 selected'),
+        findsOneWidget,
+        reason: 'a share that shared nothing must keep the selection',
       );
     });
   });

--- a/test/features/media/presentation/media_selection_test.dart
+++ b/test/features/media/presentation/media_selection_test.dart
@@ -555,10 +555,21 @@ void main() {
       expect(find.text('1 selected'), findsOneWidget);
 
       // Writing the share temp file is real I/O, which deadlocks under the
-      // test zone's fake async unless it runs through runAsync.
+      // test zone's fake async unless it runs through runAsync. Wait for the
+      // platform call rather than a fixed span: how long the resolve and the
+      // write take belongs to the filesystem, so any constant is a race a
+      // slow runner eventually loses. The deadline only bounds a share that
+      // never arrives, and the assertions below are what fail when it does
+      // not.
       await tester.runAsync(() async {
         await tester.tap(find.byKey(const ValueKey('selection_action_share')));
-        await Future<void>.delayed(const Duration(milliseconds: 100));
+        final deadline = DateTime.now().add(const Duration(seconds: 10));
+        while (platform.calls.isEmpty && DateTime.now().isBefore(deadline)) {
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+        }
+        // The call is recorded on entry to the fake's share(); one more turn
+        // lets the bar's handler resume and report its outcome.
+        await Future<void>.delayed(Duration.zero);
       });
       await tester.pump();
 

--- a/test/features/media/presentation/media_selection_test.dart
+++ b/test/features/media/presentation/media_selection_test.dart
@@ -497,16 +497,24 @@ void main() {
     // regression guard for the whole rule on a real surface.
     final platform = _FakeSharePlatform();
     late Directory tempDir;
+    late PathProviderPlatform originalPathProvider;
 
     setUpAll(() => SharePlatform.instance = platform);
 
     setUp(() async {
       platform.calls.clear();
       tempDir = await Directory.systemTemp.createTemp('library-share-test');
+      // PathProviderPlatform is read per call, so a fake left installed points
+      // later tests in this isolate at a temp directory that tearDown has
+      // already deleted. Put the real one back.
+      originalPathProvider = PathProviderPlatform.instance;
       PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
     });
 
-    tearDown(() => tempDir.delete(recursive: true));
+    tearDown(() async {
+      PathProviderPlatform.instance = originalPathProvider;
+      await tempDir.delete(recursive: true);
+    });
 
     Widget host(List<MediaLibraryEntry> entries) => ProviderScope(
       overrides: [

--- a/test/features/media/presentation/media_share_helper_test.dart
+++ b/test/features/media/presentation/media_share_helper_test.dart
@@ -153,16 +153,33 @@ void main() {
     expect(platform.calls, isEmpty);
   });
 
-  /// Taps Share and lets the real event loop run.
+  /// Taps Share and waits for the share to reach the platform.
   ///
   /// writeShareTempFile does genuine file I/O, and testWidgets' fake async
   /// clock never advances real time -- pumpAndSettle would spin through its
   /// whole budget while the write sits pending. runAsync hands control back
   /// to the real loop for the duration.
+  ///
+  /// It polls for the recorded call rather than sleeping a fixed span: how
+  /// long the resolve and the temp-file write take is a property of the
+  /// filesystem, so any constant is a race that a slow CI runner eventually
+  /// loses. The deadline only bounds a share that never arrives, and the
+  /// caller's own assertion is what fails when it does not.
+  ///
+  /// Every caller is a success-path test, so "a call was recorded" is the
+  /// right thing to wait for. A test asserting the sheet never opens has
+  /// nothing to wait for and drives the tap itself.
   Future<void> tapShareAndDrain(WidgetTester tester) async {
     await tester.runAsync(() async {
       await tester.tap(find.text('SHARE'));
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      final deadline = DateTime.now().add(const Duration(seconds: 10));
+      while (platform.calls.isEmpty && DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      // The call is recorded on entry to the fake's share(), so yield one
+      // more turn to let the awaiting handler resume and report its result.
+      // A scheduling yield, not a wall-clock guess.
+      await Future<void>.delayed(Duration.zero);
     });
     await tester.pump();
   }

--- a/test/features/media/presentation/media_share_helper_test.dart
+++ b/test/features/media/presentation/media_share_helper_test.dart
@@ -253,6 +253,94 @@ void main() {
     expect(platform.calls, isEmpty);
   });
 
+  group('what the share reports back', () {
+    // The library's selection bar leaves multi-select only when its action
+    // says it finished (#1262), so this return value is what stops Share
+    // being the one bulk action that strands the diver in the mode.
+    Widget recordingHost({
+      required ResolvedAssetResult Function(MediaItem) resolve,
+      required List<bool?> log,
+    }) {
+      return ProviderScope(
+        overrides: [
+          resolvedFullResolutionProvider.overrideWith(
+            (ref, MediaItem arg) async => resolve(arg),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Consumer(
+              builder: (context, ref, _) => TextButton(
+                onPressed: () async =>
+                    log.add(await shareMediaItems(context, ref, [item('a')])),
+                child: const Text('SHARE'),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('an opened share sheet reports success', (tester) async {
+      final log = <bool?>[];
+      await tester.pumpWidget(
+        recordingHost(resolve: (_) => resolved(), log: log),
+      );
+      // Real temp-file I/O on the success path, so this needs runAsync the
+      // same way the other success assertions do.
+      await tapShareAndDrain(tester);
+
+      expect(platform.calls, hasLength(1));
+      expect(log, [true]);
+    });
+
+    testWidgets('nothing resolvable reports failure', (tester) async {
+      final log = <bool?>[];
+      await tester.pumpWidget(
+        recordingHost(resolve: (_) => unavailable, log: log),
+      );
+      await tester.tap(find.text('SHARE'));
+      await tester.pumpAndSettle();
+
+      expect(platform.calls, isEmpty);
+      expect(log, [false]);
+    });
+
+    testWidgets('a throwing resolve reports failure', (tester) async {
+      final log = <bool?>[];
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            resolvedFullResolutionProvider.overrideWith(
+              (ref, MediaItem arg) async => throw StateError('disk gone'),
+            ),
+          ],
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) => TextButton(
+                  onPressed: () async =>
+                      log.add(await shareMediaItems(context, ref, [item('a')])),
+                  child: const Text('SHARE'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('SHARE'));
+      await tester.pumpAndSettle();
+
+      expect(log, [false]);
+    });
+  });
+
   group('iPad share popover anchor', () {
     // On iPad the share sheet is a popover and must point at the control that
     // opened it. share_plus takes that as ShareParams.sharePositionOrigin;

--- a/test/features/media/presentation/media_share_helper_test.dart
+++ b/test/features/media/presentation/media_share_helper_test.dart
@@ -33,9 +33,14 @@ class _FakePathProvider extends PathProviderPlatform
 class _FakeSharePlatform extends SharePlatform {
   final List<ShareParams> calls = [];
 
+  /// Makes the platform call fail after it has been recorded, which is how a
+  /// real share sheet fails: invoked, then thrown out of.
+  bool throwOnShare = false;
+
   @override
   Future<ShareResult> share(ShareParams params) async {
     calls.add(params);
+    if (throwOnShare) throw StateError('share sheet unavailable');
     return const ShareResult('ok', ShareResultStatus.success);
   }
 }
@@ -59,16 +64,24 @@ void main() {
   // is exactly one, reset between tests.
   final platform = _FakeSharePlatform();
   late Directory tempDir;
+  late PathProviderPlatform originalPathProvider;
 
   setUpAll(() => SharePlatform.instance = platform);
 
   setUp(() async {
     platform.calls.clear();
     tempDir = await Directory.systemTemp.createTemp('share-helper-test');
+    // Unlike SharePlatform above, PathProviderPlatform is read per call, so
+    // leaving the fake installed points later tests in this isolate at a temp
+    // directory tearDown has already deleted.
+    originalPathProvider = PathProviderPlatform.instance;
     PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
   });
 
-  tearDown(() => tempDir.delete(recursive: true));
+  tearDown(() async {
+    PathProviderPlatform.instance = originalPathProvider;
+    await tempDir.delete(recursive: true);
+  });
 
   Widget host({
     required List<MediaItem> items,
@@ -390,6 +403,73 @@ void main() {
       // TextButton, not just its label.
       expect(origin, tester.getRect(find.byType(TextButton)));
       expect(origin!.isEmpty, isFalse);
+    });
+  });
+
+  group('a failing share leaves the page it was opened from', () {
+    // The progress dialog is popped before the platform call, and the catch
+    // popped again. A throwing share therefore took the route UNDERNEATH the
+    // dialog with it, dropping the diver out of the page they shared from.
+    testWidgets('a throwing share sheet does not pop the page underneath', (
+      tester,
+    ) async {
+      platform.throwOnShare = true;
+      addTearDown(() => platform.throwOnShare = false);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            resolvedFullResolutionProvider.overrideWith(
+              (ref, MediaItem arg) async => resolved(),
+            ),
+          ],
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => TextButton(
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => Scaffold(
+                        body: Consumer(
+                          builder: (context, ref, _) => Column(
+                            children: [
+                              const Text('DETAIL'),
+                              TextButton(
+                                onPressed: () =>
+                                    shareMediaItems(context, ref, [item('a')]),
+                                child: const Text('SHARE'),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  child: const Text('OPEN'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('OPEN'));
+      await tester.pumpAndSettle();
+      expect(find.text('DETAIL'), findsOneWidget);
+
+      await tapShareAndDrain(tester);
+      await tester.pumpAndSettle();
+
+      expect(platform.calls, hasLength(1));
+      expect(
+        find.text('DETAIL'),
+        findsOneWidget,
+        reason: 'a failed share must dismiss its own dialog, nothing else',
+      );
+      expect(find.textContaining('Failed to share'), findsOneWidget);
     });
   });
 }

--- a/test/features/tags/presentation/pages/tag_manage_page_test.dart
+++ b/test/features/tags/presentation/pages/tag_manage_page_test.dart
@@ -5,6 +5,7 @@ import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
 import 'package:submersion/features/tags/presentation/pages/tag_manage_page.dart';
 import 'package:submersion/features/tags/presentation/providers/tag_providers.dart';
+import 'package:submersion/features/tags/presentation/widgets/tag_merge_sheet.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/selection_contract.dart';
@@ -47,6 +48,11 @@ class _MockTagListNotifier extends StateNotifier<AsyncValue<List<Tag>>>
     implements TagListNotifier {
   _MockTagListNotifier(List<Tag> tags) : super(AsyncValue.data(tags));
 
+  /// What the bulk paths actually asked for, so an outcome assertion is
+  /// backed by real work rather than only by the bar disappearing.
+  final List<String> deleted = [];
+  final List<List<String>> bulkDeleted = [];
+
   @override
   Future<void> refresh() async {}
   @override
@@ -59,9 +65,9 @@ class _MockTagListNotifier extends StateNotifier<AsyncValue<List<Tag>>>
   @override
   Future<void> updateTag(Tag tag) async {}
   @override
-  Future<void> deleteTag(String id) async {}
+  Future<void> deleteTag(String id) async => deleted.add(id);
   @override
-  Future<void> deleteTags(List<String> ids) async {}
+  Future<void> deleteTags(List<String> ids) async => bulkDeleted.add(ids);
   @override
   Future<void> mergeTags({
     required List<String> sourceTagIds,
@@ -93,12 +99,15 @@ class _MockTagRepository extends TagRepository {
 List<Tag> _tagsFromStats(List<TagStatistic> stats) =>
     stats.map((s) => s.tag).toList();
 
-Widget _buildTestWidget({List<TagStatistic> stats = const []}) {
+Widget _buildTestWidget({
+  List<TagStatistic> stats = const [],
+  _MockTagListNotifier? notifier,
+}) {
   return ProviderScope(
     overrides: [
       tagStatisticsProvider.overrideWith((ref) => Future.value(stats)),
       tagListNotifierProvider.overrideWith(
-        (ref) => _MockTagListNotifier(_tagsFromStats(stats)),
+        (ref) => notifier ?? _MockTagListNotifier(_tagsFromStats(stats)),
       ),
       tagRepositoryProvider.overrideWithValue(_MockTagRepository()),
     ],
@@ -306,6 +315,127 @@ void main() {
             .onPressed,
         isNotNull,
       );
+    });
+  });
+
+  group('a bulk action returns the diver to the normal list', () {
+    // #1262. This surface used to call _exitSelectionMode() inside each
+    // handler; the exit now travels back to SelectionAppBar as a
+    // BulkActionOutcome, so these cover the decision that replaced it.
+
+    Future<void> enterSelection(WidgetTester tester, List<String> names) async {
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      for (final name in names) {
+        await tester.tap(find.text(name));
+        await tester.pumpAndSettle();
+      }
+    }
+
+    /// Delete sits in the overflow on every surface, never inline.
+    Future<void> openDelete(WidgetTester tester) async {
+      await tester.tap(find.byKey(const ValueKey('selection_overflow')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_delete')));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('deleting several tags ends selection mode', (tester) async {
+      final notifier = _MockTagListNotifier(_tagsFromStats(_testStats));
+      await tester.pumpWidget(
+        _buildTestWidget(stats: _testStats, notifier: notifier),
+      );
+      await tester.pumpAndSettle();
+
+      await enterSelection(tester, ['Night Dive', 'Photography']);
+      expect(find.text('2 selected'), findsOneWidget);
+
+      await openDelete(tester);
+      await tester.tap(find.widgetWithText(TextButton, 'Delete'));
+      await tester.pumpAndSettle();
+
+      expect(notifier.bulkDeleted, [
+        ['tag1', 'tag2'],
+      ]);
+      expect(
+        find.byKey(const ValueKey('selection_exit')),
+        findsNothing,
+        reason: 'a completed delete must return the diver to the tag list',
+      );
+    });
+
+    testWidgets('cancelling a multi-tag delete keeps the selection', (
+      tester,
+    ) async {
+      final notifier = _MockTagListNotifier(_tagsFromStats(_testStats));
+      await tester.pumpWidget(
+        _buildTestWidget(stats: _testStats, notifier: notifier),
+      );
+      await tester.pumpAndSettle();
+
+      await enterSelection(tester, ['Night Dive', 'Photography']);
+      await openDelete(tester);
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(notifier.bulkDeleted, isEmpty);
+      expect(find.text('2 selected'), findsOneWidget);
+    });
+
+    testWidgets('deleting a single tag ends selection mode', (tester) async {
+      final notifier = _MockTagListNotifier(_tagsFromStats(_testStats));
+      await tester.pumpWidget(
+        _buildTestWidget(stats: _testStats, notifier: notifier),
+      );
+      await tester.pumpAndSettle();
+
+      // One checked row takes the single-tag branch, which names the tag and
+      // its dive count rather than counting a selection.
+      await enterSelection(tester, ['Night Dive']);
+      await openDelete(tester);
+      await tester.tap(find.widgetWithText(TextButton, 'Delete'));
+      await tester.pumpAndSettle();
+
+      expect(notifier.deleted, ['tag1']);
+      expect(find.byKey(const ValueKey('selection_exit')), findsNothing);
+    });
+
+    testWidgets('cancelling a single-tag delete keeps the selection', (
+      tester,
+    ) async {
+      final notifier = _MockTagListNotifier(_tagsFromStats(_testStats));
+      await tester.pumpWidget(
+        _buildTestWidget(stats: _testStats, notifier: notifier),
+      );
+      await tester.pumpAndSettle();
+
+      await enterSelection(tester, ['Night Dive']);
+      await openDelete(tester);
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(notifier.deleted, isEmpty);
+      expect(find.text('1 selected'), findsOneWidget);
+    });
+
+    testWidgets('dismissing the merge sheet keeps the selection', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildTestWidget(stats: _testStats));
+      await tester.pumpAndSettle();
+
+      await enterSelection(tester, ['Night Dive', 'Photography']);
+      await tester.tap(find.byKey(const ValueKey('selection_action_merge')));
+      await tester.pumpAndSettle();
+      expect(find.byType(TagMergeSheet), findsOneWidget);
+
+      // Tapping the barrier dismisses the sheet with no result, which is the
+      // diver changing their mind rather than a merge.
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TagMergeSheet), findsNothing);
+      expect(find.text('2 selected'), findsOneWidget);
     });
   });
 }

--- a/test/shared/selection/bulk_action_test.dart
+++ b/test/shared/selection/bulk_action_test.dart
@@ -14,7 +14,7 @@ void main() {
     minCount: minCount,
     maxCount: maxCount,
     alwaysEnabled: alwaysEnabled,
-    onInvoke: () {},
+    onInvoke: () => BulkActionOutcome.completed,
   );
 
   group('BulkAction.isEnabledFor', () {
@@ -55,7 +55,7 @@ void main() {
         id: 'retire',
         icon: Icons.archive,
         label: 'Retire',
-        onInvoke: () {},
+        onInvoke: () => BulkActionOutcome.completed,
         isEnabled: (ids) => ids.every((id) => id.startsWith('active-')),
       );
       expect(action.isEnabledForSelection(2, {'active-1', 'active-2'}), isTrue);
@@ -72,7 +72,7 @@ void main() {
         icon: Icons.merge_type,
         label: 'Merge',
         minCount: 2,
-        onInvoke: () {},
+        onInvoke: () => BulkActionOutcome.completed,
         isEnabled: (ids) => true,
       );
       expect(action.isEnabledForSelection(1, {'a'}), isFalse);

--- a/test/shared/selection/selection_app_bar_test.dart
+++ b/test/shared/selection/selection_app_bar_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/shared/selection/bulk_action.dart';
@@ -15,7 +17,7 @@ void main() {
   Widget host({
     SelectionBarShell shell = SelectionBarShell.appBar,
     List<BulkAction> actions = const [],
-    VoidCallback? onDelete,
+    FutureOr<BulkActionOutcome> Function()? onDelete,
     int maxInlineActions = 3,
     List<String> selectableIds = const ['a', 'b', 'c'],
   }) {
@@ -24,7 +26,7 @@ void main() {
       selectableIds: selectableIds,
       actions: actions,
       shell: shell,
-      onDelete: onDelete ?? () {},
+      onDelete: onDelete ?? () => BulkActionOutcome.completed,
       maxInlineActions: maxInlineActions,
     );
     return testApp(
@@ -134,7 +136,14 @@ void main() {
     ) async {
       var deleted = false;
       controller.enterImplicit('a');
-      await tester.pumpWidget(host(onDelete: () => deleted = true));
+      await tester.pumpWidget(
+        host(
+          onDelete: () {
+            deleted = true;
+            return BulkActionOutcome.completed;
+          },
+        ),
+      );
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const ValueKey('selection_overflow')));
       await tester.pumpAndSettle();
@@ -154,7 +163,7 @@ void main() {
               id: '__selection_delete__',
               icon: Icons.merge_type,
               label: 'Collides',
-              onInvoke: () {},
+              onInvoke: () => BulkActionOutcome.completed,
             ),
           ],
         ),
@@ -175,7 +184,7 @@ void main() {
               id: 'merge',
               icon: Icons.merge_type,
               label: 'Merge',
-              onInvoke: () {},
+              onInvoke: () => BulkActionOutcome.completed,
             ),
           ],
         ),
@@ -243,7 +252,7 @@ void main() {
               icon: Icons.merge_type,
               label: 'Merge',
               minCount: 2,
-              onInvoke: () {},
+              onInvoke: () => BulkActionOutcome.completed,
             ),
           ],
         ),
@@ -267,7 +276,10 @@ void main() {
               icon: Icons.merge_type,
               label: 'Merge',
               minCount: 2,
-              onInvoke: () => invoked = true,
+              onInvoke: () {
+                invoked = true;
+                return BulkActionOutcome.completed;
+              },
             ),
           ],
         ),
@@ -290,7 +302,7 @@ void main() {
               icon: Icons.date_range,
               label: 'By date range',
               alwaysEnabled: true,
-              onInvoke: () {},
+              onInvoke: () => BulkActionOutcome.completed,
             ),
           ],
         ),
@@ -314,13 +326,13 @@ void main() {
               id: 'one',
               icon: Icons.merge_type,
               label: 'One',
-              onInvoke: () {},
+              onInvoke: () => BulkActionOutcome.completed,
             ),
             BulkAction(
               id: 'two',
               icon: Icons.ios_share,
               label: 'Two',
-              onInvoke: () {},
+              onInvoke: () => BulkActionOutcome.completed,
             ),
           ],
         ),
@@ -347,7 +359,10 @@ void main() {
               id: 'two',
               icon: Icons.ios_share,
               label: 'Two',
-              onInvoke: () => invoked = true,
+              onInvoke: () {
+                invoked = true;
+                return BulkActionOutcome.completed;
+              },
             ),
           ],
         ),
@@ -372,7 +387,7 @@ void main() {
               id: 'merge',
               icon: Icons.merge_type,
               label: 'Merge',
-              onInvoke: () {},
+              onInvoke: () => BulkActionOutcome.completed,
             ),
           ],
         ),
@@ -391,6 +406,127 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('selection_overflow')));
       await tester.pumpAndSettle();
       expect(find.byKey(const ValueKey('selection_delete')), findsOneWidget);
+    });
+  });
+
+  group('SelectionAppBar action outcomes', () {
+    /// Puts the bar in an explicitly entered mode with one item checked, so
+    /// nothing but the dispatch under test can end the mode: an explicit mode
+    /// survives at zero checked, and one checked item enables every action.
+    void enterWithOneChecked() {
+      controller.enterExplicit();
+      controller.toggle('a');
+    }
+
+    BulkAction merge(
+      BulkActionOutcome outcome, {
+      bool exitsSelectionOnComplete = true,
+    }) => BulkAction(
+      id: 'merge',
+      icon: Icons.merge_type,
+      label: 'Merge',
+      exitsSelectionOnComplete: exitsSelectionOnComplete,
+      onInvoke: () async => outcome,
+    );
+
+    testWidgets('a completed action leaves selection mode', (tester) async {
+      enterWithOneChecked();
+      await tester.pumpWidget(
+        host(actions: [merge(BulkActionOutcome.completed)]),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_action_merge')));
+      await tester.pumpAndSettle();
+      expect(controller.value.isActive, isFalse);
+    });
+
+    testWidgets('a cancelled action keeps the selection', (tester) async {
+      enterWithOneChecked();
+      await tester.pumpWidget(
+        host(actions: [merge(BulkActionOutcome.cancelled)]),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_action_merge')));
+      await tester.pumpAndSettle();
+
+      // Backing out of a dialog did nothing, so the selection the diver built
+      // must still be there to act on.
+      expect(controller.value.isActive, isTrue);
+      expect(controller.value.checkedIds, {'a'});
+    });
+
+    testWidgets('a failed action keeps the selection for a retry', (
+      tester,
+    ) async {
+      enterWithOneChecked();
+      await tester.pumpWidget(host(actions: [merge(BulkActionOutcome.failed)]));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_action_merge')));
+      await tester.pumpAndSettle();
+      expect(controller.value.isActive, isTrue);
+      expect(controller.value.checkedIds, {'a'});
+    });
+
+    testWidgets('an action that builds the selection does not end the mode', (
+      tester,
+    ) async {
+      enterWithOneChecked();
+      await tester.pumpWidget(
+        host(
+          actions: [
+            merge(BulkActionOutcome.completed, exitsSelectionOnComplete: false),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_action_merge')));
+      await tester.pumpAndSettle();
+      expect(controller.value.isActive, isTrue);
+    });
+
+    testWidgets('an overflow entry exits on the same rule as an inline icon', (
+      tester,
+    ) async {
+      enterWithOneChecked();
+      await tester.pumpWidget(
+        host(
+          maxInlineActions: 0,
+          actions: [merge(BulkActionOutcome.completed)],
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_overflow')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_menu_merge')));
+      await tester.pumpAndSettle();
+      expect(controller.value.isActive, isFalse);
+    });
+
+    testWidgets('a completed delete leaves selection mode', (tester) async {
+      enterWithOneChecked();
+      await tester.pumpWidget(
+        host(onDelete: () async => BulkActionOutcome.completed),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_overflow')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_delete')));
+      await tester.pumpAndSettle();
+      expect(controller.value.isActive, isFalse);
+    });
+
+    testWidgets('a cancelled delete keeps the selection', (tester) async {
+      enterWithOneChecked();
+      await tester.pumpWidget(
+        host(onDelete: () async => BulkActionOutcome.cancelled),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_overflow')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_delete')));
+      await tester.pumpAndSettle();
+      expect(controller.value.isActive, isTrue);
+      expect(controller.value.checkedIds, {'a'});
     });
   });
 }

--- a/test/shared/selection/selection_app_bar_test.dart
+++ b/test/shared/selection/selection_app_bar_test.dart
@@ -484,6 +484,38 @@ void main() {
       expect(controller.value.isActive, isTrue);
     });
 
+    testWidgets('a handler that throws keeps the selection', (tester) async {
+      // A throw is not a reported outcome, so the contract has to hold
+      // anyway: nothing completed, so the mode must survive and the diver
+      // keeps the rows they picked. The error itself belongs to the log, not
+      // to the zone, or it lands on whichever test happens to be running when
+      // it surfaces.
+      enterWithOneChecked();
+      await tester.pumpWidget(
+        host(
+          actions: [
+            BulkAction(
+              id: 'merge',
+              icon: Icons.merge_type,
+              label: 'Merge',
+              onInvoke: () async => throw StateError('merge blew up'),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_action_merge')));
+      await tester.pumpAndSettle();
+
+      expect(controller.value.isActive, isTrue);
+      expect(controller.value.checkedIds, {'a'});
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: 'the failure is logged against the bar, not left to the zone',
+      );
+    });
+
     testWidgets('an overflow entry exits on the same rule as an inline icon', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

Fixes #1262. Taking an action on a multi-select left the diver in multi-select
on some surfaces and returned them to the normal list on others.

The behaviour already existed in 32 of the app's 33 bulk actions, but only
because each handler remembered to call `SelectionController.exit()` itself.
One had not: the Media Library's **Share** finished and left the contextual bar
standing, inline beside Move to dive and Unlink, which both exited. That is the
shape of the problem worth fixing, not the missing call.

`SelectionAppBar` already injects the baseline controls "so no list can ship
without them". Leaving the mode after an action is now injected the same way.

## Changes

- `BulkAction.onInvoke` returns a `BulkActionOutcome` (`completed`,
  `cancelled`, `failed`) instead of `void`. `SelectionAppBar` decides from that
  in one place, for inline icons, overflow entries and the baseline delete
  alike:
  - **completed** leaves selection mode, returning the diver to the normal list
  - **cancelled** keeps the selection, so backing out of a confirm dialog, an
    export sheet or a merge page does not discard the rows the diver picked
  - **failed** keeps the selection, so a repository error can be retried after
    reading the snackbar rather than rebuilding the selection
- Returning an outcome is not optional, so a new action cannot repeat the
  omission without failing to compile. `exitsSelectionOnComplete: false` is the
  single opt-out, used by select-by-date-range, which builds the selection
  rather than consuming it.
- All 33 handlers across 17 surfaces migrated. Handlers that exit *before*
  their async work keep doing so, so the bar still disappears the instant a
  bulk delete is confirmed instead of lingering through it. `exit()` is
  idempotent (`SelectionState` defines `==`, so `ValueNotifier` suppresses the
  second notification), which is what lets the shared exit be a guaranteed
  floor rather than a behaviour rewrite.
- `shareMediaItems` now reports whether it opened the sheet with files, which
  is what lets the library's Share tell a real share from one where nothing
  could be resolved. The full-screen viewer's single-item call is unaffected.
- The dive log's bulk export sheet pops the chosen format instead of firing the
  export unawaited, so the export's outcome can reach the bar at all.
- Removed three helpers that fell dead as a result.

## Known limitation

Bulk edit still leaves selection mode on both save and cancel. Its form
navigates away with `context.go('/dives')` rather than popping a result, so
both paths complete the pushed route's future with `null` and are
indistinguishable from the list. Teaching it to pop a result would need a
`canPop()` fallback for the `go`-navigated entry that the existing snackbar
test uses, and popping inside the shell navigator is what blanks a
master-detail pane. That is a larger change than this issue asks for, and the
reason is written into the handler's doc comment.

## Test Plan

- [x] `flutter test` passes (25592 passed, 21 skipped, 0 failures)
- [x] `flutter analyze` passes (whole project, no issues)
- [x] `dart format` clean

New tests:

- `selection_app_bar_test.dart`: seven cases covering the dispatch rule, for
  inline icons, overflow entries, the baseline delete and the opt-out.
- `media_selection_test.dart`: a completed library Share ends the mode; a share
  that resolves nothing keeps the selection.
- `media_share_helper_test.dart`: what `shareMediaItems` reports on success, on
  nothing-resolvable and on a throwing resolve.

All new assertions were mutation-tested: forcing the dispatch to always exit,
to never exit, and forcing Share back to its shipped behaviour each fail
exactly the tests that should catch them. That mattered here because the
initial red was a compile error, which proves nothing about whether an
assertion can detect a wrong dispatch.

Existing contracts stay green unchanged, including
`bulk_delete_contract.dart`'s "cancelling must leave the selection intact" and
`site_media_section_test.dart`'s "a failing unlink surfaces the error and keeps
the selection".
