### PR TITLE
ci(android): raise the Android build timeout from 30 to 45 minutes

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -735,7 +735,10 @@ jobs:
   build-android:
     name: Build Android
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # A normal run takes 24-25 minutes (two full release builds, APK and AAB),
+    # so a 30-minute cap left no room for a slow runner: Beta run 34482861977
+    # was killed mid-AAB at 30m with every other platform green.
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Beta run [34482861977](https://github.com/submersion-app/submersion/actions/runs/34482861977) was cancelled: the Android build job hit its 30-minute `timeout-minutes` cap partway through the App Bundle step. Every other platform built successfully, but the publish and upload jobs need all builds, so nothing was published for `f7ebec349a3`.

No code was at fault. A normal Android job takes 24-25 minutes because it runs two full release builds (APK and AAB, with different dart-defines), leaving about five minutes of headroom. This run landed on a slow runner:

| Step | 06:03 run | 07:38 run | Cancelled run |
| --- | --- | --- | --- |
| Install dependencies | 6:19 | 5:47 | 8:32 |
| Build Android APK | 12:36 | 12:41 | 15:07 |
| Build Android App Bundle | 4:18 | 3:45 | killed at 5:12 |

## Changes

- `build-all.yml`: `build-android` `timeout-minutes` goes from 30 to 45, matching the macOS job, with a comment recording why. `build-all.yml` is shared by `beta.yml` and `release.yml`, so both get the new limit.

## Test Plan

- [x] `flutter test` passes: not applicable, no Dart changes
- [x] `flutter analyze` passes (pre-push hook)
- [x] `actionlint` reports no new findings; the parsed `jobs.build-android.timeout-minutes` is 45
- [x] Manual testing on: the next Beta run on main completes the Android job
