### PR TITLE
fix(data-quality): stop offering Consolidate on same-computer duplicates

### DIFF
--- a/lib/features/data_quality/domain/detectors/duplicate_detector.dart
+++ b/lib/features/data_quality/domain/detectors/duplicate_detector.dart
@@ -14,7 +14,7 @@ class DuplicateDetector extends QualityDetector {
   @override
   String get id => 'duplicate';
   @override
-  int get version => 1;
+  int get version => 2;
   @override
   QualityCategory get category => QualityCategory.duplicate;
 
@@ -27,6 +27,7 @@ class DuplicateDetector extends QualityDetector {
     if (maxDepth == null || duration == null || duration <= 0) {
       return const [];
     }
+    final serial = dive.diveComputerSerial;
     final out = <QualityFinding>[];
     for (final n in ctx.neighbors) {
       final nDepth = n.maxDepth;
@@ -57,6 +58,17 @@ class DuplicateDetector extends QualityDetector {
             'timeDiffMinutes': entry.difference(n.entryTime).inMinutes.abs(),
             'thisMaxDepth': maxDepth,
             'otherMaxDepth': nDepth,
+            // Two records from one physical computer are a re-download, not
+            // a second computer's view of the dive, and
+            // DiveConsolidationBuilder refuses to merge them. Recorded here
+            // so the inbox can withhold a Consolidate button that could only
+            // ever fail. An unknown serial on either side stays false: the
+            // pair may well be consolidatable, and the service is the one
+            // that decides.
+            'sameComputer':
+                serial != null &&
+                serial.isNotEmpty &&
+                serial == n.computerSerial,
           },
         ),
       );

--- a/lib/features/data_quality/domain/repairs/quality_repair_action.dart
+++ b/lib/features/data_quality/domain/repairs/quality_repair_action.dart
@@ -189,8 +189,15 @@ List<QualityRepairAction> repairOptionsFor(QualityFinding f) {
       return [GoToDiveRepair(diveId)];
 
     case 'duplicate':
+      // Consolidation folds a SECOND computer's recording into the dive.
+      // DiveConsolidationBuilder rejects a pair that shares one physical
+      // computer, so offering the repair there is a button that can only
+      // ever fail; the card falls back to its no-automatic-fix row instead.
+      // Findings written before the detector reported this (no key at all)
+      // stay repairable until a rescan fills the fact in.
+      final consolidatable = p['sameComputer'] != true;
       return [
-        if (related != null)
+        if (related != null && consolidatable)
           ConsolidateDuplicateRepair(
             targetDiveId: diveId,
             secondaryDiveId: related,

--- a/lib/features/dive_log/presentation/widgets/run_dive_consolidation.dart
+++ b/lib/features/dive_log/presentation/widgets/run_dive_consolidation.dart
@@ -88,16 +88,22 @@ Future<void> runDiveConsolidation({
 /// Maps a [DiveConsolidationService.apply] failure to user-visible text.
 ///
 /// `apply` throws [ArgumentError] whose message either starts with
-/// `sameComputer` (the service's own FK-level guard) or is
+/// `sameComputer` (the service's own FK-level guard) or embeds
 /// `DiveConsolidationBuilder.build`'s `ConsolidationInvalid(reason.name)`
-/// wrapper, which encodes the invalid-consolidation reason by name. Only the
-/// reasons that are actually surfaced with distinct copy are matched here;
-/// anything else -- including tooFewDives/mixedDivers, which do not have
-/// dedicated error strings -- falls back to the generic error text.
+/// wrapper, which encodes the invalid-consolidation reason by name. Both
+/// shapes are matched by substring: the wrapper prefixes the reason with
+/// `build() requires a consolidatable selection; got `, so a `startsWith`
+/// test could never see it, and a same-computer re-download -- which
+/// `classify` rejects on serial, long before the service reaches the
+/// computer FK -- reported only the generic "nothing was changed" text.
+///
+/// Only the reasons that are actually surfaced with distinct copy are
+/// matched here; anything else -- including tooFewDives/mixedDivers, which
+/// do not have dedicated error strings -- falls back to the generic text.
 String consolidationErrorText(AppLocalizations l10n, Object error) {
   if (error is ArgumentError) {
     final message = error.message?.toString() ?? '';
-    if (message.startsWith('sameComputer')) {
+    if (message.contains('sameComputer')) {
       return l10n.diveLog_consolidate_error_sameComputer;
     }
     if (message.contains('notOverlapping')) {

--- a/test/features/data_quality/data/quality_prefilters_test.dart
+++ b/test/features/data_quality/data/quality_prefilters_test.dart
@@ -41,7 +41,11 @@ void main() {
         'source_conflict',
       }),
     );
-    expect(qualityDetectorVersions()['duplicate'], 1);
+    // v2 records `sameComputer` on every duplicate pair. The bump is what
+    // raises the "new checks are available" banner, so an existing library
+    // gets the flag on a rescan instead of keeping a Consolidate button that
+    // cannot work.
+    expect(qualityDetectorVersions()['duplicate'], 2);
   });
 
   test('profile detectors only get dives that have profiles', () async {

--- a/test/features/data_quality/domain/detectors/cross_dive_detectors_test.dart
+++ b/test/features/data_quality/domain/detectors/cross_dive_detectors_test.dart
@@ -120,6 +120,56 @@ void main() {
       expect(out.single.params['score'], closeTo(1.0, 1e-9));
     });
 
+    test('records that the pair came from one physical computer', () {
+      // A re-download from the same computer cannot be consolidated (the
+      // builder rejects it on serial), so the finding has to say so and the
+      // inbox has to withhold the Consolidate repair.
+      final ctx = makeContext(
+        dive: makeTestDive(id: 'dB', entry: entry, maxDepth: 30, serial: 'S1'),
+        neighbors: [
+          QualityNeighbor(
+            id: 'dA',
+            entryTime: entry.add(const Duration(minutes: 5)),
+            maxDepth: 30,
+            durationSeconds: 2400,
+            computerSerial: 'S1',
+          ),
+        ],
+      );
+      expect(det.detect(ctx).single.params['sameComputer'], isTrue);
+    });
+
+    test('two different computers are consolidatable', () {
+      final ctx = makeContext(
+        dive: makeTestDive(id: 'dB', entry: entry, maxDepth: 30, serial: 'S1'),
+        neighbors: [
+          QualityNeighbor(
+            id: 'dA',
+            entryTime: entry.add(const Duration(minutes: 5)),
+            maxDepth: 30,
+            durationSeconds: 2400,
+            computerSerial: 'S2',
+          ),
+        ],
+      );
+      expect(det.detect(ctx).single.params['sameComputer'], isFalse);
+    });
+
+    test('an unknown serial on either side is not assumed same-computer', () {
+      final ctx = makeContext(
+        dive: makeTestDive(id: 'dB', entry: entry, maxDepth: 30),
+        neighbors: [
+          QualityNeighbor(
+            id: 'dA',
+            entryTime: entry.add(const Duration(minutes: 5)),
+            maxDepth: 30,
+            durationSeconds: 2400,
+          ),
+        ],
+      );
+      expect(det.detect(ctx).single.params['sameComputer'], isFalse);
+    });
+
     test('12 min apart, same profile -> 0.65 -> warning', () {
       // timeScore = 1 - (12-5)/(15-5) = 0.3; score = .5*.3 + .3 + .2 = 0.65.
       final ctx = makeContext(

--- a/test/features/data_quality/presentation/data_quality_inbox_page_test.dart
+++ b/test/features/data_quality/presentation/data_quality_inbox_page_test.dart
@@ -1089,6 +1089,42 @@ void main() {
     await tester.pumpAndSettle(const Duration(seconds: 6));
   });
 
+  testWidgets('a same-computer duplicate offers no Consolidate button', (
+    tester,
+  ) async {
+    // The real-world duplicate is the same dive downloaded twice from one
+    // computer, and DiveConsolidationBuilder refuses to merge those. The
+    // inbox used to offer Consolidate anyway, so the tap could only ever
+    // fail; the card now explains that no automatic fix exists instead.
+    final prefs = await _prefs();
+    await tester.pumpWidget(
+      _scope(
+        prefs,
+        findings: [
+          _f(
+            id: 'r-dup-same',
+            diveId: 'd1',
+            relatedDiveId: 'd2',
+            detectorId: 'duplicate',
+            category: QualityCategory.duplicate,
+            params: const {
+              'score': 0.9,
+              'timeDiffMinutes': 1,
+              'sameComputer': true,
+            },
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Consolidate'), findsNothing);
+    expect(
+      find.text('No automatic fix. Open the dive to correct this.'),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('split-source repair reports a failure through a SnackBar', (
     tester,
   ) async {

--- a/test/features/data_quality/presentation/data_quality_inbox_page_test.dart
+++ b/test/features/data_quality/presentation/data_quality_inbox_page_test.dart
@@ -146,6 +146,11 @@ Future<Widget> _wrap(_FakeFindingsRepository repo) async {
       settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
     ],
     child: const MaterialApp(
+      // Every assertion in this file is an English literal, and an unpinned
+      // MaterialApp resolves against the HOST machine's locale list (not a
+      // fixed en_US), so the app's own translations would win on a
+      // non-English dev machine and the finders would match nothing.
+      locale: Locale('en'),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: DataQualityInboxPage(),
@@ -232,6 +237,9 @@ Widget _scope(
     diveRepository: diveRepository,
   ).cast(),
   child: localizedMaterialApp(
+    // See the note in _wrap: pinned so the English finders below survive a
+    // non-English host locale.
+    locale: const Locale('en'),
     home: DataQualityInboxPage(filterDiveId: filterDiveId),
   ),
 );

--- a/test/features/data_quality/repairs/repair_mapping_test.dart
+++ b/test/features/data_quality/repairs/repair_mapping_test.dart
@@ -39,6 +39,32 @@ void main() {
     expect(c.secondaryDiveId, 'd2');
   });
 
+  test('duplicate from the SAME computer offers no consolidate', () {
+    // DiveConsolidationBuilder refuses two records from one physical
+    // computer, so a Consolidate button on that pair can only ever fail.
+    final actions = repairOptionsFor(
+      f(
+        detectorId: 'duplicate',
+        relatedDiveId: 'd2',
+        params: {'sameComputer': true},
+      ),
+    );
+    expect(actions.whereType<ConsolidateDuplicateRepair>(), isEmpty);
+    // The pair is still navigable from the card's expanded row.
+    expect(actions.whereType<GoToDiveRepair>(), isNotEmpty);
+  });
+
+  test('duplicate from two different computers still offers consolidate', () {
+    final actions = repairOptionsFor(
+      f(
+        detectorId: 'duplicate',
+        relatedDiveId: 'd2',
+        params: {'sameComputer': false},
+      ),
+    );
+    expect(actions.whereType<ConsolidateDuplicateRepair>(), hasLength(1));
+  });
+
   test('split pair maps to combine', () {
     final actions = repairOptionsFor(
       f(detectorId: 'split_pair', relatedDiveId: 'd2'),

--- a/test/features/dive_log/presentation/widgets/consolidation_error_text_test.dart
+++ b/test/features/dive_log/presentation/widgets/consolidation_error_text_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/services/dive_consolidation_builder.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/run_dive_consolidation.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// `DiveConsolidationService.apply` surfaces an invalid selection in two
+/// shapes, and both have to reach the diver as the reason they hit, not as
+/// "Couldn't merge the dives":
+///
+/// - the service's own FK-level guard, `sameComputer: <id> shares <computer>`
+/// - `DiveConsolidationBuilder.build`'s wrapper around the classification,
+///   `build() requires a consolidatable selection; got
+///   ConsolidationInvalid(sameComputer)`
+///
+/// The second one is what a same-computer re-download actually produces,
+/// because `classify` checks serials before the service ever looks at the
+/// computer FK.
+void main() {
+  late AppLocalizations l10n;
+
+  setUpAll(() async {
+    l10n = await AppLocalizations.delegate.load(const Locale('en'));
+  });
+
+  ArgumentError builderRejection(ConsolidationInvalidReason reason) =>
+      ArgumentError(
+        'build() requires a consolidatable selection; got '
+        '${ConsolidationInvalid(reason)}',
+      );
+
+  test('the builder\'s same-computer rejection is explained', () {
+    expect(
+      consolidationErrorText(
+        l10n,
+        builderRejection(ConsolidationInvalidReason.sameComputer),
+      ),
+      l10n.diveLog_consolidate_error_sameComputer,
+    );
+  });
+
+  test('the service\'s own same-computer guard is explained', () {
+    expect(
+      consolidationErrorText(
+        l10n,
+        ArgumentError('sameComputer: d2 shares computer-1'),
+      ),
+      l10n.diveLog_consolidate_error_sameComputer,
+    );
+  });
+
+  test('the builder\'s non-overlapping rejection is explained', () {
+    expect(
+      consolidationErrorText(
+        l10n,
+        builderRejection(ConsolidationInvalidReason.notOverlapping),
+      ),
+      l10n.diveLog_consolidate_error_notOverlapping,
+    );
+  });
+
+  test('reasons without dedicated copy fall back to the generic text', () {
+    for (final reason in [
+      ConsolidationInvalidReason.tooFewDives,
+      ConsolidationInvalidReason.mixedDivers,
+    ]) {
+      expect(
+        consolidationErrorText(l10n, builderRejection(reason)),
+        l10n.diveLog_consolidate_error_generic,
+        reason: reason.name,
+      );
+    }
+  });
+
+  test('a non-ArgumentError failure falls back to the generic text', () {
+    expect(
+      consolidationErrorText(l10n, StateError('dive deleted mid-flow')),
+      l10n.diveLog_consolidate_error_generic,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

The Consolidate button on a Data Quality duplicate finding did nothing. The
commonest duplicate is one dive downloaded twice from a single computer, and
`DiveConsolidationBuilder.classify` refuses to merge two records that share a
serial: a re-download is not a second computer's view of the dive. But
`repairOptionsFor` is pure over the finding's params and cannot see the dives,
so it offered `ConsolidateDuplicateRepair` for every duplicate that had a
related dive, including the pairs the service was always going to reject. The
button could only ever fail.

The failure did not explain itself either. `consolidationErrorText` matched the
same-computer reason with `startsWith('sameComputer')`, but the builder wraps
it as `build() requires a consolidatable selection; got
ConsolidationInvalid(sameComputer)`, so the test never matched and every
same-computer rejection fell through to the generic "Couldn't merge the dives.
Nothing was changed." The neighbouring `notOverlapping` branch used `contains`
and worked correctly, which is why the file read as symmetric.

Found on a real library: a 35 min / 20 m dive paired with a 13 s / 1.7 m
fragment from the same computer (they do not overlap either), offering a
Consolidate button that could never succeed.

## Changes

- `DuplicateDetector` records `sameComputer` on every pair and goes to
  **version 2**, so `hasNewDetectorVersions` raises the "new checks are
  available" banner and an existing library picks the flag up on a rescan.
- `repairOptionsFor` withholds `ConsolidateDuplicateRepair` when
  `sameComputer` is true. The card's `GoToDiveRepair`s are filtered out of the
  button row, so `primary` goes null and it renders the existing
  `dataQuality_repair_needsReview` line rather than a bare row (#1035).
  Findings written before the bump have no key at all and stay repairable
  until the rescan, matching the `sample_gap`/`fillableGapCount` precedent.
- `consolidationErrorText` matches both message shapes by substring, so a
  same-computer rejection from either guard says so.
- Regression coverage for the detector params, the repair mapping, the inbox
  card, and every error-message shape, including a new
  `consolidation_error_text_test.dart` that builds the error the way the
  throwing layer really does so a future `startsWith` cannot silently reopen
  this.

## Test Plan

- [x] `flutter test` passes (25688 passed, 21 skipped)
- [x] `flutter analyze` passes (no issues)
- [x] `dart format .` reports no changes
- [x] Verified end to end against the real failing pair: after the rescan the
      finding carries `sameComputer: true` and its repairs come back as
      navigation only.
- [x] Manual testing on: macOS (pending; the change is exercised by widget
      tests driving the real inbox against a real database)

## Notes

Deliberately out of scope, filed separately: a delete-duplicate repair (the
action that would actually finish the job for a re-download), and the inbox
passing the lexicographically smaller UUID as the surviving dive.
