### PR TITLE
fix(pre-dive): render the recorded value in the diver's decimal separator

### DIFF
--- a/lib/core/utils/number_input.dart
+++ b/lib/core/utils/number_input.dart
@@ -9,6 +9,10 @@ import 'package:intl/intl.dart';
 /// because the repositories write `Value(null)` rather than `Value.absent()`,
 /// that null erases the stored value instead of leaving it alone (#1091).
 ///
+/// The same separator problem applies to numbers a diver only reads, so the
+/// display-side twin [formatDecimalForDisplay] lives here too, sharing the
+/// locale cache and separator swap rather than growing a second copy of them.
+///
 /// The seeded text and the parser must share one convention. Seeding a field
 /// with `double.toString()` and reading it back through a locale-aware parser
 /// is worse than the original bug: under de/es/it, '.' is the GROUPING
@@ -119,18 +123,24 @@ int? parseUserInt(String text) {
 /// "12.050000000000001"). Callers wanting fewer decimals round before calling.
 String formatDecimalForInput(double value) {
   if (!value.isFinite) return '';
-  var text = value.toString();
-  // Very large or very small magnitudes stringify in exponent notation, which
-  // no diver can meaningfully edit and no parser here reads back.
-  if (text.contains('e') || text.contains('E')) {
-    final format = NumberFormat.decimalPattern()
-      ..turnOffGrouping()
-      ..maximumFractionDigits = 15;
-    return format.format(value);
-  }
-  // "1250.0" reads as a half-finished edit; the field wants "1250".
-  if (text.endsWith('.0')) text = text.substring(0, text.length - 2);
-  return _localiseSeparators(text);
+  return _localiseDouble(value, stripTrailingZero: true);
+}
+
+/// [value] rendered for display in the active locale, keeping whatever
+/// precision the value itself carries: 200.0 renders "200,0" under de, not
+/// "200".
+///
+/// The display twin of [formatDecimalForInput]. The two differ only in that
+/// trailing ".0", and the difference is load bearing: the input form strips it
+/// because a field seeded "1250.0" reads as a half-finished edit, while a
+/// recorded reading is not an edit. A diver who logged 200.0 bar logged one
+/// decimal of precision, so dropping it changes what the value claims.
+///
+/// Use this for anything a diver only reads. Callers wanting a pinned number
+/// of decimals should round before calling.
+String formatDecimalForDisplay(double value) {
+  if (!value.isFinite) return '';
+  return _localiseDouble(value, stripTrailingZero: false);
 }
 
 /// [value] rounded to [fractionDigits] and rendered for seeding, with trailing
@@ -156,6 +166,28 @@ String formatRoundedForInput(double value, int fractionDigits) {
 String formatFixedForInput(double value, int fractionDigits) {
   if (!value.isFinite) return '';
   return _localiseSeparators(value.toStringAsFixed(fractionDigits));
+}
+
+/// The shared body of [formatDecimalForInput] and [formatDecimalForDisplay].
+///
+/// [stripTrailingZero] is applied here rather than by either caller because it
+/// matches on the ASCII '.' that [double.toString] emits; once the text has
+/// been localised it carries the locale's separator instead, and under de the
+/// '.' it would then match is the grouping separator.
+String _localiseDouble(double value, {required bool stripTrailingZero}) {
+  var text = value.toString();
+  // Very large or very small magnitudes stringify in exponent notation, which
+  // no diver can meaningfully read or edit and no parser here reads back.
+  if (text.contains('e') || text.contains('E')) {
+    final format = NumberFormat.decimalPattern()
+      ..turnOffGrouping()
+      ..maximumFractionDigits = 15;
+    return format.format(value);
+  }
+  if (stripTrailingZero && text.endsWith('.0')) {
+    text = text.substring(0, text.length - 2);
+  }
+  return _localiseSeparators(text);
 }
 
 /// Swaps the ASCII '.' and '-' produced by Dart's own number formatting for the

--- a/lib/features/pre_dive/presentation/widgets/session_item_tile.dart
+++ b/lib/features/pre_dive/presentation/widgets/session_item_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/number_input.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/equipment/domain/entities/overdue_service_entry.dart';
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
@@ -106,7 +107,8 @@ class SessionItemTile extends ConsumerWidget {
         ? [
             if (item.valueLabel != null) item.valueLabel!,
             if (item.valueNumber != null)
-              '${item.valueNumber}${item.valueUnit == null ? '' : ' ${item.valueUnit}'}',
+              '${formatDecimalForDisplay(item.valueNumber!)}'
+                  '${item.valueUnit == null ? '' : ' ${item.valueUnit}'}',
           ].join(': ')
         : null;
 

--- a/test/core/utils/number_input_test.dart
+++ b/test/core/utils/number_input_test.dart
@@ -158,6 +158,56 @@ void main() {
     });
   });
 
+  group('formatDecimalForDisplay', () {
+    test('uses the locale decimal separator', () {
+      Intl.defaultLocale = 'de';
+      expect(formatDecimalForDisplay(200.0), '200,0');
+      Intl.defaultLocale = 'en_US';
+      expect(formatDecimalForDisplay(200.0), '200.0');
+    });
+
+    test('keeps a trailing zero where the input form drops it', () {
+      // Asserted as a pair on purpose: these two differ in exactly one way,
+      // and it is load bearing. A field seeded "200.0" reads as a
+      // half-finished edit, so the input form strips it; a recorded reading
+      // of 200.0 bar states a precision the diver logged, so the display form
+      // keeps it. Routing a display through the input helper silently drops
+      // a decimal the tile was claiming.
+      Intl.defaultLocale = 'en_US';
+      expect(formatDecimalForDisplay(200.0), '200.0');
+      expect(formatDecimalForInput(200.0), '200');
+    });
+
+    test('localises a negative value', () {
+      Intl.defaultLocale = 'de';
+      expect(formatDecimalForDisplay(-3.5), '-3,5');
+    });
+
+    test('omits grouping separators, matching the input form', () {
+      Intl.defaultLocale = 'de';
+      expect(formatDecimalForDisplay(1250.5), '1250,5');
+    });
+
+    test('does not silently truncate precision', () {
+      Intl.defaultLocale = 'en_US';
+      expect(formatDecimalForDisplay(12.345678), '12.345678');
+    });
+
+    test('spells out a magnitude that stringifies in exponent notation', () {
+      // No diver can read "1e+21" off a checklist tile.
+      Intl.defaultLocale = 'en_US';
+      expect(formatDecimalForDisplay(1e21), isNot(contains('e')));
+    });
+
+    test('renders nothing for a non-finite value', () {
+      // Unreachable through parseUserDecimal, which rejects both, but the
+      // display form must not put "NaN" in front of a diver either way.
+      Intl.defaultLocale = 'en_US';
+      expect(formatDecimalForDisplay(double.nan), '');
+      expect(formatDecimalForDisplay(double.infinity), '');
+    });
+  });
+
   group('formatRoundedForInput', () {
     test('rounds to the requested precision and drops trailing zeros', () {
       Intl.defaultLocale = 'en_US';

--- a/test/features/pre_dive/presentation/widgets/session_item_tile_test.dart
+++ b/test/features/pre_dive/presentation/widgets/session_item_tile_test.dart
@@ -18,11 +18,17 @@ void main() {
   // The value line formats through Intl.getCurrentLocale(), which resolves the
   // Intl.defaultLocale process global rather than the MaterialApp locale. The
   // app assigns it from the diver's locale (lib/app.dart); a widget test that
-  // pumps the tile alone never runs that, so tests pin it and put it back.
+  // pumps the tile alone never runs that.
+  //
+  // Pinned rather than merely saved. Left unset, getCurrentLocale falls back to
+  // Intl.systemLocale, and the assertions below that spell out a '.' would then
+  // rest on that fallback happening to be en_US: a default owned by intl, not
+  // by this file. Tests that need another locale set it in the test body.
   late String? previousLocale;
 
   setUp(() {
     previousLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en_US';
   });
 
   tearDown(() {

--- a/test/features/pre_dive/presentation/widgets/session_item_tile_test.dart
+++ b/test/features/pre_dive/presentation/widgets/session_item_tile_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 import 'package:submersion/features/equipment/domain/entities/overdue_service_entry.dart';
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
 import 'package:submersion/features/equipment/domain/entities/service_kind.dart';
@@ -13,6 +14,20 @@ import '../../../../helpers/test_app.dart';
 
 void main() {
   final now = DateTime.fromMillisecondsSinceEpoch(1700000000000);
+
+  // The value line formats through Intl.getCurrentLocale(), which resolves the
+  // Intl.defaultLocale process global rather than the MaterialApp locale. The
+  // app assigns it from the diver's locale (lib/app.dart); a widget test that
+  // pumps the tile alone never runs that, so tests pin it and put it back.
+  late String? previousLocale;
+
+  setUp(() {
+    previousLocale = Intl.defaultLocale;
+  });
+
+  tearDown(() {
+    Intl.defaultLocale = previousLocale;
+  });
 
   PreDiveSession session({bool locked = false, bool strict = false}) =>
       PreDiveSession(
@@ -76,10 +91,11 @@ void main() {
     VoidCallback? onAddNote,
     VoidCallback? onReset,
     List<dynamic> overrides = const [],
+    Locale locale = const Locale('en'),
   }) async {
     await tester.pumpWidget(
       testApp(
-        locale: const Locale('en'),
+        locale: locale,
         overrides: overrides,
         child: SessionItemTile(
           session: s,
@@ -190,6 +206,26 @@ void main() {
         ),
       );
       expect(find.text('SPG: 200.0 bar'), findsOneWidget);
+    });
+
+    testWidgets('value line follows a comma-decimal locale', (tester) async {
+      // double.toString() always emits '.', so the recorded reading read
+      // "200.0 bar" to a German diver while every number they typed used a
+      // comma. Both the process global and the MaterialApp locale are set:
+      // the first drives the separator, the second the surrounding strings.
+      Intl.defaultLocale = 'de';
+      await pumpTile(
+        tester,
+        s: session(),
+        it: item(
+          type: PreDiveItemType.value,
+          valueLabel: 'SPG',
+          valueNumber: 200,
+          valueUnit: 'bar',
+        ),
+        locale: const Locale('de'),
+      );
+      expect(find.text('SPG: 200,0 bar'), findsOneWidget);
     });
 
     testWidgets('out-of-range value line is bold', (tester) async {


### PR DESCRIPTION
## Summary

The pre-dive checklist tile built its recorded-value subtitle with raw Dart
string interpolation. `double.toString()` always emits '.' as the decimal
separator, so a diver in a comma-decimal locale (de, es, fr, it, nl, pt, hu)
read "SPG: 200.0 bar" while every number they typed into the app used a comma.

Input was made locale-aware in #1091. This is the display side of the same
problem, for this one tile.

Display only. Nothing stored or parsed changes.

## Changes

- Add `formatDecimalForDisplay` to `lib/core/utils/number_input.dart`, beside
  `formatDecimalForInput`. It localises the separator while preserving the
  value's own precision.
- Both functions now run through one private `_localiseDouble`, which differ
  only in whether a trailing ".0" is stripped.
- Route the tile's value line through it.

`formatDecimalForInput` was not reusable here: it strips a trailing ".0"
because it seeds editable text fields, where "1250.0" reads as a half-finished
edit. A recorded reading is not an edit, and a diver who logged 200.0 bar
logged one decimal of precision, so it would have turned "200.0 bar" into
"200 bar" and broken two existing assertions that are correct as written.

The strip stays inside the shared body rather than moving to a caller because
it matches the ASCII '.' that `double.toString()` emits. After localisation the
'.' it would match under de is the grouping separator.

`UnitFormatter` was checked first and has nothing suitable: it renders through
`toStringAsFixed` in 21 places and localises nothing. See the follow-ups below.

## Test Plan

- [x] `flutter analyze` passes (whole project, no issues)
- [x] `dart format .` clean
- [x] `test/core/utils/number_input_test.dart` 34/34
- [x] `test/features/pre_dive/presentation/widgets/session_item_tile_test.dart`
      27/27, including the two pre-existing `SPG: 200.0 bar` assertions
- [x] Pre-push ranked subset passes
- [x] `flutter test` full suite: 25,666 passed, exit 0

Tests were written first. The widget test failed against unfixed code with
`Found 0 widgets with text "SPG: 200,0 bar"`. Because the unit tests could only
fail to *compile* before the new function existed, which proves nothing about
whether their assertions bite, both were mutation-checked afterwards:

- Reverting the call site to `'${item.valueNumber}'` turns the German widget
  test red, and only that test.
- Flipping the display helper to `stripTrailingZero: true` turns "keeps a
  trailing zero where the input form drops it" red, and only that test.

### Review follow-up

Copilot flagged that this file now depends on `Intl.defaultLocale` without
pinning it. Taken, in `c2bac7cd4af`: `setUp` pins `en_US`, the restore in
`tearDown` is unchanged.

The stated mechanism was off, which is worth recording. `getCurrentLocale()` is
`defaultLocale ??= systemLocale`, and `systemLocale` is a hardcoded `en_US`
(intl `src/global_state.dart:7`), not the machine locale; it only picks up the
real one if something calls `findSystemLocale()`, and nothing here does. So
these were not flaky on a non-dot machine today. The pin is still right,
because the coupling to a global this file never set was new and left the
assertions resting on another package's default. Verified both ways with
`Intl.systemLocale` forced to `de`: with the pin all 27 pass, without it two
fail.

### A note on the locale test

The new widget test sets **both** `Intl.defaultLocale` and the `MaterialApp`
locale. `formatDecimalForDisplay` resolves `Intl.getCurrentLocale()`, which
reads the `Intl.defaultLocale` process global. That global is assigned at
`lib/app.dart:387`, inside the real app widget, which a test pumping the tile
alone never builds. A test that set only the `MaterialApp` locale would pass
against unfixed code, so it would have been worse than no test. `pumpTile`
gained a `locale` parameter defaulting to `Locale('en')`, leaving every
existing caller unchanged.

## Follow-ups

Filed rather than folded in, to keep this change display-only and reviewable:

- #1682: the cell linearity line on this same tile has the same bug, in
  `'$air'` and `expected.toStringAsFixed(1)`. Blocked on #986 landing.
- #1683: `UnitFormatter` emits ASCII separators across most numeric display in
  the app. Needs sizing before anyone starts.

Worth flagging for reviewers: the app does not currently show "200,0 bar"
anywhere else. `number_input.dart` and `rig_composer.dart` are the only files
that localise separators at all, and both are input paths. This tile is now the
first localised display site, which is what #1683 is about.
