### PR TITLE
fix(dive-log): stop a dive losing its gear on save, import, and duplicate delete (#1720)

### DIFF
--- a/lib/features/data_quality/data/services/quality_context_builder.dart
+++ b/lib/features/data_quality/data/services/quality_context_builder.dart
@@ -138,6 +138,7 @@ class QualityContextBuilder {
 
     final sources = await _diveRepo.getDataSources(dive.id);
     final neighbors = await _neighbors(dive);
+    final carriesDiverData = await _carriesDiverData(dive.id);
 
     return DiveQualityContext(
       dive: dive,
@@ -145,6 +146,7 @@ class QualityContextBuilder {
       sources: sources,
       primarySamples: samples,
       primarySampleCount: primarySampleCount,
+      carriesDiverData: carriesDiverData,
       tanks: dive.tanks,
       pressuresByTankId: pressures,
       gasSwitches: switches,
@@ -152,6 +154,62 @@ class QualityContextBuilder {
       ppO2MaxBar: await _ppO2Max(dive.diverId),
       knownTransmitterSerials: await _knownSerials(dive.diverId),
     );
+  }
+
+  /// Whether a `dives` row reachable as `dives` in the enclosing query
+  /// carries anything the diver put there themselves, as a 1/0 expression.
+  ///
+  /// The scalar columns and the seven child tables are the ones a dive
+  /// computer download never fills in; tanks, dive types, profile series and
+  /// their events are deliberately absent because every download produces
+  /// them, so their presence says nothing about whether a human has worked on
+  /// the dive. `OR` short-circuits, so a dive the diver has annotated stops
+  /// at its first hit instead of running all fourteen tests.
+  static const _diverDataSql =
+      "(dives.notes IS NOT NULL AND TRIM(dives.notes) != '') "
+      'OR dives.rating IS NOT NULL '
+      'OR dives.is_favorite = 1 '
+      'OR dives.site_id IS NOT NULL '
+      'OR dives.trip_id IS NOT NULL '
+      'OR dives.dive_center_id IS NOT NULL '
+      'OR dives.course_id IS NOT NULL '
+      'OR EXISTS (SELECT 1 FROM dive_equipment c WHERE c.dive_id = dives.id) '
+      'OR EXISTS (SELECT 1 FROM dive_buddies c WHERE c.dive_id = dives.id) '
+      'OR EXISTS (SELECT 1 FROM dive_tags c WHERE c.dive_id = dives.id) '
+      'OR EXISTS (SELECT 1 FROM dive_weights c WHERE c.dive_id = dives.id) '
+      'OR EXISTS (SELECT 1 FROM dive_custom_fields c '
+      'WHERE c.dive_id = dives.id) '
+      'OR EXISTS (SELECT 1 FROM sightings c WHERE c.dive_id = dives.id) '
+      'OR EXISTS (SELECT 1 FROM media c WHERE c.dive_id = dives.id)';
+
+  /// Every table [_diverDataSql] reads, so a write to any of them invalidates
+  /// a query that carries the fragment.
+  Set<ResultSetImplementation<dynamic, dynamic>> get _diverDataTables => {
+    _db.dives,
+    _db.diveEquipment,
+    _db.diveBuddies,
+    _db.diveTags,
+    _db.diveWeights,
+    _db.diveCustomFields,
+    _db.sightings,
+    _db.media,
+  };
+
+  /// [DiveQualityContext.carriesDiverData] for one dive. Read through the same
+  /// fragment the neighbor query uses so a duplicate pair's two sides are
+  /// measured identically; null when the row is gone, which leaves the
+  /// delete-duplicate repair withheld rather than offered on a guess (#1720).
+  Future<bool?> _carriesDiverData(String diveId) async {
+    final rows = await _db
+        .customSelect(
+          'SELECT ($_diverDataSql) AS carries_diver_data '
+          'FROM dives WHERE id = ?1',
+          variables: [Variable.withString(diveId)],
+          readsFrom: _diverDataTables,
+        )
+        .get();
+    if (rows.isEmpty) return null;
+    return (rows.single.read<int?>('carries_diver_data') ?? 0) != 0;
   }
 
   Future<List<QualityNeighbor>> _neighbors(domain.Dive dive) async {
@@ -187,7 +245,11 @@ class QualityContextBuilder {
           // NULL (not 0) when the neighbor has no primary series, so an
           // unknown recording never reads as an empty one.
           '(SELECT SUM(s.sample_count) FROM dive_profile_series s '
-          'WHERE s.dive_id = dives.id AND s.is_primary = 1) AS sample_count '
+          'WHERE s.dive_id = dives.id AND s.is_primary = 1) AS sample_count, '
+          // Projected here rather than looked up per neighbor: the scan
+          // resolves this window for every dive in the library, and a second
+          // round trip per neighbor would be an N+1 (#1720).
+          '($_diverDataSql) AS carries_diver_data '
           'FROM dives WHERE id != ?1 AND diver_id IS ?2 '
           'AND COALESCE(entry_time, dive_date_time) BETWEEN ?3 AND ?4 '
           'ORDER BY COALESCE(entry_time, dive_date_time) ASC',
@@ -197,7 +259,7 @@ class QualityContextBuilder {
             Variable.withInt(entry.millisecondsSinceEpoch - windowMs),
             Variable.withInt(exit.millisecondsSinceEpoch + windowMs),
           ],
-          readsFrom: {_db.dives, _db.diveProfileSeries},
+          readsFrom: {..._diverDataTables, _db.diveProfileSeries},
         )
         .get();
     final out = <QualityNeighbor>[];
@@ -226,6 +288,7 @@ class QualityContextBuilder {
           firstSampleDepth: _finiteDepth(row.read<double?>('first_depth')),
           lastSampleDepth: _finiteDepth(row.read<double?>('last_depth')),
           sampleCount: row.read<int?>('sample_count'),
+          carriesDiverData: (row.read<int?>('carries_diver_data') ?? 0) != 0,
         ),
       );
     }

--- a/lib/features/data_quality/domain/detectors/duplicate_detector.dart
+++ b/lib/features/data_quality/domain/detectors/duplicate_detector.dart
@@ -14,7 +14,7 @@ class DuplicateDetector extends QualityDetector {
   @override
   String get id => 'duplicate';
   @override
-  int get version => 3;
+  int get version => 4;
   @override
   QualityCategory get category => QualityCategory.duplicate;
 
@@ -61,12 +61,14 @@ class DuplicateDetector extends QualityDetector {
                 sampleCount: ctx.primarySampleCount,
                 durationSeconds: storedDuration,
                 maxDepth: maxDepth,
+                carriesDiverData: ctx.carriesDiverData,
               ),
               b: (
                 id: n.id,
                 sampleCount: n.sampleCount,
                 durationSeconds: nDuration,
                 maxDepth: nDepth,
+                carriesDiverData: n.carriesDiverData,
               ),
             )
           : null;
@@ -92,7 +94,8 @@ class DuplicateDetector extends QualityDetector {
             'sameComputer': sameComputer,
             // The copy a same-computer re-download can lose without losing
             // data. Absent when neither side clearly dominates (an exact
-            // tie, a mixed pair, or an unknown metric), so the card falls
+            // tie, a mixed pair, or an unknown metric) and when the dominated
+            // copy carries the diver's own entries (#1720), so the card falls
             // back to its no-automatic-fix row and the diver decides.
             'redundantDiveId': ?redundant,
           },
@@ -103,13 +106,15 @@ class DuplicateDetector extends QualityDetector {
   }
 }
 
-/// One side of a same-computer duplicate pair, reduced to the metrics that
-/// say how much of the dive it recorded.
+/// One side of a same-computer duplicate pair: the metrics that say how much
+/// of the dive it recorded, plus whether the diver has written anything of
+/// their own onto it.
 typedef DuplicateRecording = ({
   String id,
   int? sampleCount,
   int? durationSeconds,
   double? maxDepth,
+  bool? carriesDiverData,
 });
 
 /// The dive a same-computer re-download can delete without losing data, or
@@ -122,6 +127,16 @@ typedef DuplicateRecording = ({
 /// blocks the choice rather than volunteering a dive on a fact nobody
 /// recorded. Symmetric in its arguments, which matters because the pair has
 /// one canonical finding written by whichever side the scan reached last.
+///
+/// Recording richness is not the whole story, which is what issue #1720
+/// reported: a diver had logged gear onto an older download and the fresh
+/// re-download recorded more samples, so the poorer RECORDING was the richer
+/// LOG and deleting it threw the diver's work away. A copy the diver has
+/// written on is therefore never named, however little of the dive it
+/// recorded -- the same reasoning the exact tie already applies, which is
+/// that a copy holding the diver's own entries is theirs to judge. Unknown
+/// blocks the choice here too: this decision deletes a dive, so "nobody
+/// checked" must not read as "nothing to lose".
 String? redundantDuplicate({
   required DuplicateRecording a,
   required DuplicateRecording b,
@@ -146,10 +161,16 @@ String? redundantDuplicate({
     aDepth.compareTo(bDepth),
   ];
   if (comparisons.every((c) => c <= 0) && comparisons.any((c) => c < 0)) {
-    return a.id;
+    return _losslessToDelete(a);
   }
   if (comparisons.every((c) => c >= 0) && comparisons.any((c) => c > 0)) {
-    return b.id;
+    return _losslessToDelete(b);
   }
   return null;
 }
+
+/// [doomed]'s id when nothing of the diver's would go with it, else null.
+/// Applied to the dominated side only: the survivor keeps whatever it holds,
+/// so its own entries are never a reason to withhold the repair.
+String? _losslessToDelete(DuplicateRecording doomed) =>
+    doomed.carriesDiverData == false ? doomed.id : null;

--- a/lib/features/data_quality/domain/entities/dive_quality_context.dart
+++ b/lib/features/data_quality/domain/entities/dive_quality_context.dart
@@ -30,6 +30,7 @@ class QualityNeighbor {
     this.firstSampleDepth,
     this.lastSampleDepth,
     this.sampleCount,
+    this.carriesDiverData,
   });
 
   final String id;
@@ -45,6 +46,11 @@ class QualityNeighbor {
   /// column [DiveQualityContext.primarySampleCount] reads, so the two sides
   /// of a pair are compared on one measure. Null when unknown.
   final int? sampleCount;
+
+  /// Whether the diver has written anything of their own onto this dive, from
+  /// the same measure [DiveQualityContext.carriesDiverData] reads. Null when
+  /// unknown. See that field for what counts.
+  final bool? carriesDiverData;
 }
 
 /// Everything a detector may look at for one dive. Built once per dive per
@@ -57,6 +63,7 @@ class DiveQualityContext {
     this.sources = const [],
     this.primarySamples = const [],
     this.primarySampleCount,
+    this.carriesDiverData,
     this.tanks = const [],
     this.pressuresByTankId = const {},
     this.gasSwitches = const [],
@@ -76,6 +83,21 @@ class DiveQualityContext {
   /// column, so comparing the two would make a pair's richer side depend on
   /// which dive the scan happened to start from. Null when unknown.
   final int? primarySampleCount;
+
+  /// Whether the diver has written anything of their own onto this dive:
+  /// gear, buddies, tags, marine life, weights, media, custom fields, notes,
+  /// a rating, a favourite mark, or a link to a site, trip, dive centre or
+  /// course. Deliberately excludes everything a dive computer download
+  /// produces by itself (tanks, dive types, profile series and their events),
+  /// so it reads as "a human has been here" rather than "this row is
+  /// populated".
+  ///
+  /// A pair's two sides must be measured the same way or the verdict would
+  /// depend on which dive the scan reached first, so this comes from the same
+  /// query [QualityNeighbor.carriesDiverData] does rather than from the
+  /// hydrated entity. Null when unknown.
+  final bool? carriesDiverData;
+
   final List<domain.DiveTank> tanks;
   final Map<String, List<QualityPressureSample>> pressuresByTankId;
   final List<GasSwitch> gasSwitches;

--- a/lib/features/data_quality/domain/repairs/quality_repair_action.dart
+++ b/lib/features/data_quality/domain/repairs/quality_repair_action.dart
@@ -221,8 +221,17 @@ List<QualityRepairAction> repairOptionsFor(QualityFinding f) {
       // trusted when it names one side of THIS pair: a stale or foreign id
       // must never volunteer a dive.
       final redundant = p['redundantDiveId'] as String?;
+      // Detector 3 named the redundant copy on recording richness alone, so
+      // it could name the copy holding the diver's gear and notes (#1720).
+      // Detector 4 withholds the name in that case, but findings already on
+      // disk carry the old verdict: an unread key would be a guess, so the
+      // repair waits for the rescan the version bump offers. Unlike
+      // `sameComputer`, an absent fact CANNOT default to repairable here --
+      // this repair deletes a dive.
+      final checkedForDiverData = f.detectorVersion >= 4;
       final deletable =
           !consolidatable &&
+          checkedForDiverData &&
           related != null &&
           (redundant == diveId || redundant == related);
       return [

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1565,288 +1565,298 @@ class DiveRepository {
 
       final now = DateTime.now().millisecondsSinceEpoch;
 
-      await (_db.update(_db.dives)..where((t) => t.id.equals(dive.id))).write(
-        DivesCompanion(
-          diverId: Value(dive.diverId),
-          diveNumber: Value(dive.diveNumber),
-          diveDateTime: Value(dive.dateTime.millisecondsSinceEpoch),
-          entryTime: Value(dive.entryTime?.millisecondsSinceEpoch),
-          exitTime: Value(dive.exitTime?.millisecondsSinceEpoch),
-          bottomTime: Value(dive.bottomTime?.inSeconds),
-          runtime: Value(dive.runtime?.inSeconds),
-          maxDepth: Value(dive.maxDepth),
-          avgDepth: Value(dive.avgDepth),
-          waterTemp: Value(dive.waterTemp),
-          airTemp: Value(dive.airTemp),
-          visibilityMeters: Value(dive.visibilityMeters),
-          // A measured distance supersedes the legacy bucket. Value(null)
-          // rather than Value.absent(): absent() preserves the existing column
-          // on a companion write, which would leave the dive carrying both a
-          // measurement and a contradicting bucket.
-          visibility: dive.visibilityMeters != null
-              ? const Value(null)
-              : Value(dive.visibility?.name),
-          diveType: Value(dive.diveTypeId),
-          buddy: Value(dive.buddy),
-          diveMaster: Value(dive.diveMaster),
-          diverRole: Value(dive.diverRoleId),
-          notes: Value(dive.notes),
-          name: Value(dive.name),
-          siteId: Value(dive.site?.id),
-          diveCenterId: Value(dive.diveCenter?.id),
-          tripId: Value(dive.tripId ?? dive.trip?.id),
-          rating: Value(dive.rating),
-          // Conditions fields
-          currentDirection: Value(dive.currentDirection?.name),
-          currentStrength: Value(dive.currentStrength?.name),
-          swellHeight: Value(dive.swellHeight),
-          entryMethod: Value(dive.entryMethod?.name),
-          exitMethod: Value(dive.exitMethod?.name),
-          waterType: Value(dive.waterType?.name),
-          altitude: Value(dive.altitude),
-          surfacePressure: Value(dive.surfacePressure),
-          // Weather conditions
-          windSpeed: Value(dive.windSpeed),
-          windDirection: Value(dive.windDirection?.name),
-          cloudCover: Value(dive.cloudCover?.name),
-          precipitation: Value(dive.precipitation?.name),
-          humidity: Value(dive.humidity),
-          weatherDescription: Value(dive.weatherDescription),
-          weatherCode: Value(dive.weatherCode),
-          weatherSource: Value(dive.weatherSource?.name),
-          weatherFetchedAt: Value(
-            dive.weatherFetchedAt != null
-                ? dive.weatherFetchedAt!.millisecondsSinceEpoch ~/ 1000
-                : null,
-          ),
-          // Surface interval and deco settings
-          surfaceIntervalSeconds: Value(dive.surfaceInterval?.inSeconds),
-          gradientFactorLow: Value(dive.gradientFactorLow),
-          gradientFactorHigh: Value(dive.gradientFactorHigh),
-          decoAlgorithm: Value(dive.decoAlgorithm),
-          decoConservatism: Value(dive.decoConservatism),
-          diveComputerModel: Value(dive.diveComputerModel),
-          diveComputerSerial: Value(dive.diveComputerSerial),
-          diveComputerFirmware: Value(dive.diveComputerFirmware),
-          // Weight system fields
-          weightAmount: Value(dive.weightAmount),
-          weightType: Value(dive.weightType?.name),
-          weightingFeedback: Value(dive.weightingFeedback?.name),
-          weightingFeedbackKg: Value(dive.weightingFeedbackKg),
-          // Favorite flag
-          isFavorite: Value(dive.isFavorite),
-          excludedFromStats: Value(dive.excludedFromStats),
-          excludedFromGasStats: Value(dive.excludedFromGasStats),
-          // CCR/SCR rebreather fields (v1.5)
-          diveMode: Value(dive.diveMode.code),
-          setpointLow: Value(dive.setpointLow),
-          setpointHigh: Value(dive.setpointHigh),
-          setpointDeco: Value(dive.setpointDeco),
-          scrType: Value(dive.scrType?.code),
-          scrInjectionRate: Value(dive.scrInjectionRate),
-          scrAdditionRatio: Value(dive.scrAdditionRatio),
-          scrOrificeSize: Value(dive.scrOrificeSize),
-          assumedVo2: Value(dive.assumedVo2),
-          diluentO2: Value(dive.diluentGas?.o2),
-          diluentHe: Value(dive.diluentGas?.he),
-          loopO2Min: Value(dive.loopO2Min),
-          loopO2Max: Value(dive.loopO2Max),
-          loopO2Avg: Value(dive.loopO2Avg),
-          loopVolume: Value(dive.loopVolume),
-          scrubberType: Value(dive.scrubber?.type),
-          scrubberDurationMinutes: Value(dive.scrubber?.ratedMinutes),
-          scrubberRemainingMinutes: Value(dive.scrubber?.remainingMinutes),
-          // Dive planner (v1.5)
-          isPlanned: Value(dive.isPlanned),
-          // Training course (v1.5)
-          courseId: Value(dive.courseId),
-          // Import source tracking
-          importSource: Value(dive.importSource),
-          importId: Value(dive.importId),
-          updatedAt: Value(now),
-        ),
-      );
-      await _syncRepository.markRecordPending(
-        entityType: 'dives',
-        recordId: dive.id,
-        localUpdatedAt: now,
-      );
-      await _replaceDiveTypeRows(dive.id, dive.diveTypeIds, now);
-
-      // Update tanks:
-      // Try to match existing tanks by ID to do updates instead of delete+insert when possible,
-      // to preserve sync records and avoid unnecessary deletions/insertions in the sync engine.
-      // Delete tanks that are no longer present.
-      // This is more complex but should result in better sync behavior and performance when tanks
-      // are edited but not completely changed (which is more likely).
-
-      // Get existing tank IDs for this dive
-      final existingTankRows = await (_db.select(
-        _db.diveTanks,
-      )..where((t) => t.diveId.equals(dive.id))).get();
-      final existingTankIds = existingTankRows.map((t) => t.id).toSet();
-      final updatedTankIds = <String>{};
-
-      // Update or insert tanks
-      for (final tank in dive.tanks) {
-        // Tank ID is guaranteed to be non-empty by validation at start of method
-        final tankId = tank.id;
-        updatedTankIds.add(tankId);
-
-        if (existingTankIds.contains(tankId)) {
-          // Update existing tank
-          await (_db.update(
-            _db.diveTanks,
-          )..where((t) => t.id.equals(tankId))).write(
-            DiveTanksCompanion(
-              volume: Value(tank.volume),
-              workingPressure: Value(tank.workingPressure),
-              startPressure: Value(tank.startPressure),
-              endPressure: Value(tank.endPressure),
-              o2Percent: Value(tank.gasMix.o2),
-              hePercent: Value(tank.gasMix.he),
-              tankOrder: Value(tank.order),
-              tankRole: Value(tank.role.name),
-              tankMaterial: Value(tank.material?.name),
-              tankName: Value(tank.name),
-              presetName: Value(tank.presetName),
-              // computerId and transmitterSerial are computer-owned identity
-              // and deliberately not written here: edit flows rebuild the
-              // tank field by field, and a rebuild that forgot them must not
-              // wipe what the download recorded.
-              // The regulator link is user-authored, unlike the two above,
-              // so an edit does write it.
-              regulatorEquipmentId: Value(tank.regulatorEquipmentId),
+      // One transaction for the dive and every child it owns, the way
+      // createDive already does it. Without one, a throw partway through
+      // left the dive committed with some children rewritten and others
+      // not, and the gear write was the worst of them: it deletes the rows
+      // it is replacing before inserting the replacements one at a time, so
+      // a failure mid-loop kept a strict PREFIX of the diver's gear. The
+      // next read then reported that truncation as the truth, and a retry
+      // saved it (#1720).
+      await _db.transaction(() async {
+        await (_db.update(_db.dives)..where((t) => t.id.equals(dive.id))).write(
+          DivesCompanion(
+            diverId: Value(dive.diverId),
+            diveNumber: Value(dive.diveNumber),
+            diveDateTime: Value(dive.dateTime.millisecondsSinceEpoch),
+            entryTime: Value(dive.entryTime?.millisecondsSinceEpoch),
+            exitTime: Value(dive.exitTime?.millisecondsSinceEpoch),
+            bottomTime: Value(dive.bottomTime?.inSeconds),
+            runtime: Value(dive.runtime?.inSeconds),
+            maxDepth: Value(dive.maxDepth),
+            avgDepth: Value(dive.avgDepth),
+            waterTemp: Value(dive.waterTemp),
+            airTemp: Value(dive.airTemp),
+            visibilityMeters: Value(dive.visibilityMeters),
+            // A measured distance supersedes the legacy bucket. Value(null)
+            // rather than Value.absent(): absent() preserves the existing column
+            // on a companion write, which would leave the dive carrying both a
+            // measurement and a contradicting bucket.
+            visibility: dive.visibilityMeters != null
+                ? const Value(null)
+                : Value(dive.visibility?.name),
+            diveType: Value(dive.diveTypeId),
+            buddy: Value(dive.buddy),
+            diveMaster: Value(dive.diveMaster),
+            diverRole: Value(dive.diverRoleId),
+            notes: Value(dive.notes),
+            name: Value(dive.name),
+            siteId: Value(dive.site?.id),
+            diveCenterId: Value(dive.diveCenter?.id),
+            tripId: Value(dive.tripId ?? dive.trip?.id),
+            rating: Value(dive.rating),
+            // Conditions fields
+            currentDirection: Value(dive.currentDirection?.name),
+            currentStrength: Value(dive.currentStrength?.name),
+            swellHeight: Value(dive.swellHeight),
+            entryMethod: Value(dive.entryMethod?.name),
+            exitMethod: Value(dive.exitMethod?.name),
+            waterType: Value(dive.waterType?.name),
+            altitude: Value(dive.altitude),
+            surfacePressure: Value(dive.surfacePressure),
+            // Weather conditions
+            windSpeed: Value(dive.windSpeed),
+            windDirection: Value(dive.windDirection?.name),
+            cloudCover: Value(dive.cloudCover?.name),
+            precipitation: Value(dive.precipitation?.name),
+            humidity: Value(dive.humidity),
+            weatherDescription: Value(dive.weatherDescription),
+            weatherCode: Value(dive.weatherCode),
+            weatherSource: Value(dive.weatherSource?.name),
+            weatherFetchedAt: Value(
+              dive.weatherFetchedAt != null
+                  ? dive.weatherFetchedAt!.millisecondsSinceEpoch ~/ 1000
+                  : null,
             ),
-          );
-          // Log as pending update (assuming sync handles updates)
-          await _syncRepository.markRecordPending(
+            // Surface interval and deco settings
+            surfaceIntervalSeconds: Value(dive.surfaceInterval?.inSeconds),
+            gradientFactorLow: Value(dive.gradientFactorLow),
+            gradientFactorHigh: Value(dive.gradientFactorHigh),
+            decoAlgorithm: Value(dive.decoAlgorithm),
+            decoConservatism: Value(dive.decoConservatism),
+            diveComputerModel: Value(dive.diveComputerModel),
+            diveComputerSerial: Value(dive.diveComputerSerial),
+            diveComputerFirmware: Value(dive.diveComputerFirmware),
+            // Weight system fields
+            weightAmount: Value(dive.weightAmount),
+            weightType: Value(dive.weightType?.name),
+            weightingFeedback: Value(dive.weightingFeedback?.name),
+            weightingFeedbackKg: Value(dive.weightingFeedbackKg),
+            // Favorite flag
+            isFavorite: Value(dive.isFavorite),
+            excludedFromStats: Value(dive.excludedFromStats),
+            excludedFromGasStats: Value(dive.excludedFromGasStats),
+            // CCR/SCR rebreather fields (v1.5)
+            diveMode: Value(dive.diveMode.code),
+            setpointLow: Value(dive.setpointLow),
+            setpointHigh: Value(dive.setpointHigh),
+            setpointDeco: Value(dive.setpointDeco),
+            scrType: Value(dive.scrType?.code),
+            scrInjectionRate: Value(dive.scrInjectionRate),
+            scrAdditionRatio: Value(dive.scrAdditionRatio),
+            scrOrificeSize: Value(dive.scrOrificeSize),
+            assumedVo2: Value(dive.assumedVo2),
+            diluentO2: Value(dive.diluentGas?.o2),
+            diluentHe: Value(dive.diluentGas?.he),
+            loopO2Min: Value(dive.loopO2Min),
+            loopO2Max: Value(dive.loopO2Max),
+            loopO2Avg: Value(dive.loopO2Avg),
+            loopVolume: Value(dive.loopVolume),
+            scrubberType: Value(dive.scrubber?.type),
+            scrubberDurationMinutes: Value(dive.scrubber?.ratedMinutes),
+            scrubberRemainingMinutes: Value(dive.scrubber?.remainingMinutes),
+            // Dive planner (v1.5)
+            isPlanned: Value(dive.isPlanned),
+            // Training course (v1.5)
+            courseId: Value(dive.courseId),
+            // Import source tracking
+            importSource: Value(dive.importSource),
+            importId: Value(dive.importId),
+            updatedAt: Value(now),
+          ),
+        );
+        await _syncRepository.markRecordPending(
+          entityType: 'dives',
+          recordId: dive.id,
+          localUpdatedAt: now,
+        );
+        await _replaceDiveTypeRows(dive.id, dive.diveTypeIds, now);
+
+        // Update tanks:
+        // Try to match existing tanks by ID to do updates instead of delete+insert when possible,
+        // to preserve sync records and avoid unnecessary deletions/insertions in the sync engine.
+        // Delete tanks that are no longer present.
+        // This is more complex but should result in better sync behavior and performance when tanks
+        // are edited but not completely changed (which is more likely).
+
+        // Get existing tank IDs for this dive
+        final existingTankRows = await (_db.select(
+          _db.diveTanks,
+        )..where((t) => t.diveId.equals(dive.id))).get();
+        final existingTankIds = existingTankRows.map((t) => t.id).toSet();
+        final updatedTankIds = <String>{};
+
+        // Update or insert tanks
+        for (final tank in dive.tanks) {
+          // Tank ID is guaranteed to be non-empty by validation at start of method
+          final tankId = tank.id;
+          updatedTankIds.add(tankId);
+
+          if (existingTankIds.contains(tankId)) {
+            // Update existing tank
+            await (_db.update(
+              _db.diveTanks,
+            )..where((t) => t.id.equals(tankId))).write(
+              DiveTanksCompanion(
+                volume: Value(tank.volume),
+                workingPressure: Value(tank.workingPressure),
+                startPressure: Value(tank.startPressure),
+                endPressure: Value(tank.endPressure),
+                o2Percent: Value(tank.gasMix.o2),
+                hePercent: Value(tank.gasMix.he),
+                tankOrder: Value(tank.order),
+                tankRole: Value(tank.role.name),
+                tankMaterial: Value(tank.material?.name),
+                tankName: Value(tank.name),
+                presetName: Value(tank.presetName),
+                // computerId and transmitterSerial are computer-owned identity
+                // and deliberately not written here: edit flows rebuild the
+                // tank field by field, and a rebuild that forgot them must not
+                // wipe what the download recorded.
+                // The regulator link is user-authored, unlike the two above,
+                // so an edit does write it.
+                regulatorEquipmentId: Value(tank.regulatorEquipmentId),
+              ),
+            );
+            // Log as pending update (assuming sync handles updates)
+            await _syncRepository.markRecordPending(
+              entityType: 'diveTanks',
+              recordId: tankId,
+              localUpdatedAt: now,
+            );
+          } else {
+            // Insert new tank
+            await _db
+                .into(_db.diveTanks)
+                .insert(
+                  DiveTanksCompanion(
+                    id: Value(tankId),
+                    diveId: Value(dive.id),
+                    volume: Value(tank.volume),
+                    workingPressure: Value(tank.workingPressure),
+                    startPressure: Value(tank.startPressure),
+                    endPressure: Value(tank.endPressure),
+                    o2Percent: Value(tank.gasMix.o2),
+                    hePercent: Value(tank.gasMix.he),
+                    tankOrder: Value(tank.order),
+                    tankRole: Value(tank.role.name),
+                    tankMaterial: Value(tank.material?.name),
+                    tankName: Value(tank.name),
+                    presetName: Value(tank.presetName),
+                    computerId: Value(tank.computerId),
+                    transmitterSerial: Value(tank.transmitterSerial),
+                    regulatorEquipmentId: Value(tank.regulatorEquipmentId),
+                    sourceTankIndex: Value(tank.sourceTankIndex),
+                  ),
+                );
+            await _syncRepository.markRecordPending(
+              entityType: 'diveTanks',
+              recordId: tankId,
+              localUpdatedAt: now,
+            );
+          }
+        }
+
+        // Delete tanks that are no longer present
+        // This will cascade to both tank_pressure_series and gas_switches for removed tanks
+        final tanksToDelete = existingTankIds.difference(updatedTankIds);
+        for (final tankId in tanksToDelete) {
+          await (_db.delete(
+            _db.diveTanks,
+          )..where((t) => t.id.equals(tankId))).go();
+          await _syncRepository.logDeletion(
             entityType: 'diveTanks',
             recordId: tankId,
-            localUpdatedAt: now,
           );
-        } else {
-          // Insert new tank
+        }
+
+        // Update weights: delete and re-insert
+        final existingWeights = await (_db.select(
+          _db.diveWeights,
+        )..where((t) => t.diveId.equals(dive.id))).get();
+        await (_db.delete(
+          _db.diveWeights,
+        )..where((t) => t.diveId.equals(dive.id))).go();
+        for (final weight in existingWeights) {
+          await _syncRepository.logDeletion(
+            entityType: 'diveWeights',
+            recordId: weight.id,
+          );
+        }
+        for (final weight in dive.weights) {
+          final weightId = weight.id.isNotEmpty ? weight.id : _uuid.v4();
           await _db
-              .into(_db.diveTanks)
+              .into(_db.diveWeights)
               .insert(
-                DiveTanksCompanion(
-                  id: Value(tankId),
+                DiveWeightsCompanion(
+                  id: Value(weightId),
                   diveId: Value(dive.id),
-                  volume: Value(tank.volume),
-                  workingPressure: Value(tank.workingPressure),
-                  startPressure: Value(tank.startPressure),
-                  endPressure: Value(tank.endPressure),
-                  o2Percent: Value(tank.gasMix.o2),
-                  hePercent: Value(tank.gasMix.he),
-                  tankOrder: Value(tank.order),
-                  tankRole: Value(tank.role.name),
-                  tankMaterial: Value(tank.material?.name),
-                  tankName: Value(tank.name),
-                  presetName: Value(tank.presetName),
-                  computerId: Value(tank.computerId),
-                  transmitterSerial: Value(tank.transmitterSerial),
-                  regulatorEquipmentId: Value(tank.regulatorEquipmentId),
-                  sourceTankIndex: Value(tank.sourceTankIndex),
+                  weightType: Value(weight.weightType.name),
+                  amountKg: Value(weight.amountKg),
+                  notes: Value(weight.notes),
+                  createdAt: Value(DateTime.now().millisecondsSinceEpoch),
                 ),
               );
           await _syncRepository.markRecordPending(
-            entityType: 'diveTanks',
-            recordId: tankId,
+            entityType: 'diveWeights',
+            recordId: weightId,
             localUpdatedAt: now,
           );
         }
-      }
 
-      // Delete tanks that are no longer present
-      // This will cascade to both tank_pressure_series and gas_switches for removed tanks
-      final tanksToDelete = existingTankIds.difference(updatedTankIds);
-      for (final tankId in tanksToDelete) {
+        // Equipment: a diff keyed by equipment id, shared with the bulk
+        // operations, so an unchanged row is neither tombstoned nor
+        // re-marked pending (issue #1487).
+        final desiredGear = [for (final g in dive.gear) g.provenance];
+        await _writeGearDiff(dive.id, desiredGear, now);
+
+        // Update custom fields: delete and re-insert
+        final existingCustomFields = await (_db.select(
+          _db.diveCustomFields,
+        )..where((cf) => cf.diveId.equals(dive.id))).get();
         await (_db.delete(
-          _db.diveTanks,
-        )..where((t) => t.id.equals(tankId))).go();
-        await _syncRepository.logDeletion(
-          entityType: 'diveTanks',
-          recordId: tankId,
-        );
-      }
+          _db.diveCustomFields,
+        )..where((cf) => cf.diveId.equals(dive.id))).go();
+        for (final cf in existingCustomFields) {
+          await _syncRepository.logDeletion(
+            entityType: 'diveCustomFields',
+            recordId: cf.id,
+          );
+        }
+        for (final field in dive.customFields) {
+          final fieldId = field.id.isNotEmpty ? field.id : _uuid.v4();
+          await _db
+              .into(_db.diveCustomFields)
+              .insert(
+                DiveCustomFieldsCompanion(
+                  id: Value(fieldId),
+                  diveId: Value(dive.id),
+                  fieldKey: Value(field.key),
+                  fieldValue: Value(field.value),
+                  sortOrder: Value(field.sortOrder),
+                  createdAt: Value(DateTime.now().millisecondsSinceEpoch),
+                ),
+              );
+          await _syncRepository.markRecordPending(
+            entityType: 'diveCustomFields',
+            recordId: fieldId,
+            localUpdatedAt: now,
+          );
+        }
 
-      // Update weights: delete and re-insert
-      final existingWeights = await (_db.select(
-        _db.diveWeights,
-      )..where((t) => t.diveId.equals(dive.id))).get();
-      await (_db.delete(
-        _db.diveWeights,
-      )..where((t) => t.diveId.equals(dive.id))).go();
-      for (final weight in existingWeights) {
-        await _syncRepository.logDeletion(
-          entityType: 'diveWeights',
-          recordId: weight.id,
-        );
-      }
-      for (final weight in dive.weights) {
-        final weightId = weight.id.isNotEmpty ? weight.id : _uuid.v4();
-        await _db
-            .into(_db.diveWeights)
-            .insert(
-              DiveWeightsCompanion(
-                id: Value(weightId),
-                diveId: Value(dive.id),
-                weightType: Value(weight.weightType.name),
-                amountKg: Value(weight.amountKg),
-                notes: Value(weight.notes),
-                createdAt: Value(DateTime.now().millisecondsSinceEpoch),
-              ),
-            );
-        await _syncRepository.markRecordPending(
-          entityType: 'diveWeights',
-          recordId: weightId,
-          localUpdatedAt: now,
-        );
-      }
-
-      // Equipment: a diff keyed by equipment id, shared with the bulk
-      // operations, so an unchanged row is neither tombstoned nor
-      // re-marked pending (issue #1487).
-      final desiredGear = [for (final g in dive.gear) g.provenance];
-      await _writeGearDiff(dive.id, desiredGear, now);
-
-      // Update custom fields: delete and re-insert
-      final existingCustomFields = await (_db.select(
-        _db.diveCustomFields,
-      )..where((cf) => cf.diveId.equals(dive.id))).get();
-      await (_db.delete(
-        _db.diveCustomFields,
-      )..where((cf) => cf.diveId.equals(dive.id))).go();
-      for (final cf in existingCustomFields) {
-        await _syncRepository.logDeletion(
-          entityType: 'diveCustomFields',
-          recordId: cf.id,
-        );
-      }
-      for (final field in dive.customFields) {
-        final fieldId = field.id.isNotEmpty ? field.id : _uuid.v4();
-        await _db
-            .into(_db.diveCustomFields)
-            .insert(
-              DiveCustomFieldsCompanion(
-                id: Value(fieldId),
-                diveId: Value(dive.id),
-                fieldKey: Value(field.key),
-                fieldValue: Value(field.value),
-                sortOrder: Value(field.sortOrder),
-                createdAt: Value(DateTime.now().millisecondsSinceEpoch),
-              ),
-            );
-        await _syncRepository.markRecordPending(
-          entityType: 'diveCustomFields',
-          recordId: fieldId,
-          localUpdatedAt: now,
-        );
-      }
-
-      // Update tags
-      await _tagRepository.setTagsForDive(dive.id, dive.tags);
+        // Update tags
+        await _tagRepository.setTagsForDive(dive.id, dive.tags);
+      });
 
       SyncEventBus.notifyLocalChange();
       _log.info('Updated dive: ${dive.id}');

--- a/lib/features/dive_log/domain/services/dive_altitude_enricher.dart
+++ b/lib/features/dive_log/domain/services/dive_altitude_enricher.dart
@@ -47,7 +47,15 @@ class DiveAltitudeEnricher {
       }
       final meters = resolution.altitudeMeters;
       if (meters == null) return false;
-      await _dives.updateDive(dive.copyWith(altitude: meters));
+      // Re-read rather than writing [dive] back: updateDive rewrites every
+      // child collection from the entity it is handed, and every import seam
+      // runs DiveEquipmentDefaulter (and the checklist linker) between
+      // persisting the dive and calling this, so the in-memory entity's gear
+      // list is already stale. Writing it back deleted the gear the defaulter
+      // had just applied (#1720). The resolver above still reads the passed
+      // entity, whose locations are what the caller parsed.
+      final stored = await _dives.getDiveById(dive.id) ?? dive;
+      await _dives.updateDive(stored.copyWith(altitude: meters));
       return true;
     } catch (_) {
       // Best-effort: never let altitude enrichment fail the dive operation.

--- a/test/core/database/gear_links_survive_migration_test.dart
+++ b/test/core/database/gear_links_survive_migration_test.dart
@@ -1,0 +1,132 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+
+/// Issue #1720: a diver upgrading to a beta reported that gear had vanished
+/// from many dives, and the first suspicion was the schema ladder. It was not
+/// the cause -- every rung from v199 on is `ALTER TABLE ADD COLUMN` or
+/// `CREATE TABLE IF NOT EXISTS` -- but nothing pinned that, and the risk is
+/// real and permanent: `dive_equipment.equipment_id` is
+/// `REFERENCES equipment(id) ON DELETE CASCADE`, so any rung that rebuilds
+/// `equipment` the SQLite way (create new, copy, drop old) would take every
+/// dive's gear with it while foreign keys are on. A junction row carries no
+/// clock and cannot be recovered from a peer, so the loss would be silent and
+/// final.
+///
+/// This walks real gear links up the ladder and insists they arrive.
+void main() {
+  /// A v199 database holding two dives, three pieces of gear and the links
+  /// between them. Minimal on purpose: each rung guards on the tables it
+  /// touches, so a fixture only needs the ones under test.
+  NativeDatabase strandedAt(int version) => NativeDatabase.memory(
+    setup: (rawDb) {
+      rawDb.execute('PRAGMA user_version = $version');
+      rawDb.execute('''
+        CREATE TABLE divers (
+          id TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL,
+          created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)
+      ''');
+      rawDb.execute('''
+        CREATE TABLE dives (
+          id TEXT NOT NULL PRIMARY KEY, diver_id TEXT,
+          dive_date_time INTEGER NOT NULL,
+          notes TEXT NOT NULL DEFAULT '',
+          created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)
+      ''');
+      rawDb.execute('''
+        CREATE TABLE equipment (
+          id TEXT NOT NULL PRIMARY KEY, diver_id TEXT, name TEXT NOT NULL,
+          type TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'active',
+          purchase_currency TEXT NOT NULL DEFAULT 'USD',
+          notes TEXT NOT NULL DEFAULT '', is_active INTEGER NOT NULL DEFAULT 1,
+          created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, hlc TEXT)
+      ''');
+      rawDb.execute('''
+        CREATE TABLE dive_equipment (
+          dive_id TEXT NOT NULL
+            REFERENCES dives(id) ON DELETE CASCADE,
+          equipment_id TEXT NOT NULL
+            REFERENCES equipment(id) ON DELETE CASCADE,
+          PRIMARY KEY (dive_id, equipment_id))
+      ''');
+      rawDb.execute("INSERT INTO divers VALUES ('dr1', 'Diver', 1, 1)");
+      for (final id in ['dv1', 'dv2']) {
+        rawDb.execute(
+          "INSERT INTO dives (id, diver_id, dive_date_time, created_at, "
+          "updated_at) VALUES ('$id', 'dr1', 1, 1, 1)",
+        );
+      }
+      // The two types the reporter named, plus one more.
+      for (final (id, type) in [
+        ('e-bcd', 'bcd'),
+        ('e-smb', 'smb'),
+        ('e-reg', 'regulator'),
+      ]) {
+        rawDb.execute(
+          "INSERT INTO equipment (id, diver_id, name, type, created_at, "
+          "updated_at) VALUES ('$id', 'dr1', '$id', '$type', 1, 1)",
+        );
+      }
+      for (final dive in ['dv1', 'dv2']) {
+        for (final gear in ['e-bcd', 'e-smb', 'e-reg']) {
+          rawDb.execute("INSERT INTO dive_equipment VALUES ('$dive', '$gear')");
+        }
+      }
+    },
+  );
+
+  Future<Set<String>> gearLinks(AppDatabase db) async {
+    final rows = await db
+        .customSelect('SELECT dive_id, equipment_id FROM dive_equipment')
+        .get();
+    return {
+      for (final r in rows)
+        '${r.read<String>('dive_id')}|${r.read<String>('equipment_id')}',
+    };
+  }
+
+  test('every gear link survives the ladder from v199 to current', () async {
+    final db = AppDatabase(strandedAt(199));
+    addTearDown(db.close);
+
+    // Forces the open, and with it onUpgrade and every beforeOpen backstop.
+    expect(
+      await db
+          .customSelect('PRAGMA user_version')
+          .getSingle()
+          .then((r) => r.read<int>('user_version')),
+      AppDatabase.currentSchemaVersion,
+    );
+
+    expect(await gearLinks(db), {
+      'dv1|e-bcd',
+      'dv1|e-smb',
+      'dv1|e-reg',
+      'dv2|e-bcd',
+      'dv2|e-smb',
+      'dv2|e-reg',
+    });
+    final equipment = await db.customSelect('SELECT id FROM equipment').get();
+    expect(
+      equipment.map((r) => r.read<String>('id')),
+      containsAll(['e-bcd', 'e-smb', 'e-reg']),
+      reason: 'a rebuilt equipment table would cascade the links away',
+    );
+  });
+
+  test('foreign keys are on after the ladder, so a cascade would have '
+      'fired if a rung had dropped the parent', () async {
+    final db = AppDatabase(strandedAt(199));
+    addTearDown(db.close);
+
+    expect(
+      await db
+          .customSelect('PRAGMA foreign_keys')
+          .getSingle()
+          .then((r) => r.read<int>('foreign_keys')),
+      1,
+      reason: 'the previous test would pass vacuously with cascades disabled',
+    );
+  });
+}

--- a/test/features/data_quality/data/quality_context_builder_test.dart
+++ b/test/features/data_quality/data/quality_context_builder_test.dart
@@ -1,5 +1,6 @@
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/data_quality/data/services/quality_context_builder.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
@@ -9,6 +10,7 @@ import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
 import 'package:submersion/features/dive_log/domain/codecs/tank_pressure_series_codec.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 import 'package:submersion/features/settings/data/repositories/diver_settings_repository.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
@@ -37,6 +39,7 @@ void main() {
     String? serial,
     String? diverId,
     List<domain.DiveProfilePoint> profile = const [],
+    List<domain.DiveTank> tanks = const [],
   }) async {
     final dive = domain.Dive(
       id: id,
@@ -47,6 +50,7 @@ void main() {
       diveComputerSerial: serial,
       diverId: diverId,
       profile: profile,
+      tanks: tanks,
     );
     await diveRepo.createDive(dive);
     return id;
@@ -312,4 +316,106 @@ void main() {
       expect(ctx.neighbors.single.lastSampleDepth, 1.5);
     },
   );
+
+  // Issue #1720. The delete-duplicate verdict deletes a whole dive, so it has
+  // to know whether the copy it names holds anything the diver put there.
+  // Both sides of a pair are measured by the same SQL so the answer cannot
+  // depend on which dive the scan reached first.
+  group('carriesDiverData', () {
+    Future<void> seedGearOn(String diveId) async {
+      const item = EquipmentItem(
+        id: 'e1',
+        name: 'My BCD',
+        type: EquipmentType.bcd,
+      );
+      await db
+          .into(db.equipment)
+          .insert(
+            EquipmentCompanion.insert(
+              id: item.id,
+              name: item.name,
+              type: item.type.name,
+              createdAt: 0,
+              updatedAt: 0,
+            ),
+          );
+      await db
+          .into(db.diveEquipment)
+          .insert(
+            DiveEquipmentCompanion.insert(diveId: diveId, equipmentId: item.id),
+          );
+    }
+
+    test('false for a dive nothing but the computer has touched', () async {
+      await seedDive(id: 'd1', entry: DateTime.utc(2026, 7, 1, 10));
+      final ctx = (await builder.buildAll(['d1'])).single;
+      expect(ctx.carriesDiverData, isFalse);
+    });
+
+    test('true once the dive carries a gear link', () async {
+      await seedDive(id: 'd1', entry: DateTime.utc(2026, 7, 1, 10));
+      await seedGearOn('d1');
+      final ctx = (await builder.buildAll(['d1'])).single;
+      expect(ctx.carriesDiverData, isTrue);
+    });
+
+    test('true for notes, a rating, or a site link', () async {
+      final entry = DateTime.utc(2026, 7, 1, 10);
+      await seedDive(id: 'dNotes', entry: entry);
+      await (db.update(db.dives)..where((t) => t.id.equals('dNotes'))).write(
+        const DivesCompanion(notes: Value('viz was poor')),
+      );
+      expect(
+        (await builder.buildAll(['dNotes'])).single.carriesDiverData,
+        isTrue,
+      );
+
+      await seedDive(id: 'dRating', entry: entry.add(const Duration(days: 5)));
+      await (db.update(db.dives)..where((t) => t.id.equals('dRating'))).write(
+        const DivesCompanion(rating: Value(4)),
+      );
+      expect(
+        (await builder.buildAll(['dRating'])).single.carriesDiverData,
+        isTrue,
+      );
+    });
+
+    // Whitespace is not an entry: a blank notes column must not make a
+    // pristine download look annotated and withhold the repair for nothing.
+    test('blank notes do not count as diver data', () async {
+      await seedDive(id: 'd1', entry: DateTime.utc(2026, 7, 1, 10));
+      await (db.update(db.dives)..where((t) => t.id.equals('d1'))).write(
+        const DivesCompanion(notes: Value('   ')),
+      );
+      expect((await builder.buildAll(['d1'])).single.carriesDiverData, isFalse);
+    });
+
+    // The tanks and dive types every download produces say nothing about
+    // whether a human has worked on the dive, so they are excluded.
+    test('a downloaded dive with tanks still reads as untouched', () async {
+      await seedDive(
+        id: 'd1',
+        entry: DateTime.utc(2026, 7, 1, 10),
+        tanks: [const domain.DiveTank(id: 't1', name: 'AL80')],
+      );
+      final ctx = (await builder.buildAll(['d1'])).single;
+      expect(ctx.tanks, hasLength(1));
+      expect(ctx.carriesDiverData, isFalse);
+    });
+
+    test('reported for a neighbor from the same query', () async {
+      final entry = DateTime.utc(2026, 7, 1, 10);
+      await seedDive(id: 'dA', entry: entry, serial: 'SN-1');
+      await seedDive(
+        id: 'dB',
+        entry: entry.add(const Duration(hours: 1)),
+        serial: 'SN-1',
+      );
+      await seedGearOn('dB');
+      final ctx = (await builder.buildAll(['dA'])).single;
+      expect(ctx.carriesDiverData, isFalse);
+      expect(ctx.neighbors.single.id, 'dB');
+      expect(ctx.neighbors.single.carriesDiverData, isTrue);
+    });
+  });
 }

--- a/test/features/data_quality/data/quality_prefilters_test.dart
+++ b/test/features/data_quality/data/quality_prefilters_test.dart
@@ -42,11 +42,14 @@ void main() {
         'source_conflict',
       }),
     );
-    // v2 records `sameComputer` on every duplicate pair. The bump is what
-    // raises the "new checks are available" banner, so an existing library
-    // gets the flag on a rescan instead of keeping a Consolidate button that
-    // cannot work.
-    expect(qualityDetectorVersions()['duplicate'], 3);
+    // Each bump is what raises the "new checks are available" banner, so an
+    // existing library gets the new fact on a rescan rather than keeping a
+    // button the fact would have withheld. v2 records `sameComputer` on every
+    // duplicate pair, so a Consolidate that cannot work is not offered. v4
+    // withholds `redundantDiveId` when the copy it would delete carries the
+    // diver's own entries (#1720), and the repair mapping refuses to act on a
+    // pre-v4 finding, so the rescan is what restores the repair.
+    expect(qualityDetectorVersions()['duplicate'], 4);
   });
 
   test('profile detectors only get dives that have profiles', () async {

--- a/test/features/data_quality/domain/detectors/cross_dive_detectors_test.dart
+++ b/test/features/data_quality/domain/detectors/cross_dive_detectors_test.dart
@@ -185,6 +185,7 @@ void main() {
         int durationSeconds = 2100,
         double maxDepth = 20,
         String? serial = 'S1',
+        bool? carriesDiverData = false,
       }) => QualityNeighbor(
         id: id,
         entryTime: entry.add(const Duration(minutes: 1)),
@@ -192,6 +193,7 @@ void main() {
         durationSeconds: durationSeconds,
         computerSerial: serial,
         sampleCount: samples,
+        carriesDiverData: carriesDiverData,
       );
 
       test('names the fragment when the other recording dominates', () {
@@ -433,6 +435,104 @@ void main() {
         expect(fromA.single.id, fromB.single.id);
         expect(fromA.single.params['redundantDiveId'], 'dB');
         expect(fromB.single.params['redundantDiveId'], 'dB');
+      });
+
+      // Issue #1720. The reporter had logged gear onto an older, shorter
+      // download and then re-downloaded the dive; the fresh copy recorded
+      // more, so the poorer RECORDING was the richer LOG and naming it
+      // redundant offered to delete the diver's work. Recording richness
+      // alone must not decide that.
+      test('withholds the name when the dominated copy carries diver data', () {
+        final ctx = makeContext(
+          dive: makeTestDive(
+            id: 'dA',
+            entry: entry,
+            maxDepth: 20,
+            runtime: const Duration(minutes: 35),
+            serial: 'S1',
+          ),
+          primarySampleCount: 420,
+          neighbors: [
+            neighbor(
+              id: 'dB',
+              samples: 3,
+              durationSeconds: 13,
+              maxDepth: 1.7,
+              carriesDiverData: true,
+            ),
+          ],
+        );
+        final params = det.detect(ctx).single.params;
+        expect(params['sameComputer'], isTrue);
+        expect(params.containsKey('redundantDiveId'), isFalse);
+      });
+
+      test('withholds when the scanned dive is the dominated side and '
+          'carries diver data', () {
+        final ctx = makeContext(
+          dive: makeTestDive(
+            id: 'dB',
+            entry: entry,
+            maxDepth: 1.7,
+            runtime: const Duration(seconds: 13),
+            serial: 'S1',
+          ),
+          primarySampleCount: 3,
+          carriesDiverData: true,
+          neighbors: [neighbor(id: 'dA', samples: 420, durationSeconds: 2100)],
+        );
+        expect(
+          det.detect(ctx).single.params.containsKey('redundantDiveId'),
+          isFalse,
+        );
+      });
+
+      // Only the copy about to be deleted matters: the survivor keeps
+      // whatever it holds, so its own entries are no reason to withhold.
+      test('the survivor carrying diver data does not withhold the name', () {
+        final ctx = makeContext(
+          dive: makeTestDive(
+            id: 'dA',
+            entry: entry,
+            maxDepth: 20,
+            runtime: const Duration(minutes: 35),
+            serial: 'S1',
+          ),
+          primarySampleCount: 420,
+          carriesDiverData: true,
+          neighbors: [
+            neighbor(id: 'dB', samples: 3, durationSeconds: 13, maxDepth: 1.7),
+          ],
+        );
+        expect(det.detect(ctx).single.params['redundantDiveId'], 'dB');
+      });
+
+      // This verdict deletes a dive, so "nobody checked" must not read as
+      // "nothing to lose" -- the same rule the recording metrics follow.
+      test('withholds when the dominated copy\'s diver data is unknown', () {
+        final ctx = makeContext(
+          dive: makeTestDive(
+            id: 'dA',
+            entry: entry,
+            maxDepth: 20,
+            runtime: const Duration(minutes: 35),
+            serial: 'S1',
+          ),
+          primarySampleCount: 420,
+          neighbors: [
+            neighbor(
+              id: 'dB',
+              samples: 3,
+              durationSeconds: 13,
+              maxDepth: 1.7,
+              carriesDiverData: null,
+            ),
+          ],
+        );
+        expect(
+          det.detect(ctx).single.params.containsKey('redundantDiveId'),
+          isFalse,
+        );
       });
     });
 

--- a/test/features/data_quality/helpers/quality_test_helpers.dart
+++ b/test/features/data_quality/helpers/quality_test_helpers.dart
@@ -38,12 +38,17 @@ DiveQualityContext makeContext({
   double ppO2MaxBar = 1.6,
   int? primarySampleCount,
   Set<String> knownTransmitterSerials = const {},
+  // Fixtures describe a pristine download unless they say otherwise. Pass
+  // null to model "nobody checked", which the delete-duplicate verdict treats
+  // as a reason to withhold itself (#1720).
+  bool? carriesDiverData = false,
 }) => DiveQualityContext(
   dive: dive,
   now: now ?? DateTime.utc(2026, 7, 17, 12),
   sources: sources,
   primarySamples: samples,
   primarySampleCount: primarySampleCount,
+  carriesDiverData: carriesDiverData,
   tanks: dive.tanks,
   pressuresByTankId: pressures,
   gasSwitches: gasSwitches,

--- a/test/features/data_quality/presentation/data_quality_inbox_page_test.dart
+++ b/test/features/data_quality/presentation/data_quality_inbox_page_test.dart
@@ -121,13 +121,14 @@ QualityFinding _f({
   required QualityCategory category,
   Map<String, Object?> params = const {},
   QualitySeverity severity = QualitySeverity.warning,
+  int detectorVersion = 1,
 }) => QualityFinding(
   id: id,
   diveId: diveId,
   relatedDiveId: relatedDiveId,
   computerId: computerId,
   detectorId: detectorId,
-  detectorVersion: 1,
+  detectorVersion: detectorVersion,
   category: category,
   severity: severity,
   status: QualityStatus.open,
@@ -1154,6 +1155,10 @@ void main() {
         relatedDiveId: 'd2',
         detectorId: 'duplicate',
         category: QualityCategory.duplicate,
+        // Only detector 4 checks whether the doomed copy carries the diver's
+        // own entries, and the repair mapping will not act on an older
+        // finding (#1720), so a fixture offering the repair must say 4.
+        detectorVersion: 4,
         params: const {
           'score': 0.9,
           'timeDiffMinutes': 1,

--- a/test/features/data_quality/repairs/repair_mapping_test.dart
+++ b/test/features/data_quality/repairs/repair_mapping_test.dart
@@ -6,12 +6,13 @@ QualityFinding f({
   required String detectorId,
   Map<String, Object?> params = const {},
   String? relatedDiveId,
+  int detectorVersion = 1,
 }) => QualityFinding(
   id: 'f1',
   diveId: 'd1',
   relatedDiveId: relatedDiveId,
   detectorId: detectorId,
-  detectorVersion: 1,
+  detectorVersion: detectorVersion,
   category: QualityCategory.profile,
   severity: QualitySeverity.warning,
   status: QualityStatus.open,
@@ -77,6 +78,7 @@ void main() {
           detectorId: 'duplicate',
           relatedDiveId: 'd2',
           params: {'sameComputer': true, 'redundantDiveId': 'd2'},
+          detectorVersion: 4,
         ),
       );
       final d = actions.whereType<DeleteDuplicateRepair>().single;
@@ -92,6 +94,7 @@ void main() {
           detectorId: 'duplicate',
           relatedDiveId: 'd2',
           params: {'sameComputer': true, 'redundantDiveId': 'd1'},
+          detectorVersion: 4,
         ),
       );
       final d = actions.whereType<DeleteDuplicateRepair>().single;
@@ -105,6 +108,7 @@ void main() {
           detectorId: 'duplicate',
           relatedDiveId: 'd2',
           params: {'sameComputer': true},
+          detectorVersion: 4,
         ),
       );
       expect(actions.whereType<DeleteDuplicateRepair>(), isEmpty);
@@ -117,6 +121,7 @@ void main() {
           detectorId: 'duplicate',
           relatedDiveId: 'd2',
           params: {'sameComputer': false, 'redundantDiveId': 'd2'},
+          detectorVersion: 4,
         ),
       );
       expect(actions.whereType<DeleteDuplicateRepair>(), isEmpty);
@@ -129,9 +134,29 @@ void main() {
           detectorId: 'duplicate',
           relatedDiveId: 'd2',
           params: {'sameComputer': true, 'redundantDiveId': 'd9'},
+          detectorVersion: 4,
         ),
       );
       expect(actions.whereType<DeleteDuplicateRepair>(), isEmpty);
+    });
+
+    // Detector 3 chose the redundant copy on recording richness alone, so it
+    // could name the copy holding the diver's gear (#1720). A finding it
+    // wrote is still on disk after the update; the repair must wait for the
+    // rescan rather than act on the old verdict.
+    test('withheld for a finding written before the diver-data check', () {
+      final actions = repairOptionsFor(
+        f(
+          detectorId: 'duplicate',
+          relatedDiveId: 'd2',
+          params: {'sameComputer': true, 'redundantDiveId': 'd2'},
+          detectorVersion: 3,
+        ),
+      );
+      expect(actions.whereType<DeleteDuplicateRepair>(), isEmpty);
+      // Still no Consolidate either: a same-computer pair cannot be merged,
+      // so the card keeps its no-automatic-fix row.
+      expect(actions.whereType<ConsolidateDuplicateRepair>(), isEmpty);
     });
   });
 

--- a/test/features/dive_log/data/repositories/dive_repository_gear_provenance_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_gear_provenance_test.dart
@@ -5,6 +5,8 @@ import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
+import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart'
+    as weight;
 import 'package:submersion/features/equipment/data/repositories/equipment_component_repository.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
@@ -86,6 +88,61 @@ void main() {
     for (final r in await db.select(db.syncRecords).get())
       if (r.entityType == 'diveEquipment') r.recordId,
   };
+
+  // Issue #1720. updateDive rewrites a dive's children in sequence: weights
+  // are deleted and re-inserted, then the gear diff deletes the rows that are
+  // no longer wanted and inserts the new ones. With no transaction around it,
+  // a throw partway through committed everything before the throw, so a dive
+  // was left holding a strict PREFIX of the diver's gear -- and the next read
+  // reported that truncation as the truth.
+  test(
+    'a failed update leaves the dive\'s gear and weights untouched',
+    () async {
+      await repo.createDive(
+        domain.Dive(
+          id: 'dv',
+          dateTime: DateTime(2026, 1, 1),
+          gear: looseGear([item('fins'), item('mask')]),
+          weights: const [
+            weight.DiveWeight(
+              id: 'w1',
+              diveId: 'dv',
+              weightType: WeightType.belt,
+              amountKg: 4,
+            ),
+          ],
+        ),
+      );
+      expect((await rowsOf('dv')).keys, unorderedEquals(['fins', 'mask']));
+
+      // 'ghost' is not in the equipment table, so its junction insert violates
+      // the foreign key -- the same shape as a link whose gear item has gone.
+      // The delete of 'fins' and the weight rewrite both run before it.
+      await expectLater(
+        repo.updateDive(
+          domain.Dive(
+            id: 'dv',
+            dateTime: DateTime(2026, 1, 1),
+            gear: looseGear([item('mask'), item('ghost')]),
+            weights: const [],
+          ),
+        ),
+        throwsA(anything),
+      );
+
+      expect(
+        (await rowsOf('dv')).keys,
+        unorderedEquals(['fins', 'mask']),
+        reason: 'the rolled-back update must not cost the diver their gear',
+      );
+      final weights = await (db.select(
+        db.diveWeights,
+      )..where((t) => t.diveId.equals('dv'))).get();
+      expect(weights.map((w) => w.id), [
+        'w1',
+      ], reason: 'every child the update touched rolls back together');
+    },
+  );
 
   test('createDive writes provenance and marks each link pending', () async {
     await repo.createDive(

--- a/test/features/dive_log/domain/services/dive_altitude_enricher_test.dart
+++ b/test/features/dive_log/domain/services/dive_altitude_enricher_test.dart
@@ -3,6 +3,10 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/database/database.dart'
+    show DiveEquipmentCompanion, EquipmentCompanion;
+import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/services/dive_altitude_enricher.dart';
@@ -67,6 +71,49 @@ void main() {
     expect(applied, isTrue);
     final stored = await repository.getDiveById(dive.id);
     expect(stored!.altitude, 740.0);
+  });
+
+  // Issue #1720. Every file-import seam persists the dive, runs
+  // DiveEquipmentDefaulter (which writes dive_equipment), and only then calls
+  // this enricher with the SAME in-memory entity -- whose gear list predates
+  // the defaulter. updateDive rewrites a dive's children from the entity it is
+  // handed, so writing that stale entity back deleted the gear the defaulter
+  // had just applied. The enricher must write back what storage holds now.
+  test('does not wipe gear written after the entity was built', () async {
+    final dive = await repository.createDive(
+      buildDive('d-gear', entryLocation: const GeoPoint(46.4, 8.0)),
+    );
+    // Stands in for DiveEquipmentDefaulter: a gear row lands after `dive` was
+    // built, so the entity the caller still holds knows nothing about it.
+    final db = DatabaseService.instance.database;
+    await db
+        .into(db.equipment)
+        .insert(
+          EquipmentCompanion.insert(
+            id: 'e-bcd',
+            name: 'My BCD',
+            type: EquipmentType.bcd.name,
+            createdAt: 0,
+            updatedAt: 0,
+          ),
+        );
+    await db
+        .into(db.diveEquipment)
+        .insert(
+          DiveEquipmentCompanion.insert(diveId: dive.id, equipmentId: 'e-bcd'),
+        );
+
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService([]),
+      diveRepository: repository,
+    );
+    expect(await enricher.applyForImportedDive(dive), isTrue);
+
+    final stored = await repository.getDiveById(dive.id);
+    expect(stored!.altitude, 740.0, reason: 'the enrichment still lands');
+    expect(stored.gear.map((g) => g.item.id), [
+      'e-bcd',
+    ], reason: 'the gear the defaulter applied must survive the write-back');
   });
 
   test('skips dives that already have altitude', () async {


### PR DESCRIPTION
Fixes #1720, where a diver on beta 1.7.8.8140 found gear missing from many
dives, "notably BCD entries, DSMB entries".

Three separate ways a dive could lose its gear, none of them the new grouping.

## The likely cause: a dive save was not atomic

`updateDive` rewrote a dive's children in a bare sequence of awaits, with no
transaction anywhere in its 300-line body, while `createDive` wraps its own
children in one and documents why. So a throw partway through committed
everything before it. The gear write is the worst place for that, because it
deletes before it inserts: a failure mid-loop left the dive holding a strict
**prefix** of the diver's gear, the next read reported that truncation as the
truth, and a retry saved it. A dangling equipment id is enough to trigger it,
since the junction insert then violates the foreign key.

#1680's new `ORDER BY equipment.type, name, id` on the gear hydrate is what
decides where the damage starts. The list now arrives sorted by enum name,
where `bcd` is second and `smb` is twenty-second, so a failure at the BCD takes
the BCD, the SMB and essentially the whole rig and leaves only the battery.
That is the reported shape, and it is the only mechanism I found that predicts
those two types.

## New in that beta: delete-duplicate could delete the copy worth keeping

`redundantDuplicate` named the copy to delete from `sampleCount`,
`durationSeconds` and `maxDepth` alone, and the confirmation names both dives
by number, site, time, depth and duration without saying what is logged on
them. That inverts on the commonest shape: a first download runs short, the
diver logs gear onto it, a re-download carries the fuller profile, so the
poorer **recording** is the richer **log**. Unlike `DiveConsolidationService`,
this repair unions nothing onto the survivor, so `deleteDive` cascaded the gear
away.

Each side of a pair now reports `carriesDiverData`, and the verdict is withheld
when the dominated copy carries anything the diver put there. Unknown withholds
it too: this deletes a dive, so "nobody checked" must not read as "nothing to
lose", which is the rule the recording metrics already follow. Only the doomed
side is tested, since the survivor keeps whatever it holds.

Both sides come from **one** SQL fragment rather than the hydrated entity on one
side and a query on the other, because a pair has one canonical finding written
by whichever dive the scan reached last and the two must not disagree. The file
already carries that warning twice, for the stored runtime and the stored sample
count.

What counts is what a download never produces: gear, buddies, tags, marine
life, weights, custom fields, media, non-blank notes, a rating, a favourite
mark, or a link to a site, trip, dive centre or course. Tanks, dive types,
profile series and their events are excluded, since every download makes those.

## Live on main: file imports wiped the gear the defaulter had just applied

Every file-import seam persists the dive, runs `DiveEquipmentDefaulter` (which
writes `dive_equipment`), then hands the altitude enricher the **same**
in-memory entity, whose gear list is by then stale. `updateDive` rewrites
children from the entity it is given, so the write-back deleted that gear. The
enricher now re-reads first, which is what the dive computer download path
already did.

## Behaviour change worth knowing

The detector goes to 4 and `repairOptionsFor` requires that version, so
findings already on disk withhold the delete-duplicate repair until the diver
runs the rescan the version bump offers. Intentional, but it will look like a
missing button to anyone who does not know why. Note this is the **opposite**
default from `sameComputer`, whose absent key stays repairable: that one
withholds a button which could only fail, this one withholds a button that
deletes a dive.

## Ruled out, with evidence

- **The new grouping.** `arrangeEquipment` has two branches: ungrouped copies
  the whole list, grouped buckets every item with `putIfAbsent`. No filter, no
  limit, no dedupe. `equipmentTypeRank` returns `table.length` for an unknown
  type, so it sorts last rather than dropping, and the TEXT to enum parse falls
  back to `other`. The card is not in a height-constrained slot.
- **The enum gaining `o2Cell` and `battery`.** `equipment.type` is a TEXT
  column holding the enum name, so no index ever shifts.
- **The schema ladder.** Every rung from v199 is `ALTER TABLE ADD COLUMN` or
  `CREATE TABLE IF NOT EXISTS`. Now pinned by a new test that walks real gear
  links from v199 to current, plus a second test asserting
  `PRAGMA foreign_keys` is 1 so the first cannot pass vacuously.
- Weather enricher and bulk edit: the first reads through `getDiveById`, the
  second emits add/remove deltas only and never `replace`.

## Testing

Full suite green: 25,856 passed, 20 skipped. Analyze and format clean. Every
new assertion was mutation-tested, reverting the fix to confirm it fails and
then restoring: without the transaction the regression case leaves the dive
holding `['mask']` instead of `['fins', 'mask']`.

## Follow-ups, not in this PR

- `diveWeights` and `diveCustomFields` in `updateDive` are still
  delete-all-then-reinsert and still tombstone keys they immediately re-insert,
  the collision #1716 fixed for gear. The transaction here stops the
  truncation; the tombstones remain.
- `dive_equipment` carries no `updatedAt` or `hlc`, so a remote tombstone is
  applied unconditionally and a lost link can never be revived by a live copy
  from a peer. That is what makes any single loss permanent.
- The delete-duplicate dialog still does not disclose what the doomed copy
  carries.
