### PR TITLE
docs(releases): add v1.7.8.8156 release notes

### DIFF
--- a/docs/releases/v1.7.8.8156.md
+++ b/docs/releases/v1.7.8.8156.md
@@ -1,0 +1,147 @@
+# 🎉 Submersion v1.7.8.8156 Release Notes
+
+v1.7.8 brings 75 merged changes since v1.7.7. The headliners are equipment assemblies (a regulator built from its first stage, second stages and hoses, attached to a dive as one item), a transmitter registry so downloaded cylinders arrive with the right size and role, service clocks that count salt-water hours, cold dives and high-O2 hours instead of bare dive counts, collapsible trip groups in the dive list, type-to-search filters, FFESSM certifications and cards that carry more than one agency's recognition, Swiss lake bathymetry in the 3D views, reusable weight presets, your own ppO2 limits, optional dive computer clock sync after a download, an O2 cell linearity check for rebreather builds, and numbers that finally use your locale's decimal separator. This release upgrades the database (schema 191 to 207), so please read the upgrade notes at the end.
+
+---
+
+## ✨ New and improved
+
+### Build gear from its parts
+
+An equipment item can now be assembled from other items: a regulator from its first stage, second stages and hoses, a backplate-and-wing from its plate, wing and harness, a camera from its housing and strobes. The Components card on an item's detail page adds, reorders, replaces and removes parts, and the item's service badge rolls up the most urgent clock among them, so a hose due for replacement surfaces on the regulator that carries it. Eight new equipment types come with this: First Stage, Second Stage, Hose, Backplate, Wing, Harness, Housing and Strobe. Attaching an assembly to a dive or a plan records every part and where it came from, the dive remembers which equipment set was applied, both dive pages show sets and assemblies nested inside your gear arrangement, and buoyancy no longer counts an assembly and its parts twice. Changing an assembly's parts when it is already on logged dives asks once whether to apply the change from now on or to past dives as well. Assemblies and gear provenance travel through the full UDDF export and restore, and the equipment CSV and Excel exports list each assembly's parts.
+
+### Cylinders that know which transmitter feeds them
+
+Air-integrated computers report pressure per transmitter but almost never a cylinder's size, and never its role, so every download landed as the default preset and CCR, sidemount and stage setups needed hand correction after each import. libdivecomputer now reports the transmitter serial and Submersion stores it on each tank. A new Settings > Manage > Transmitters page maps each serial to a cylinder role, size and working pressure, or to a cylinder from your equipment list; the mapping is applied on every download, a "seen in downloads, not assigned" list catches new transmitters as they appear, and an Assign chip on the dive's cylinders card does the same in place. Assigning a transmitter straight after a download offers to apply it to the dives already logged. The serial is also the first key when consolidating two computers' tanks, so two Terics paired to the same transmitter with 31% programmed on one and 32% on the other no longer show the same cylinder twice with doubled gas consumption. Moving a pressure series to another cylinder now survives re-parse, and a swap is its own inverse so undo is lossless.
+
+### Service clocks that count exposure
+
+Service schedules could only count days, dives and hours. They can now count salt-water hours, cold dives, high-O2 hours, deep dives and battery cycles, read from each dive's mode, depth, minimum temperature, water type and gas. The thresholds for cold, deep and high-O2 are yours to set under Settings > Equipment condition, in your own units. O2 cells and batteries become child items that inherit their parent's dives from the date they were installed, and a tank can name the regulator breathed from it so high-O2 contact reaches the regulator's own clock. Built-in service kinds are seeded with starting defaults (regulator service every 50 cold dives, O2 cleaning every 50 high-O2 hours, drysuit seals every 200 salt-water hours, transmitter battery every 250 hours), and a usage-driven clock that reaches due-soon or overdue sends one reminder.
+
+### Trips fold up in the dive list
+
+Consecutive dives from the same trip can collapse under a trip header, so a 14-dive liveaboard tidies away to reach the dives on either side. The header pins while you scroll through its group, reads "6 of 14 dives" when only part of a trip has paged in, and carries a tri-state checkbox in selection mode. Grouped dive cards keep exactly the width of loose ones. It is off by default, under the list's overflow menu beside Expand all trips and Collapse all trips, and applies to the card view under a chronological sort.
+
+### Type to search
+
+The dive type, site and dive computer filters on the dive list, and the site, trip, dive center, dive type and custom field pickers on advanced search, are now fields you type into, with the list narrowing as you go. Matching ignores case and accents ("cancun" finds "Cancún") and covers more than the name: a site by its location, country or region, a computer by its manufacturer and model, a trip by its resort or liveaboard, a dive center by its city. Every find-as-you-type field in the app, including checklist categories and import tags, now shows the row the arrow keys have highlighted and commits it on Enter, and checklist categories that differ only in case merge into one.
+
+### FFESSM, and a card that carries several recognitions
+
+The Fédération française d'études et de sports sous-marins joins the built-in agencies with its full scuba ladder (Plongeur de Bronze through MF2), the PE and PA aptitudes, nitrox, trimix and rebreather qualifications, and the biology, cave and imaging commissions, 47 levels in all, so French divers no longer file everything under Other. A certification card can now grant more than one agency's credential at the same rank, an FFESSM Niveau 1 that is also a CMAS 1-star for instance, with every recognition shown on the list tile, the detail page, the wallet card and the certification picker. FFESSM is also a dive center affiliation, and a buddy whose certification is filed under Other now shows the name on the card instead of "Other · Other".
+
+### Swiss lake bathymetry
+
+The 3D dive site and dive terrain views can draw Swiss lakes from swisstopo's swissBATHY3D data, far finer than the global sources, with the required swisstopo attribution. Depth scaling in both views now follows the fetched terrain alone.
+
+### Weight presets
+
+Divers re-enter the same belt on every dive. The weight section of the dive editor gains "Use preset" and "Save as preset", and Settings > Manage > Weight Presets lists, creates and edits named rigs. Editing a preset never changes the dives that already used it. The weight field also stops rounding stored values to a tenth: a 0.65 kg lead reads 0.65, not 0.7, so belt totals no longer drift by a kilo.
+
+### Your own ppO2 limits
+
+MOD, gas planning and every oxygen-toxicity warning were pinned to 1.4 and 1.6 bar. Settings > Decompression & safety > Oxygen toxicity now sets the working and maximum ppO2, the toxicity card and the gas-MOD data quality check compare against them, and the MOD on the cylinders card and in the tank editor follows the working limit you chose, with the label saying which value it used.
+
+### Set your dive computer's clock
+
+After a successful download, Submersion can set the computer's clock to this device's local time through libdivecomputer. It is off by default: a switch on the Dive Computers page turns it on for downloads from this device, and each computer's detail page can override it to Always or Never. Models that cannot be set say so instead of showing a switch that does nothing, and the download completion step reports "Clock synced", "not supported by this model" or "failed" without affecting the download itself. Android also now reports the computer's serial number and firmware version after a download.
+
+### O2 cell linearity in pre-dive checklists
+
+A new checklist item type records a CCR cell's output in pure oxygen, reads that cell's air reading back from an earlier item in the same checklist, and shows the linearity percentage, so a build no longer means noting millivolts down and reaching for a calculator three times. The ratio cancels ambient pressure, so it is correct at any altitude. The linearity row sits beside the existing 8.5 to 13.0 mV air-reading band rather than replacing it, since a uniformly aged cell reads low in both and scores linear while being unfit. The built-in CCR template gains the pairs, cloning it keeps the links, and a completed reading is frozen so a later correction cannot rewrite the record.
+
+### Numbers in your own decimal separator
+
+Divers in a comma-decimal locale (German, Spanish, French, Italian, Dutch, Portuguese, Hungarian) typed "12,5" into a depth field and read back "12.5 m". Every depth, temperature, pressure, volume, SAC, weight, speed and distance the app renders now uses the locale's separator, as do recorded checklist values and the cell linearity working. Coordinates and CSV exports deliberately stay dot-based so they remain parseable.
+
+### Duplicates the Data Quality inbox can actually fix
+
+The Data Quality page named its dives by their internal id, so a finding could not say which dive it meant. Headers now read as a dive you recognise (number, site, date and time, depth and duration), cross-dive findings name the dive they pair with, and findings record which computer produced them. The Consolidate button on a same-computer re-download could only ever fail, since two records from one computer are not two views of a dive; the inbox now withholds it there and instead offers Delete duplicate, which names the copy to keep and the copy to delete, lists what the doomed copy carries (gear, buddies, notes, photos), and refuses to name a redundant copy at all when it holds anything you entered by hand. Consolidating a different-computer pair now opens the same dialog the multi-select path uses so you choose which dive survives, rather than the one with the smaller internal id winning every time. Undo for a delete-duplicate stays on screen for ten seconds.
+
+### Smaller additions
+
+- **The home tab draws the real dive profile chart** for your latest dive, with every legend toggle, marker, gas segment and gesture the detail page has, instead of a depth-only preview. The desktop home layout pairs Recent media (now two rows of thumbnails) beside Recent sites, and This year moves under Milestones.
+- **Site statistics link to their dives.** Deepest, shallowest, longest, first and last on a site's page open the dive itself, the detail page loses two cards that restated its header and pairs related cards side by side on wide panes, and the Sites list gains first dived, average depth, longest dive and average duration fields plus Countries, Not-dived and Recently Dived tiles in its summary pane.
+- **Arrange the gear on a dive.** Group by type or not, order types alphabetically, head to toe, in dressing order or by function, then sort within a type by name, purchase date, date added or last service, each reversible. One synced preference, applied to the dive detail and edit pages, the Add Equipment picker (which also gains status and category filters), equipment sets and the detailed PDF. Gear on a dive previously had no defined order at all.
+- **A "Sold" equipment status**, a second terminal state beside Retired: a sold item leaves the active list and every picker but stays reachable through the status filter.
+- **The planner takes water type.** Deco plans choose salt, fresh or a custom salinity instead of always assuming 10 m per bar, with a per-diver default under Settings > Units.
+- **Suunto Cloud and Garmin Connect share one fetch step**: the latest 15 dives first, Load More, Fetch All, and a checkbox list before review on both. The page-size setting this briefly introduced is gone again. Suunto Cloud now imports the full event set (tank pressure and gas time alarms, CNS and OTU warnings, deco and safety stop states, broken stops) rather than three event types.
+- **A "Computed events" legend toggle** shows or hides the app's own ascent-rate and safety-stop markers separately from the computer's, hidden by default on a dive whose computer reported its own events so the two no longer stack into a smear.
+- **Reclaim forgotten backups.** A backup file whose record was lost (a preferences reset, a reinstall over a kept Documents folder, a crash mid-backup) was invisible to every prune and permanent. Storage usage now lists them with the device that wrote each one and lets you free the ones this device wrote.
+- **Checklists**: built-in pre-dive templates open read-only instead of needing a clone to be read, GUE EDGE seeds its full seven-point sequence (Goal, Unified team, Equipment, Exposure, Decompression, Gas, Environment) and repairs existing installs, the home card offers both pre-dive and trip checklists, completed checklists show when they finished and link to dives by their completion time, and "Checklist Templates" under Settings > Manage is now "Trip Checklist Templates".
+- **Splitting a multi-source dive** now lives only in the Data Sources card, no longer one tap from a chart marker.
+- **Localisation**: equipment types and statuses, tank roles and materials, dive modes, water types, visibility, altitude, site difficulty, profile event markers and certification levels render in your language instead of English, as do the trip type and the dive editor's water type and dive mode labels. French gains its missing diacritics across about 1,400 strings, and "Prête" for a loaned item (which meant "ready") becomes "Prêté".
+- **libdivecomputer is synced with upstream**: Mares average depth, Divesystem DSX dive time from the footer, an OSTC3 header check fix, and the iDive surface timeout excluded from dive time.
+
+---
+
+## 🐞 Bug fixes
+
+**Sync, backup and cloud storage**
+
+- A gear link dropped by any bug was gone for good, because the gear junction tables carried no clock and a stale tombstone from another device always won. They have one now, so the next sync heals a lost link. Dive-plan gear had never synced at all; it does now.
+- A species tag added to a photo on one device never reached the others (untagging did), because the tag rode the photo's clock and tagging does not edit the photo. Tags get their own clock, and tags already on disk are published at the next sync.
+- Repair Sync and Reset Sync State deleted the retired identity's cloud files even when they were the only copy of the library, contradicting the dialog's promise that your data was safe. They are kept whenever no other device publishes the library.
+- A new dive's tanks, weights and custom fields only reached other devices on a full export, never incrementally.
+- Every save of a dive published a deletion for each of its weights and custom fields and then re-inserted them, so whichever a peer applied last decided whether the row lived. Saves now write only what changed.
+- Android users who installed the APK from GitHub Releases saw "Google Sign-In was cancelled ... Account reauth failed" on every Google Drive connection while Play installs worked, because that APK's signing certificate was not registered with Google. The release now verifies the signer, and a refusal by Play services is no longer reported as a cancellation.
+
+**Dive computers and imports**
+
+- A long Bluetooth download stopped when the phone's screen locked and skipped the remaining dives. The screen now stays awake for the length of the download, PIN prompt included.
+- Computers that log depth more often than temperature (the Suunto Nautic at 10 Hz against 0.8 Hz) produced a temperature trace that was mostly gaps. The last reading now carries forward. See the upgrade notes for re-parsing.
+- Two computers paired to the same transmitter drew one pressure line that alternated between them every sample, a fuzzy band where they disagreed and an invisible second computer where they agreed. The chart now draws the active source's own series.
+- MacDive's surface interval is minutes, not seconds, so a 2 h 18 min interval imported as 2 min and "no prior dive" imported as 0 min. Future imports are correct; see the upgrade notes.
+- Bottom time could exceed the dive's own duration on a very shallow dive whose computer kept logging after the surface (a 13-second dive with a 368-second bottom time). It is now capped at the dive's total time.
+
+**Dive log and charts**
+
+- Gear could go missing from dives, notably BCDs and DSMBs. A dive save was not atomic, so a failure partway through left the dive holding a prefix of its gear; file imports overwrote the gear the defaulter had just applied; and the delete-duplicate repair could delete the copy that carried your gear. All three are closed, and gear links can now heal through sync (above).
+- Saving an edit left the dive list spinning forever and lost your place, because the refresh fetched one page whatever had been loaded. The list keeps every loaded page and its scroll position.
+- A filter naming a dive computer you had since deleted emptied the dive log with no explanation.
+- Tank MOD on the cylinders card and in the tank editor ignored the configured working ppO2, and the label said "1.4" whatever you had set.
+- After a bulk action, some surfaces returned you to the normal list and others left you in multi-select. Every action now leaves selection mode on completion and keeps the selection when you cancel or it fails.
+- A buddy whose primary certification was filed under Other showed "Other · Other" in the buddy list and pickers instead of the name on the card.
+
+**Interface and platforms**
+
+- Creating a checklist appeared to offer no way to save it on the Tropical and Console themes, because the app bar's Save text was painted in the app bar's own colour. Sixteen app bar actions had the same defect and all are fixed, with a guard that stops it coming back.
+- The startup splash carried no theme, so the "Your Data Is Newer Than This App" screen painted white text on a near-white card in dark mode and its restore offer was unreadable.
+- Scanned logbook pages were filed in a `scanned_logs` folder among your personal documents on Windows and Linux. They now live under the Submersion folder, and existing pages are moved on first launch.
+- The trip checklist template item dialog stacked its fields with no gap and titled itself "Add item" while editing; the edit page said "Templates" while editing one template.
+- A site geocoded on mainland France read "Metropolitan France, France". Country-restating pseudo-regions are dropped from new geocodes; stored values are left as they are.
+- The trip type selector and the water type and dive mode dropdowns in the dive editor showed English in every language.
+
+---
+
+## ⚠️ Upgrade notes
+
+- **The database upgrades from schema 191 to 207.** The migration runs once on first launch and the app takes an automatic backup beforehand, so there is nothing you need to do first. Older devices in your sync library are not held from syncing this time, but transmitters, weight presets, assemblies and the new gear-link clocks only reach a device once it updates, so update every device in your library reasonably soon.
+- **Re-parse your dives once after updating.** The temperature carry-forward, the transmitter serial on each tank and the bottom-time cap apply only to new downloads. Open each dive computer's page and run "Re-parse all dives" to rebuild existing dives from their stored raw data. Then assign your transmitters; each assignment offers to apply itself to the dives already logged.
+- **Run the data quality rescan when the "new checks available" banner appears.** The duplicate, gas MOD and tank assignment checks were revised. Until the rescan runs, existing duplicate findings show no Delete duplicate button, by design, since that repair deletes a dive.
+- **MacDive surface intervals imported before this release** are sixty times too small and are not repaired automatically, because nothing distinguishes them from correct values written by another importer. Re-import from MacDive, or correct them by hand.
+- **Gear on a dive now has a defined order**: grouped by type, types alphabetical, items A to Z. Change it from the arrange action on any gear surface or under Settings > Appearance. UDDF, CSV and Excel exports use a fixed order and ignore the display preference.
+- **The home tab's default card order changed** to seat the new pairing. A card order you set yourself is kept.
+- **Renames**: "Checklist Templates" under Settings > Manage is now "Trip Checklist Templates", and the home card setting "Pre-dive" is now "Checklists".
+- **The cloud import page size setting is gone**; imports fetch 15 dives at a time with Load More and Fetch All.
+- **Computed events are hidden by default** on dives whose computer reported its own events. The "Computed events" legend toggle brings them back for the session.
+- **Clock sync is off by default** and every setting for it is local to the device, so a phone with automatic time can sync your computer's clock while a laptop with a hand-set timezone does not.
+- **Weight values now show three decimals** where they have them; a weight already rounded to a tenth by an earlier save stays as saved.
+- **No minimum operating system change** on macOS, Windows, iOS, Android or Linux.
+
+---
+
+## 🙏 Contributors
+
+Thank you to everyone whose work is in this release. A first-time contributor, @urbamax, wrote 23 of its changes: the FFESSM agency and its 47 levels, multi-agency certification cards and the picker that shows them, FFESSM as a dive center affiliation, the "Sold" status, weight presets and their editor, the configurable ppO2 limits and the MOD fix, the "Computed events" toggle, the temperature carry-forward in libdivecomputer, the 0.1 kg weight fix, the buddy list certification name, the screen staying awake during downloads, the full Suunto Cloud event set, the geocoding pseudo-region fix, the localised enum, trip type and dive editor labels, and the French diacritics. @dotanalon contributed the planner's water type and salinity and the shared cloud import fetch flow. @alpheios-one contributed the Swiss lake bathymetry. And @ericgriffin.
+
+---
+
+## ⬇️ Download
+
+- **Website:** [submersion.app](https://submersion.app)
+- **All platforms, release page:** [v1.7.8.8156 on GitHub](https://github.com/submersion-app/submersion/releases/tag/v1.7.8.8156)
+- **macOS:** [Submersion-v1.7.8.8156-macOS.dmg](https://github.com/submersion-app/submersion/releases/download/v1.7.8.8156/Submersion-v1.7.8.8156-macOS.dmg)
+- **Windows:** [Submersion-v1.7.8.8156-Windows-Setup.exe](https://github.com/submersion-app/submersion/releases/download/v1.7.8.8156/Submersion-v1.7.8.8156-Windows-Setup.exe)
+- **Linux:** [.deb](https://github.com/submersion-app/submersion/releases/download/v1.7.8.8156/Submersion-v1.7.8.8156-Linux-amd64.deb) for Debian and Ubuntu, [.rpm](https://github.com/submersion-app/submersion/releases/download/v1.7.8.8156/Submersion-v1.7.8.8156-Linux-x86_64.rpm) for Fedora, openSUSE and RHEL, or the [tarball](https://github.com/submersion-app/submersion/releases/download/v1.7.8.8156/Submersion-v1.7.8.8156-Linux.tar.gz) for everything else
+- **Android:** [Submersion-v1.7.8.8156-Android.apk](https://github.com/submersion-app/submersion/releases/download/v1.7.8.8156/Submersion-v1.7.8.8156-Android.apk)


### PR DESCRIPTION
## Summary

Adds the v1.7.8.8156 release announcement to `docs/releases/`, in the same ScubaBoard format as the v1.7.7.8077 notes.

Scope is everything merged to `main` since the v1.7.7.8077 tag, resolved by merge-commit ancestry: 75 PRs plus three direct commits. The ten PRs that merged on the tag's UTC day but before the tag itself are already covered by the v1.7.7 notes and are excluded. Schema 191 to 207; the sync compatibility floor is unchanged, which the upgrade notes reflect.

Headline sections cover equipment assemblies, the transmitter registry, exposure-based service clocks, collapsible trip groups, type-to-search filters, FFESSM and multi-agency certification cards, Swiss lake bathymetry, weight presets, configurable ppO2 limits, dive computer clock sync, the O2 cell linearity check, localised decimal separators, and the Data Quality duplicate repairs. Bug fixes are grouped by area as one-line, symptom-first bullets.

Contributors were cross-checked against the PR authors rather than taken from the generated changelog alone: @urbamax is confirmed as a first-time contributor (no merged PRs before the tag), with @dotanalon and @alpheios-one returning.

## Test Plan

- [x] Scanned for em-dashes, en-dashes and spaced hyphens: none
- [x] Version is the 4-segment form in the filename, header and every download link
- [x] Docs only, no code change