### PR TITLE
fix(dive-log): stop the dive header map blinking on every selection

### DIFF
--- a/lib/features/dashboard/presentation/widgets/recent_sites_map_card.dart
+++ b/lib/features/dashboard/presentation/widgets/recent_sites_map_card.dart
@@ -88,11 +88,9 @@ class _RecentSitesMapCardState extends ConsumerState<RecentSitesMapCard> {
                         urlTemplate: ref.watch(mapTileUrlProvider),
                         userAgentPackageName: 'app.submersion',
                         maxZoom: ref.watch(mapTileMaxZoomProvider),
-                        tileProvider: TileCacheService.instance.isInitialized
-                            ? TileCacheService.instance.getTileProvider(
-                                urlTemplate: ref.watch(mapTileUrlProvider),
-                              )
-                            : null,
+                        tileProvider: TileCacheService.instance.tileProviderFor(
+                          urlTemplate: ref.watch(mapTileUrlProvider),
+                        ),
                       ),
                       MarkerLayer(
                         markers: [

--- a/lib/features/dashboard/presentation/widgets/recent_sites_map_card.dart
+++ b/lib/features/dashboard/presentation/widgets/recent_sites_map_card.dart
@@ -89,7 +89,9 @@ class _RecentSitesMapCardState extends ConsumerState<RecentSitesMapCard> {
                         userAgentPackageName: 'app.submersion',
                         maxZoom: ref.watch(mapTileMaxZoomProvider),
                         tileProvider: TileCacheService.instance.isInitialized
-                            ? TileCacheService.instance.getTileProvider()
+                            ? TileCacheService.instance.getTileProvider(
+                                urlTemplate: ref.watch(mapTileUrlProvider),
+                              )
                             : null,
                       ),
                       MarkerLayer(

--- a/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
@@ -624,7 +624,9 @@ class _MapSectionState extends ConsumerState<_MapSection> {
                     userAgentPackageName: 'app.submersion',
                     maxZoom: ref.watch(mapTileMaxZoomProvider),
                     tileProvider: TileCacheService.instance.isInitialized
-                        ? TileCacheService.instance.getTileProvider()
+                        ? TileCacheService.instance.getTileProvider(
+                            urlTemplate: ref.watch(mapTileUrlProvider),
+                          )
                         : null,
                   ),
                   MarkerLayer(
@@ -723,7 +725,9 @@ class _MapSectionState extends ConsumerState<_MapSection> {
                   userAgentPackageName: 'app.submersion',
                   maxZoom: ref.watch(mapTileMaxZoomProvider),
                   tileProvider: TileCacheService.instance.isInitialized
-                      ? TileCacheService.instance.getTileProvider()
+                      ? TileCacheService.instance.getTileProvider(
+                          urlTemplate: ref.watch(mapTileUrlProvider),
+                        )
                       : null,
                 ),
                 MarkerLayer(

--- a/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_detail_page.dart
@@ -623,11 +623,9 @@ class _MapSectionState extends ConsumerState<_MapSection> {
                     urlTemplate: ref.watch(mapTileUrlProvider),
                     userAgentPackageName: 'app.submersion',
                     maxZoom: ref.watch(mapTileMaxZoomProvider),
-                    tileProvider: TileCacheService.instance.isInitialized
-                        ? TileCacheService.instance.getTileProvider(
-                            urlTemplate: ref.watch(mapTileUrlProvider),
-                          )
-                        : null,
+                    tileProvider: TileCacheService.instance.tileProviderFor(
+                      urlTemplate: ref.watch(mapTileUrlProvider),
+                    ),
                   ),
                   MarkerLayer(
                     markers: [
@@ -724,11 +722,9 @@ class _MapSectionState extends ConsumerState<_MapSection> {
                   urlTemplate: ref.watch(mapTileUrlProvider),
                   userAgentPackageName: 'app.submersion',
                   maxZoom: ref.watch(mapTileMaxZoomProvider),
-                  tileProvider: TileCacheService.instance.isInitialized
-                      ? TileCacheService.instance.getTileProvider(
-                          urlTemplate: ref.watch(mapTileUrlProvider),
-                        )
-                      : null,
+                  tileProvider: TileCacheService.instance.tileProviderFor(
+                    urlTemplate: ref.watch(mapTileUrlProvider),
+                  ),
                 ),
                 MarkerLayer(
                   markers: [

--- a/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
@@ -233,7 +233,9 @@ class _DiveCenterMapPageState extends ConsumerState<DiveCenterMapPage>
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
                 tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider()
+                    ? TileCacheService.instance.getTileProvider(
+                        urlTemplate: ref.watch(mapTileUrlProvider),
+                      )
                     : null,
               ),
               MarkerClusterLayerWidget(

--- a/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
@@ -232,11 +232,9 @@ class _DiveCenterMapPageState extends ConsumerState<DiveCenterMapPage>
                 urlTemplate: ref.watch(mapTileUrlProvider),
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
-                tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider(
-                        urlTemplate: ref.watch(mapTileUrlProvider),
-                      )
-                    : null,
+                tileProvider: TileCacheService.instance.tileProviderFor(
+                  urlTemplate: ref.watch(mapTileUrlProvider),
+                ),
               ),
               MarkerClusterLayerWidget(
                 options: MarkerClusterLayerOptions(

--- a/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
+++ b/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
@@ -227,7 +227,9 @@ class _DiveCenterMapContentState extends ConsumerState<DiveCenterMapContent>
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
                 tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider()
+                    ? TileCacheService.instance.getTileProvider(
+                        urlTemplate: ref.watch(mapTileUrlProvider),
+                      )
                     : null,
               ),
               MarkerClusterLayerWidget(

--- a/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
+++ b/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
@@ -226,11 +226,9 @@ class _DiveCenterMapContentState extends ConsumerState<DiveCenterMapContent>
                 urlTemplate: ref.watch(mapTileUrlProvider),
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
-                tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider(
-                        urlTemplate: ref.watch(mapTileUrlProvider),
-                      )
-                    : null,
+                tileProvider: TileCacheService.instance.tileProviderFor(
+                  urlTemplate: ref.watch(mapTileUrlProvider),
+                ),
               ),
               MarkerClusterLayerWidget(
                 options: MarkerClusterLayerOptions(

--- a/lib/features/dive_log/presentation/widgets/dive_locations_map.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_locations_map.dart
@@ -242,7 +242,16 @@ class _DiveLocationsMapState extends ConsumerState<DiveLocationsMap> {
                   : const InteractionOptions(flags: InteractiveFlag.none),
             ),
             children: [
-              submersionTileLayer(ref),
+              // The decorative header remounts on every dive selected in the
+              // master-detail pane, and the default fade restarts each tile at
+              // opacity 0 even when it is already in memory, which blinked
+              // the header's map background on every selection.
+              submersionTileLayer(
+                ref,
+                tileDisplay: interactive
+                    ? const TileDisplay.fadeIn()
+                    : const TileDisplay.instantaneous(),
+              ),
               // Drawn before the drift line and markers so the surface track
               // sits underneath both.
               if (hasTrack)

--- a/lib/features/dive_log/presentation/widgets/dive_map_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_map_content.dart
@@ -318,7 +318,9 @@ class _DiveMapContentState extends ConsumerState<DiveMapContent>
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
                 tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider()
+                    ? TileCacheService.instance.getTileProvider(
+                        urlTemplate: ref.watch(mapTileUrlProvider),
+                      )
                     : null,
               ),
               // Markers layer - shows sites with dives

--- a/lib/features/dive_log/presentation/widgets/dive_map_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_map_content.dart
@@ -317,11 +317,9 @@ class _DiveMapContentState extends ConsumerState<DiveMapContent>
                 urlTemplate: ref.watch(mapTileUrlProvider),
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
-                tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider(
-                        urlTemplate: ref.watch(mapTileUrlProvider),
-                      )
-                    : null,
+                tileProvider: TileCacheService.instance.tileProviderFor(
+                  urlTemplate: ref.watch(mapTileUrlProvider),
+                ),
               ),
               // Markers layer - shows sites with dives
               MarkerClusterLayerWidget(

--- a/lib/features/dive_sites/presentation/pages/site_detail_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_detail_page.dart
@@ -540,7 +540,9 @@ class _SiteDetailContentState extends ConsumerState<_SiteDetailContent> {
                     userAgentPackageName: 'app.submersion',
                     maxZoom: ref.watch(mapTileMaxZoomProvider),
                     tileProvider: TileCacheService.instance.isInitialized
-                        ? TileCacheService.instance.getTileProvider()
+                        ? TileCacheService.instance.getTileProvider(
+                            urlTemplate: ref.watch(mapTileUrlProvider),
+                          )
                         : null,
                   ),
                   BathymetryDepthOverlayLayer(location: site.location),
@@ -1826,7 +1828,9 @@ class _FullscreenSiteScapePageState
                     userAgentPackageName: 'app.submersion',
                     maxZoom: ref.watch(mapTileMaxZoomProvider),
                     tileProvider: TileCacheService.instance.isInitialized
-                        ? TileCacheService.instance.getTileProvider()
+                        ? TileCacheService.instance.getTileProvider(
+                            urlTemplate: ref.watch(mapTileUrlProvider),
+                          )
                         : null,
                   ),
                   BathymetryDepthOverlayLayer(location: site.location),

--- a/lib/features/dive_sites/presentation/pages/site_detail_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_detail_page.dart
@@ -539,11 +539,9 @@ class _SiteDetailContentState extends ConsumerState<_SiteDetailContent> {
                     urlTemplate: ref.watch(mapTileUrlProvider),
                     userAgentPackageName: 'app.submersion',
                     maxZoom: ref.watch(mapTileMaxZoomProvider),
-                    tileProvider: TileCacheService.instance.isInitialized
-                        ? TileCacheService.instance.getTileProvider(
-                            urlTemplate: ref.watch(mapTileUrlProvider),
-                          )
-                        : null,
+                    tileProvider: TileCacheService.instance.tileProviderFor(
+                      urlTemplate: ref.watch(mapTileUrlProvider),
+                    ),
                   ),
                   BathymetryDepthOverlayLayer(location: site.location),
                   SiteFeatureMarkerLayer(siteId: site.id),
@@ -1827,11 +1825,9 @@ class _FullscreenSiteScapePageState
                     urlTemplate: ref.watch(mapTileUrlProvider),
                     userAgentPackageName: 'app.submersion',
                     maxZoom: ref.watch(mapTileMaxZoomProvider),
-                    tileProvider: TileCacheService.instance.isInitialized
-                        ? TileCacheService.instance.getTileProvider(
-                            urlTemplate: ref.watch(mapTileUrlProvider),
-                          )
-                        : null,
+                    tileProvider: TileCacheService.instance.tileProviderFor(
+                      urlTemplate: ref.watch(mapTileUrlProvider),
+                    ),
                   ),
                   BathymetryDepthOverlayLayer(location: site.location),
                   SiteFeatureMarkerLayer(siteId: site.id),

--- a/lib/features/dive_sites/presentation/pages/site_map_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_map_page.dart
@@ -344,11 +344,9 @@ class _SiteMapPageState extends ConsumerState<SiteMapPage>
                 urlTemplate: ref.watch(mapTileUrlProvider),
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
-                tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider(
-                        urlTemplate: ref.watch(mapTileUrlProvider),
-                      )
-                    : null,
+                tileProvider: TileCacheService.instance.tileProviderFor(
+                  urlTemplate: ref.watch(mapTileUrlProvider),
+                ),
               ),
               // Depth overlay for the selected site: same layer the
               // master-detail map and site detail render, so the app-bar

--- a/lib/features/dive_sites/presentation/pages/site_map_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_map_page.dart
@@ -345,7 +345,9 @@ class _SiteMapPageState extends ConsumerState<SiteMapPage>
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
                 tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider()
+                    ? TileCacheService.instance.getTileProvider(
+                        urlTemplate: ref.watch(mapTileUrlProvider),
+                      )
                     : null,
               ),
               // Depth overlay for the selected site: same layer the

--- a/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
@@ -178,7 +178,9 @@ class _LocationPickerMapState extends ConsumerState<LocationPickerMap> {
                     userAgentPackageName: 'app.submersion',
                     maxZoom: ref.watch(mapTileMaxZoomProvider),
                     tileProvider: TileCacheService.instance.isInitialized
-                        ? TileCacheService.instance.getTileProvider()
+                        ? TileCacheService.instance.getTileProvider(
+                            urlTemplate: ref.watch(mapTileUrlProvider),
+                          )
                         : null,
                   ),
                   if (_selectedLocation != null)

--- a/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/location_picker_map.dart
@@ -177,11 +177,9 @@ class _LocationPickerMapState extends ConsumerState<LocationPickerMap> {
                     urlTemplate: ref.watch(mapTileUrlProvider),
                     userAgentPackageName: 'app.submersion',
                     maxZoom: ref.watch(mapTileMaxZoomProvider),
-                    tileProvider: TileCacheService.instance.isInitialized
-                        ? TileCacheService.instance.getTileProvider(
-                            urlTemplate: ref.watch(mapTileUrlProvider),
-                          )
-                        : null,
+                    tileProvider: TileCacheService.instance.tileProviderFor(
+                      urlTemplate: ref.watch(mapTileUrlProvider),
+                    ),
                   ),
                   if (_selectedLocation != null)
                     MarkerLayer(

--- a/lib/features/dive_sites/presentation/widgets/match_sites_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/match_sites_map.dart
@@ -73,7 +73,9 @@ class _MatchSitesMapState extends ConsumerState<MatchSitesMap> {
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
                 tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider()
+                    ? TileCacheService.instance.getTileProvider(
+                        urlTemplate: ref.watch(mapTileUrlProvider),
+                      )
                     : null,
               ),
               MarkerLayer(

--- a/lib/features/dive_sites/presentation/widgets/match_sites_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/match_sites_map.dart
@@ -72,11 +72,9 @@ class _MatchSitesMapState extends ConsumerState<MatchSitesMap> {
                 urlTemplate: ref.watch(mapTileUrlProvider),
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
-                tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider(
-                        urlTemplate: ref.watch(mapTileUrlProvider),
-                      )
-                    : null,
+                tileProvider: TileCacheService.instance.tileProviderFor(
+                  urlTemplate: ref.watch(mapTileUrlProvider),
+                ),
               ),
               MarkerLayer(
                 markers: [

--- a/lib/features/dive_sites/presentation/widgets/site_list_tile.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_tile.dart
@@ -325,11 +325,10 @@ class _SiteListTileState extends ConsumerState<SiteListTile> {
                           urlTemplate: ref.watch(mapTileUrlProvider),
                           userAgentPackageName: 'app.submersion',
                           maxZoom: ref.watch(mapTileMaxZoomProvider),
-                          tileProvider: TileCacheService.instance.isInitialized
-                              ? TileCacheService.instance.getTileProvider(
-                                  urlTemplate: ref.watch(mapTileUrlProvider),
-                                )
-                              : null,
+                          tileProvider: TileCacheService.instance
+                              .tileProviderFor(
+                                urlTemplate: ref.watch(mapTileUrlProvider),
+                              ),
                         ),
                         const MapAttribution(),
                       ],

--- a/lib/features/dive_sites/presentation/widgets/site_list_tile.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_tile.dart
@@ -326,7 +326,9 @@ class _SiteListTileState extends ConsumerState<SiteListTile> {
                           userAgentPackageName: 'app.submersion',
                           maxZoom: ref.watch(mapTileMaxZoomProvider),
                           tileProvider: TileCacheService.instance.isInitialized
-                              ? TileCacheService.instance.getTileProvider()
+                              ? TileCacheService.instance.getTileProvider(
+                                  urlTemplate: ref.watch(mapTileUrlProvider),
+                                )
                               : null,
                         ),
                         const MapAttribution(),

--- a/lib/features/dive_sites/presentation/widgets/site_map_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_map_content.dart
@@ -332,7 +332,9 @@ class _SiteMapContentState extends ConsumerState<SiteMapContent>
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
                 tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider()
+                    ? TileCacheService.instance.getTileProvider(
+                        urlTemplate: ref.watch(mapTileUrlProvider),
+                      )
                     : null,
               ),
               // Depth overlay: the selected site's bathymetry as a

--- a/lib/features/dive_sites/presentation/widgets/site_map_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_map_content.dart
@@ -331,11 +331,9 @@ class _SiteMapContentState extends ConsumerState<SiteMapContent>
                 urlTemplate: ref.watch(mapTileUrlProvider),
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
-                tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider(
-                        urlTemplate: ref.watch(mapTileUrlProvider),
-                      )
-                    : null,
+                tileProvider: TileCacheService.instance.tileProviderFor(
+                  urlTemplate: ref.watch(mapTileUrlProvider),
+                ),
               ),
               // Depth overlay: the selected site's bathymetry as a
               // translucent ramp + contours, above tiles, below markers.

--- a/lib/features/maps/data/services/tile_cache_service.dart
+++ b/lib/features/maps/data/services/tile_cache_service.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_tile_caching/flutter_map_tile_caching.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:submersion/core/services/logger_service.dart';
@@ -353,14 +355,35 @@ class TileCacheService {
     BrowseLoadingStrategy loadingStrategy = BrowseLoadingStrategy.cacheFirst,
   }) {
     _ensureInitialized();
-    return FMTCTileProvider(
-      stores: browseStoreStrategies(),
-      otherStoresStrategy: otherStoresStrategy,
-      loadingStrategy: loadingStrategy,
-      errorHandler: handleTileError,
-    );
     // coverage:ignore-end
+    return browseTileProvider(loadingStrategy: loadingStrategy);
   }
+
+  /// The one HTTP client every provider this service builds shares.
+  ///
+  /// FMTCTileProvider's equality compares its client by identity, and that
+  /// equality is half of the ImageCache key for every tile. Left to itself the
+  /// constructor creates a new client per provider, so no two providers were
+  /// ever equal and a remounted map (the dive header, on every selection)
+  /// missed the in-memory cache for tiles it had just shown. Lives for the
+  /// process: FMTC only closes a client it created itself, so disposing a map
+  /// leaves this one open for the next.
+  static final http.Client _httpClient = IOClient(
+    HttpClient()..userAgent = null,
+  );
+
+  /// The provider [getTileProvider] hands out, without the initialization
+  /// guard, so its identity can be asserted without an ObjectBox backend.
+  @visibleForTesting
+  static FMTCTileProvider browseTileProvider({
+    BrowseLoadingStrategy loadingStrategy = BrowseLoadingStrategy.cacheFirst,
+  }) => FMTCTileProvider(
+    stores: browseStoreStrategies(),
+    otherStoresStrategy: otherStoresStrategy,
+    loadingStrategy: loadingStrategy,
+    errorHandler: handleTileError,
+    httpClient: _httpClient,
+  );
 
   /// Handles a tile fetch failure: logs it (offline misses at info, real
   /// transport/HTTP errors at warning) and returns null so the map shows a
@@ -421,13 +444,19 @@ class TileCacheService {
   FMTCTileProvider getOfflineTileProvider() {
     // coverage:ignore-start
     _ensureInitialized();
-    return FMTCTileProvider(
-      stores: offlineStoreStrategies(),
-      otherStoresStrategy: otherStoresStrategy,
-      loadingStrategy: BrowseLoadingStrategy.cacheOnly,
-    );
     // coverage:ignore-end
+    return offlineTileProvider();
   }
+
+  /// The provider [getOfflineTileProvider] hands out, without the
+  /// initialization guard, so its identity can be asserted in tests.
+  @visibleForTesting
+  static FMTCTileProvider offlineTileProvider() => FMTCTileProvider(
+    stores: offlineStoreStrategies(),
+    otherStoresStrategy: otherStoresStrategy,
+    loadingStrategy: BrowseLoadingStrategy.cacheOnly,
+    httpClient: _httpClient,
+  );
 
   /// Estimate the number of tiles in a rectangular region.
   ///

--- a/lib/features/maps/data/services/tile_cache_service.dart
+++ b/lib/features/maps/data/services/tile_cache_service.dart
@@ -77,7 +77,9 @@ class TileDownloadProgress {
 /// await TileCacheService.instance.initialize();
 ///
 /// // Get a tile provider for use with FlutterMap
-/// final tileProvider = TileCacheService.instance.getTileProvider();
+/// final tileProvider = TileCacheService.instance.getTileProvider(
+///   urlTemplate: ref.watch(mapTileUrlProvider),
+/// );
 /// ```
 class TileCacheService {
   static TileCacheService? _instance;
@@ -345,44 +347,59 @@ class TileCacheService {
   ///   Widget build(BuildContext context, WidgetRef ref) {
   ///     return TileLayer(
   ///       urlTemplate: ref.watch(mapTileUrlProvider),
-  ///       tileProvider: TileCacheService.instance.getTileProvider(),
+  ///       tileProvider: TileCacheService.instance.getTileProvider(
+  ///         urlTemplate: ref.watch(mapTileUrlProvider),
+  ///       ),
   ///     );
   ///   }
   /// }
   /// ```
   FMTCTileProvider getTileProvider({
+    required String urlTemplate,
     // coverage:ignore-start
     BrowseLoadingStrategy loadingStrategy = BrowseLoadingStrategy.cacheFirst,
   }) {
     _ensureInitialized();
     // coverage:ignore-end
-    return browseTileProvider(loadingStrategy: loadingStrategy);
+    return browseTileProvider(
+      urlTemplate: urlTemplate,
+      loadingStrategy: loadingStrategy,
+    );
   }
 
-  /// The one HTTP client every provider this service builds shares.
+  /// One HTTP client per tile URL template, shared by every provider this
+  /// service builds for that template.
   ///
   /// FMTCTileProvider's equality compares its client by identity, and that
   /// equality is half of the ImageCache key for every tile. Left to itself the
   /// constructor creates a new client per provider, so no two providers were
   /// ever equal and a remounted map (the dive header, on every selection)
-  /// missed the in-memory cache for tiles it had just shown. Lives for the
+  /// missed the in-memory cache for tiles it had just shown.
+  ///
+  /// The key does not include the tile URL, so one client for everything
+  /// would make every map style's provider equal, and switching style would
+  /// paint the previous style's cached bitmap for the same z/x/y. A client
+  /// per template keeps providers equal within a style and distinct across
+  /// styles. Bounded by the handful of map styles, and each lives for the
   /// process: FMTC only closes a client it created itself, so disposing a map
-  /// leaves this one open for the next.
-  static final http.Client _httpClient = IOClient(
-    HttpClient()..userAgent = null,
-  );
+  /// leaves these open for the next.
+  static final Map<String, http.Client> _httpClients = {};
+
+  static http.Client _httpClientFor(String urlTemplate) => _httpClients
+      .putIfAbsent(urlTemplate, () => IOClient(HttpClient()..userAgent = null));
 
   /// The provider [getTileProvider] hands out, without the initialization
   /// guard, so its identity can be asserted without an ObjectBox backend.
   @visibleForTesting
   static FMTCTileProvider browseTileProvider({
+    required String urlTemplate,
     BrowseLoadingStrategy loadingStrategy = BrowseLoadingStrategy.cacheFirst,
   }) => FMTCTileProvider(
     stores: browseStoreStrategies(),
     otherStoresStrategy: otherStoresStrategy,
     loadingStrategy: loadingStrategy,
     errorHandler: handleTileError,
-    httpClient: _httpClient,
+    httpClient: _httpClientFor(urlTemplate),
   );
 
   /// Handles a tile fetch failure: logs it (offline misses at info, real
@@ -441,22 +458,23 @@ class TileCacheService {
   ///
   /// This provider will only use cached tiles and will not make network
   /// requests.
-  FMTCTileProvider getOfflineTileProvider() {
+  FMTCTileProvider getOfflineTileProvider({required String urlTemplate}) {
     // coverage:ignore-start
     _ensureInitialized();
     // coverage:ignore-end
-    return offlineTileProvider();
+    return offlineTileProvider(urlTemplate: urlTemplate);
   }
 
   /// The provider [getOfflineTileProvider] hands out, without the
   /// initialization guard, so its identity can be asserted in tests.
   @visibleForTesting
-  static FMTCTileProvider offlineTileProvider() => FMTCTileProvider(
-    stores: offlineStoreStrategies(),
-    otherStoresStrategy: otherStoresStrategy,
-    loadingStrategy: BrowseLoadingStrategy.cacheOnly,
-    httpClient: _httpClient,
-  );
+  static FMTCTileProvider offlineTileProvider({required String urlTemplate}) =>
+      FMTCTileProvider(
+        stores: offlineStoreStrategies(),
+        otherStoresStrategy: otherStoresStrategy,
+        loadingStrategy: BrowseLoadingStrategy.cacheOnly,
+        httpClient: _httpClientFor(urlTemplate),
+      );
 
   /// Estimate the number of tiles in a rectangular region.
   ///

--- a/lib/features/maps/data/services/tile_cache_service.dart
+++ b/lib/features/maps/data/services/tile_cache_service.dart
@@ -360,12 +360,21 @@ class TileCacheService {
     BrowseLoadingStrategy loadingStrategy = BrowseLoadingStrategy.cacheFirst,
   }) {
     _ensureInitialized();
-    // coverage:ignore-end
     return browseTileProvider(
       urlTemplate: urlTemplate,
       loadingStrategy: loadingStrategy,
     );
+    // coverage:ignore-end
   }
+
+  /// The browse provider for [urlTemplate], or null until [initialize] has
+  /// succeeded.
+  ///
+  /// This is what a map hands to `TileLayer.tileProvider`: null there means
+  /// flutter_map's own network provider, so a cache that failed to start
+  /// leaves the maps working, just uncached.
+  FMTCTileProvider? tileProviderFor({required String urlTemplate}) =>
+      isInitialized ? getTileProvider(urlTemplate: urlTemplate) : null;
 
   /// One HTTP client per tile URL template, shared by every provider this
   /// service builds for that template.
@@ -454,16 +463,16 @@ class TileCacheService {
     }
   }
 
+  // coverage:ignore-start
   /// Get a tile provider configured for offline-only usage.
   ///
   /// This provider will only use cached tiles and will not make network
   /// requests.
   FMTCTileProvider getOfflineTileProvider({required String urlTemplate}) {
-    // coverage:ignore-start
     _ensureInitialized();
-    // coverage:ignore-end
     return offlineTileProvider(urlTemplate: urlTemplate);
   }
+  // coverage:ignore-end
 
   /// The provider [getOfflineTileProvider] hands out, without the
   /// initialization guard, so its identity can be asserted in tests.

--- a/lib/features/maps/presentation/pages/dive_activity_map_page.dart
+++ b/lib/features/maps/presentation/pages/dive_activity_map_page.dart
@@ -283,11 +283,9 @@ class _DiveActivityMapPageState extends ConsumerState<DiveActivityMapPage>
                 urlTemplate: ref.watch(mapTileUrlProvider),
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
-                tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider(
-                        urlTemplate: ref.watch(mapTileUrlProvider),
-                      )
-                    : null,
+                tileProvider: TileCacheService.instance.tileProviderFor(
+                  urlTemplate: ref.watch(mapTileUrlProvider),
+                ),
               ),
               // Markers layer - shows sites with dives
               MarkerClusterLayerWidget(

--- a/lib/features/maps/presentation/pages/dive_activity_map_page.dart
+++ b/lib/features/maps/presentation/pages/dive_activity_map_page.dart
@@ -284,7 +284,9 @@ class _DiveActivityMapPageState extends ConsumerState<DiveActivityMapPage>
                 userAgentPackageName: 'app.submersion',
                 maxZoom: ref.watch(mapTileMaxZoomProvider),
                 tileProvider: TileCacheService.instance.isInitialized
-                    ? TileCacheService.instance.getTileProvider()
+                    ? TileCacheService.instance.getTileProvider(
+                        urlTemplate: ref.watch(mapTileUrlProvider),
+                      )
                     : null,
               ),
               // Markers layer - shows sites with dives

--- a/lib/features/maps/presentation/pages/region_picker_page.dart
+++ b/lib/features/maps/presentation/pages/region_picker_page.dart
@@ -64,7 +64,9 @@ class _RegionPickerPageState extends ConsumerState<RegionPickerPage> {
                   userAgentPackageName: 'app.submersion',
                   maxZoom: ref.watch(mapTileMaxZoomProvider),
                   tileProvider: TileCacheService.instance.isInitialized
-                      ? TileCacheService.instance.getTileProvider()
+                      ? TileCacheService.instance.getTileProvider(
+                          urlTemplate: ref.watch(mapTileUrlProvider),
+                        )
                       : null,
                 ),
                 const MapAttribution(),

--- a/lib/features/maps/presentation/pages/region_picker_page.dart
+++ b/lib/features/maps/presentation/pages/region_picker_page.dart
@@ -63,11 +63,9 @@ class _RegionPickerPageState extends ConsumerState<RegionPickerPage> {
                   urlTemplate: ref.watch(mapTileUrlProvider),
                   userAgentPackageName: 'app.submersion',
                   maxZoom: ref.watch(mapTileMaxZoomProvider),
-                  tileProvider: TileCacheService.instance.isInitialized
-                      ? TileCacheService.instance.getTileProvider(
-                          urlTemplate: ref.watch(mapTileUrlProvider),
-                        )
-                      : null,
+                  tileProvider: TileCacheService.instance.tileProviderFor(
+                    urlTemplate: ref.watch(mapTileUrlProvider),
+                  ),
                 ),
                 const MapAttribution(),
               ],

--- a/lib/features/maps/presentation/widgets/submersion_tile_layer.dart
+++ b/lib/features/maps/presentation/widgets/submersion_tile_layer.dart
@@ -8,11 +8,20 @@ import 'package:submersion/features/maps/presentation/providers/map_tile_provide
 /// zoom, and the offline cache when it has been initialized.
 ///
 /// Extracted because several maps had grown byte-identical copies of this.
-TileLayer submersionTileLayer(WidgetRef ref, {double? maxZoomOverride}) {
+///
+/// [tileDisplay] defaults to flutter_map's fade-in. A decorative map that
+/// remounts often should pass [TileDisplay.instantaneous], because the fade
+/// starts every tile at opacity 0 even when its image is already in memory.
+TileLayer submersionTileLayer(
+  WidgetRef ref, {
+  double? maxZoomOverride,
+  TileDisplay tileDisplay = const TileDisplay.fadeIn(),
+}) {
   return TileLayer(
     urlTemplate: ref.watch(mapTileUrlProvider),
     userAgentPackageName: 'app.submersion',
     maxZoom: maxZoomOverride ?? ref.watch(mapTileMaxZoomProvider),
+    tileDisplay: tileDisplay,
     tileProvider: TileCacheService.instance.isInitialized
         ? TileCacheService.instance.getTileProvider()
         : null,

--- a/lib/features/maps/presentation/widgets/submersion_tile_layer.dart
+++ b/lib/features/maps/presentation/widgets/submersion_tile_layer.dart
@@ -23,8 +23,8 @@ TileLayer submersionTileLayer(
     userAgentPackageName: 'app.submersion',
     maxZoom: maxZoomOverride ?? ref.watch(mapTileMaxZoomProvider),
     tileDisplay: tileDisplay,
-    tileProvider: TileCacheService.instance.isInitialized
-        ? TileCacheService.instance.getTileProvider(urlTemplate: urlTemplate)
-        : null,
+    tileProvider: TileCacheService.instance.tileProviderFor(
+      urlTemplate: urlTemplate,
+    ),
   );
 }

--- a/lib/features/maps/presentation/widgets/submersion_tile_layer.dart
+++ b/lib/features/maps/presentation/widgets/submersion_tile_layer.dart
@@ -17,13 +17,14 @@ TileLayer submersionTileLayer(
   double? maxZoomOverride,
   TileDisplay tileDisplay = const TileDisplay.fadeIn(),
 }) {
+  final urlTemplate = ref.watch(mapTileUrlProvider);
   return TileLayer(
-    urlTemplate: ref.watch(mapTileUrlProvider),
+    urlTemplate: urlTemplate,
     userAgentPackageName: 'app.submersion',
     maxZoom: maxZoomOverride ?? ref.watch(mapTileMaxZoomProvider),
     tileDisplay: tileDisplay,
     tileProvider: TileCacheService.instance.isInitialized
-        ? TileCacheService.instance.getTileProvider()
+        ? TileCacheService.instance.getTileProvider(urlTemplate: urlTemplate)
         : null,
   );
 }

--- a/lib/features/trips/presentation/widgets/story/trip_story_map_header.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_map_header.dart
@@ -151,7 +151,9 @@ class _StoryMap extends ConsumerWidget {
               userAgentPackageName: 'app.submersion',
               maxZoom: ref.watch(mapTileMaxZoomProvider),
               tileProvider: TileCacheService.instance.isInitialized
-                  ? TileCacheService.instance.getTileProvider()
+                  ? TileCacheService.instance.getTileProvider(
+                      urlTemplate: ref.watch(mapTileUrlProvider),
+                    )
                   : null,
             ),
             // A route only makes sense with at least two points.

--- a/lib/features/trips/presentation/widgets/story/trip_story_map_header.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_map_header.dart
@@ -150,11 +150,9 @@ class _StoryMap extends ConsumerWidget {
               urlTemplate: ref.watch(mapTileUrlProvider),
               userAgentPackageName: 'app.submersion',
               maxZoom: ref.watch(mapTileMaxZoomProvider),
-              tileProvider: TileCacheService.instance.isInitialized
-                  ? TileCacheService.instance.getTileProvider(
-                      urlTemplate: ref.watch(mapTileUrlProvider),
-                    )
-                  : null,
+              tileProvider: TileCacheService.instance.tileProviderFor(
+                urlTemplate: ref.watch(mapTileUrlProvider),
+              ),
             ),
             // A route only makes sense with at least two points.
             if (points.length > 1)

--- a/test/features/dive_log/presentation/widgets/dive_locations_map_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_locations_map_test.dart
@@ -70,6 +70,35 @@ void main() {
     expect(find.byKey(const ValueKey('gps-site-marker')), findsNothing);
   });
 
+  // The dive header remounts this map on every dive selected in the
+  // master-detail pane. flutter_map's default fade animates each tile up from
+  // opacity 0 even when the image is already in memory, so the header's map
+  // background blinked on every selection.
+  testWidgets('the decorative map shows tiles instantly, without a fade', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      const DiveLocationsMap(entry: GeoPoint(12.34567, 98.76543)),
+    );
+
+    final tileLayer = tester.widget<TileLayer>(find.byType(TileLayer));
+    expect(tileLayer.tileDisplay, const TileDisplay.instantaneous());
+  });
+
+  testWidgets('an interactive map keeps the default tile fade', (tester) async {
+    await _pump(
+      tester,
+      const DiveLocationsMap(
+        entry: GeoPoint(12.34567, 98.76543),
+        interactive: true,
+      ),
+    );
+
+    final tileLayer = tester.widget<TileLayer>(find.byType(TileLayer));
+    expect(tileLayer.tileDisplay, const TileDisplay.fadeIn());
+  });
+
   testWidgets('renders nothing when no points are provided', (tester) async {
     await _pump(tester, const DiveLocationsMap());
     expect(find.byType(FlutterMap), findsNothing);

--- a/test/features/maps/tile_cache_service_test.dart
+++ b/test/features/maps/tile_cache_service_test.dart
@@ -131,6 +131,16 @@ void main() {
       expect(cacheKey(before, osm), isNot(cacheKey(after, esri)));
     });
 
+    test('an uninitialized cache hands maps no provider', () {
+      // Every map passes this straight to TileLayer.tileProvider, where null
+      // means flutter_map's own network provider: a cache that failed to
+      // start must still leave the maps working.
+      expect(
+        TileCacheService.instance.tileProviderFor(urlTemplate: osm),
+        isNull,
+      );
+    });
+
     test('a different loading strategy is a different cache key', () {
       expect(
         TileCacheService.browseTileProvider(urlTemplate: osm),

--- a/test/features/maps/tile_cache_service_test.dart
+++ b/test/features/maps/tile_cache_service_test.dart
@@ -1,6 +1,9 @@
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_tile_caching/flutter_map_tile_caching.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/constants/map_tile_config.dart';
 import 'package:submersion/core/models/log_entry.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
@@ -97,33 +100,62 @@ void main() {
   // header map) builds a fresh provider, so unless two providers compare
   // equal, every tile misses the in-memory cache and blinks back in through
   // FMTC's async lookup even when it was on screen a moment ago.
+  //
+  // The tile URL is NOT part of that key, so the opposite failure is just as
+  // real: if providers for two map styles compared equal, switching styles
+  // would paint the previous style's cached bitmap for the same z/x/y.
   group('tile provider identity', () {
+    final osm = MapTileConfig.urlTemplate(MapStyle.openStreetMap);
+    final esri = MapTileConfig.urlTemplate(MapStyle.esriSatellite);
+    const coords = TileCoordinates(4, 7, 12);
+
+    // The key the ImageCache actually stores a tile under.
+    Object cacheKey(FMTCTileProvider provider, String urlTemplate) =>
+        provider.getImage(coords, TileLayer(urlTemplate: urlTemplate));
+
     test('two browse providers are equal, so remounted maps hit the cache', () {
-      final first = TileCacheService.browseTileProvider();
-      final second = TileCacheService.browseTileProvider();
+      final first = TileCacheService.browseTileProvider(urlTemplate: osm);
+      final second = TileCacheService.browseTileProvider(urlTemplate: osm);
 
       expect(identical(first, second), isFalse);
       expect(first, second);
       expect(first.hashCode, second.hashCode);
+      expect(cacheKey(first, osm), cacheKey(second, osm));
+    });
+
+    test('switching map style never reuses the old style\'s tile', () {
+      final before = TileCacheService.browseTileProvider(urlTemplate: osm);
+      final after = TileCacheService.browseTileProvider(urlTemplate: esri);
+
+      expect(before, isNot(after));
+      expect(cacheKey(before, osm), isNot(cacheKey(after, esri)));
     });
 
     test('a different loading strategy is a different cache key', () {
       expect(
-        TileCacheService.browseTileProvider(),
+        TileCacheService.browseTileProvider(urlTemplate: osm),
         isNot(
           TileCacheService.browseTileProvider(
+            urlTemplate: osm,
             loadingStrategy: BrowseLoadingStrategy.cacheOnly,
           ),
         ),
       );
     });
 
-    test('two offline providers are equal', () {
-      expect(
-        TileCacheService.offlineTileProvider(),
-        TileCacheService.offlineTileProvider(),
-      );
-    });
+    test(
+      'offline providers are equal per style and distinct across styles',
+      () {
+        expect(
+          TileCacheService.offlineTileProvider(urlTemplate: osm),
+          TileCacheService.offlineTileProvider(urlTemplate: osm),
+        );
+        expect(
+          TileCacheService.offlineTileProvider(urlTemplate: osm),
+          isNot(TileCacheService.offlineTileProvider(urlTemplate: esri)),
+        );
+      },
+    );
   });
 
   // Issue #1403: deleting a region used to free nothing, because FMTC can only

--- a/test/features/maps/tile_cache_service_test.dart
+++ b/test/features/maps/tile_cache_service_test.dart
@@ -91,6 +91,41 @@ void main() {
     });
   });
 
+  // Flutter's ImageCache keys an FMTC tile on (coordinates, provider), and
+  // FMTCTileProvider's equality includes its httpClient by identity. A map
+  // that remounts (every dive selected in the master-detail pane rebuilds its
+  // header map) builds a fresh provider, so unless two providers compare
+  // equal, every tile misses the in-memory cache and blinks back in through
+  // FMTC's async lookup even when it was on screen a moment ago.
+  group('tile provider identity', () {
+    test('two browse providers are equal, so remounted maps hit the cache', () {
+      final first = TileCacheService.browseTileProvider();
+      final second = TileCacheService.browseTileProvider();
+
+      expect(identical(first, second), isFalse);
+      expect(first, second);
+      expect(first.hashCode, second.hashCode);
+    });
+
+    test('a different loading strategy is a different cache key', () {
+      expect(
+        TileCacheService.browseTileProvider(),
+        isNot(
+          TileCacheService.browseTileProvider(
+            loadingStrategy: BrowseLoadingStrategy.cacheOnly,
+          ),
+        ),
+      );
+    });
+
+    test('two offline providers are equal', () {
+      expect(
+        TileCacheService.offlineTileProvider(),
+        TileCacheService.offlineTileProvider(),
+      );
+    });
+  });
+
   // Issue #1403: deleting a region used to free nothing, because FMTC can only
   // delete a whole store and every region shared one. Giving each downloaded
   // region its own store is what makes deletion expressible at all.


### PR DESCRIPTION
## Summary

Selecting a dive in the Dives master-detail list made the header card's map background blink: it went plain, then the map faded back in. This happened on every selection, including dives already viewed in the session.

The detail pane rebuilds each dive under its own key, so the header's `DiveLocationsMap` remounts on every selection. Two things turned that remount into a visible blink:

1. **Every tile missed the in-memory image cache.** FMTC keys a tile image on `(coordinates, provider)`, and `FMTCTileProvider.==` compares its `httpClient` by identity. `TileCacheService.getTileProvider()` never passed a client, so the FMTC constructor created a new `IOClient` for each provider and no two providers were ever equal. A remounted map sent every tile back through FMTC's async lookup and decode, even tiles it had shown a moment earlier.
2. **flutter_map fades every tile in from opacity 0.** The default `TileDisplay.fadeIn()` does this even when the image resolves synchronously from `ImageCache`.

## Changes

- `TileCacheService` now keeps one process-lifetime HTTP client per tile URL template, shared by every `FMTCTileProvider` it builds for that template. Providers compare equal within a map style, so remounted maps hit the session cache, and stay distinct across styles, so switching style never paints the previous style's cached bitmap (the URL is not part of FMTC's `ImageCache` key). `getTileProvider` and `getOfflineTileProvider` take a required `urlTemplate`, and every call site passes the same `mapTileUrlProvider` value its `TileLayer` uses. The client map is bounded by the three map styles. FMTC only closes a client it created itself, so disposing a map leaves the shared client open.
- The provider construction is extracted into `@visibleForTesting` static builders (`browseTileProvider`, `offlineTileProvider`), so provider identity can be asserted without an ObjectBox backend.
- `submersionTileLayer` gains an optional `tileDisplay` parameter. Its default (fade-in) is unchanged.
- The decorative (non-interactive) `DiveLocationsMap`, which is the dive header, uses `TileDisplay.instantaneous()`, so a cached tile paints on the first frame. Interactive maps keep the fade.

Tiles for a region not yet viewed in the session still need a real disk or network load. Those arrive a frame or two late, but no longer fade in from transparent.

## Test Plan

- [x] New `tile provider identity` tests assert on the actual `ImageCache` key (`provider.getImage`): it is equal for the same style (remount cache hit) and differs across styles (no cross-style bitmaps). Offline providers follow the same rule, and a different loading strategy is still a different key. Each test was red before its half of the fix.
- [x] New `DiveLocationsMap` tests: the decorative map uses instantaneous tile display, and the interactive map keeps the fade. The first was red before the fix.
- [x] A throwaway probe (not committed) remounted a `FlutterMap` whose tile images were already cached. On the first frame after the remount, all 16 tiles were at opacity 0.0 with `fadeIn` and at 1.0 with `instantaneous`.
- [x] `flutter test` on `test/features/maps/`, both `dive_locations_map` suites, and every `dive_detail*` page test (208 passing)
- [x] `flutter analyze` passes
- [x] Manual testing: not yet checked in the running app

