### PR TITLE
test(dive-log): cover the type-ahead filter, and share one options list

### DIFF
--- a/lib/features/dive_log/presentation/widgets/searchable_filter_dropdown.dart
+++ b/lib/features/dive_log/presentation/widgets/searchable_filter_dropdown.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 
 import 'package:submersion/core/text/fuzzy_match.dart';
 
 import 'package:submersion/features/dive_log/presentation/utils/filter_option_search.dart';
+import 'package:submersion/shared/widgets/forms/autocomplete_options_list.dart';
 
-/// Identifies the floating suggestion list.
+/// Identifies this field's floating suggestion list.
 ///
 /// Tests scope their finders to this rather than to every tappable row on the
 /// surface under it, which would otherwise match unrelated buttons and could
@@ -268,115 +268,13 @@ class _SearchableFilterDropdownState<T>
             onSubmitted: (_) => onFieldSubmitted(),
           ),
       optionsViewBuilder: (context, onSelected, options) =>
-          _FilterOptionsView<T>(onSelected: onSelected, options: options),
-    );
-  }
-}
-
-/// The suggestion list floated under the field.
-class _FilterOptionsView<T> extends StatelessWidget {
-  const _FilterOptionsView({required this.onSelected, required this.options});
-
-  final void Function(_FilterEntry<T>) onSelected;
-  final Iterable<_FilterEntry<T>> options;
-
-  @override
-  Widget build(BuildContext context) {
-    return Align(
-      key: searchableFilterOptionsKey,
-      alignment: AlignmentDirectional.topStart,
-      child: Material(
-        elevation: 4,
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxHeight: 240),
-          child: _FilterOptionsList<T>(
+          AutocompleteOptionsList<_FilterEntry<T>>(
+            key: searchableFilterOptionsKey,
+            options: options,
             onSelected: onSelected,
-            options: options.toList(),
-            // RawAutocomplete tracks which row the arrow keys have moved to,
-            // and Enter commits that row, so it has to be visible.
-            highlightedIndex: AutocompleteHighlightedOption.of(context),
+            labelFor: (entry) => entry.label,
+            maxHeight: 240,
           ),
-        ),
-      ),
-    );
-  }
-}
-
-/// The rows themselves, following Material's own autocomplete list: the
-/// highlighted row is tinted and kept scrolled into view as the arrow keys
-/// move it.
-class _FilterOptionsList<T> extends StatefulWidget {
-  const _FilterOptionsList({
-    required this.onSelected,
-    required this.options,
-    required this.highlightedIndex,
-  });
-
-  final void Function(_FilterEntry<T>) onSelected;
-  final List<_FilterEntry<T>> options;
-  final int highlightedIndex;
-
-  @override
-  State<_FilterOptionsList<T>> createState() => _FilterOptionsListState<T>();
-}
-
-class _FilterOptionsListState<T> extends State<_FilterOptionsList<T>> {
-  final _scrollController = ScrollController();
-
-  @override
-  void didUpdateWidget(covariant _FilterOptionsList<T> oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.highlightedIndex == oldWidget.highlightedIndex) return;
-    if (widget.highlightedIndex >= widget.options.length) return;
-
-    SchedulerBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      final highlightedContext = GlobalObjectKey(
-        widget.options[widget.highlightedIndex],
-      ).currentContext;
-      if (highlightedContext == null) {
-        // The row is not built yet, so jump to the end it moved towards.
-        _scrollController.jumpTo(
-          widget.highlightedIndex == 0
-              ? 0.0
-              : _scrollController.position.maxScrollExtent,
-        );
-      } else {
-        Scrollable.ensureVisible(highlightedContext, alignment: 0.5);
-      }
-    }, debugLabel: 'SearchableFilterDropdown.ensureVisible');
-  }
-
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return ListView.builder(
-      padding: EdgeInsets.zero,
-      shrinkWrap: true,
-      controller: _scrollController,
-      itemCount: widget.options.length,
-      itemBuilder: (context, index) {
-        final entry = widget.options[index];
-        final highlighted = index == widget.highlightedIndex;
-        return Semantics(
-          button: true,
-          selected: highlighted,
-          child: InkWell(
-            key: GlobalObjectKey(entry),
-            onTap: () => widget.onSelected(entry),
-            child: Container(
-              color: highlighted ? Theme.of(context).focusColor : null,
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-              child: Text(entry.label),
-            ),
-          ),
-        );
-      },
     );
   }
 }

--- a/test/features/dive_log/presentation/pages/dive_search_page_typeahead_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_search_page_typeahead_test.dart
@@ -3,6 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/presentation/pages/dive_search_page.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/searchable_filter_dropdown.dart';
+import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
+import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
@@ -17,6 +21,8 @@ import '../../../../helpers/test_database.dart';
 /// the same way, so they narrow as the diver types too.
 void main() {
   final now = DateTime(2026, 6, 1);
+  const diverId = 'diver-1';
+  const customFieldKeys = ['Boat name', 'Guide', 'Surface interval'];
 
   const sites = [
     DiveSite(id: 'site-1', name: 'Blue Hole', country: 'Egypt'),
@@ -43,6 +49,25 @@ void main() {
     ),
   ];
 
+  final centers = [
+    DiveCenter(
+      id: 'dc-1',
+      name: 'Reef Divers',
+      city: 'Dahab',
+      country: 'Egypt',
+      createdAt: now,
+      updatedAt: now,
+    ),
+    DiveCenter(
+      id: 'dc-2',
+      name: 'Blue Planet',
+      city: 'Cozumel',
+      country: 'Mexico',
+      createdAt: now,
+      updatedAt: now,
+    ),
+  ];
+
   setUp(() async {
     await setUpTestDatabase();
   });
@@ -51,8 +76,9 @@ void main() {
     await tearDownTestDatabase();
   });
 
-  Future<void> openLocationSection(WidgetTester tester) async {
+  Future<void> openSection(WidgetTester tester, String title) async {
     final overrides = await getBaseOverrides();
+    late WidgetRef capturedRef;
 
     await tester.pumpWidget(
       ProviderScope(
@@ -60,19 +86,49 @@ void main() {
           ...overrides,
           sitesProvider.overrideWith((ref) async => sites),
           allTripsProvider.overrideWith((ref) async => trips),
+          allDiveCentersProvider.overrideWith((ref) async => centers),
+          customFieldKeySuggestionsProvider(
+            diverId,
+          ).overrideWith((ref) async => customFieldKeys),
         ].cast(),
-        child: const MaterialApp(
+        child: MaterialApp(
           // Pinned: this suite drives the page by English label.
-          locale: Locale('en'),
+          locale: const Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(body: DiveSearchPage()),
+          home: Scaffold(
+            body: Consumer(
+              builder: (context, ref, _) {
+                capturedRef = ref;
+                return const DiveSearchPage();
+              },
+            ),
+          ),
         ),
       ),
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Location'));
+    // The shared base overrides seed no current diver, and the custom field
+    // suggestions are keyed by one.
+    await capturedRef
+        .read(currentDiverIdProvider.notifier)
+        .setCurrentDiver(diverId);
+    await tester.pumpAndSettle();
+
+    // The page builds its sections lazily, so a section near the bottom is
+    // not in the tree until it is scrolled to.
+    final header = find.text(title);
+    if (header.evaluate().isEmpty) {
+      await tester.scrollUntilVisible(
+        header,
+        100,
+        scrollable: find.byType(Scrollable).first,
+      );
+    }
+    await tester.ensureVisible(header.first);
+    await tester.pumpAndSettle();
+    await tester.tap(header.first);
     await tester.pumpAndSettle();
   }
 
@@ -91,7 +147,7 @@ void main() {
       .where((label) => label.isNotEmpty);
 
   testWidgets('typing narrows the dive site list', (tester) async {
-    await openLocationSection(tester);
+    await openSection(tester, 'Location');
     await tester.ensureVisible(find.text('All sites').first);
     await tester.pumpAndSettle();
 
@@ -105,7 +161,7 @@ void main() {
   });
 
   testWidgets('a trip is found by where it went', (tester) async {
-    await openLocationSection(tester);
+    await openSection(tester, 'Location');
     await tester.ensureVisible(find.text('All trips').first);
     await tester.pumpAndSettle();
 
@@ -116,5 +172,39 @@ void main() {
 
     expect(suggestions(tester), contains('Summer week'));
     expect(suggestions(tester), isNot(contains('Winter break')));
+  });
+
+  // The PR claims a centre is findable by where it is, not only by the name it
+  // was saved under, so that claim needs a test.
+  testWidgets('a dive center is found by its city', (tester) async {
+    await openSection(tester, 'Location');
+    await tester.ensureVisible(find.text('All centers').first);
+    await tester.pumpAndSettle();
+
+    await tester.tap(fieldShowing('All centers'));
+    await tester.pumpAndSettle();
+    await tester.enterText(fieldShowing('All centers'), 'cozumel');
+    await tester.pumpAndSettle();
+
+    expect(suggestions(tester), contains('Blue Planet'));
+    expect(suggestions(tester), isNot(contains('Reef Divers')));
+  });
+
+  testWidgets('typing narrows the custom field keys', (tester) async {
+    await openSection(tester, 'Custom Field Key');
+    await tester.ensureVisible(find.byIcon(Icons.extension).last);
+    await tester.pumpAndSettle();
+
+    final field = find.ancestor(
+      of: find.byIcon(Icons.extension).last,
+      matching: find.byType(TextField),
+    );
+    await tester.tap(field);
+    await tester.pumpAndSettle();
+    await tester.enterText(field, 'guide');
+    await tester.pumpAndSettle();
+
+    expect(suggestions(tester), contains('Guide'));
+    expect(suggestions(tester), isNot(contains('Boat name')));
   });
 }

--- a/test/features/dive_log/presentation/pages/dive_search_page_typeahead_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_search_page_typeahead_test.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/provider.dart';
-import 'package:submersion/features/dive_log/presentation/pages/dive_search_page.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/searchable_filter_dropdown.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
 import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_search_page.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
-import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/searchable_filter_dropdown.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';

--- a/test/features/dive_log/presentation/widgets/searchable_filter_dropdown_test.dart
+++ b/test/features/dive_log/presentation/widgets/searchable_filter_dropdown_test.dart
@@ -439,9 +439,9 @@ void main() {
       reason: 'the last row must start unbuilt for this to test anything',
     );
 
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
     await tester.pumpAndSettle();
 
     expect(openMenuLabels(tester), contains('Site 40'));

--- a/test/features/dive_log/presentation/widgets/searchable_filter_dropdown_test.dart
+++ b/test/features/dive_log/presentation/widgets/searchable_filter_dropdown_test.dart
@@ -399,6 +399,61 @@ void main() {
     expect(find.text('Blue Hole'), findsOneWidget);
   });
 
+  // Jumping to the last option skips past the rows the list has built, so the
+  // scroll has to fall back to the end rather than to a row it cannot find.
+  testWidgets('jumping to the last option scrolls it into view', (
+    tester,
+  ) async {
+    final many = List.generate(
+      40,
+      (i) => FilterDropdownOption(value: 's$i', label: 'Site ${i + 1}'),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 400,
+              child: SearchableFilterDropdown<String>(
+                value: null,
+                options: many,
+                allOptionLabel: allSitesLabel,
+                searchHintText: searchHint,
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await openMenu(tester);
+
+    expect(
+      openMenuLabels(tester),
+      isNot(contains('Site 40')),
+      reason: 'the last row must start unbuilt for this to test anything',
+    );
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+    await tester.pumpAndSettle();
+
+    expect(openMenuLabels(tester), contains('Site 40'));
+  });
+
+  // A filter can outlive the thing it points at: the site is deleted, the
+  // saved id is not. The field must not present that as a live filter.
+  testWidgets('falls back to the all-options label for a vanished option', (
+    tester,
+  ) async {
+    await pumpDropdown(tester, value: 'deleted-site');
+
+    expect(find.text(allSitesLabel), findsOneWidget);
+    expect(reported, isEmpty);
+  });
+
   testWidgets('moving focus away discards an uncommitted query', (
     tester,
   ) async {
@@ -418,5 +473,47 @@ void main() {
       reason: 'the field must show the filter that is actually in force',
     );
     expect(find.text('no such site'), findsNothing);
+  });
+
+  group('FilterDropdownOption equality', () {
+    test('options with the same fields are equal and hash alike', () {
+      final a = FilterDropdownOption(
+        value: 's1',
+        label: 'Blue Hole',
+        searchText: 'Blue Hole Egypt',
+      );
+      final b = FilterDropdownOption(
+        value: 's1',
+        label: 'Blue Hole',
+        searchText: 'Blue Hole Egypt',
+      );
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect({a, b}, hasLength(1));
+    });
+
+    test('a changed label or search text is a different option', () {
+      final base = FilterDropdownOption(value: 's1', label: 'Blue Hole');
+
+      expect(
+        base,
+        isNot(FilterDropdownOption(value: 's1', label: 'Blue Hole (north)')),
+      );
+      expect(
+        base,
+        isNot(
+          FilterDropdownOption(
+            value: 's1',
+            label: 'Blue Hole',
+            searchText: 'Blue Hole Egypt',
+          ),
+        ),
+      );
+      expect(
+        base,
+        isNot(FilterDropdownOption(value: 's2', label: 'Blue Hole')),
+      );
+    });
   });
 }

--- a/test/features/dive_log/presentation/widgets/searchable_filter_dropdown_test.dart
+++ b/test/features/dive_log/presentation/widgets/searchable_filter_dropdown_test.dart
@@ -334,15 +334,11 @@ void main() {
     expect(openMenuLabels(tester), contains('Late Arrival'));
   });
 
-  /// The background colour of the suggestion row offering [label].
-  Color? rowColor(WidgetTester tester, String label) => tester
-      .widget<Container>(
-        find.descendant(
-          of: suggestion(label),
-          matching: find.byType(Container),
-        ),
-      )
-      .color;
+  /// The suggestion row offering [label], as a tile.
+  ListTile rowTile(WidgetTester tester, String label) =>
+      tester.widget<ListTile>(
+        find.ancestor(of: find.text(label), matching: find.byType(ListTile)),
+      );
 
   // Enter commits whichever row the arrow keys have moved to, so a keyboard
   // user has to be able to see which one that is.
@@ -358,9 +354,10 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
 
-    expect(rowColor(tester, 'Blue Hole'), focusColor);
-    expect(rowColor(tester, allSitesLabel), isNull);
-    expect(rowColor(tester, 'Thistlegorm'), isNull);
+    expect(rowTile(tester, 'Blue Hole').selected, isTrue);
+    expect(rowTile(tester, 'Blue Hole').selectedTileColor, focusColor);
+    expect(rowTile(tester, allSitesLabel).selected, isFalse);
+    expect(rowTile(tester, 'Thistlegorm').selected, isFalse);
   });
 
   testWidgets('the highlighted row is exposed as selected to semantics', (

--- a/test/features/dive_log/presentation/widgets/searchable_filter_dropdown_test.dart
+++ b/test/features/dive_log/presentation/widgets/searchable_filter_dropdown_test.dart
@@ -335,9 +335,16 @@ void main() {
   });
 
   /// The suggestion row offering [label], as a tile.
+  ///
+  /// Scoped to the suggestion list: the field itself carries the selected
+  /// option's label as its text, so an unscoped find.text would have two
+  /// candidates for it.
   ListTile rowTile(WidgetTester tester, String label) =>
       tester.widget<ListTile>(
-        find.ancestor(of: find.text(label), matching: find.byType(ListTile)),
+        find.descendant(
+          of: find.byKey(searchableFilterOptionsKey),
+          matching: find.widgetWithText(ListTile, label),
+        ),
       );
 
   // Enter commits whichever row the arrow keys have moved to, so a keyboard


### PR DESCRIPTION
## Summary

Two loose ends from #1674, which merged at the same time as #1668.

**Codecov flagged #1674's patch at 91.10%**, and the cold lines were real
behaviour rather than noise. Measured locally against Codecov's own method,
reproducing its figure first:

| File | Before | After |
| --- | --- | --- |
| `dive_search_page.dart` | 75.41% | 100% |
| `searchable_filter_dropdown.dart` | 95.28% | 100% |
| Patch overall | 91.10% | 100% |

What was untested: a dive center searched by its city and the custom field key
picker had no test at all on the advanced search page (the #1674 description
claimed centers were findable by where they are, and that claim was untested);
the field's fallback when the selected option has vanished, which is what a
filter pointing at a deleted site relies on; the value equality deciding
whether a host rebuild invalidates the prepared rows; and the scroll fallback
for jumping to an option the list has not built.

**#1668 and #1674 were in flight together**, and both grew a highlighted-row
options list. #1668's is the shared one, in
`shared/widgets/forms/autocomplete_options_list.dart`; #1674's was hand-rolled
inside the filter field. Main carried both. This adopts the shared one and
deletes the duplicate, which is a straight improvement rather than only
deduplication: it keys rows by position instead of by value, so two options
comparing equal cannot collide on a global key; it guards against a superseded
scroll while an arrow key is held; and it clips the overlay so ink splashes
stay inside the rounded corners.

## Changes

- `searchable_filter_dropdown.dart` uses `AutocompleteOptionsList`, dropping
  its private `_FilterOptionsView` / `_FilterOptionsList` (382 lines to 280).
- Five new tests covering the paths above.
- The highlight test asserts the tile contract the shared list exposes
  (`selected` plus `selectedTileColor`) rather than the colour of a container
  this widget no longer builds.

No behaviour change to the filters themselves; the existing
`dive_filter_sheet_*` and `dive_search_page_*` suites pass unmodified.

## Test Plan

- [x] `flutter test` passes: 4413 across `test/features/dive_log`,
      `test/features/statistics` and `test/shared/widgets/forms`
- [x] `flutter analyze` passes, whole project, clean
- [x] `dart format .` clean
- [ ] Manual testing on: not yet run on a device

Each new assertion was mutation-tested against a deliberately broken
implementation to confirm it fails when the behaviour regresses.
