### PR TITLE
test(security): wait for the result, not a fixed pump count, after keyslot steps

### DIFF
--- a/test/features/settings/presentation/pages/security_settings_page_test.dart
+++ b/test/features/settings/presentation/pages/security_settings_page_test.dart
@@ -92,6 +92,34 @@ void main() {
     }
   }
 
+  /// [settle], but runs until [condition] holds instead of for a fixed
+  /// count, failing with [awaiting] if it never does.
+  ///
+  /// Use this after any step that runs a keyslot operation. Each iteration
+  /// advances the flow by at most one real-I/O hop (a sidecar read or write
+  /// continuation only runs on the next pump), so a flow needs a fixed number
+  /// of iterations even on an idle machine: regenerating the recovery code
+  /// needs 15 of settle's 20. On a contended CI runner some windows see no
+  /// I/O complete, and a fixed count then runs out before the result
+  /// mounts. The cap is far beyond any flow here (15 at most), so only a
+  /// result that never arrives can reach it.
+  Future<void> settleUntil(
+    WidgetTester tester,
+    bool Function() condition, {
+    required String awaiting,
+  }) async {
+    const cap = 400;
+    for (var i = 0; i < cap && !condition(); i++) {
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 25)),
+      );
+      await tester.pump();
+    }
+    if (!condition()) {
+      fail('Timed out after $cap settle iterations awaiting $awaiting');
+    }
+  }
+
   Future<void> pumpPage(WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(
@@ -170,7 +198,11 @@ void main() {
       await tester.enterText(fields.at(0), 'encrypt-only');
       await tester.enterText(fields.at(1), 'encrypt-only');
       await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
-      await settle(tester);
+      await settleUntil(
+        tester,
+        () => find.text('I saved my recovery code').evaluate().isNotEmpty,
+        awaiting: 'the recovery code step',
+      );
       await tester.tap(find.text('I saved my recovery code'));
       await tester.pump();
       await tester.tap(find.widgetWithText(FilledButton, 'Done'));
@@ -207,7 +239,11 @@ void main() {
 
       await tester.enterText(find.byType(TextField), 'existing-encryption-pw');
       await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
-      await settle(tester);
+      await settleUntil(
+        tester,
+        () => find.text('Encrypt database?').evaluate().isNotEmpty,
+        awaiting: 'the encryption confirmation',
+      );
 
       expect(find.text('Encrypt database?'), findsOneWidget);
       expect(DatabaseSecurityService.instance.appLockEnabled, false);
@@ -265,7 +301,11 @@ void main() {
 
       await tester.enterText(find.byType(TextField), 'existing-pw');
       await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
-      await settle(tester);
+      await settleUntil(
+        tester,
+        () => DatabaseSecurityService.instance.appLockEnabled,
+        awaiting: 'app lock to turn on',
+      );
 
       expect(DatabaseSecurityService.instance.appLockEnabled, true);
     },
@@ -324,12 +364,23 @@ void main() {
       await tester.enterText(fields.at(1), 'brand-new-pw');
       await tester.enterText(fields.at(2), 'brand-new-pw');
       await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
-      await settle(tester);
+      await settleUntil(
+        tester,
+        () => find.text('Incorrect password.').evaluate().isNotEmpty,
+        awaiting: 'the wrong-password error',
+      );
       expect(find.text('Incorrect password.'), findsOneWidget);
 
       await tester.enterText(fields.at(0), 'original');
       await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
-      await settle(tester);
+      // The dialog pops only after the rewrap is written. A popped route
+      // stays mounted (pump() never advances its exit animation) but stops
+      // taking pointers, so hit-testability marks the pop.
+      await settleUntil(
+        tester,
+        () => find.byType(AlertDialog).hitTestable().evaluate().isEmpty,
+        awaiting: 'the change password dialog to close',
+      );
 
       // The credential actually changed: old rejected, new accepted.
       // runAsync: the unwrap runs Argon2id, which cannot make progress on
@@ -383,7 +434,11 @@ void main() {
       await settle(tester);
       await tester.enterText(find.byType(TextField), 'pw-for-recovery');
       await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
-      await settle(tester);
+      await settleUntil(
+        tester,
+        () => find.text('Your recovery code').evaluate().isNotEmpty,
+        awaiting: 'the recovery code dialog',
+      );
 
       expect(find.text('Your recovery code'), findsOneWidget);
       final codeText = tester
@@ -417,7 +472,11 @@ void main() {
       await settle(tester);
       await tester.enterText(find.byType(TextField), 'wrong-pw');
       await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
-      await settle(tester);
+      await settleUntil(
+        tester,
+        () => find.text('Incorrect password.').evaluate().isNotEmpty,
+        awaiting: 'the wrong-password error',
+      );
 
       expect(find.text('Incorrect password.'), findsOneWidget);
       expect(find.text('Your recovery code'), findsNothing);
@@ -438,7 +497,11 @@ void main() {
       await settle(tester);
       await tester.enterText(find.byType(TextField), 'keep-encryption');
       await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
-      await settle(tester);
+      await settleUntil(
+        tester,
+        () => find.text('Turn off App Lock?').evaluate().isNotEmpty,
+        awaiting: 'the turn-off confirmation',
+      );
 
       expect(find.text('Turn off App Lock?'), findsOneWidget);
       await tester.tap(find.widgetWithText(FilledButton, 'Turn off'));
@@ -460,7 +523,11 @@ void main() {
       // Password gate first.
       await tester.enterText(find.byType(TextField), 'to-be-removed');
       await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
-      await settle(tester);
+      await settleUntil(
+        tester,
+        () => find.text('Turn off App Lock?').evaluate().isNotEmpty,
+        awaiting: 'the turn-off confirmation',
+      );
 
       // Then an explicit confirmation.
       expect(find.text('Turn off App Lock?'), findsOneWidget);

--- a/test/features/settings/presentation/pages/security_settings_page_test.dart
+++ b/test/features/settings/presentation/pages/security_settings_page_test.dart
@@ -101,8 +101,10 @@ void main() {
   /// of iterations even on an idle machine: regenerating the recovery code
   /// needs 15 of settle's 20. On a contended CI runner some windows see no
   /// I/O complete, and a fixed count then runs out before the result
-  /// mounts. The cap is far beyond any flow here (15 at most), so only a
-  /// result that never arrives can reach it.
+  /// mounts. The cap bounds iterations, not hops: no flow here needs more
+  /// than 15 hops, and the rest of the 400 is headroom for those empty
+  /// windows, so do not lower it toward the hop count. Only a result that
+  /// never arrives should reach it.
   Future<void> settleUntil(
     WidgetTester tester,
     bool Function() condition, {


### PR DESCRIPTION
## Summary

Fixes the recurring flake in `security_settings_page_test.dart`, group "regenerate recovery code", test "requires the password, then shows a code that unlocks":

```
Expected: exactly one matching candidate
  Actual: _TextWidgetFinder:<Found 0 widgets with text "Your recovery code">
```

It turned CI red on unrelated branches on 2026-08-16 (twice), 2026-08-18, and 2026-09-10 (#1734, `Test (shard 6)`, a sync and schema diff). It always passed in isolation. Test-only change; the dialog is shown correctly, and production code is untouched.

This is a different flake from the recovery-code "yo-yo" one (tests that split a code on `-` and expect 8 words). That one is unrelated and not touched here.

## Root cause: a fixed hop budget, not a slow KDF

`settle()` runs a fixed 20 iterations of `runAsync(25 ms)` plus `pump()`. Each iteration moves a flow forward by **at most one real-I/O hop**: a `dart:io` sidecar read or write completes on the real event loop, but its continuation is a microtask in testWidgets' fake zone, so it runs only on the next `pump()`, and only then does it issue the next I/O.

Argon2id itself costs no hops here. With `testKdf` (64 KiB, 16 blocks per segment), the package's every-500-blocks yield never fires and `isolateCount` is `16 ~/ 200 = 0`, so the hash runs synchronously inside a pump.

I measured how many iterations each `settle()` call in the file needs before its last observable change:

| Step | Iterations needed (of 20) |
| --- | --- |
| Regenerate: Continue shows the recovery code dialog | **15** |
| Change password: correct Continue rewraps and closes | 8 |
| Disable app lock: Continue shows "Turn off App Lock?" | 7 |
| Other unlock / wrong-password Continues | 5 |
| Setup dialog: Continue shows the recovery code step | 4 |
| Everything else | 1 or 2 |

The regenerate path does two sidecar reads (unlock, then `regenerateRecoveryCode` unwraps again) and a write, so it needs 15 iterations **on every run, however short the window** (the count stayed at 15 with 25 ms, 5 ms, 1 ms and zero windows, under load, and under background QoS). That leaves 5 spare iterations. On a contended runner, some windows pass with no I/O completing, and after six of them the budget runs out before the dialog mounts.

Reproduced deterministically by dropping the budget, which is equivalent to losing windows: at 15 iterations the test passes; at 14 it fails with the exact CI message at the same line, `security_settings_page_test.dart:388:7`.

## Changes

- Add `settleUntil(tester, condition, awaiting:)`: the same `runAsync` plus `pump` windows, repeated until `condition` holds, capped at 400 iterations, and failing with `Timed out after 400 settle iterations awaiting <what>` instead of a bare finder mismatch.
- Use it after all nine steps that run a keyslot operation (Argon2id): the reported test plus eight siblings with the same single-settle-after-KDF shape (setup Continue, orphaned-sidecar unlock, locked-credential unlock, both change-password submits, wrong-password regenerate, and both disable-app-lock password gates).
- Each condition is the thing the next assertion checks (text appears, or `appLockEnabled` turns on), so no assertion is weakened. The one exception is the successful change-password submit, which has no new text to wait for. It waits for the dialog to stop being hit-testable: `_submit` pops only after the rewrap is written, and a popping route ignores pointers, while its exit animation stays frozen because `pump()` never advances the fake clock.
- Steps with no keyslot operation keep `settle()` unchanged.

## Test Plan

- [x] Red before the fix: budget 14 fails at `:388:7` with the CI message; budget 15 passes.
- [x] The new wait is load-bearing: with the cap at 14 the test fails with `Timed out after 14 settle iterations awaiting the recovery code dialog`; at 15 it passes. A probe confirmed the change-password dialog is hit-testable right after Continue, so that condition is not vacuously true.
- [x] Whole file (22 tests) run 15 times on an idle machine: 15/15.
- [x] Whole file run 10 times under background QoS (`taskpolicy -b`), with `test/features/dive_log`, `media` and `equipment` running continuously alongside (seven back-to-back runs of 7,096 tests, load average 11 to 15 on 18 cores): 10/10.
- [x] No slowdown: the file took 38 s versus 47 s before, since `settleUntil` exits once its condition holds.
- [x] `dart format .` (0 files changed) and `flutter analyze` (no issues) clean; the file passes 22/22 again after rebasing onto #1734.
