### PR TITLE
fix(sync): give the gear junctions a clock so a lost link can come back (#1728)

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1162,6 +1162,21 @@ class DiveEquipment extends Table {
     onDelete: KeyAction.setNull,
   )();
 
+  /// When this link was last written, in Unix ms (issue #1728). NOT an LWW
+  /// clock for the row's payload: the junction carries no hlc and rides its
+  /// parent, and the merge still applies it as a clockless upsert. It exists
+  /// so the merge has an age signal at all. Without one,
+  /// `_extractUpdatedAtMillis` returns null, which collapses both guards in
+  /// `SyncService._applyRemoteDeletions` to false (each is written
+  /// `localUpdatedAt != null && ...`) and makes the revival branch in
+  /// `_mergeEntity` unreachable, so a link lost anywhere is permanent.
+  /// Nullable so a row from a pre-v207 peer still parses, and a
+  /// `clientDefault` stamps every local insert so a future call site cannot
+  /// silently reintroduce a clockless link.
+  IntColumn get updatedAt => integer().nullable().clientDefault(
+    () => DateTime.now().millisecondsSinceEpoch,
+  )();
+
   @override
   Set<Column> get primaryKey => {diveId, equipmentId};
 }
@@ -1223,6 +1238,12 @@ class DivePlanEquipment extends Table {
     onDelete: KeyAction.setNull,
   )();
 
+  /// The sync merge's age signal for this link; see [DiveEquipment.updatedAt]
+  /// for why the junctions need one (issue #1728).
+  IntColumn get updatedAt => integer().nullable().clientDefault(
+    () => DateTime.now().millisecondsSinceEpoch,
+  )();
+
   @override
   Set<Column> get primaryKey => {planId, equipmentId};
 }
@@ -1255,6 +1276,12 @@ class EquipmentSetItems extends Table {
       text().references(EquipmentSets, #id, onDelete: KeyAction.cascade)();
   TextColumn get equipmentId =>
       text().references(Equipment, #id, onDelete: KeyAction.cascade)();
+
+  /// The sync merge's age signal for this link; see [DiveEquipment.updatedAt]
+  /// for why the junctions need one (issue #1728).
+  IntColumn get updatedAt => integer().nullable().clientDefault(
+    () => DateTime.now().millisecondsSinceEpoch,
+  )();
 
   @override
   Set<Column> get primaryKey => {setId, equipmentId};
@@ -3846,7 +3873,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 204;
+  static const int currentSchemaVersion = 207;
 
   /// The oldest schema whose reader can apply this build's sync payloads
   /// without loss or misinterpretation (the compatibility floor).
@@ -4380,6 +4407,12 @@ class AppDatabase extends _$AppDatabase {
     // open, and a rung at or below the shipped version never runs its
     // onUpgrade step.
     204,
+    // v207: an updated_at on the three composite-natural-key gear junctions
+    // (issue #1728). 204 landed on main while this branch was open and 205
+    // and 206 are claimed by the condition-intelligence branches, so this
+    // rung takes 207; the list only counts remaining steps for progress
+    // reporting and is non-contiguous by design.
+    207,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -4705,6 +4738,65 @@ class AppDatabase extends _$AppDatabase {
           'REFERENCES equipment_sets (id) ON DELETE SET NULL',
         );
       }
+    }
+  }
+
+  /// v207 (issue #1728): `updated_at` on the three composite-natural-key gear
+  /// junctions, backfilled from the parent row each one rides.
+  ///
+  /// These junctions are the only clockless children a stale tombstone can
+  /// still match, because their key is the natural pair rather than a fresh
+  /// uuid. With no age signal, `SyncService._applyRemoteDeletions` applied a
+  /// remote tombstone unconditionally and `_mergeEntity` could never revive
+  /// the row, so one dropped link became permanent, library-wide data loss.
+  ///
+  /// The backfill value is the parent's `updated_at`: the junction is
+  /// rewritten wholesale whenever its parent is saved, so that is the age the
+  /// link would have carried had the column always existed. Rows whose parent
+  /// is missing keep NULL, which is exactly the pre-rung behavior (no signal).
+  ///
+  /// Idempotent, and safe to re-run from the beforeOpen backstop. The
+  /// backfill runs only for a table whose column this call just added, so a
+  /// steady-state open costs one PRAGMA per junction and never a table scan,
+  /// and a link re-stamped since the rung is never dragged back to its
+  /// parent's clock. onUpgrade runs inside a transaction, so a crash between
+  /// the ALTER and the UPDATE rolls back both rather than stranding a table
+  /// with the column but no values.
+  Future<void> _assertJunctionUpdatedAtColumns() async {
+    const parents = {
+      'dive_equipment': ('dives', 'dive_id'),
+      'equipment_set_items': ('equipment_sets', 'set_id'),
+      'dive_plan_equipment': ('dive_plans', 'plan_id'),
+    };
+    final tables = (await customSelect(
+      "SELECT name FROM sqlite_master WHERE type = 'table'",
+    ).get()).map((r) => r.read<String>('name')).toSet();
+
+    for (final entry in parents.entries) {
+      final table = entry.key;
+      final (parentTable, foreignKey) = entry.value;
+      if (!tables.contains(table)) continue;
+      final cols = await customSelect("PRAGMA table_info('$table')").get();
+      if (cols.isEmpty) continue;
+      final names = cols.map((c) => c.read<String>('name')).toSet();
+      if (names.contains('updated_at')) continue;
+      await customStatement('ALTER TABLE $table ADD COLUMN updated_at INTEGER');
+      if (!tables.contains(parentTable)) continue;
+      // The parent must also HAVE an updated_at. Minimal old-schema fixtures
+      // (and genuinely ancient databases) carry a parent table stripped to
+      // its id, and selecting a column that is not there aborts the whole
+      // open with a SQL logic error. Nothing to backfill from is not a
+      // failure: the rows keep NULL, which is the pre-rung behavior.
+      final parentCols = await customSelect(
+        "PRAGMA table_info('$parentTable')",
+      ).get();
+      final parentNames = parentCols.map((c) => c.read<String>('name')).toSet();
+      if (!parentNames.contains('updated_at')) continue;
+      await customStatement(
+        'UPDATE $table SET updated_at = ('
+        'SELECT p.updated_at FROM $parentTable p WHERE p.id = $table.$foreignKey'
+        ') WHERE updated_at IS NULL',
+      );
     }
   }
 
@@ -11262,10 +11354,27 @@ class AppDatabase extends _$AppDatabase {
           await _assertGroupTripsInDiveListColumn();
         }
         if (from < 204) await reportProgress();
+        // v207: an updated_at on the three composite-natural-key gear
+        // junctions (issue #1728), backfilled from the parent each junction
+        // rides. Numbered 207 because 205 and 206 are claimed by the
+        // condition-intelligence branches still open. Idempotent, and
+        // re-asserted in the beforeOpen backstop: a junction stranded without
+        // the column is silently unprotected against a stale peer tombstone,
+        // and the loss it lets through cannot be undone by a later sync.
+        if (from < 207) {
+          await _assertJunctionUpdatedAtColumns();
+        }
+        if (from < 207) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
         await customStatement('PRAGMA foreign_keys = ON');
+
+        // v207 backstop: re-assert the gear junctions' updated_at. A device
+        // stranded without it has no age signal on those rows, so a stale
+        // peer tombstone deletes a gear link unconditionally and no later
+        // sync can revive it (issue #1728).
+        await _assertJunctionUpdatedAtColumns();
 
         // v201 backstop: re-assert the cell linearity columns.
         await _assertTemplateItemSourceIdColumn();

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
 
@@ -1854,9 +1855,10 @@ class SyncDataSerializer {
                   ..where((t) => t.setId.equals(parts[0]))
                   ..where((t) => t.equipmentId.equals(parts[1])))
                 .getSingleOrNull();
-        return row == null
-            ? null
-            : {'setId': row.setId, 'equipmentId': row.equipmentId};
+        // toJson, not a hand-built pair: the merge's age guards read
+        // updatedAt off this map, and a hand-built one silently drops it
+        // (issue #1728). The other two junctions already use toJson.
+        return row?.toJson();
       case 'media':
         final row = await (_db.select(
           _db.media,
@@ -2751,9 +2753,7 @@ class SyncDataSerializer {
             .insertOnConflictUpdate(DiveTank.fromJson(data));
         return;
       case 'diveEquipment':
-        await _db
-            .into(_db.diveEquipment)
-            .insertOnConflictUpdate(DiveEquipmentData.fromJson(data));
+        await _upsertGearJunction(entityType, [data]);
         return;
       case 'diveWeights':
         await _db
@@ -2822,9 +2822,7 @@ class SyncDataSerializer {
             );
         return;
       case 'equipmentSetItems':
-        await _db
-            .into(_db.equipmentSetItems)
-            .insertOnConflictUpdate(EquipmentSetItem.fromJson(data));
+        await _upsertGearJunction(entityType, [data]);
         return;
       case 'media':
         await _db
@@ -3034,12 +3032,8 @@ class SyncDataSerializer {
               DivePlanSegment.fromJson(data).toCompanion(false),
             );
         return;
-      // Clockless composite-PK junction: plain data-class upsert
-      // (nullToAbsent). Do NOT add .toCompanion(false) here.
       case 'divePlanEquipment':
-        await _db
-            .into(_db.divePlanEquipment)
-            .insertOnConflictUpdate(DivePlanEquipmentData.fromJson(data));
+        await _upsertGearJunction(entityType, [data]);
         return;
       case 'diverWeightEntries':
         await _db
@@ -3491,12 +3485,7 @@ class SyncDataSerializer {
         );
         return;
       case 'diveEquipment':
-        await _db.batch(
-          (b) => b.insertAllOnConflictUpdate(
-            _db.diveEquipment,
-            records.map((r) => DiveEquipmentData.fromJson(r)).toList(),
-          ),
-        );
+        await _upsertGearJunction(entityType, records);
         return;
       case 'diveWeights':
         await _db.batch(
@@ -3601,12 +3590,7 @@ class SyncDataSerializer {
         );
         return;
       case 'equipmentSetItems':
-        await _db.batch(
-          (b) => b.insertAllOnConflictUpdate(
-            _db.equipmentSetItems,
-            records.map((r) => EquipmentSetItem.fromJson(r)).toList(),
-          ),
-        );
+        await _upsertGearJunction(entityType, records);
         return;
       case 'media':
         await _db.batch(
@@ -3927,12 +3911,7 @@ class SyncDataSerializer {
         );
         return;
       case 'divePlanEquipment':
-        await _db.batch(
-          (b) => b.insertAllOnConflictUpdate(
-            _db.divePlanEquipment,
-            records.map((r) => DivePlanEquipmentData.fromJson(r)).toList(),
-          ),
-        );
+        await _upsertGearJunction(entityType, records);
         return;
       case 'diverWeightEntries':
         await _db.batch(
@@ -4577,7 +4556,121 @@ class SyncDataSerializer {
     await _db.delete(_syncTableFor(entityType)).go();
   }
 
+  /// Upsert for the three composite-natural-key gear junctions, shared by the
+  /// single- and batch-record paths so the two cannot drift apart.
+  ///
+  /// The subtlety is the clock these tables gained in v207 (issue #1728). A
+  /// peer on an older build puts only the key pair on the wire, and Drift's
+  /// insert uses `toColumns(nullToAbsent: true)`, so the absent `updatedAt`
+  /// falls through to the column's `clientDefault` and arrives as `now`. Let
+  /// that reach the row and every base import from an old peer restamps every
+  /// gear link as freshly edited, which flips the new age guard the other way:
+  /// legitimate removals stop applying and pile up as conflicts instead.
+  ///
+  /// So rows are split on whether the WIRE carried a clock. Rows that did
+  /// upsert normally. Rows that did not leave an existing row's `updated_at`
+  /// untouched, while a genuinely new row still gets the `clientDefault`
+  /// stamp on insert.
+  ///
+  /// The provenance pointers are overwritten either way, including with null:
+  /// a peer that deleted the parent clears them on purpose.
+  Future<void> _upsertGearJunction(
+    String entityType,
+    List<Map<String, dynamic>> records,
+  ) async {
+    if (records.isEmpty) return;
+    final clocked = <Map<String, dynamic>>[];
+    final clockless = <Map<String, dynamic>>[];
+    for (final record in records) {
+      (record['updatedAt'] is int ? clocked : clockless).add(record);
+    }
+
+    switch (entityType) {
+      case 'diveEquipment':
+        if (clocked.isNotEmpty) {
+          await _db.batch(
+            (b) => b.insertAllOnConflictUpdate(
+              _db.diveEquipment,
+              clocked.map(DiveEquipmentData.fromJson).toList(),
+            ),
+          );
+        }
+        if (clockless.isNotEmpty) {
+          await _db.batch(
+            (b) => b.insertAll(
+              _db.diveEquipment,
+              clockless.map(DiveEquipmentData.fromJson).toList(),
+              onConflict:
+                  DoUpdate<$DiveEquipmentTable, DiveEquipmentData>.withExcluded(
+                    (old, excluded) => DiveEquipmentCompanion.custom(
+                      viaEquipmentId: excluded.viaEquipmentId,
+                      viaSetId: excluded.viaSetId,
+                    ),
+                  ),
+            ),
+          );
+        }
+        return;
+      case 'divePlanEquipment':
+        if (clocked.isNotEmpty) {
+          await _db.batch(
+            (b) => b.insertAllOnConflictUpdate(
+              _db.divePlanEquipment,
+              clocked.map(DivePlanEquipmentData.fromJson).toList(),
+            ),
+          );
+        }
+        if (clockless.isNotEmpty) {
+          await _db.batch(
+            (b) => b.insertAll(
+              _db.divePlanEquipment,
+              clockless.map(DivePlanEquipmentData.fromJson).toList(),
+              onConflict:
+                  DoUpdate<
+                    $DivePlanEquipmentTable,
+                    DivePlanEquipmentData
+                  >.withExcluded(
+                    (old, excluded) => DivePlanEquipmentCompanion.custom(
+                      viaEquipmentId: excluded.viaEquipmentId,
+                      viaSetId: excluded.viaSetId,
+                    ),
+                  ),
+            ),
+          );
+        }
+        return;
+      case 'equipmentSetItems':
+        if (clocked.isNotEmpty) {
+          await _db.batch(
+            (b) => b.insertAllOnConflictUpdate(
+              _db.equipmentSetItems,
+              clocked.map(EquipmentSetItem.fromJson).toList(),
+            ),
+          );
+        }
+        if (clockless.isNotEmpty) {
+          // The row's whole payload is its key, so there is nothing to update
+          // on conflict; ignoring leaves the local clock standing.
+          await _db.batch(
+            (b) => b.insertAll(
+              _db.equipmentSetItems,
+              clockless.map(EquipmentSetItem.fromJson).toList(),
+              mode: InsertMode.insertOrIgnore,
+            ),
+          );
+        }
+        return;
+    }
+    throw ArgumentError('Not a gear junction: $entityType');
+  }
+
   /// The Drift table backing a synced [entityType] (mirrors recordIdsFor).
+  /// Exposed for the structural test that pins every composite-key table to a
+  /// [SyncService.recordIdForEntity] case (issue #1728).
+  @visibleForTesting
+  TableInfo<Table, dynamic> syncTableFor(String entityType) =>
+      _syncTableFor(entityType);
+
   TableInfo<Table, dynamic> _syncTableFor(String entityType) {
     switch (entityType) {
       case 'settings':
@@ -5401,14 +5494,13 @@ class SyncDataSerializer {
       final rows = await (_db.select(
         _db.equipmentSetItems,
       )..where((t) => t.setId.isIn(setIds))).get();
-      return rows
-          .map((r) => {'setId': r.setId, 'equipmentId': r.equipmentId})
-          .toList();
+      // toJson, not a hand-built pair: the receiver's tombstone guards read
+      // updatedAt off this map, so hand-building one keeps the column from
+      // ever leaving this device (issue #1728).
+      return rows.map((r) => r.toJson()).toList();
     }
     final rows = await _db.select(_db.equipmentSetItems).get();
-    return rows
-        .map((r) => {'setId': r.setId, 'equipmentId': r.equipmentId})
-        .toList();
+    return rows.map((r) => r.toJson()).toList();
   }
 
   Future<List<Map<String, dynamic>>> _exportMedia(String? hlcSince) async {

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -4572,8 +4572,11 @@ class SyncDataSerializer {
   /// untouched, while a genuinely new row still gets the `clientDefault`
   /// stamp on insert.
   ///
-  /// The provenance pointers are overwritten either way, including with null:
-  /// a peer that deleted the parent clears them on purpose.
+  /// On `diveEquipment` and `divePlanEquipment` the provenance pointers
+  /// (`viaEquipmentId`, `viaSetId`) are overwritten either way, including with
+  /// null: a peer that deleted the parent clears them on purpose.
+  /// `equipmentSetItems` has no provenance columns; its whole payload is the
+  /// key, so a clockless row that already exists is simply ignored.
   Future<void> _upsertGearJunction(
     String entityType,
     List<Map<String, dynamic>> records,

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -1217,7 +1217,7 @@ class SyncService {
       final contradicted = <String>{};
       for (final rec in live) {
         if (rec is! Map<String, dynamic>) continue;
-        final id = _recordIdForEntity(delEntry.key, rec);
+        final id = recordIdForEntity(delEntry.key, rec);
         if (id != null && deletedIds.contains(id)) contradicted.add(id);
       }
       if (contradicted.isNotEmpty) {
@@ -1589,7 +1589,7 @@ class SyncService {
         continue;
       }
       for (final rec in entry.records) {
-        final id = _recordIdForEntity(parentType, rec);
+        final id = recordIdForEntity(parentType, rec);
         if (id == null) continue;
         final deletedAt = tombs[id];
         if (deletedAt == null) continue;
@@ -1797,7 +1797,7 @@ class SyncService {
       for (final r in p2batch!) {
         final table = r.table;
         final rec = r.row;
-        final id = _recordIdForEntity(table, rec);
+        final id = recordIdForEntity(table, rec);
         if (id == null) continue;
         if (parentTypes.contains(table) &&
             _baseApplyEntityFlags[table] == true) {
@@ -1970,7 +1970,7 @@ class SyncService {
           (parentTypes.contains(table) || deletionIds.containsKey(table)),
       onRow: (section, table, rowBytes) async {
         final rec = jsonDecode(utf8.decode(rowBytes)) as Map<String, dynamic>;
-        final id = _recordIdForEntity(table, rec);
+        final id = recordIdForEntity(table, rec);
         if (id == null) return;
         if (parentTypes.contains(table) &&
             _baseApplyEntityFlags[table] == true) {
@@ -2189,9 +2189,20 @@ class SyncService {
     );
   }
 
-  /// Per-entity "has an updatedAt column" flag, mirroring the `mergeOrder`
-  /// records in [_applyRemotePayloadInner]. The streaming base apply
-  /// ([_applyRemoteBaseFile]) uses it (via [_baseApplyEntityFlags], which
+  /// Per-entity merge-strategy flag, mirroring the `mergeOrder`
+  /// records in [_applyRemotePayloadInner].
+  ///
+  /// True means "resolve this entity as LWW": fetch the local row, compare
+  /// clocks, overlay, and raise a two-sided edit as a conflict. False means
+  /// "apply as a blind upsert". It is NOT a claim that the table has no
+  /// `updated_at`: the three composite-natural-key gear junctions carry one
+  /// as of v207 (issue #1728) and stay false here on purpose. Their payload
+  /// is the key itself, so there is nothing to overlay, and routing them
+  /// through the LWW path would surface a conflict card for a gear link.
+  /// Code that wants a row's age must call [_extractUpdatedAtMillis]
+  /// directly rather than gate on this flag.
+  ///
+  /// The streaming base apply ([_applyRemoteBaseFile]) uses it (via [_baseApplyEntityFlags], which
   /// also folds in [inboundOnlyLegacyEntities]) for (a) conflict-detection
   /// behavior in [_mergeEntity] and (b) the set of entity tables it applies
   /// (a table absent from that union is silently skipped on base import).
@@ -2563,7 +2574,7 @@ class SyncService {
     final localById = hasUpdatedAt
         ? await _serializer.fetchRecords(entityType, [
             for (final record in records)
-              ?_recordIdForEntity(entityType, record),
+              ?recordIdForEntity(entityType, record),
           ])
         : const <String, Map<String, dynamic>>{};
     final toUpsert = <Map<String, dynamic>>[];
@@ -2572,7 +2583,7 @@ class SyncService {
       String? recordId;
       int? localUpdatedAt;
       try {
-        recordId = _recordIdForEntity(entityType, record);
+        recordId = recordIdForEntity(entityType, record);
         if (recordId == null) {
           // A record with no resolvable id is malformed data, not a two-sided
           // conflict -- count it as a failure so performSync surfaces an error.
@@ -2626,9 +2637,15 @@ class SyncService {
               recordId: recordId,
             );
           } else {
-            final remoteUpdatedAt = hasUpdatedAt
-                ? _extractUpdatedAtMillis(record)
-                : null;
+            // Read the remote clock whether or not this entity resolves as
+            // LWW. [hasUpdatedAt] selects the merge STRATEGY (an entity that
+            // is false here is applied as a blind upsert, never overlaid or
+            // conflicted); it is not a claim that the row carries no
+            // timestamp. Gating on it made this branch unreachable for the
+            // gear junctions, so a link lost anywhere could never be revived
+            // by a live copy from a peer (issue #1728). A genuinely clockless
+            // entity still yields null here and is unaffected.
+            final remoteUpdatedAt = _extractUpdatedAtMillis(record);
             if (remoteUpdatedAt == null || remoteUpdatedAt <= deletedAt) {
               // No newer remote edit -- the deletion wins; stay deleted.
               continue;
@@ -2818,7 +2835,17 @@ class SyncService {
     }
   }
 
-  String? _recordIdForEntity(String entityType, Map<String, dynamic> record) {
+  /// The id the merge keys a record by: `id` for most entities, the natural
+  /// key for the handful that have none. Must agree with the id
+  /// [SyncDataSerializer.recordIdsFor] emits and [SyncDataSerializer
+  /// .deleteRecord] accepts, or the entity's rows silently fail to merge --
+  /// which is what a missing `divePlanEquipment` case did (issue #1728).
+  /// A structural test pins every composite-key table to a case here.
+  @visibleForTesting
+  static String? recordIdForEntity(
+    String entityType,
+    Map<String, dynamic> record,
+  ) {
     switch (entityType) {
       case 'settings':
         return record['key'] as String?;
@@ -2831,12 +2858,21 @@ class SyncService {
       case 'equipmentSetItems':
         return record['id'] as String? ??
             _compositeId(record['setId'], record['equipmentId']);
+      case 'divePlanEquipment':
+        // Composite (planId, equipmentId), same shape as diveEquipment. The
+        // serializer has always keyed it that way in fetchRecord,
+        // deleteRecord and allRecordIds; without this case the merge fell
+        // through to record['id'], which these rows do not have, so every
+        // incoming dive-plan gear row was counted as malformed and never
+        // applied.
+        return record['id'] as String? ??
+            _compositeId(record['planId'], record['equipmentId']);
       default:
         return record['id'] as String?;
     }
   }
 
-  String? _compositeId(Object? left, Object? right) {
+  static String? _compositeId(Object? left, Object? right) {
     if (left == null || right == null) return null;
     return '$left|$right';
   }
@@ -3629,7 +3665,7 @@ class SyncService {
         final entityType = entry.key;
         final records = (entry.value as List).cast<Map<String, dynamic>>();
         for (final record in records) {
-          final id = _recordIdForEntity(entityType, record);
+          final id = recordIdForEntity(entityType, record);
           if (id == null) continue;
           (cloudIds[entityType] ??= <String>{}).add(id);
           (restored[entityType] ??= {})[id] = record;
@@ -3642,7 +3678,7 @@ class SyncService {
       final entityType = entry.key;
       final records = (entry.value as List).cast<Map<String, dynamic>>();
       for (final record in records) {
-        final id = _recordIdForEntity(entityType, record);
+        final id = recordIdForEntity(entityType, record);
         if (id == null) continue;
         if (!(cloudIds[entityType]?.contains(id) ?? false)) {
           await _serializer.deleteRecord(entityType, id);
@@ -3721,7 +3757,7 @@ class SyncService {
     ) async {
       final valid = [
         for (final r in records)
-          if (_recordIdForEntity(table, r) != null) r,
+          if (recordIdForEntity(table, r) != null) r,
       ];
       if (valid.isEmpty) return;
       await _serializer.upsertRecords(table, valid);

--- a/test/core/database/migration_v203_equipment_assemblies_test.dart
+++ b/test/core/database/migration_v203_equipment_assemblies_test.dart
@@ -33,7 +33,7 @@ Future<Set<String>> _foreignKeys(AppDatabase db, String table) async {
 }
 
 void main() {
-  test('v203 is the current schema version and is in the ladder', () {
+  test('v203 is in the ladder and shipped', () {
     // Renumbered twice: the cell linearity link took 201 and condition
     // intelligence took 202 while this branch was open.
     // Relaxed as this rung's own convention asks, now that v204 (dive list

--- a/test/core/database/migration_v207_junction_clock_test.dart
+++ b/test/core/database/migration_v207_junction_clock_test.dart
@@ -1,0 +1,216 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+
+/// v207 gives the three composite-natural-key gear junctions an `updated_at`
+/// (issue #1728). Without one, `_extractUpdatedAtMillis` returns null for
+/// these rows, which collapses both of `_applyRemoteDeletions`' guards to
+/// false and makes `_mergeEntity`'s revival branch unreachable -- so a lost
+/// link is permanent. The rung backfills from the parent the junction rides.
+
+Future<Set<String>> _columns(AppDatabase db, String table) async {
+  final rows = await db.customSelect("PRAGMA table_info('$table')").get();
+  return rows.map((r) => r.read<String>('name')).toSet();
+}
+
+Future<int?> _updatedAt(AppDatabase db, String table, String sql) async {
+  final rows = await db.customSelect(sql).get();
+  return rows.single.read<int?>('updated_at');
+}
+
+const _junctions = [
+  'dive_equipment',
+  'equipment_set_items',
+  'dive_plan_equipment',
+];
+
+void main() {
+  test('v207 is the current schema version and is in the ladder', () {
+    expect(AppDatabase.currentSchemaVersion, 207);
+    expect(AppDatabase.migrationVersions, contains(207));
+  });
+
+  test('a fresh database has updated_at on all three junctions', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    for (final table in _junctions) {
+      expect(await _columns(db, table), contains('updated_at'), reason: table);
+    }
+  });
+
+  test('an inserted link is stamped without the caller saying so', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final before = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.equipment)
+        .insert(
+          EquipmentCompanion.insert(
+            id: 'gear-1',
+            name: 'Wing',
+            type: 'bcd',
+            createdAt: 1,
+            updatedAt: 1,
+          ),
+        );
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion.insert(
+            id: 'dive-1',
+            diveDateTime: 1,
+            createdAt: 1,
+            updatedAt: 1,
+          ),
+        );
+    await db
+        .into(db.diveEquipment)
+        .insert(
+          DiveEquipmentCompanion.insert(
+            diveId: 'dive-1',
+            equipmentId: 'gear-1',
+          ),
+        );
+
+    final row = await db.select(db.diveEquipment).getSingle();
+    expect(
+      row.updatedAt,
+      isNotNull,
+      reason:
+          'a clientDefault stamps every insert site, so a future call '
+          'site cannot silently reintroduce a clockless link',
+    );
+    expect(row.updatedAt, greaterThanOrEqualTo(before));
+  });
+
+  test('a parent stripped to its id is survivable, not fatal', () async {
+    // beforeOpen re-asserts this rung on EVERY open, including against the
+    // minimal old-schema fixtures other migration tests build and against
+    // genuinely ancient databases. Selecting a column the parent does not
+    // have aborts the open with a SQL logic error, so "nothing to backfill
+    // from" must leave NULL rather than throw.
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 206');
+        rawDb.execute('CREATE TABLE dives (id TEXT NOT NULL PRIMARY KEY)');
+        rawDb.execute('''
+          CREATE TABLE dive_equipment (
+            dive_id TEXT NOT NULL,
+            equipment_id TEXT NOT NULL,
+            PRIMARY KEY (dive_id, equipment_id)
+          )
+        ''');
+        rawDb.execute("INSERT INTO dives VALUES ('d1')");
+        rawDb.execute("INSERT INTO dive_equipment VALUES ('d1', 'g1')");
+      },
+    );
+    final db = AppDatabase(nativeDb);
+    addTearDown(db.close);
+
+    expect(await _columns(db, 'dive_equipment'), contains('updated_at'));
+    expect(
+      await _updatedAt(
+        db,
+        'dive_equipment',
+        'SELECT updated_at FROM dive_equipment',
+      ),
+      isNull,
+    );
+  });
+
+  test(
+    'a stranded database gains the column, backfilled from its parent',
+    () async {
+      final nativeDb = NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute('PRAGMA user_version = 206');
+          rawDb.execute('''
+          CREATE TABLE dives (
+            id TEXT NOT NULL PRIMARY KEY,
+            updated_at INTEGER NOT NULL
+          )
+        ''');
+          rawDb.execute('''
+          CREATE TABLE equipment_sets (
+            id TEXT NOT NULL PRIMARY KEY,
+            updated_at INTEGER NOT NULL
+          )
+        ''');
+          rawDb.execute('''
+          CREATE TABLE dive_plans (
+            id TEXT NOT NULL PRIMARY KEY,
+            updated_at INTEGER NOT NULL
+          )
+        ''');
+          rawDb.execute('''
+          CREATE TABLE dive_equipment (
+            dive_id TEXT NOT NULL,
+            equipment_id TEXT NOT NULL,
+            PRIMARY KEY (dive_id, equipment_id)
+          )
+        ''');
+          rawDb.execute('''
+          CREATE TABLE equipment_set_items (
+            set_id TEXT NOT NULL,
+            equipment_id TEXT NOT NULL,
+            PRIMARY KEY (set_id, equipment_id)
+          )
+        ''');
+          rawDb.execute('''
+          CREATE TABLE dive_plan_equipment (
+            plan_id TEXT NOT NULL,
+            equipment_id TEXT NOT NULL,
+            PRIMARY KEY (plan_id, equipment_id)
+          )
+        ''');
+          rawDb.execute("INSERT INTO dives VALUES ('d1', 7000)");
+          rawDb.execute("INSERT INTO equipment_sets VALUES ('s1', 7100)");
+          rawDb.execute("INSERT INTO dive_plans VALUES ('p1', 7200)");
+          rawDb.execute("INSERT INTO dive_equipment VALUES ('d1', 'g1')");
+          rawDb.execute("INSERT INTO equipment_set_items VALUES ('s1', 'g1')");
+          rawDb.execute("INSERT INTO dive_plan_equipment VALUES ('p1', 'g1')");
+        },
+      );
+      final db = AppDatabase(nativeDb);
+      addTearDown(db.close);
+
+      for (final table in _junctions) {
+        expect(
+          await _columns(db, table),
+          contains('updated_at'),
+          reason: table,
+        );
+      }
+      expect(
+        await _updatedAt(
+          db,
+          'dive_equipment',
+          'SELECT updated_at FROM dive_equipment',
+        ),
+        7000,
+        reason:
+            'the junction rides its dive, so the dive\'s updated_at is the '
+            'age the link would have had',
+      );
+      expect(
+        await _updatedAt(
+          db,
+          'equipment_set_items',
+          'SELECT updated_at FROM equipment_set_items',
+        ),
+        7100,
+      );
+      expect(
+        await _updatedAt(
+          db,
+          'dive_plan_equipment',
+          'SELECT updated_at FROM dive_plan_equipment',
+        ),
+        7200,
+      );
+    },
+  );
+}

--- a/test/core/services/sync/sync_data_serializer_record_ids_test.dart
+++ b/test/core/services/sync/sync_data_serializer_record_ids_test.dart
@@ -101,6 +101,36 @@ void main() {
     }
   });
 
+  test('every synced entity has a recordIdForEntity case', () async {
+    // The merge keys each incoming record with SyncService.recordIdForEntity;
+    // an entity with no case falls through to record['id'], and a table whose
+    // primary key is not a plain `id` has none -- so every one of its rows is
+    // counted as malformed and silently never applied. That is what happened
+    // to divePlanEquipment until issue #1728 found it.
+    //
+    // Driven off the live Drift schema rather than a hand-kept list, so a new
+    // composite-key or natural-key synced table fails here until it is wired
+    // up.
+    final s = SyncDataSerializer();
+    for (final entity in SyncService.entityHasUpdatedAt.keys) {
+      final primaryKey = s
+          .syncTableFor(entity)
+          .$primaryKey
+          .map((c) => c.name)
+          .toList();
+      final record = <String, dynamic>{
+        for (final column in primaryKey) _camelCase(column): 'x-$column',
+      };
+      expect(
+        SyncService.recordIdForEntity(entity, record),
+        isNotNull,
+        reason:
+            '$entity keys on ${primaryKey.join(' + ')}, which recordIdForEntity '
+            'cannot resolve; add a case for it or its rows will never merge',
+      );
+    }
+  });
+
   test('every synced entity has a deleteAllRecords case', () async {
     // deleteAllRecords -> _syncTableFor throws on an entity with no case, so
     // iterating every synced entity fails loudly if one is ever added without a
@@ -158,3 +188,11 @@ Map<String, dynamic> _equipment(String id) => {
   'createdAt': 1000,
   'updatedAt': 1000,
 };
+
+/// `dive_id` -> `diveId`: the column naming Drift's own toJson emits, which is
+/// the shape the merge sees on the wire.
+String _camelCase(String columnName) {
+  final parts = columnName.split('_');
+  return parts.first +
+      parts.skip(1).map((p) => p[0].toUpperCase() + p.substring(1)).join();
+}

--- a/test/core/services/sync/sync_junction_clock_test.dart
+++ b/test/core/services/sync/sync_junction_clock_test.dart
@@ -205,9 +205,11 @@ void main() {
 
     test('a pre-v207 peer cannot null out a clock we already hold', () async {
       // Rollout hazard: a peer on an older build sends these rows with no
-      // updatedAt at all. A plain upsert writes that null over the stamp this
-      // device holds, returning the row to the unprotected state -- so the
-      // very next stale tombstone deletes it for good.
+      // updatedAt at all. Drift's insert drops the absent field, so the
+      // column's clientDefault fires and a plain upsert overwrites the stamp
+      // this device holds with `now`. Every base import from an old peer
+      // would then make every gear link look freshly edited, flipping the age
+      // guard so legitimate removals pile up as conflicts.
       final serializer = SyncDataSerializer();
       final diveRepo = DiveRepository();
       final db = DatabaseService.instance.database;
@@ -239,6 +241,96 @@ void main() {
         8000,
         reason: 'a wire row with no clock must leave the local one standing',
       );
+    });
+
+    test(
+      'a clockless dive-plan row keeps our clock but still clears provenance',
+      () async {
+        // The dive-plan twin of the test above, and the case the upsert's doc
+        // comment distinguishes: an old peer's row must leave the local clock
+        // standing, yet an explicit null provenance pointer (a peer that
+        // deleted the assembly) must still be applied, not dropped.
+        final serializer = SyncDataSerializer();
+        final db = DatabaseService.instance.database;
+
+        await serializer.upsertRecord(
+          'equipment',
+          equipmentRow('gear-6', 'Regulator', 'regulator'),
+        );
+        await serializer.upsertRecord(
+          'equipment',
+          equipmentRow('rig-6', 'Travel rig', 'regulator'),
+        );
+        await db
+            .into(db.divePlans)
+            .insert(
+              DivePlansCompanion.insert(
+                id: 'plan-6',
+                name: 'Reef 18 m',
+                gfLow: 50,
+                gfHigh: 80,
+                createdAt: 1000,
+                updatedAt: 1000,
+              ),
+            );
+        await serializer.upsertRecord('divePlanEquipment', {
+          'planId': 'plan-6',
+          'equipmentId': 'gear-6',
+          'viaEquipmentId': 'rig-6',
+          'updatedAt': 8000,
+        });
+
+        await serializer.upsertRecord('divePlanEquipment', {
+          'planId': 'plan-6',
+          'equipmentId': 'gear-6',
+          'viaEquipmentId': null,
+        });
+
+        final row = await (db.select(
+          db.divePlanEquipment,
+        )..where((t) => t.planId.equals('plan-6'))).getSingle();
+        expect(row.updatedAt, 8000, reason: 'the wire carried no clock');
+        expect(
+          row.viaEquipmentId,
+          isNull,
+          reason: 'an explicit null provenance pointer is a deliberate clear',
+        );
+      },
+    );
+
+    test('an incremental changeset carries the set-item clock', () async {
+      // _exportEquipmentSetItems used to hand-build {setId, equipmentId}, so
+      // the clock never left the device and every receiver's age guard saw
+      // null again. The incremental path (a watermark, a changed set) is the
+      // one ordinary syncs take.
+      final serializer = SyncDataSerializer();
+
+      await serializer.upsertRecord(
+        'equipment',
+        equipmentRow('gear-7', 'Hood', 'hood'),
+      );
+      await serializer.upsertRecord('equipmentSets', {
+        'id': 'set-7',
+        'name': 'Cold water',
+        'description': '',
+        'isDefault': false,
+        'createdAt': 1000,
+        'updatedAt': 1000,
+        'hlc': '0002-changed-hlc',
+      });
+      await serializer.upsertRecord('equipmentSetItems', {
+        'setId': 'set-7',
+        'equipmentId': 'gear-7',
+        'updatedAt': 7000,
+      });
+
+      final payload = await serializer.exportChangeset(
+        deviceId: 'this-dev',
+        hlcWatermark: '0001-older-hlc',
+        deletions: const [],
+      );
+
+      expect(payload.data.equipmentSetItems, [containsPair('updatedAt', 7000)]);
     });
 
     test('a dive-plan gear row merges instead of failing', () async {

--- a/test/core/services/sync/sync_junction_clock_test.dart
+++ b/test/core/services/sync/sync_junction_clock_test.dart
@@ -1,0 +1,292 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/changeset_test_helpers.dart';
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../helpers/test_database.dart';
+
+/// Regression tests for issue #1728.
+///
+/// The composite-natural-key gear junctions carried no clock, which broke the
+/// merge in two directions at once:
+///
+///  * `_applyRemoteDeletions` derives both of its guards from
+///    `localUpdatedAt`, each written as `localUpdatedAt != null && ...`, so a
+///    null collapsed both to false and an uncontradicted remote tombstone
+///    applied unconditionally.
+///  * `_mergeEntity`'s local-tombstone branch computed `remoteUpdatedAt` as
+///    `hasUpdatedAt ? ... : null` and bailed on null, so the revival path was
+///    unreachable for a clockless entity. A link lost anywhere was permanent.
+///
+/// These use tombstones with NO matching live row in the same payload, which
+/// is what defeats the same-payload contradiction check that #347 added.
+void main() {
+  group('Gear junctions carry a clock (issue #1728)', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() async {
+      await tearDownTestDatabase();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    Map<String, dynamic> equipmentRow(String id, String name, String type) => {
+      'id': id,
+      'name': name,
+      'type': type,
+      'status': 'active',
+      'purchaseCurrency': 'USD',
+      'notes': '',
+      'isActive': true,
+      'createdAt': 1000,
+      'updatedAt': 1000,
+    };
+
+    SyncPayload payloadOf(SyncData data, Map<String, List<SyncDeletion>> dels) {
+      final checksum = sha256
+          .convert(utf8.encode(jsonEncode(data.toJson())))
+          .toString();
+      return SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: 9000,
+        deviceId: 'peer-dev',
+        checksum: checksum,
+        data: data,
+        deletions: dels,
+      );
+    }
+
+    test('a link edited after the tombstone survives it', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+      final db = DatabaseService.instance.database;
+
+      await serializer.upsertRecord(
+        'equipment',
+        equipmentRow('gear-1', 'Wing', 'bcd'),
+      );
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-1', diveNumber: 1),
+      );
+      // This device re-attached the gear at 6000, AFTER the peer deleted it.
+      await serializer.upsertRecord('diveEquipment', {
+        'diveId': 'dive-1',
+        'equipmentId': 'gear-1',
+        'updatedAt': 6000,
+      });
+
+      final payload = payloadOf(const SyncData(), {
+        'diveEquipment': [
+          const SyncDeletion(id: 'dive-1|gear-1', deletedAt: 5000),
+        ],
+      });
+      await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      final links = await (db.select(
+        db.diveEquipment,
+      )..where((t) => t.diveId.equals('dive-1'))).get();
+      expect(
+        links.map((l) => l.equipmentId),
+        contains('gear-1'),
+        reason:
+            'the local link is newer than the tombstone, so the age guard '
+            'must route it to a conflict rather than delete it',
+      );
+      expect(result.conflictsFound, greaterThan(0));
+    });
+
+    test('a lost link is revived by a newer live copy from a peer', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+      final db = DatabaseService.instance.database;
+
+      await serializer.upsertRecord(
+        'equipment',
+        equipmentRow('gear-2', 'Regulator', 'regulator'),
+      );
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-2', diveNumber: 2),
+      );
+      // This device already lost the link and holds the tombstone.
+      await SyncRepository().logDeletion(
+        entityType: 'diveEquipment',
+        recordId: 'dive-2|gear-2',
+        deletedAt: 4000,
+      );
+
+      // A peer that never lost it publishes the live row, and nothing in the
+      // payload contradicts our tombstone.
+      final payload = payloadOf(
+        const SyncData(
+          diveEquipment: [
+            {'diveId': 'dive-2', 'equipmentId': 'gear-2', 'updatedAt': 5000},
+          ],
+        ),
+        const {},
+      );
+      await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      final links = await (db.select(
+        db.diveEquipment,
+      )..where((t) => t.diveId.equals('dive-2'))).get();
+      expect(
+        links.map((l) => l.equipmentId),
+        contains('gear-2'),
+        reason:
+            'a live copy newer than the local tombstone must revive the '
+            'link, otherwise a single lost link is permanent',
+      );
+    });
+
+    test('a genuine deletion of an older link still applies', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+      final db = DatabaseService.instance.database;
+
+      await serializer.upsertRecord(
+        'equipment',
+        equipmentRow('gear-3', 'Fins', 'fins'),
+      );
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-3', diveNumber: 3),
+      );
+      await serializer.upsertRecord('diveEquipment', {
+        'diveId': 'dive-3',
+        'equipmentId': 'gear-3',
+        'updatedAt': 3000,
+      });
+
+      final payload = payloadOf(const SyncData(), {
+        'diveEquipment': [
+          const SyncDeletion(id: 'dive-3|gear-3', deletedAt: 5000),
+        ],
+      });
+      await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      final links = await (db.select(
+        db.diveEquipment,
+      )..where((t) => t.diveId.equals('dive-3'))).get();
+      expect(
+        links,
+        isEmpty,
+        reason:
+            'the guard must not turn every removal into a conflict: a '
+            'link older than the tombstone is still deleted',
+      );
+    });
+
+    test('a pre-v207 peer cannot null out a clock we already hold', () async {
+      // Rollout hazard: a peer on an older build sends these rows with no
+      // updatedAt at all. A plain upsert writes that null over the stamp this
+      // device holds, returning the row to the unprotected state -- so the
+      // very next stale tombstone deletes it for good.
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
+      final db = DatabaseService.instance.database;
+
+      await serializer.upsertRecord(
+        'equipment',
+        equipmentRow('gear-5', 'Torch', 'light'),
+      );
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-5', diveNumber: 5),
+      );
+      await serializer.upsertRecord('diveEquipment', {
+        'diveId': 'dive-5',
+        'equipmentId': 'gear-5',
+        'updatedAt': 8000,
+      });
+
+      // Exactly what an older build puts on the wire: the key and nothing else.
+      await serializer.upsertRecord('diveEquipment', {
+        'diveId': 'dive-5',
+        'equipmentId': 'gear-5',
+      });
+
+      final row = await (db.select(
+        db.diveEquipment,
+      )..where((t) => t.diveId.equals('dive-5'))).getSingle();
+      expect(
+        row.updatedAt,
+        8000,
+        reason: 'a wire row with no clock must leave the local one standing',
+      );
+    });
+
+    test('a dive-plan gear row merges instead of failing', () async {
+      final serializer = SyncDataSerializer();
+      final db = DatabaseService.instance.database;
+
+      await serializer.upsertRecord(
+        'equipment',
+        equipmentRow('gear-4', 'Mask', 'mask'),
+      );
+      await db
+          .into(db.divePlans)
+          .insert(
+            DivePlansCompanion.insert(
+              id: 'plan-1',
+              name: 'Wreck 60 m',
+              gfLow: 50,
+              gfHigh: 80,
+              createdAt: 1000,
+              updatedAt: 1000,
+              hlc: const Value('0001-test-hlc'),
+            ),
+          );
+
+      final payload = payloadOf(
+        const SyncData(
+          divePlanEquipment: [
+            {'planId': 'plan-1', 'equipmentId': 'gear-4', 'updatedAt': 5000},
+          ],
+        ),
+        const {},
+      );
+      await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      final links = await (db.select(
+        db.divePlanEquipment,
+      )..where((t) => t.planId.equals('plan-1'))).get();
+      expect(
+        links.map((l) => l.equipmentId),
+        contains('gear-4'),
+        reason:
+            '_recordIdForEntity had no divePlanEquipment case, so every '
+            'incoming dive-plan gear row resolved to a null id and was '
+            'counted as malformed instead of applied',
+      );
+    });
+  });
+}

--- a/test/core/services/sync/sync_junction_reinsert_test.dart
+++ b/test/core/services/sync/sync_junction_reinsert_test.dart
@@ -189,10 +189,15 @@ void main() {
         'createdAt': 1000,
         'updatedAt': 1000,
       });
-      // The membership currently exists locally.
+      // The membership currently exists locally, and predates the peer's
+      // deletion. Since v207 these rows carry a clock (issue #1728), and a
+      // row left unstamped would be stamped `now` by the column's
+      // clientDefault -- newer than this tombstone, which the age guard would
+      // then correctly refuse to apply.
       await serializer.upsertRecord('equipmentSetItems', {
         'setId': 'set-2',
         'equipmentId': 'gear-3',
+        'updatedAt': 3000,
       });
 
       // Peer removed the item: a tombstone with NO matching live row.
@@ -298,9 +303,13 @@ void main() {
           'updatedAt': 1000,
         });
         // C is currently a member locally and is being removed by the edit.
+        // Stamped before the tombstone: since v207 the row carries a clock,
+        // and a membership newer than the deletion is a conflict, not a
+        // removal (issue #1728).
         await serializer.upsertRecord('equipmentSetItems', {
           'setId': 'set-4',
           'equipmentId': 'g-c',
+          'updatedAt': 3000,
         });
 
         // updateSet on the peer keeps A and B (live + reinsert tombstone) and


### PR DESCRIPTION
Fixes #1728.

`dive_equipment`, `equipment_set_items` and `dive_plan_equipment` each had two
columns and a composite primary key, and no clock of any kind. That is what
made a single dropped gear link permanent rather than something the next sync
heals, so any one bug that drops a link turned into unrecoverable data loss.

## Both halves of the merge failed on the same missing value

`_applyRemoteDeletions` derives both of its guards from `localUpdatedAt`, and
each is written `localUpdatedAt != null && ...`, so a null collapses both to
`false` in one stroke. A clockless table is not weakly protected against a
stale peer tombstone; it is unprotected.

`_mergeEntity` then computed the remote clock as
`hasUpdatedAt ? _extractUpdatedAtMillis(record) : null` and bailed on null,
which made the revival branch not merely hard to reach but unreachable for
exactly these tables. Deletion was absorbing.

The tombstone also gained strength on every hop. `logDeletionIfMissing`
re-mints it locally with a fresh HLC after applying it, so the receiver
republishes it; the dive's own `hlc` did not change, so the live row is not in
that changeset to contradict it. Each hop stripped the last defence, and every
base import carries the full deletion log, so the pending-entity skip only
deferred it a round.

## The fix

Schema **v207** adds a nullable `updated_at` to all three junctions,
backfilled from the parent each one rides. Nullable so a pre-v207 peer's rows
still parse (`fromJson` casts every non-nullable column, so a NOT NULL column
would throw mid-sync). Declared with a Drift `clientDefault` so every insert
site stamps it without remembering to, and a future call site cannot silently
reintroduce a clockless link. The rung is numbered 207 because 204 through 206
are claimed by branches still open.

The junctions deliberately stay `hasUpdatedAt: false`. That flag picks the
merge **strategy**, not whether a timestamp exists: their payload is the key
itself, so there is nothing to overlay, and routing them through the LWW path
would raise a user-visible conflict card for a gear link. `_mergeEntity` now
reads the remote clock unconditionally; a genuinely clockless entity still
yields null and is unaffected. The flag's doc comment now says so.

## Two more gaps found while wiring it up

**Dive-plan gear never synced at all.** `_recordIdForEntity` had cases for
`diveEquipment` and `equipmentSetItems` but not `divePlanEquipment`, so it fell
through to `record['id']`, which those rows do not have. Every incoming
dive-plan gear row resolved to a null id and was counted as malformed rather
than applied. The serializer had always keyed it as a composite in
`fetchRecord`, `deleteRecord` and `allRecordIds`; only the merge disagreed.

A structural test now drives off the live Drift schema and fails for any synced
table whose primary key `recordIdForEntity` cannot resolve, naming the columns
in the failure message. That is the guard that would have caught this one.

**`equipment_set_items` hand-built its wire map**, in both `_exportEquipmentSetItems`
and `fetchRecord`, from the key pair alone. Left alone, the new column would
never have left the device on one side and never been read on the other.

## Rollout hazard, and what the test found

A peer on an older build sends only the key pair. Drift's `insert` uses
`toColumns(nullToAbsent: true)`, so the absent `updatedAt` falls through to the
`clientDefault` and lands as `now` rather than null. Left alone, that restamps
every gear link as freshly edited on every base import from an old peer, which
flips the new guard the other way: legitimate removals stop applying and pile
up as conflicts for as long as one device stays behind.

The six junction upsert sites (three tables x the single- and batch-record
paths) are now one helper that splits rows on whether the **wire** carried a
clock. Rows that did upsert normally; rows that did not leave an existing row's
`updated_at` untouched, while a genuinely new row still gets the stamp.

## Testing

New `test/core/services/sync/sync_junction_clock_test.dart` and
`test/core/database/migration_v207_junction_clock_test.dart`. Every regression
test was mutation-checked against the pre-fix behaviour: the three that assert
the fix flip red, and the control that asserts a genuine deletion of an older
link still applies stays green, so the guard is discriminating rather than
simply refusing every tombstone.

Two pre-existing tests in `sync_junction_reinsert_test.dart` needed their
fixtures aged. They inserted a membership row with no clock and paired it with
a synthetic `deletedAt: 5000`, which the `clientDefault` now makes newer than
the tombstone. They are stamped before the deletion, which is what they always
meant. `migration_v203`'s `currentSchemaVersion` equality is relaxed to
`greaterThanOrEqualTo` so the newest rung's own test is the only tripwire.

The migration helper is PRAGMA-guarded on the parent's `updated_at` as well as
its own table (an old fixture carries a parent stripped to its id, and
selecting a column that is not there aborts the whole open), and the backfill
runs only for a table whose column the call just added, so the `beforeOpen`
backstop costs three PRAGMAs at steady state rather than three table scans on
every launch.

The compatibility floor is unchanged: a new nullable column is explicitly on
the "do NOT raise" list.
