### PR TITLE
fix(sync): diff a dive's weights and custom fields instead of replacing them (#1727)

### DIFF
--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1867,39 +1867,9 @@ class DiveRepository {
           );
         }
 
-        // Update weights: delete and re-insert
-        final existingWeights = await (_db.select(
-          _db.diveWeights,
-        )..where((t) => t.diveId.equals(dive.id))).get();
-        await (_db.delete(
-          _db.diveWeights,
-        )..where((t) => t.diveId.equals(dive.id))).go();
-        for (final weight in existingWeights) {
-          await _syncRepository.logDeletion(
-            entityType: 'diveWeights',
-            recordId: weight.id,
-          );
-        }
-        for (final weight in dive.weights) {
-          final weightId = weight.id.isNotEmpty ? weight.id : _uuid.v4();
-          await _db
-              .into(_db.diveWeights)
-              .insert(
-                DiveWeightsCompanion(
-                  id: Value(weightId),
-                  diveId: Value(dive.id),
-                  weightType: Value(weight.weightType.name),
-                  amountKg: Value(weight.amountKg),
-                  notes: Value(weight.notes),
-                  createdAt: Value(DateTime.now().millisecondsSinceEpoch),
-                ),
-              );
-          await _syncRepository.markRecordPending(
-            entityType: 'diveWeights',
-            recordId: weightId,
-            localUpdatedAt: now,
-          );
-        }
+        // Weights: a diff keyed by row id, so an unchanged row is neither
+        // tombstoned nor re-marked pending (issue #1727).
+        await _writeWeightDiff(dive.id, dive.weights, now);
 
         // Equipment: a diff keyed by equipment id, shared with the bulk
         // operations, so an unchanged row is neither tombstoned nor
@@ -1907,39 +1877,8 @@ class DiveRepository {
         final desiredGear = [for (final g in dive.gear) g.provenance];
         await _writeGearDiff(dive.id, desiredGear, now);
 
-        // Update custom fields: delete and re-insert
-        final existingCustomFields = await (_db.select(
-          _db.diveCustomFields,
-        )..where((cf) => cf.diveId.equals(dive.id))).get();
-        await (_db.delete(
-          _db.diveCustomFields,
-        )..where((cf) => cf.diveId.equals(dive.id))).go();
-        for (final cf in existingCustomFields) {
-          await _syncRepository.logDeletion(
-            entityType: 'diveCustomFields',
-            recordId: cf.id,
-          );
-        }
-        for (final field in dive.customFields) {
-          final fieldId = field.id.isNotEmpty ? field.id : _uuid.v4();
-          await _db
-              .into(_db.diveCustomFields)
-              .insert(
-                DiveCustomFieldsCompanion(
-                  id: Value(fieldId),
-                  diveId: Value(dive.id),
-                  fieldKey: Value(field.key),
-                  fieldValue: Value(field.value),
-                  sortOrder: Value(field.sortOrder),
-                  createdAt: Value(DateTime.now().millisecondsSinceEpoch),
-                ),
-              );
-          await _syncRepository.markRecordPending(
-            entityType: 'diveCustomFields',
-            recordId: fieldId,
-            localUpdatedAt: now,
-          );
-        }
+        // Custom fields: the same id-keyed diff, for the same reason.
+        await _writeCustomFieldDiff(dive.id, dive.customFields, now);
 
         // Update tags
         await _tagRepository.setTagsForDive(dive.id, dive.tags);
@@ -5954,6 +5893,147 @@ class DiveRepository {
       await _syncRepository.markRecordPending(
         entityType: 'diveEquipment',
         recordId: '$diveId|${p.equipmentId}',
+        localUpdatedAt: now,
+      );
+    }
+  }
+
+  /// Makes the dive's weight rows equal to [desired]: rows whose values
+  /// changed are updated in place, added rows inserted, removed rows deleted
+  /// with a tombstone, and every written row marked pending.
+  ///
+  /// Delete-all-then-reinsert published a deletion and a pending mark for the
+  /// same key in one sync round, and `dive_weights` carries no `updatedAt` for
+  /// the merge to order them by, so whichever a peer applied last decided
+  /// whether the row lived. It also re-stamped `createdAt` on rows the diver
+  /// never touched (issue #1727).
+  Future<void> _writeWeightDiff(
+    String diveId,
+    List<domain.DiveWeight> desired,
+    int now,
+  ) async {
+    final existing = await (_db.select(
+      _db.diveWeights,
+    )..where((t) => t.diveId.equals(diveId))).get();
+    final existingById = {for (final r in existing) r.id: r};
+    final desiredIds = {
+      for (final w in desired)
+        if (w.id.isNotEmpty) w.id,
+    };
+    for (final row in existing) {
+      if (desiredIds.contains(row.id)) continue;
+      await (_db.delete(
+        _db.diveWeights,
+      )..where((t) => t.id.equals(row.id))).go();
+      await _syncRepository.logDeletion(
+        entityType: 'diveWeights',
+        recordId: row.id,
+      );
+    }
+    for (final weight in desired) {
+      final current = weight.id.isNotEmpty ? existingById[weight.id] : null;
+      if (current != null &&
+          current.weightType == weight.weightType.name &&
+          current.amountKg == weight.amountKg &&
+          current.notes == weight.notes) {
+        continue;
+      }
+      final rowId = weight.id.isNotEmpty ? weight.id : _uuid.v4();
+      if (current != null) {
+        await (_db.update(
+          _db.diveWeights,
+        )..where((t) => t.id.equals(rowId))).write(
+          DiveWeightsCompanion(
+            weightType: Value(weight.weightType.name),
+            amountKg: Value(weight.amountKg),
+            notes: Value(weight.notes),
+          ),
+        );
+      } else {
+        await _db
+            .into(_db.diveWeights)
+            .insert(
+              DiveWeightsCompanion(
+                id: Value(rowId),
+                diveId: Value(diveId),
+                weightType: Value(weight.weightType.name),
+                amountKg: Value(weight.amountKg),
+                notes: Value(weight.notes),
+                createdAt: Value(now),
+              ),
+            );
+      }
+      await _syncRepository.markRecordPending(
+        entityType: 'diveWeights',
+        recordId: rowId,
+        localUpdatedAt: now,
+      );
+    }
+  }
+
+  /// Makes the dive's custom fields equal to [desired], on the same id-keyed
+  /// diff as [_writeWeightDiff] and for the same reason: `dive_custom_fields`
+  /// has no `updatedAt` either, so a tombstone racing its own re-insert was
+  /// resolved by apply order (issue #1727).
+  Future<void> _writeCustomFieldDiff(
+    String diveId,
+    List<domain.DiveCustomField> desired,
+    int now,
+  ) async {
+    final existing = await (_db.select(
+      _db.diveCustomFields,
+    )..where((t) => t.diveId.equals(diveId))).get();
+    final existingById = {for (final r in existing) r.id: r};
+    final desiredIds = {
+      for (final f in desired)
+        if (f.id.isNotEmpty) f.id,
+    };
+    for (final row in existing) {
+      if (desiredIds.contains(row.id)) continue;
+      await (_db.delete(
+        _db.diveCustomFields,
+      )..where((t) => t.id.equals(row.id))).go();
+      await _syncRepository.logDeletion(
+        entityType: 'diveCustomFields',
+        recordId: row.id,
+      );
+    }
+    for (final field in desired) {
+      final current = field.id.isNotEmpty ? existingById[field.id] : null;
+      if (current != null &&
+          current.fieldKey == field.key &&
+          current.fieldValue == field.value &&
+          current.sortOrder == field.sortOrder) {
+        continue;
+      }
+      final rowId = field.id.isNotEmpty ? field.id : _uuid.v4();
+      if (current != null) {
+        await (_db.update(
+          _db.diveCustomFields,
+        )..where((t) => t.id.equals(rowId))).write(
+          DiveCustomFieldsCompanion(
+            fieldKey: Value(field.key),
+            fieldValue: Value(field.value),
+            sortOrder: Value(field.sortOrder),
+          ),
+        );
+      } else {
+        await _db
+            .into(_db.diveCustomFields)
+            .insert(
+              DiveCustomFieldsCompanion(
+                id: Value(rowId),
+                diveId: Value(diveId),
+                fieldKey: Value(field.key),
+                fieldValue: Value(field.value),
+                sortOrder: Value(field.sortOrder),
+                createdAt: Value(now),
+              ),
+            );
+      }
+      await _syncRepository.markRecordPending(
+        entityType: 'diveCustomFields',
+        recordId: rowId,
         localUpdatedAt: now,
       );
     }

--- a/test/features/dive_log/data/repositories/dive_repository_child_diff_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_child_diff_test.dart
@@ -1,0 +1,275 @@
+import 'package:drift/drift.dart' show OrderingTerm, Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/dive_log/domain/entities/dive_custom_field.dart'
+    as domain_field;
+import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart'
+    as domain_weight;
+
+import '../../../../helpers/test_database.dart';
+
+/// Issue #1727. `updateDive` used to delete every weight and custom field a
+/// dive held and re-insert them, which published a deletion tombstone and a
+/// pending mark for the same key in one sync round. Neither table carries an
+/// `updatedAt` the merge can compare, so whichever a peer applied last decided
+/// whether the row lived. Both children now diff on the row id, the way the
+/// gear writer added in #1716 does.
+void main() {
+  late AppDatabase db;
+  late DiveRepository repo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = DiveRepository();
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion.insert(
+            id: 'd1',
+            name: 'd1',
+            createdAt: 1,
+            updatedAt: 1,
+          ),
+        );
+  });
+
+  tearDown(tearDownTestDatabase);
+
+  domain_weight.DiveWeight weight(
+    String id,
+    WeightType type,
+    double kg, {
+    String notes = '',
+  }) => domain_weight.DiveWeight(
+    id: id,
+    diveId: 'dv',
+    weightType: type,
+    amountKg: kg,
+    notes: notes,
+  );
+
+  Future<List<DiveWeight>> weightRows() async =>
+      (await (db.select(db.diveWeights)
+            ..where((t) => t.diveId.equals('dv'))
+            ..orderBy([(t) => OrderingTerm(expression: t.id)]))
+          .get());
+
+  Future<List<DiveCustomField>> customFieldRows() async =>
+      (await (db.select(db.diveCustomFields)
+            ..where((t) => t.diveId.equals('dv'))
+            ..orderBy([(t) => OrderingTerm(expression: t.id)]))
+          .get());
+
+  Future<List<String>> tombstonesFor(String entityType) async => [
+    for (final t in await db.select(db.deletionLog).get())
+      if (t.entityType == entityType) t.recordId,
+  ];
+
+  Future<Set<String>> pendingFor(String entityType) async => {
+    for (final r in await db.select(db.syncRecords).get())
+      if (r.entityType == entityType && r.syncStatus == 'pending') r.recordId,
+  };
+
+  /// Pretends every pending row for [entityType] has reached the peers, so a
+  /// later re-mark is visible as the row going pending again.
+  Future<void> markEverythingSynced(String entityType) async {
+    await (db.update(db.syncRecords)
+          ..where((t) => t.entityType.equals(entityType)))
+        .write(const SyncRecordsCompanion(syncStatus: Value('synced')));
+  }
+
+  Future<domain.Dive> seed({
+    List<domain_weight.DiveWeight> weights = const [],
+    List<domain_field.DiveCustomField> customFields = const [],
+  }) async {
+    await repo.createDive(
+      domain.Dive(
+        id: 'dv',
+        dateTime: DateTime(2026, 1, 1),
+        weights: weights,
+        customFields: customFields,
+      ),
+    );
+    return (await repo.getDiveById('dv'))!;
+  }
+
+  group('weights', () {
+    test('an unchanged weight is neither tombstoned nor re-marked', () async {
+      final dive = await seed(
+        weights: [
+          weight('w1', WeightType.belt, 4),
+          weight('w2', WeightType.trimWeights, 1),
+        ],
+      );
+      final createdAtBefore = {
+        for (final r in await weightRows()) r.id: r.createdAt,
+      };
+      await markEverythingSynced('diveWeights');
+
+      await repo.updateDive(dive);
+
+      expect(
+        await tombstonesFor('diveWeights'),
+        isEmpty,
+        reason: 'a row the save re-writes unchanged must not be tombstoned',
+      );
+      expect(await pendingFor('diveWeights'), isEmpty);
+      expect(
+        {for (final r in await weightRows()) r.id: r.createdAt},
+        createdAtBefore,
+        reason: 'an untouched row keeps its identity, not just its values',
+      );
+    });
+
+    test('a changed weight is updated in place, not replaced', () async {
+      final dive = await seed(weights: [weight('w1', WeightType.belt, 4)]);
+      final createdAtBefore = (await weightRows()).single.createdAt;
+      await markEverythingSynced('diveWeights');
+
+      await repo.updateDive(
+        dive.copyWith(
+          weights: [weight('w1', WeightType.belt, 5, notes: 'one more block')],
+        ),
+      );
+
+      expect(await tombstonesFor('diveWeights'), isEmpty);
+      expect(await pendingFor('diveWeights'), {'w1'});
+      final row = (await weightRows()).single;
+      expect(row.amountKg, 5);
+      expect(row.notes, 'one more block');
+      expect(row.createdAt, createdAtBefore);
+    });
+
+    test('a removed weight is deleted and tombstoned', () async {
+      final dive = await seed(
+        weights: [
+          weight('w1', WeightType.belt, 4),
+          weight('w2', WeightType.trimWeights, 1),
+        ],
+      );
+      await markEverythingSynced('diveWeights');
+
+      await repo.updateDive(
+        dive.copyWith(weights: [weight('w1', WeightType.belt, 4)]),
+      );
+
+      expect(await tombstonesFor('diveWeights'), ['w2']);
+      expect((await weightRows()).map((r) => r.id), ['w1']);
+      expect(await pendingFor('diveWeights'), isEmpty);
+    });
+
+    test('an added weight is inserted and marked pending', () async {
+      final dive = await seed(weights: [weight('w1', WeightType.belt, 4)]);
+      await markEverythingSynced('diveWeights');
+
+      await repo.updateDive(
+        dive.copyWith(
+          weights: [
+            weight('w1', WeightType.belt, 4),
+            weight('w2', WeightType.ankleWeights, 0.5),
+          ],
+        ),
+      );
+
+      expect(await tombstonesFor('diveWeights'), isEmpty);
+      expect(await pendingFor('diveWeights'), {'w2'});
+      expect((await weightRows()).map((r) => r.id), ['w1', 'w2']);
+    });
+
+    test('a weight arriving without an id is inserted', () async {
+      final dive = await seed(weights: [weight('w1', WeightType.belt, 4)]);
+
+      await repo.updateDive(
+        dive.copyWith(
+          weights: [
+            weight('w1', WeightType.belt, 4),
+            weight('', WeightType.trimWeights, 1),
+          ],
+        ),
+      );
+
+      final rows = await weightRows();
+      expect(rows, hasLength(2));
+      expect(rows.map((r) => r.id), contains('w1'));
+      expect(rows.every((r) => r.id.isNotEmpty), isTrue);
+      expect(await tombstonesFor('diveWeights'), isEmpty);
+    });
+  });
+
+  group('custom fields', () {
+    domain_field.DiveCustomField field(
+      String id,
+      String key,
+      String value, {
+      int sort = 0,
+    }) => domain_field.DiveCustomField(
+      id: id,
+      key: key,
+      value: value,
+      sortOrder: sort,
+    );
+
+    test(
+      'an unchanged custom field is neither tombstoned nor re-marked',
+      () async {
+        final dive = await seed(
+          customFields: [
+            field('c1', 'Wetsuit', '5mm'),
+            field('c2', 'Ferry', 'Ischia', sort: 1),
+          ],
+        );
+        final createdAtBefore = {
+          for (final r in await customFieldRows()) r.id: r.createdAt,
+        };
+        await markEverythingSynced('diveCustomFields');
+
+        await repo.updateDive(dive);
+
+        expect(await tombstonesFor('diveCustomFields'), isEmpty);
+        expect(await pendingFor('diveCustomFields'), isEmpty);
+        expect({
+          for (final r in await customFieldRows()) r.id: r.createdAt,
+        }, createdAtBefore);
+      },
+    );
+
+    test('a changed custom field is updated in place, not replaced', () async {
+      final dive = await seed(customFields: [field('c1', 'Wetsuit', '5mm')]);
+      final createdAtBefore = (await customFieldRows()).single.createdAt;
+      await markEverythingSynced('diveCustomFields');
+
+      await repo.updateDive(
+        dive.copyWith(customFields: [field('c1', 'Wetsuit', '7mm', sort: 2)]),
+      );
+
+      expect(await tombstonesFor('diveCustomFields'), isEmpty);
+      expect(await pendingFor('diveCustomFields'), {'c1'});
+      final row = (await customFieldRows()).single;
+      expect(row.fieldValue, '7mm');
+      expect(row.sortOrder, 2);
+      expect(row.createdAt, createdAtBefore);
+    });
+
+    test('a removed custom field is deleted and tombstoned', () async {
+      final dive = await seed(
+        customFields: [
+          field('c1', 'Wetsuit', '5mm'),
+          field('c2', 'Ferry', 'Ischia'),
+        ],
+      );
+      await markEverythingSynced('diveCustomFields');
+
+      await repo.updateDive(
+        dive.copyWith(customFields: [field('c1', 'Wetsuit', '5mm')]),
+      );
+
+      expect(await tombstonesFor('diveCustomFields'), ['c2']);
+      expect((await customFieldRows()).map((r) => r.id), ['c1']);
+      expect(await pendingFor('diveCustomFields'), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Closes #1727. Follows #1726 and #1725, both now on `main`.

## The bug

`updateDive` rewrote a dive's weights and custom fields by deleting every row
the dive held and re-inserting them:

```dart
final existingWeights = await (select diveWeights where diveId == dive.id).get();
await (delete diveWeights where diveId == dive.id).go();
for (existingWeights) logDeletion('diveWeights', weightId);
for (final weight in dive.weights) { insert(...); markRecordPending(...); }
```

So every save published a deletion tombstone for each weight and custom field
the dive held, including the ones it re-inserted unchanged on the next line,
and marked each of those rows pending too. One key was both live and tombstoned
in the same sync round. Neither table carries an `updatedAt` for the merge to
order the two by, so whichever a peer applied last decided whether the row
lived.

This is the same shape that `_writeGearDiff` was introduced for in #1716; the
two children either side of it were left as they were.

The transaction added in #1726 fixed the *local* half: a throw partway through
no longer leaves the dive holding a prefix of its weights. It does nothing about
the tombstones, which were committed correctly, alongside the rows they
contradicted.

## The change

Both children now diff on the row id:

- unchanged row: skipped entirely, no tombstone, no pending mark
- changed row: updated in place, marked pending
- added row: inserted, marked pending
- removed row: deleted and tombstoned

Two notes on how the writers differ from `_writeGearDiff`:

- They use an explicit `update` where the gear writer upserts. `dive_equipment`
  has a composite key `(dive_id, equipment_id)` so an upsert there can only land
  on this dive, but `dive_weights` and `dive_custom_fields` are keyed on `id`
  alone: an upsert would silently reparent another dive's row on an id
  collision, where the old `insert` threw. The explicit update keeps that
  failure loud.
- They leave `created_at` alone. The old path re-stamped it on every save, so an
  untouched weight silently changed its birth date each time the diver edited
  the dive.

This also makes `updateDive` treat all four child collections the same way:
tanks already did update-or-insert keyed on id, twenty lines above.

## Relies on #1725

`createDive` batches its child inserts through `_db.batch`, a *synchronous*
closure, and before #1725 it never called `markRecordPending` for weights or
custom fields. The delete-and-reinsert in `updateDive` marked them by accident
on the next save, which was the only reason a new dive's weights ever published
incrementally.

With unchanged rows now skipped, that accident is gone, and #1725 (merged) is
what publishes a new dive's children. The tests here account for it: each one
flips the rows `createDive` marked back to synced before calling `updateDive`,
so a re-mark is visible as the row going pending again.

## Follow-up filed

The issue asked whether these tables carry an `updatedAt` the sync merge can
compare. They do not: both have `id` and `created_at` only, no `updated_at` and
no `hlc`. Filed as #1731, sibling of #1728.

Worth being explicit about one consequence, since it cuts the other way.
`_extractUpdatedAtMillis` falls back to `created_at`, and the old path's
re-stamping made an edited weight look freshly created, which had the accidental
effect of protecting it from a stale remote tombstone via the age guard in
`_applyRemoteDeletions`. Not re-stamping is correct (the row was not created
then) but removes that accident. Net it is still a clear win: this PR stops the
local half generating the contradicting tombstone at all, which is the thing
that was actually costing rows. #1731 covers the remaining half.

## Testing

New `dive_repository_child_diff_test.dart`, 8 cases across both tables:
unchanged, changed, removed, added, and a weight arriving without an id. Each
asserts the deletion log, the pending set, and that `created_at` survives.

All 8 fail on the pre-change code with real tombstone lists (`['w1','w2']` for a
save that changed nothing), not compile errors.

Full suite before the rebase onto `main`: 26498 passed, 21 skipped, 0 failed.
After it, the dive repository and sync suites: 1967 passed, 0 failed.
`flutter analyze` clean across the project.
