### PR TITLE
fix(dive-log): bulk Use Set keeps the set's items, and the confirmation names every change (#1754)

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -86,6 +86,7 @@ import 'package:submersion/features/weight_presets/presentation/providers/weight
 import 'package:submersion/features/weight_presets/presentation/widgets/name_prompt_dialog.dart';
 import 'package:submersion/features/weight_presets/presentation/widgets/weight_preset_picker_sheet.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/edit_sighting_sheet.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/bulk_change_summary.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/bulk_membership_editor.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/equipment_picker_sheet.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/equipment_set_picker_sheet.dart';
@@ -1011,6 +1012,11 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
   List<BulkMembershipItem> _equipmentMembers = [];
   MembershipDelta _equipmentDelta = MembershipDelta.empty;
 
+  /// The last "Use Set" instruction to the equipment editor: every item of the
+  /// set goes on all the selected dives (#1754). The serial makes each
+  /// application a fresh request, even for the same set.
+  ({int serial, Set<String> ids})? _equipmentEnsureOn;
+
   Map<String, int> _tagCounts = {};
   List<BulkMembershipItem> _tagMembers = [];
   MembershipDelta _tagDelta = MembershipDelta.empty;
@@ -1417,6 +1423,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
             label: Text(l10n.diveLog_edit_useSet),
           ),
           onChanged: (d) => setState(() => _equipmentDelta = d),
+          ensureOn: _equipmentEnsureOn,
           // Assembly and part-of chips, as on the equipment list (#1487).
           trailingBuilder: (item) => AssemblyChips(itemId: item.id),
         ),
@@ -1939,12 +1946,51 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         : 0;
     if (!mounted) return;
 
+    // Name every membership change up front: a stray removal otherwise lands
+    // on every selected dive with nothing but "Apply changes?" to warn (#1754).
+    final changes = summarizeBulkMembership([
+      (
+        title: l10n.diveLog_edit_section_tags,
+        delta: _tagDelta,
+        members: _tagMembers,
+      ),
+      (
+        title: l10n.diveLog_edit_label_diveTypes,
+        delta: _diveTypeDelta,
+        members: _diveTypeMembers,
+      ),
+      (
+        title: l10n.diveLog_edit_section_equipment,
+        delta: _equipmentDelta,
+        members: _equipmentMembers,
+      ),
+      (
+        title: l10n.diveLog_edit_group_buddies,
+        delta: _buddyDelta,
+        members: _buddyMembers,
+      ),
+    ]);
+
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
         title: Text(l10n.diveLog_bulkEdit_confirmTitle),
-        content: skipped > 0
-            ? Text(l10n.diveLog_bulkEdit_tankSpecsSkipped(skipped))
+        content: skipped > 0 || changes.isNotEmpty
+            ? SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (changes.isNotEmpty)
+                      BulkChangeSummary(
+                        sections: changes,
+                        totalDives: ids.length,
+                      ),
+                    if (skipped > 0)
+                      Text(l10n.diveLog_bulkEdit_tankSpecsSkipped(skipped)),
+                  ],
+                ),
+              )
             : null,
         actions: [
           TextButton(
@@ -3611,6 +3657,13 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
                       icon: equipmentTypeIcon(item.type),
                     ),
               ];
+              // Rows already listed keep whatever the user set them to, so
+              // appending alone would let an unchecked row remove a set item
+              // from every dive (#1754). Switch the whole set on.
+              _equipmentEnsureOn = (
+                serial: (_equipmentEnsureOn?.serial ?? 0) + 1,
+                ids: {for (final item in items) item.id},
+              );
             });
             Navigator.of(context).pop();
           },

--- a/lib/features/dive_log/presentation/widgets/bulk_change_summary.dart
+++ b/lib/features/dive_log/presentation/widgets/bulk_change_summary.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/features/dive_log/presentation/widgets/bulk_membership_editor.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// One bulk-editable collection as the confirmation sees it: its heading,
+/// the delta its editor reported, and the rows that name its ids.
+typedef BulkMembershipCollection = ({
+  String title,
+  MembershipDelta delta,
+  List<BulkMembershipItem> members,
+});
+
+/// What a bulk save will do to one collection, by name.
+class BulkChangeSection {
+  final String title;
+  final List<String> added;
+  final List<String> removed;
+
+  const BulkChangeSection({
+    required this.title,
+    required this.added,
+    required this.removed,
+  });
+}
+
+/// Names every membership change a bulk save is about to make, one section per
+/// collection that changes, so the confirmation can show the diver what comes
+/// off every selected dive before it happens (#1754).
+///
+/// Names are sorted case-insensitively so a long list can be scanned. An id
+/// with no listed row falls back to the id itself rather than disappearing.
+List<BulkChangeSection> summarizeBulkMembership(
+  List<BulkMembershipCollection> collections,
+) {
+  List<String> names(List<String> ids, Map<String, String> labels) =>
+      [for (final id in ids) labels[id] ?? id]
+        ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+
+  return collections.where((c) => !c.delta.isEmpty).map((c) {
+    final labels = {for (final m in c.members) m.id: m.label};
+    return BulkChangeSection(
+      title: c.title,
+      added: names(c.delta.addIds, labels),
+      removed: names(c.delta.removeIds, labels),
+    );
+  }).toList();
+}
+
+/// The body of the bulk-edit confirmation: per collection, what is being added
+/// to and removed from every selected dive. Removals use the error color.
+class BulkChangeSummary extends StatelessWidget {
+  const BulkChangeSummary({
+    super.key,
+    required this.sections,
+    required this.totalDives,
+  });
+
+  final List<BulkChangeSection> sections;
+  final int totalDives;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final section in sections) ...[
+          Text(section.title, style: theme.textTheme.titleSmall),
+          if (section.added.isNotEmpty) ...[
+            Text(
+              l10n.diveLog_bulkEdit_confirmAdding(totalDives),
+              style: theme.textTheme.labelMedium,
+            ),
+            Text(section.added.join(', ')),
+          ],
+          if (section.removed.isNotEmpty) ...[
+            Text(
+              l10n.diveLog_bulkEdit_confirmRemoving(totalDives),
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+            ),
+            Text(
+              section.removed.join(', '),
+              style: TextStyle(color: theme.colorScheme.error),
+            ),
+          ],
+          const SizedBox(height: 12),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart
+++ b/lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart
@@ -76,6 +76,7 @@ class BulkMembershipEditor extends StatefulWidget {
     this.addLabel,
     this.secondaryAction,
     this.trailingBuilder,
+    this.ensureOn,
   });
 
   final String title;
@@ -93,6 +94,14 @@ class BulkMembershipEditor extends StatefulWidget {
   /// (tags, dive types, equipment) leave it null.
   final Widget Function(BulkMembershipItem item)? trailingBuilder;
 
+  /// A one-shot instruction to put [ids] on every selected dive, whatever
+  /// their rows currently say. An update carrying the same [serial] changes
+  /// nothing, so a row the user unchecks afterwards stays unchecked; a fresh
+  /// State (a remount) starts from the defaults and applies it again.
+  /// Applying an equipment set sends one, because the set's items must end up
+  /// on all the dives, including rows the user had already unchecked (#1754).
+  final ({int serial, Set<String> ids})? ensureOn;
+
   @override
   State<BulkMembershipEditor> createState() => _BulkMembershipEditorState();
 }
@@ -106,6 +115,7 @@ class _BulkMembershipEditorState extends State<BulkMembershipEditor> {
     for (final item in widget.items) {
       _choices[item.id] = _defaultChoice(_presenceOf(item.id));
     }
+    _applyEnsureOn();
     // Emit the baseline so the parent has a delta before any interaction.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) widget.onChanged(_delta());
@@ -123,6 +133,9 @@ class _BulkMembershipEditorState extends State<BulkMembershipEditor> {
         changed = true;
       }
     }
+    if (widget.ensureOn?.serial != old.ensureOn?.serial) {
+      changed = _applyEnsureOn() || changed;
+    }
     final before = _choices.length;
     _choices.removeWhere((id, _) => !ids.contains(id));
     changed = changed || _choices.length != before;
@@ -131,6 +144,21 @@ class _BulkMembershipEditorState extends State<BulkMembershipEditor> {
         if (mounted) widget.onChanged(_delta());
       });
     }
+  }
+
+  /// Sets every listed row named by [BulkMembershipEditor.ensureOn] to
+  /// [MembershipChoice.ensureOn]. Returns whether any choice changed.
+  bool _applyEnsureOn() {
+    final request = widget.ensureOn;
+    if (request == null) return false;
+    var changed = false;
+    for (final item in widget.items) {
+      if (!request.ids.contains(item.id)) continue;
+      if (_choices[item.id] == MembershipChoice.ensureOn) continue;
+      _choices[item.id] = MembershipChoice.ensureOn;
+      changed = true;
+    }
+    return changed;
   }
 
   MembershipPresence _presenceOf(String id) {

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -311,6 +311,8 @@
   "diveLog_bulkEdit_tankOnlyIfEmpty": "الغطسات التي لا تحتوي على أسطوانة فقط",
   "diveLog_bulkEdit_confirmTitle": "تطبيق التغييرات؟",
   "diveLog_bulkEdit_confirmApply": "تطبيق",
+  "diveLog_bulkEdit_confirmAdding": "{count, plural, =1{إضافة إلى غطسة واحدة} other{إضافة إلى كل الـ {count} غطسة}}",
+  "diveLog_bulkEdit_confirmRemoving": "{count, plural, =1{إزالة من غطسة واحدة} other{إزالة من كل الـ {count} غطسة}}",
   "diveLog_bulkEdit_nothingSelected": "فعّل حقلاً واحداً على الأقل لتطبيق التغييرات.",
   "diveLog_bulkEdit_applied": "تم تحديث {count} غطسة",
   "settings_cloudSync_error_icloudSignedOut": "iCloud غير متوفر. يُرجى تسجيل الدخول إلى iCloud من إعدادات جهازك.",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -311,6 +311,8 @@
   "diveLog_bulkEdit_tankOnlyIfEmpty": "Nur Tauchgänge ohne vorhandene Flasche",
   "diveLog_bulkEdit_confirmTitle": "Änderungen anwenden?",
   "diveLog_bulkEdit_confirmApply": "Anwenden",
+  "diveLog_bulkEdit_confirmAdding": "{count, plural, =1{Wird zu 1 Tauchgang hinzugefügt} other{Wird zu allen {count} Tauchgängen hinzugefügt}}",
+  "diveLog_bulkEdit_confirmRemoving": "{count, plural, =1{Wird von 1 Tauchgang entfernt} other{Wird von allen {count} Tauchgängen entfernt}}",
   "diveLog_bulkEdit_nothingSelected": "Aktiviere mindestens ein Feld, um Änderungen anzuwenden.",
   "diveLog_bulkEdit_applied": "{count} Tauchgänge aktualisiert",
   "settings_cloudSync_error_icloudSignedOut": "iCloud ist nicht verfügbar. Bitte melde dich in den Geräteeinstellungen bei iCloud an.",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -390,6 +390,22 @@
   },
   "diveLog_bulkEdit_confirmTitle": "Apply changes?",
   "diveLog_bulkEdit_confirmApply": "Apply",
+  "diveLog_bulkEdit_confirmAdding": "{count, plural, =1{Adding to 1 dive} other{Adding to all {count} dives}}",
+  "@diveLog_bulkEdit_confirmAdding": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "diveLog_bulkEdit_confirmRemoving": "{count, plural, =1{Removing from 1 dive} other{Removing from all {count} dives}}",
+  "@diveLog_bulkEdit_confirmRemoving": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "diveLog_bulkEdit_nothingSelected": "Turn on at least one field to apply changes.",
   "diveLog_bulkEdit_applied": "Updated {count} dives",
   "@diveLog_bulkEdit_applied": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -311,6 +311,8 @@
   "diveLog_bulkEdit_tankOnlyIfEmpty": "Solo inmersiones que aún no tienen botella",
   "diveLog_bulkEdit_confirmTitle": "¿Aplicar cambios?",
   "diveLog_bulkEdit_confirmApply": "Aplicar",
+  "diveLog_bulkEdit_confirmAdding": "{count, plural, =1{Añadiendo a 1 inmersión} other{Añadiendo a todas las {count} inmersiones}}",
+  "diveLog_bulkEdit_confirmRemoving": "{count, plural, =1{Quitando de 1 inmersión} other{Quitando de todas las {count} inmersiones}}",
   "diveLog_bulkEdit_nothingSelected": "Activa al menos un campo para aplicar cambios.",
   "diveLog_bulkEdit_applied": "{count} inmersiones actualizadas",
   "settings_cloudSync_error_icloudSignedOut": "iCloud no está disponible. Inicia sesión en iCloud en los ajustes de tu dispositivo.",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -311,6 +311,8 @@
   "diveLog_bulkEdit_tankOnlyIfEmpty": "Seulement les plongées sans bloc existant",
   "diveLog_bulkEdit_confirmTitle": "Appliquer les modifications ?",
   "diveLog_bulkEdit_confirmApply": "Appliquer",
+  "diveLog_bulkEdit_confirmAdding": "{count, plural, =1{Ajout à 1 plongée} other{Ajout à toutes les {count} plongées}}",
+  "diveLog_bulkEdit_confirmRemoving": "{count, plural, =1{Retrait de 1 plongée} other{Retrait de toutes les {count} plongées}}",
   "diveLog_bulkEdit_nothingSelected": "Activez au moins un champ pour appliquer les modifications.",
   "diveLog_bulkEdit_applied": "{count} plongées mises à jour",
   "settings_cloudSync_error_icloudSignedOut": "iCloud n'est pas disponible. Connectez-vous à iCloud dans les réglages de votre appareil.",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -311,6 +311,8 @@
   "diveLog_bulkEdit_tankOnlyIfEmpty": "רק צלילות ללא מכל קיים",
   "diveLog_bulkEdit_confirmTitle": "להחיל שינויים?",
   "diveLog_bulkEdit_confirmApply": "החל",
+  "diveLog_bulkEdit_confirmAdding": "{count, plural, =1{מוסיף לצלילה אחת} other{מוסיף לכל {count} הצלילות}}",
+  "diveLog_bulkEdit_confirmRemoving": "{count, plural, =1{מסיר מצלילה אחת} other{מסיר מכל {count} הצלילות}}",
   "diveLog_bulkEdit_nothingSelected": "הפעל לפחות שדה אחד כדי להחיל שינויים.",
   "diveLog_bulkEdit_applied": "{count} צלילות עודכנו",
   "settings_cloudSync_error_icloudSignedOut": "iCloud אינו זמין. היכנס ל-iCloud דרך הגדרות המכשיר.",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -311,6 +311,8 @@
   "diveLog_bulkEdit_tankOnlyIfEmpty": "Csak a meglévő palack nélküli merülések",
   "diveLog_bulkEdit_confirmTitle": "Alkalmazza a módosításokat?",
   "diveLog_bulkEdit_confirmApply": "Alkalmaz",
+  "diveLog_bulkEdit_confirmAdding": "{count, plural, =1{Hozzáadás 1 merüléshez} other{Hozzáadás mind a {count} merüléshez}}",
+  "diveLog_bulkEdit_confirmRemoving": "{count, plural, =1{Eltávolítás 1 merülésből} other{Eltávolítás mind a {count} merülésből}}",
   "diveLog_bulkEdit_nothingSelected": "Engedélyezzen legalább egy mezőt a módosítások alkalmazásához.",
   "diveLog_bulkEdit_applied": "{count} merülés frissítve",
   "settings_cloudSync_error_icloudSignedOut": "Az iCloud nem érhető el. Jelentkezz be az iCloudba a készülék beállításaiban.",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -311,6 +311,8 @@
   "diveLog_bulkEdit_tankOnlyIfEmpty": "Solo immersioni senza bombola esistente",
   "diveLog_bulkEdit_confirmTitle": "Applicare le modifiche?",
   "diveLog_bulkEdit_confirmApply": "Applica",
+  "diveLog_bulkEdit_confirmAdding": "{count, plural, =1{Aggiunta a 1 immersione} other{Aggiunta a tutte le {count} immersioni}}",
+  "diveLog_bulkEdit_confirmRemoving": "{count, plural, =1{Rimozione da 1 immersione} other{Rimozione da tutte le {count} immersioni}}",
   "diveLog_bulkEdit_nothingSelected": "Attiva almeno un campo per applicare le modifiche.",
   "diveLog_bulkEdit_applied": "{count} immersioni aggiornate",
   "settings_cloudSync_error_icloudSignedOut": "iCloud non è disponibile. Accedi a iCloud nelle impostazioni del dispositivo.",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -991,6 +991,18 @@ abstract class AppLocalizations {
   /// **'Apply'**
   String get diveLog_bulkEdit_confirmApply;
 
+  /// No description provided for @diveLog_bulkEdit_confirmAdding.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Adding to 1 dive} other{Adding to all {count} dives}}'**
+  String diveLog_bulkEdit_confirmAdding(int count);
+
+  /// No description provided for @diveLog_bulkEdit_confirmRemoving.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Removing from 1 dive} other{Removing from all {count} dives}}'**
+  String diveLog_bulkEdit_confirmRemoving(int count);
+
   /// No description provided for @diveLog_bulkEdit_nothingSelected.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -597,6 +597,28 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveLog_bulkEdit_confirmApply => 'تطبيق';
 
   @override
+  String diveLog_bulkEdit_confirmAdding(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'إضافة إلى كل الـ $count غطسة',
+      one: 'إضافة إلى غطسة واحدة',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveLog_bulkEdit_confirmRemoving(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'إزالة من كل الـ $count غطسة',
+      one: 'إزالة من غطسة واحدة',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get diveLog_bulkEdit_nothingSelected =>
       'فعّل حقلاً واحداً على الأقل لتطبيق التغييرات.';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -599,6 +599,28 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveLog_bulkEdit_confirmApply => 'Anwenden';
 
   @override
+  String diveLog_bulkEdit_confirmAdding(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Wird zu allen $count Tauchgängen hinzugefügt',
+      one: 'Wird zu 1 Tauchgang hinzugefügt',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveLog_bulkEdit_confirmRemoving(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Wird von allen $count Tauchgängen entfernt',
+      one: 'Wird von 1 Tauchgang entfernt',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get diveLog_bulkEdit_nothingSelected =>
       'Aktiviere mindestens ein Feld, um Änderungen anzuwenden.';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -596,6 +596,28 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveLog_bulkEdit_confirmApply => 'Apply';
 
   @override
+  String diveLog_bulkEdit_confirmAdding(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Adding to all $count dives',
+      one: 'Adding to 1 dive',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveLog_bulkEdit_confirmRemoving(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Removing from all $count dives',
+      one: 'Removing from 1 dive',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get diveLog_bulkEdit_nothingSelected =>
       'Turn on at least one field to apply changes.';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -603,6 +603,28 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveLog_bulkEdit_confirmApply => 'Aplicar';
 
   @override
+  String diveLog_bulkEdit_confirmAdding(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Añadiendo a todas las $count inmersiones',
+      one: 'Añadiendo a 1 inmersión',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveLog_bulkEdit_confirmRemoving(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Quitando de todas las $count inmersiones',
+      one: 'Quitando de 1 inmersión',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get diveLog_bulkEdit_nothingSelected =>
       'Activa al menos un campo para aplicar cambios.';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -604,6 +604,28 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveLog_bulkEdit_confirmApply => 'Appliquer';
 
   @override
+  String diveLog_bulkEdit_confirmAdding(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Ajout à toutes les $count plongées',
+      one: 'Ajout à 1 plongée',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveLog_bulkEdit_confirmRemoving(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Retrait de toutes les $count plongées',
+      one: 'Retrait de 1 plongée',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get diveLog_bulkEdit_nothingSelected =>
       'Activez au moins un champ pour appliquer les modifications.';
 

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -593,6 +593,28 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveLog_bulkEdit_confirmApply => 'החל';
 
   @override
+  String diveLog_bulkEdit_confirmAdding(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'מוסיף לכל $count הצלילות',
+      one: 'מוסיף לצלילה אחת',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveLog_bulkEdit_confirmRemoving(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'מסיר מכל $count הצלילות',
+      one: 'מסיר מצלילה אחת',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get diveLog_bulkEdit_nothingSelected =>
       'הפעל לפחות שדה אחד כדי להחיל שינויים.';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -600,6 +600,28 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveLog_bulkEdit_confirmApply => 'Alkalmaz';
 
   @override
+  String diveLog_bulkEdit_confirmAdding(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Hozzáadás mind a $count merüléshez',
+      one: 'Hozzáadás 1 merüléshez',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveLog_bulkEdit_confirmRemoving(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Eltávolítás mind a $count merülésből',
+      one: 'Eltávolítás 1 merülésből',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get diveLog_bulkEdit_nothingSelected =>
       'Engedélyezzen legalább egy mezőt a módosítások alkalmazásához.';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -604,6 +604,28 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveLog_bulkEdit_confirmApply => 'Applica';
 
   @override
+  String diveLog_bulkEdit_confirmAdding(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Aggiunta a tutte le $count immersioni',
+      one: 'Aggiunta a 1 immersione',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveLog_bulkEdit_confirmRemoving(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rimozione da tutte le $count immersioni',
+      one: 'Rimozione da 1 immersione',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get diveLog_bulkEdit_nothingSelected =>
       'Attiva almeno un campo per applicare le modifiche.';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -598,6 +598,28 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveLog_bulkEdit_confirmApply => 'Toepassen';
 
   @override
+  String diveLog_bulkEdit_confirmAdding(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Toevoegen aan alle $count duiken',
+      one: 'Toevoegen aan 1 duik',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveLog_bulkEdit_confirmRemoving(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Verwijderen van alle $count duiken',
+      one: 'Verwijderen van 1 duik',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get diveLog_bulkEdit_nothingSelected =>
       'Schakel minstens één veld in om wijzigingen toe te passen.';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -602,6 +602,28 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveLog_bulkEdit_confirmApply => 'Aplicar';
 
   @override
+  String diveLog_bulkEdit_confirmAdding(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Adicionando a todos os $count mergulhos',
+      one: 'Adicionando a 1 mergulho',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveLog_bulkEdit_confirmRemoving(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Removendo de todos os $count mergulhos',
+      one: 'Removendo de 1 mergulho',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get diveLog_bulkEdit_nothingSelected =>
       'Ative pelo menos um campo para aplicar alterações.';
 

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -577,6 +577,28 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveLog_bulkEdit_confirmApply => '应用';
 
   @override
+  String diveLog_bulkEdit_confirmAdding(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '添加到全部 $count 次潜水',
+      one: '添加到 1 次潜水',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveLog_bulkEdit_confirmRemoving(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '从全部 $count 次潜水移除',
+      one: '从 1 次潜水移除',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get diveLog_bulkEdit_nothingSelected => '至少启用一个字段以应用更改。';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -311,6 +311,8 @@
   "diveLog_bulkEdit_tankOnlyIfEmpty": "Alleen duiken zonder bestaande fles",
   "diveLog_bulkEdit_confirmTitle": "Wijzigingen toepassen?",
   "diveLog_bulkEdit_confirmApply": "Toepassen",
+  "diveLog_bulkEdit_confirmAdding": "{count, plural, =1{Toevoegen aan 1 duik} other{Toevoegen aan alle {count} duiken}}",
+  "diveLog_bulkEdit_confirmRemoving": "{count, plural, =1{Verwijderen van 1 duik} other{Verwijderen van alle {count} duiken}}",
   "diveLog_bulkEdit_nothingSelected": "Schakel minstens één veld in om wijzigingen toe te passen.",
   "diveLog_bulkEdit_applied": "{count} duiken bijgewerkt",
   "settings_cloudSync_error_icloudSignedOut": "iCloud is niet beschikbaar. Log in bij iCloud in de instellingen van je apparaat.",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -311,6 +311,8 @@
   "diveLog_bulkEdit_tankOnlyIfEmpty": "Apenas mergulhos sem cilindro existente",
   "diveLog_bulkEdit_confirmTitle": "Aplicar alterações?",
   "diveLog_bulkEdit_confirmApply": "Aplicar",
+  "diveLog_bulkEdit_confirmAdding": "{count, plural, =1{Adicionando a 1 mergulho} other{Adicionando a todos os {count} mergulhos}}",
+  "diveLog_bulkEdit_confirmRemoving": "{count, plural, =1{Removendo de 1 mergulho} other{Removendo de todos os {count} mergulhos}}",
   "diveLog_bulkEdit_nothingSelected": "Ative pelo menos um campo para aplicar alterações.",
   "diveLog_bulkEdit_applied": "{count} mergulhos atualizados",
   "settings_cloudSync_error_icloudSignedOut": "O iCloud não está disponível. Inicie sessão no iCloud nas definições do seu dispositivo.",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -311,6 +311,8 @@
   "diveLog_bulkEdit_tankOnlyIfEmpty": "仅没有气瓶的潜水",
   "diveLog_bulkEdit_confirmTitle": "应用更改？",
   "diveLog_bulkEdit_confirmApply": "应用",
+  "diveLog_bulkEdit_confirmAdding": "{count, plural, =1{添加到 1 次潜水} other{添加到全部 {count} 次潜水}}",
+  "diveLog_bulkEdit_confirmRemoving": "{count, plural, =1{从 1 次潜水移除} other{从全部 {count} 次潜水移除}}",
   "diveLog_bulkEdit_nothingSelected": "至少启用一个字段以应用更改。",
   "diveLog_bulkEdit_applied": "已更新 {count} 次潜水",
   "settings_cloudSync_error_icloudSignedOut": "iCloud 不可用。请在设备设置中登录 iCloud。",

--- a/test/features/dive_log/presentation/pages/bulk_membership_wiring_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_membership_wiring_test.dart
@@ -2,7 +2,8 @@ import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
-import 'package:submersion/core/database/database.dart' hide Buddy, Dive;
+import 'package:submersion/core/database/database.dart'
+    hide Buddy, Dive, EquipmentSet;
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/buddies/presentation/widgets/buddy_picker.dart';
@@ -16,6 +17,8 @@ import 'package:submersion/features/dive_log/presentation/widgets/pickers/equipm
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/equipment_set_picker_sheet.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_set.dart';
+import 'package:submersion/features/equipment/presentation/providers/equipment_set_providers.dart';
 import 'package:submersion/features/tags/presentation/widgets/tag_picker_sheet.dart';
 import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
 
@@ -95,7 +98,11 @@ void main() {
     /// are the same object, so a sheet pushed onto the wrong navigator still
     /// lands on top and the test sees nothing wrong; under the app's real
     /// `ShellRoute` it opens *behind* the dialog instead (#1366).
-    Future<void> pump(WidgetTester tester, List<String> ids) async {
+    Future<void> pump(
+      WidgetTester tester,
+      List<String> ids, {
+      List<EquipmentSet> sets = const [],
+    }) async {
       final overrides = await getBaseOverrides();
       await tester.pumpWidget(
         testAppInShell(
@@ -109,6 +116,12 @@ void main() {
               (ref) => DiveListNotifier(repository, ref),
             ),
             customTankPresetsProvider.overrideWith((ref) async => []),
+            if (sets.isNotEmpty) ...[
+              equipmentSetsProvider.overrideWith((ref) async => sets),
+              equipmentSetWithItemsProvider.overrideWith(
+                (ref, id) async => sets.firstWhere((s) => s.id == id),
+              ),
+            ],
           ],
           child: DiveEditPage(bulkDiveIds: ids, embedded: true),
         ),
@@ -461,6 +474,128 @@ void main() {
       await tester.tap(useSet);
       await tester.pumpAndSettle();
       expect(find.byType(EquipmentSetPickerSheet), findsOneWidget);
+    });
+
+    // Issue #1754 (found in #1720): clearing the old gear and then applying a
+    // set must keep every set item, including the ones already on the dives.
+    testWidgets('use-set keeps set items the diver had unchecked', (
+      tester,
+    ) async {
+      const wing = EquipmentItem(
+        id: 'e1',
+        name: 'Wing',
+        type: EquipmentType.bcd,
+      );
+      const dsmb = EquipmentItem(
+        id: 'e2',
+        name: 'DSMB',
+        type: EquipmentType.smb,
+      );
+      const camera = EquipmentItem(
+        id: 'e3',
+        name: 'Camera',
+        type: EquipmentType.camera,
+      );
+      const knife = EquipmentItem(
+        id: 'e4',
+        name: 'Knife',
+        type: EquipmentType.knife,
+      );
+      for (final item in [wing, dsmb, camera, knife]) {
+        await EquipmentRepository().createEquipment(item);
+      }
+      await seedDive('d1');
+      await seedDive('d2');
+      await repository.bulkAddEquipment(['d1', 'd2'], ['e1', 'e2', 'e3']);
+      final tripKit = EquipmentSet(
+        id: 's1',
+        name: 'Trip kit',
+        equipmentIds: const ['e1', 'e2', 'e4'],
+        items: const [wing, dsmb, knife],
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+      );
+
+      await pump(tester, ['d1', 'd2'], sets: [tripKit]);
+
+      // Clear the old gear, then apply the set.
+      for (final id in ['e1', 'e2', 'e3']) {
+        final f = find.byKey(ValueKey('membership-toggle-$id'));
+        await tester.ensureVisible(f);
+        await tester.tap(f);
+        await tester.pumpAndSettle();
+      }
+      final useSet = find.descendant(
+        of: editorFor('Equipment'),
+        matching: find.widgetWithText(TextButton, 'Use Set'),
+      );
+      await tester.ensureVisible(useSet);
+      await tester.tap(useSet);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Trip kit'));
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      for (final diveId in ['d1', 'd2']) {
+        final rows = await (db.select(
+          db.diveEquipment,
+        )..where((t) => t.diveId.equals(diveId))).get();
+        expect(rows.map((r) => r.equipmentId).toSet(), {
+          'e1',
+          'e2',
+          'e4',
+        }, reason: 'dive $diveId keeps the set and drops only the camera');
+      }
+    });
+
+    // Issue #1754: the confirmation must say what the save is about to change,
+    // so a stray removal is caught before it lands on every dive.
+    testWidgets('the confirmation names what the save adds and removes', (
+      tester,
+    ) async {
+      await seedTag('t1', 'Nitrox');
+      await EquipmentRepository().createEquipment(
+        const EquipmentItem(
+          id: 'e3',
+          name: 'Camera',
+          type: EquipmentType.camera,
+        ),
+      );
+      await EquipmentRepository().createEquipment(
+        const EquipmentItem(id: 'e5', name: 'Fins', type: EquipmentType.fins),
+      );
+      await seedDive('d1');
+      await seedDive('d2');
+      await repository.bulkAddTags(['d1', 'd2'], ['t1']);
+      await repository.bulkAddEquipment(['d1', 'd2'], ['e3']);
+      await repository.bulkAddEquipment(['d1'], ['e5']);
+
+      await pump(tester, ['d1', 'd2']);
+
+      // Remove the tag and the camera from both dives; put the fins on both.
+      for (final id in ['t1', 'e3', 'e5']) {
+        final f = find.byKey(ValueKey('membership-toggle-$id'));
+        await tester.ensureVisible(f);
+        await tester.tap(f);
+        await tester.pumpAndSettle();
+      }
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      final dialog = find.byType(AlertDialog);
+      Finder inDialog(String text) =>
+          find.descendant(of: dialog, matching: find.text(text));
+      expect(inDialog('Adding to all 2 dives'), findsOneWidget);
+      expect(inDialog('Fins'), findsOneWidget);
+      expect(inDialog('Removing from all 2 dives'), findsNWidgets(2));
+      expect(inDialog('Nitrox'), findsOneWidget);
+      expect(inDialog('Camera'), findsOneWidget);
     });
 
     testWidgets('the bulk tag dialog can browse previously used tags', (

--- a/test/features/dive_log/presentation/widgets/bulk_change_summary_test.dart
+++ b/test/features/dive_log/presentation/widgets/bulk_change_summary_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/bulk_change_summary.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/bulk_membership_editor.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  const equipment = [
+    BulkMembershipItem(id: 'e1', label: 'Wing'),
+    BulkMembershipItem(id: 'e2', label: 'DSMB'),
+    BulkMembershipItem(id: 'e3', label: 'camera'),
+    BulkMembershipItem(id: 'e4', label: 'Knife'),
+  ];
+  const tags = [BulkMembershipItem(id: 't1', label: 'Nitrox')];
+
+  group('summarizeBulkMembership', () {
+    test('names the adds and removes of each changed collection', () {
+      final sections = summarizeBulkMembership([
+        (
+          title: 'Tags',
+          delta: const MembershipDelta([], ['t1']),
+          members: tags,
+        ),
+        (
+          title: 'Equipment',
+          delta: const MembershipDelta(['e4'], ['e2', 'e3', 'e1']),
+          members: equipment,
+        ),
+      ]);
+
+      expect(sections.map((s) => s.title), ['Tags', 'Equipment']);
+      expect(sections[0].added, isEmpty);
+      expect(sections[0].removed, ['Nitrox']);
+      expect(sections[1].added, ['Knife']);
+      // Sorted case-insensitively, so the diver can scan for a name.
+      expect(sections[1].removed, ['camera', 'DSMB', 'Wing']);
+    });
+
+    test('leaves out a collection with no change', () {
+      final sections = summarizeBulkMembership([
+        (title: 'Tags', delta: MembershipDelta.empty, members: tags),
+        (
+          title: 'Equipment',
+          delta: const MembershipDelta(['e4'], []),
+          members: equipment,
+        ),
+      ]);
+
+      expect(sections.map((s) => s.title), ['Equipment']);
+    });
+
+    test('falls back to the id for an item with no listed row', () {
+      final sections = summarizeBulkMembership([
+        (
+          title: 'Equipment',
+          delta: const MembershipDelta(['gone'], []),
+          members: equipment,
+        ),
+      ]);
+
+      expect(sections.single.added, ['gone']);
+    });
+  });
+
+  group('BulkChangeSummary', () {
+    Future<void> pumpSummary(
+      WidgetTester tester,
+      List<BulkChangeSection> sections,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: BulkChangeSummary(sections: sections, totalDives: 19),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('shows what is added to and removed from every dive', (
+      tester,
+    ) async {
+      await pumpSummary(tester, const [
+        BulkChangeSection(
+          title: 'Equipment',
+          added: ['Knife'],
+          removed: ['DSMB', 'Wing'],
+        ),
+      ]);
+
+      expect(find.text('Equipment'), findsOneWidget);
+      expect(find.text('Adding to all 19 dives'), findsOneWidget);
+      expect(find.text('Knife'), findsOneWidget);
+      expect(find.text('Removing from all 19 dives'), findsOneWidget);
+      expect(find.text('DSMB, Wing'), findsOneWidget);
+    });
+
+    testWidgets('omits the heading of an empty side', (tester) async {
+      await pumpSummary(tester, const [
+        BulkChangeSection(title: 'Tags', added: [], removed: ['Nitrox']),
+      ]);
+
+      expect(find.text('Adding to all 19 dives'), findsNothing);
+      expect(find.text('Removing from all 19 dives'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/dive_log/presentation/widgets/bulk_membership_editor_test.dart
+++ b/test/features/dive_log/presentation/widgets/bulk_membership_editor_test.dart
@@ -19,6 +19,9 @@ void main() {
   }) async {
     await tester.pumpWidget(
       MaterialApp(
+        // Every assertion matches an English label, so pin the locale instead
+        // of inheriting the ambient platform one.
+        locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(

--- a/test/features/dive_log/presentation/widgets/bulk_membership_editor_test.dart
+++ b/test/features/dive_log/presentation/widgets/bulk_membership_editor_test.dart
@@ -15,6 +15,7 @@ void main() {
   Future<void> pumpEditor(
     WidgetTester tester, {
     void Function(MembershipDelta)? onChanged,
+    ({int serial, Set<String> ids})? ensureOn,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -28,6 +29,7 @@ void main() {
             counts: counts,
             onAdd: () {},
             onChanged: onChanged ?? (_) {},
+            ensureOn: ensureOn,
           ),
         ),
       ),
@@ -102,4 +104,68 @@ void main() {
       expect(last!.removeIds, isNot(contains('c')));
     },
   );
+
+  // Issue #1754: applying an equipment set must put every item in the set on
+  // all the selected dives, including rows that are already listed.
+  group('ensureOn request', () {
+    testWidgets('turns an unchecked on-all row back on', (tester) async {
+      MembershipDelta? last;
+      await pumpEditor(tester, onChanged: (d) => last = d);
+      await tester.tap(find.byKey(const ValueKey('membership-toggle-a')));
+      await tester.pump();
+      expect(last!.removeIds, contains('a'));
+
+      await pumpEditor(
+        tester,
+        onChanged: (d) => last = d,
+        ensureOn: (serial: 1, ids: {'a'}),
+      );
+      expect(last!.removeIds, isNot(contains('a')));
+      expect(find.text('removing from all'), findsNothing);
+      expect(find.text('on all 3'), findsOneWidget);
+    });
+
+    testWidgets('puts an on-some row on every dive', (tester) async {
+      MembershipDelta? last;
+      await pumpEditor(
+        tester,
+        onChanged: (d) => last = d,
+        ensureOn: (serial: 1, ids: {'b'}),
+      );
+      expect(last!.addIds, contains('b'));
+      expect(find.text('on 2 of 3'), findsNothing);
+    });
+
+    testWidgets('a rebuild with the same serial keeps a later uncheck', (
+      tester,
+    ) async {
+      MembershipDelta? last;
+      const request = (serial: 1, ids: {'a'});
+      await pumpEditor(tester, onChanged: (d) => last = d, ensureOn: request);
+      await tester.tap(find.byKey(const ValueKey('membership-toggle-a')));
+      await tester.pump();
+      expect(last!.removeIds, contains('a'));
+
+      await pumpEditor(tester, onChanged: (d) => last = d, ensureOn: request);
+      expect(last!.removeIds, contains('a'));
+    });
+
+    testWidgets('a new serial applies again after an uncheck', (tester) async {
+      MembershipDelta? last;
+      await pumpEditor(
+        tester,
+        onChanged: (d) => last = d,
+        ensureOn: (serial: 1, ids: {'a'}),
+      );
+      await tester.tap(find.byKey(const ValueKey('membership-toggle-a')));
+      await tester.pump();
+
+      await pumpEditor(
+        tester,
+        onChanged: (d) => last = d,
+        ensureOn: (serial: 2, ids: {'a'}),
+      );
+      expect(last!.removeIds, isNot(contains('a')));
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Closes #1754. Found while tracing #1720, where it removed a primary DSMB, BCD parts and a dive computer from 27 dives.

In bulk dive edit, **Use Set** only appended the set items that were not already rows in the equipment section. A row that was already listed kept whatever the diver had set it to. So a diver who unchecked their old gear and then applied a set lost every set item that had been part of that gear: those rows stayed "removing from all", and the save took them off every selected dive. The confirmation said only "Apply changes?", so nothing warned them.

This PR makes Use Set switch on every item in the set, and makes the confirmation list every membership change before it applies.

## Changes

- `BulkMembershipEditor` takes an optional one-shot `ensureOn` request. It switches the named rows on whatever their current state, and applies once per `serial`, so a row the diver unchecks afterwards stays unchecked.
- `_bulkUseEquipmentSet` sends that request with every item in the set. The whole set now reaches all the selected dives, including rows that were unchecked or on only some of them.
- New `summarizeBulkMembership` and `BulkChangeSummary` (`bulk_change_summary.dart`). The confirmation now names what is being added to and removed from all N dives, for tags, dive types, equipment and buddies. Removals are shown in the error color. The summary is built from the same deltas the save turns into operations.
- Two new plural strings in all eleven locales. The generated l10n is committed.

## Test Plan

- [x] `flutter test` passes (full suite: 26,668 passed, 21 skipped)
- [x] `flutter analyze` passes
- [x] Manual testing on: not run. The #1720 scenario is reproduced as a widget test against a real database: clear the old gear, apply a set that overlaps it, then save. That test failed on `main`, leaving only `{e4}` instead of `{e1, e2, e4}`, and passes now.

New and changed tests:

- `bulk_membership_editor_test.dart`
  - an `ensureOn` request turns an unchecked "on all" row back on
  - it puts an "on some" row on every dive
  - a rebuild with the same serial keeps a later uncheck (mutation-checked: re-applying on every rebuild fails this test)
  - a new serial applies again
- `bulk_membership_wiring_test.dart`
  - the #1720 reproduction above
  - the confirmation names the added and removed items
- `bulk_change_summary_test.dart`
  - the pure builder: case-insensitive sorting, unchanged collections left out, id fallback
  - the widget: headings, and no heading for an empty side
