### PR TITLE
docs(releases): add v1.7.9.8162 release notes

### DIFF
--- a/docs/releases/v1.7.9.8162.md
+++ b/docs/releases/v1.7.9.8162.md
@@ -1,0 +1,38 @@
+# 🎉 Submersion v1.7.9.8162 Release Notes
+
+v1.7.9 is a small follow-up to v1.7.8 with one fix that matters if you edit gear on many dives at once: applying an equipment set in bulk edit no longer removes gear from the selected dives. There is no database change in this release.
+
+---
+
+## 🐞 Bug fixes
+
+### Use Set in bulk edit keeps every item in the set
+
+Selecting several dives, opening bulk edit, unchecking the gear already on them and then choosing **Use Set** could strip gear from every selected dive instead of replacing it. Use Set only added the set items that were not already listed in the equipment section, so any set item that had been part of the old gear kept its "removing from all dives" state and came off on save. The confirmation said only "Apply changes?", with no hint of what was about to happen.
+
+Use Set now switches on every item in the set, whatever state its row was in, and an item you uncheck afterwards stays unchecked. The confirmation lists what is being added to and removed from all of the selected dives, for equipment, buddies, tags and dive types, with removals shown in red, so a bulk save never removes anything you did not ask it to.
+
+---
+
+## ⚠️ Upgrade notes
+
+- **No database change**: the schema stays at 207, so nothing runs on first launch and every device in your sync library can update in any order.
+- **Gear already removed by an earlier bulk Use Set is not put back automatically.** Select the affected dives, open bulk edit and apply the set again; the new confirmation shows exactly what will be added before you save.
+- **No minimum operating system change** on macOS, Windows, iOS, Android or Linux.
+
+---
+
+## 🙏 Contributors
+
+Thank you to @ogbillavista, whose report of gear vanishing after a bulk edit led straight to this bug. The fix is by @ericgriffin.
+
+---
+
+## ⬇️ Download
+
+- **Website:** [submersion.app](https://submersion.app)
+- **All platforms, release page:** [v1.7.9.8162 on GitHub](https://github.com/submersion-app/submersion/releases/tag/v1.7.9.8162)
+- **macOS:** [Submersion-v1.7.9.8162-macOS.dmg](https://github.com/submersion-app/submersion/releases/download/v1.7.9.8162/Submersion-v1.7.9.8162-macOS.dmg)
+- **Windows:** [Submersion-v1.7.9.8162-Windows-Setup.exe](https://github.com/submersion-app/submersion/releases/download/v1.7.9.8162/Submersion-v1.7.9.8162-Windows-Setup.exe)
+- **Linux:** [.deb](https://github.com/submersion-app/submersion/releases/download/v1.7.9.8162/Submersion-v1.7.9.8162-Linux-amd64.deb) for Debian and Ubuntu, [.rpm](https://github.com/submersion-app/submersion/releases/download/v1.7.9.8162/Submersion-v1.7.9.8162-Linux-x86_64.rpm) for Fedora, openSUSE and RHEL, or the [tarball](https://github.com/submersion-app/submersion/releases/download/v1.7.9.8162/Submersion-v1.7.9.8162-Linux.tar.gz) for everything else
+- **Android:** [Submersion-v1.7.9.8162-Android.apk](https://github.com/submersion-app/submersion/releases/download/v1.7.9.8162/Submersion-v1.7.9.8162-Android.apk)


### PR DESCRIPTION
## Summary

Adds the ScubaBoard-format release announcement for v1.7.9.8162 at `docs/releases/v1.7.9.8162.md`, following the same structure as the v1.7.8.8156 notes.

The release spans one user-facing change since the v1.7.8.8156 tag, the bulk edit Use Set fix from #1755, so the notes carry a single headline fix. The CI timeout change (#1748) and the test change (#1743) are omitted as not customer-facing.

## Contents

- Intro stating the release's purpose and that there is no database change (schema stays at 207 on both tags)
- Bug fixes: Use Set in bulk edit keeps every item in the set, and the confirmation names each addition and removal
- Upgrade notes: no schema change, how to put back gear removed by an earlier bulk Use Set, no minimum OS change
- Contributors: thanks the reporter of #1720
- Download links, verified against the asset names on the published GitHub release

## Test Plan

- [x] `flutter test`: not applicable, docs only
- [x] `flutter analyze`: not applicable, docs only
- [x] Every download link matches an asset name on the v1.7.9.8162 release