### PR TITLE
fix(transmitters): route the edit page Save through AppBarTextAction

### DIFF
--- a/lib/features/transmitters/presentation/pages/transmitter_edit_page.dart
+++ b/lib/features/transmitters/presentation/pages/transmitter_edit_page.dart
@@ -21,6 +21,7 @@ import 'package:submersion/features/transmitters/data/repositories/transmitter_r
 import 'package:submersion/features/transmitters/domain/entities/transmitter.dart';
 import 'package:submersion/features/transmitters/presentation/providers/transmitter_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_bar_text_action.dart';
 
 /// Full-screen editor for one registry entry. Picking a gear cylinder or a
 /// preset copies its specs into the fields (snapshot rule); the fields stay
@@ -327,9 +328,9 @@ class _TransmitterEditPageState extends ConsumerState<TransmitterEditPage> {
           tooltip: l10n.common_action_close,
         ),
         actions: [
-          TextButton(
+          AppBarTextAction(
+            label: l10n.common_action_save,
             onPressed: _loading ? null : _save,
-            child: Text(l10n.common_action_save),
           ),
         ],
       ),


### PR DESCRIPTION
`test/shared/widgets/app_bar_text_action_adoption_test.dart` is currently **red on `main`** (shard failure on `7a46e8a3d`).

The transmitter registry editor (#1677) shipped its AppBar Save as a bare `TextButton`:

```dart
actions: [
  TextButton(onPressed: _loading ? null : _save, child: Text(l10n.common_action_save)),
],
```

That's the exact defect #1231 / #1675 fixed everywhere else — a bare `TextButton` in `AppBar.actions` takes its foreground from `colorScheme.primary`, which the Tropical and Console themes set to the app-bar background, so the label renders invisible. #1675 (which added the adoption test) and #1677 (which added this page) landed too close together for either PR's CI to catch the other.

Fix: use `AppBarTextAction`, like every other editor.

## Testing

`app_bar_text_action_adoption_test` green; `transmitter_edit_page_test` green; analyze + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
