### PR TITLE
fix(dive-log): resolve a deleted computer filter outside build

### DIFF
--- a/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
@@ -167,6 +167,16 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
   /// A list that has not loaded yet says nothing about whether the computer
   /// still exists, so the id is kept: a slow load must not quietly clear the
   /// diver's filter.
+  ///
+  /// Read through this State's own [ref] rather than `widget.ref`. The two
+  /// divide by who owns the provider: `widget.ref` is passed in paired with
+  /// `widget.filterProvider`, so the filter write lands in the caller's
+  /// container and outlives the sheet's pop, while every app-wide provider is
+  /// read through the sheet's own ref, this one and the section's watch of the
+  /// same provider included. Were the two ever to resolve different
+  /// containers, reading the computer list through the caller's ref is what
+  /// would diverge: the applied id would be reconciled against a different
+  /// list from the one the diver was just shown.
   String? _resolveComputerId() {
     final computers = ref.read(allDiveComputersProvider).valueOrNull;
     return computers == null ? _computerId : _computerIdWithin(computers);

--- a/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:submersion/core/utils/number_input.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/dive_types/presentation/dive_type_display.dart';
@@ -150,6 +151,26 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
   /// invalid input clears the bound. A blanket replaceAll(',', '.') would
   /// misread the en_US thousands separator, turning "1,250" into 1.25 (#1091).
   double? _parseThicknessBound(String value) => parseUserDecimal(value);
+
+  /// The selected computer, or null when [computers] no longer contains it.
+  String? _computerIdWithin(List<DiveComputer> computers) =>
+      computers.any((c) => c.id == _computerId) ? _computerId : null;
+
+  /// The computer filter to apply, dropping a computer deleted since the
+  /// filter was saved so that it resolves to All computers.
+  ///
+  /// Resolved here rather than while the Dive Computer section builds. That
+  /// section reconciles only on the branch that renders a populated list, so
+  /// deleting the last computer left the stale id in place and the sheet
+  /// re-applied a filter that matches no dive.
+  ///
+  /// A list that has not loaded yet says nothing about whether the computer
+  /// still exists, so the id is kept: a slow load must not quietly clear the
+  /// diver's filter.
+  String? _resolveComputerId() {
+    final computers = ref.read(allDiveComputersProvider).valueOrNull;
+    return computers == null ? _computerId : _computerIdWithin(computers);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -525,15 +546,13 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
                                       ),
                                 );
                               }
-                              // Reset to null if the saved computer is no longer known
-                              // (deleted since the filter was set).
-                              final validId =
-                                  computers.any((c) => c.id == _computerId)
-                                  ? _computerId
-                                  : null;
-                              if (validId != _computerId) {
-                                _computerId = validId;
-                              }
+                              // Shown as All computers if the saved computer
+                              // is no longer known (deleted since the filter
+                              // was set). Reconciling the field itself is left
+                              // to _applyFilters: assigning to state from
+                              // build is a side effect in build, and this
+                              // branch is not the only one the sheet can take.
+                              final validId = _computerIdWithin(computers);
                               return SearchableFilterDropdown<String>(
                                 value: validId,
                                 allOptionLabel:
@@ -1235,7 +1254,7 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
       minRating: _minRating,
       minBottomTimeMinutes: _minDurationMinutes,
       maxBottomTimeMinutes: _maxDurationMinutes,
-      computerId: _computerId,
+      computerId: _resolveComputerId(),
       equipmentAttrKey: (_suitThicknessMin != null || _suitThicknessMax != null)
           ? 'thickness_mm'
           : null,

--- a/test/features/dive_log/presentation/widgets/dive_filter_sheet_interactions_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_filter_sheet_interactions_test.dart
@@ -87,6 +87,7 @@ void main() {
   Future<WidgetRef> openSheet(
     WidgetTester tester, {
     DiveFilterState initial = const DiveFilterState(),
+    List<DiveComputer>? registeredComputers,
   }) async {
     final overrides = await getBaseOverrides();
     late WidgetRef capturedRef;
@@ -98,7 +99,9 @@ void main() {
           filterProvider.overrideWith((ref) => initial),
           diveTypesProvider.overrideWith((ref) async => diveTypes),
           sitesProvider.overrideWith((ref) async => sites),
-          allDiveComputersProvider.overrideWith((ref) async => computers),
+          allDiveComputersProvider.overrideWith(
+            (ref) async => registeredComputers ?? computers,
+          ),
         ].cast(),
         child: MaterialApp(
           // Pinned: this suite drives the sheet by English label.
@@ -254,6 +257,28 @@ void main() {
 
     await tapText(tester, 'Apply Filters');
     expect(ref.read(filterProvider).computerId, 'c2');
+  });
+
+  // The saved filter is reconciled against the registered computers so a
+  // computer deleted since the filter was set falls back to All computers.
+  // Reconciling inside the section's builder missed the case below, because
+  // the empty-list branch returns before reaching it: the diver kept
+  // filtering on a computer that no longer exists and saw an empty dive log.
+  testWidgets('deleted computer resolves to All computers when none remain', (
+    tester,
+  ) async {
+    final ref = await openSheet(
+      tester,
+      initial: const DiveFilterState(computerId: 'GHOST'),
+      registeredComputers: const [],
+    );
+
+    // Confirms the section took its empty-list branch, the one that returns
+    // before any reconciliation the builder could do.
+    await scrollTo(tester, find.text('No dive computers registered'));
+
+    await tapText(tester, 'Apply Filters');
+    expect(ref.read(filterProvider).computerId, isNull);
   });
 
   testWidgets('depth, buddy and duration text fields write values', (


### PR DESCRIPTION
Follow-up to #1674, which converted these dropdowns to type-ahead fields and
deliberately left this alone as out of scope.

## The smell

The Dive Computer section reconciled the saved computer id against the
registered computers while building, assigning to the state field from inside
`build`:

```dart
final validId = computers.any((c) => c.id == _computerId) ? _computerId : null;
if (validId != _computerId) {
  _computerId = validId;
}
```

Introduced in e05e2c3086a, well before #1674.

## It was not only a smell

The assignment sat **after** the `computers.isEmpty` early return, so it ran on
one render branch only. A diver who deleted their last dive computer kept a
filter naming it: the sheet re-applied the stale id and the dive log came back
empty, with nothing on screen explaining why.

## The change

The saved id is now reconciled where it is used, not where it is drawn.

- The section computes the displayed value purely and passes it to the field,
  so an unknown id still shows as All computers. No assignment.
- `_applyFilters` resolves the id against the loaded list, which fixes the
  empty-list case for free because it no longer depends on which branch the UI
  took.
- A list that has not loaded yet says nothing about whether the computer still
  exists, so the id is kept rather than dropped. A slow load must not quietly
  clear the diver's filter, and this matches the previous behaviour, where the
  loading branch never reconciled either.

No deferred frame, so no flash of a stale computer name, and no extra rebuild.

### On the alternatives

A `ref.listen` on `allDiveComputersProvider` would have shipped a quieter
version of the same class of bug: listeners fire on *change*, so a
`FutureProvider` already cached with data (the second time the sheet is opened
in a session) produces no transition and no reconciliation. A widget test would
not catch that, because the test override starts in `loading` and transitions
to `data`.

## Testing

New case in `dive_filter_sheet_interactions_test.dart` covering a filter that
names a deleted computer when none remain registered. It fails on the previous
arrangement with `Expected: null, Actual: 'GHOST'`.

Neither existing test distinguished the two arrangements: both tap the computer
field before applying, which forces the populated branch to build.

`openSheet` grew an optional `registeredComputers` override so a test can vary
the registered list.

Whole project: `dart format .` clean, `flutter analyze` reports no issues,
1425 tests pass across the dive-log widget, filter-sheet page and statistics
suites.
