### PR TITLE
fix(transmitters): keep Save visible on the transmitter editor app bar

### DIFF
--- a/lib/features/transmitters/presentation/pages/transmitter_edit_page.dart
+++ b/lib/features/transmitters/presentation/pages/transmitter_edit_page.dart
@@ -21,6 +21,7 @@ import 'package:submersion/features/transmitters/data/repositories/transmitter_r
 import 'package:submersion/features/transmitters/domain/entities/transmitter.dart';
 import 'package:submersion/features/transmitters/presentation/providers/transmitter_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 /// Full-screen editor for one registry entry. Picking a gear cylinder or a
 /// preset copies its specs into the fields (snapshot rule); the fields stay
@@ -327,9 +328,9 @@ class _TransmitterEditPageState extends ConsumerState<TransmitterEditPage> {
           tooltip: l10n.common_action_close,
         ),
         actions: [
-          TextButton(
+          AppBarTextAction(
+            label: l10n.common_action_save,
             onPressed: _loading ? null : _save,
-            child: Text(l10n.common_action_save),
           ),
         ],
       ),


### PR DESCRIPTION
`main` is currently red. `test/shared/widgets/app_bar_text_action_adoption_test.dart`
fails on a clean checkout of `origin/main`:

```
Expected: empty
  Actual: ['lib/features/transmitters/presentation/pages/transmitter_edit_page.dart:330']
Use AppBarTextAction from lib/shared/widgets/app_bar_text_action.dart for
AppBar.actions text buttons, so the label stays visible on the themes whose
primary color matches their app bar background.
```

## Why main went red without either PR being wrong

The guard arrived in #1231 and deliberately scans the whole of `lib/`, so the
invisible-Save defect "cannot come back on a page nobody thought to check". The
transmitter editor arrived in #1677, branched before the guard existed. Each
PR's CI ran the tree it knew about, neither ran the guard against the other's
page, and the merge of the two is red. A repo-wide guard only holds if something
runs it on the merge result.

## The defect it caught is real

A bare `TextButton` takes its foreground from `colorScheme.primary`. The
Tropical and Console themes set that to the same colour as their app bar
background, so on those themes the transmitter editor shows no Save button at
all. `AppBarTextAction` pins the foreground to the app bar's own instead.

## The change

```dart
actions: [
  AppBarTextAction(
    label: l10n.common_action_save,
    onPressed: _loading ? null : _save,
  ),
],
```

Label, callback and loading gate are unchanged. The disabled rendering does
change, and intentionally: a null `onPressed` now draws at the app bar
foreground's disabled opacity rather than the theme's `onSurface` default,
which is the saving-in-progress case the widget's own doc calls out as
dark-on-dark under the Console app bar.

## Tests

No new test. The guard that catches this already exists and already covers
every file in `lib/`; a second assertion of the same rule would be duplicate
coverage. It was watched failing on a clean `origin/main` worktree before the
change and passing after.

- `app_bar_text_action_adoption_test.dart` plus `test/features/transmitters/`:
  26 passing
- `flutter analyze`: no issues
- `dart format .`: no changes

## Knock-on

PR #1679 currently fails "Test (shard 7)" for what looks like this same guard,
inherited when it merged `main`. Merging this should clear that too.
