### PR TITLE
fix(sync): mark a new dive's tanks, weights and custom fields pending

### DIFF
--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1429,17 +1429,34 @@ class DiveRepository {
         );
         await _replaceDiveTypeRows(id, dive.diveTypeIds, now);
 
+        // Child ids are resolved before the batch rather than inside it:
+        // _db.batch takes a synchronous closure, so an id minted in there is
+        // unreachable from the async markRecordPending calls below and the
+        // rows would only ever publish on a full base export.
+        final tankIds = [
+          for (final tank in dive.tanks)
+            tank.id.isNotEmpty ? tank.id : _uuid.v4(),
+        ];
+        final weightIds = [
+          for (final weight in dive.weights)
+            weight.id.isNotEmpty ? weight.id : _uuid.v4(),
+        ];
+        final customFieldIds = [
+          for (final field in dive.customFields)
+            field.id.isNotEmpty ? field.id : _uuid.v4(),
+        ];
+
         // Batch insert all child records for performance
         // Profile points, tanks, weights, and equipment are inserted in a single
         // transaction, which is ~100x faster than individual inserts.
         await _db.batch((batch) {
           // Insert tanks (preserve provided IDs if not empty, otherwise generate)
-          for (final tank in dive.tanks) {
-            final tankId = tank.id.isNotEmpty ? tank.id : _uuid.v4();
+          for (var i = 0; i < dive.tanks.length; i++) {
+            final tank = dive.tanks[i];
             batch.insert(
               _db.diveTanks,
               DiveTanksCompanion(
-                id: Value(tankId),
+                id: Value(tankIds[i]),
                 diveId: Value(id),
                 volume: Value(tank.volume),
                 workingPressure: Value(tank.workingPressure),
@@ -1461,12 +1478,12 @@ class DiveRepository {
           }
 
           // Insert weights
-          for (final weight in dive.weights) {
-            final weightId = weight.id.isNotEmpty ? weight.id : _uuid.v4();
+          for (var i = 0; i < dive.weights.length; i++) {
+            final weight = dive.weights[i];
             batch.insert(
               _db.diveWeights,
               DiveWeightsCompanion(
-                id: Value(weightId),
+                id: Value(weightIds[i]),
                 diveId: Value(id),
                 weightType: Value(weight.weightType.name),
                 amountKg: Value(weight.amountKg),
@@ -1477,12 +1494,12 @@ class DiveRepository {
           }
 
           // Insert custom fields
-          for (final field in dive.customFields) {
-            final fieldId = field.id.isNotEmpty ? field.id : _uuid.v4();
+          for (var i = 0; i < dive.customFields.length; i++) {
+            final field = dive.customFields[i];
             batch.insert(
               _db.diveCustomFields,
               DiveCustomFieldsCompanion(
-                id: Value(fieldId),
+                id: Value(customFieldIds[i]),
                 diveId: Value(id),
                 fieldKey: Value(field.key),
                 fieldValue: Value(field.value),
@@ -1506,9 +1523,31 @@ class DiveRepository {
           }
         });
 
-        // The links above were batched; mark them pending like the other
-        // child rows so a new dive's gear reaches peers without waiting
-        // for a full snapshot.
+        // The rows above were batched, so nothing in the closure could mark
+        // them. Mark them here, like updateDive does, so a new dive's tanks,
+        // weights, custom fields and gear reach peers incrementally instead
+        // of waiting for a full snapshot.
+        for (final tankId in tankIds) {
+          await _syncRepository.markRecordPending(
+            entityType: 'diveTanks',
+            recordId: tankId,
+            localUpdatedAt: now,
+          );
+        }
+        for (final weightId in weightIds) {
+          await _syncRepository.markRecordPending(
+            entityType: 'diveWeights',
+            recordId: weightId,
+            localUpdatedAt: now,
+          );
+        }
+        for (final fieldId in customFieldIds) {
+          await _syncRepository.markRecordPending(
+            entityType: 'diveCustomFields',
+            recordId: fieldId,
+            localUpdatedAt: now,
+          );
+        }
         for (final g in dive.gear) {
           await _syncRepository.markRecordPending(
             entityType: 'diveEquipment',

--- a/test/features/dive_log/data/repositories/dive_repository_create_child_pending_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_create_child_pending_test.dart
@@ -54,7 +54,8 @@ void main() {
         gasMix: domain.GasMix(o2: 32, he: 0),
         order: 0,
       ),
-      // Empty id: createDive mints one inside the batch closure.
+      // Empty id: createDive mints one, so the pending mark has to carry
+      // the minted value rather than anything the caller supplied.
       domain.DiveTank(id: '', gasMix: domain.GasMix(o2: 21, he: 0), order: 1),
     ],
     weights: const [

--- a/test/features/dive_log/data/repositories/dive_repository_create_child_pending_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_create_child_pending_test.dart
@@ -45,8 +45,12 @@ void main() {
     for (final r in await db.select(db.diveCustomFields).get()) r.id,
   };
 
-  domain.Dive diveWithChildren({String id = 'dv'}) => domain.Dive(
-    id: id,
+  // One id for the dive and for the diveId its weights carry, so the two
+  // cannot drift apart if this helper ever builds a second dive.
+  const diveId = 'dv';
+
+  domain.Dive diveWithChildren() => domain.Dive(
+    id: diveId,
     dateTime: DateTime.utc(2026, 1, 1, 10),
     tanks: const [
       domain.DiveTank(
@@ -61,13 +65,13 @@ void main() {
     weights: const [
       domain.DiveWeight(
         id: 'weight-given',
-        diveId: 'dv',
+        diveId: diveId,
         weightType: WeightType.integrated,
         amountKg: 4,
       ),
       domain.DiveWeight(
         id: '',
-        diveId: 'dv',
+        diveId: diveId,
         weightType: WeightType.belt,
         amountKg: 2,
       ),

--- a/test/features/dive_log/data/repositories/dive_repository_create_child_pending_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_create_child_pending_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/dive_log/domain/entities/dive_custom_field.dart'
+    as domain;
+import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart'
+    as domain;
+
+import '../../../../helpers/test_database.dart';
+
+/// Every child row [DiveRepository.createDive] writes has to be marked
+/// pending, or gear, tanks, weights and custom fields entered at creation
+/// time only ever reach peers on a full base export. The three loops inside
+/// the child batch used to mint their ids inside the synchronous batch
+/// closure, where no pending mark could reach them.
+void main() {
+  late AppDatabase db;
+  late DiveRepository repo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = DiveRepository();
+  });
+
+  tearDown(tearDownTestDatabase);
+
+  /// Record ids marked pending for [entityType].
+  Future<Set<String>> pending(String entityType) async => {
+    for (final r in await db.select(db.syncRecords).get())
+      if (r.entityType == entityType) r.recordId,
+  };
+
+  /// Ids actually written to the child tables, so the assertions compare the
+  /// pending marks against the rows rather than against ids the test minted.
+  Future<Set<String>> tankIds() async => {
+    for (final r in await db.select(db.diveTanks).get()) r.id,
+  };
+  Future<Set<String>> weightIds() async => {
+    for (final r in await db.select(db.diveWeights).get()) r.id,
+  };
+  Future<Set<String>> fieldIds() async => {
+    for (final r in await db.select(db.diveCustomFields).get()) r.id,
+  };
+
+  domain.Dive diveWithChildren({String id = 'dv'}) => domain.Dive(
+    id: id,
+    dateTime: DateTime.utc(2026, 1, 1, 10),
+    tanks: const [
+      domain.DiveTank(
+        id: 'tank-given',
+        gasMix: domain.GasMix(o2: 32, he: 0),
+        order: 0,
+      ),
+      // Empty id: createDive mints one inside the batch closure.
+      domain.DiveTank(id: '', gasMix: domain.GasMix(o2: 21, he: 0), order: 1),
+    ],
+    weights: const [
+      domain.DiveWeight(
+        id: 'weight-given',
+        diveId: 'dv',
+        weightType: WeightType.integrated,
+        amountKg: 4,
+      ),
+      domain.DiveWeight(
+        id: '',
+        diveId: 'dv',
+        weightType: WeightType.belt,
+        amountKg: 2,
+      ),
+    ],
+    customFields: const [
+      domain.DiveCustomField(
+        id: 'field-given',
+        key: 'shop',
+        value: 'Blue Water',
+      ),
+      domain.DiveCustomField(id: '', key: 'boat', value: 'Nautilus'),
+    ],
+  );
+
+  test('createDive marks every tank it writes pending', () async {
+    await repo.createDive(diveWithChildren());
+
+    final written = await tankIds();
+    expect(written, hasLength(2));
+    expect(await pending('diveTanks'), written);
+  });
+
+  test('createDive marks every weight it writes pending', () async {
+    await repo.createDive(diveWithChildren());
+
+    final written = await weightIds();
+    expect(written, hasLength(2));
+    expect(await pending('diveWeights'), written);
+  });
+
+  test('createDive marks every custom field it writes pending', () async {
+    await repo.createDive(diveWithChildren());
+
+    final written = await fieldIds();
+    expect(written, hasLength(2));
+    expect(await pending('diveCustomFields'), written);
+  });
+}


### PR DESCRIPTION
## Summary

`DiveRepository.createDive` wrote its tank, weight and custom-field rows inside
the child batch and never called `markRecordPending` for any of them. Those rows
therefore never published incrementally; they only ever reached peers on a full
base export.

The cause is structural rather than a per-entity oversight. `_db.batch` takes a
**synchronous** closure, so no `await markRecordPending(...)` can run inside it,
and all three loops minted their ids with `_uuid.v4()` in that closure, leaving
the ids unreachable once the batch returned. `diveEquipment` escaped the same
fate only because its record id (`'$diveId|${item.id}'`) is derivable outside the
batch.

This was found while investigating a reported gap in the `diveEquipment` marks.
That gap is already closed (#1716), and its test passes; auditing the rest of the
transaction turned up these three instead:

| Child written in `createDive` | Writer | Pending mark before this PR |
| --- | --- | --- |
| `dives` | direct insert | yes |
| `diveDiveTypes` | `_replaceDiveTypeRows` | yes |
| `diveProfileSeries` | `_profileSeries.insertSeries` | yes |
| `diveTags` | `_tagRepository.setTagsForDive` | yes |
| `diveEquipment` | batch, marked after it | yes (#1716) |
| `diveTanks` | batch loop | **no** |
| `diveWeights` | batch loop | **no** |
| `diveCustomFields` | batch loop | **no** |

This also repairs the undo of `QualityRepairExecutor.deleteDuplicate`, which
restores a dive through `createDive` and so previously republished only the
parent dive row.

## Changes

- Resolve the tank, weight and custom-field id lists **before** `_db.batch`, so
  the same value reaches both the insert and the pending mark. The
  `id.isNotEmpty ? id : _uuid.v4()` expression is unchanged, preserving the
  caller-supplied-ids-win contract that the import and undo paths rely on.
- Mark each written row pending after the batch, alongside the existing
  `diveEquipment` loop, matching how `updateDive` and the bulk gear writers
  already do it.
- New regression test `dive_repository_create_child_pending_test.dart`, three
  cases, each covering both a caller-supplied id and a minted one, asserting the
  pending set equals the ids actually present in the child tables.

## Test Plan

- [x] `flutter test` passes
  - New test verified failing first: rows written, pending set empty.
  - `test/features/dive_log/data/` + `test/features/data_quality/`: 1391 passed.
  - `test/integration/sync` + `test/core/services/sync`: 873 passed.
  - Pre-push affected-test selection: 571 passed.
- [x] `flutter analyze` passes (No issues found)
- [x] `dart format .` clean (0 changed)
- [x] Manual testing: not applicable, repository-layer sync bookkeeping with no UI surface.
