### PR TITLE
fix(bathymetry): version swissBATHY3D tile cache against its reference level

### DIFF
--- a/lib/core/database/local_cache_database.dart
+++ b/lib/core/database/local_cache_database.dart
@@ -545,6 +545,25 @@ class LocalCacheDatabase extends _$LocalCacheDatabase {
           PRIMARY KEY (tile_key)
         )
       ''');
+      // CREATE TABLE IF NOT EXISTS above is a no-op when the table already
+      // exists -- the exact ladder-collision case this backstop is meant to
+      // heal, e.g. a database stamped at v17 (by a colliding branch that
+      // claimed the same user_version first) whose table still has the v16
+      // shape. The onUpgrade `from < 17` step never runs then, since Drift
+      // reads the already-stamped v17 and sees nothing to upgrade from, so
+      // the column would otherwise stay permanently missing.
+      final swissBathyCols = await customSelect(
+        "PRAGMA table_info('swiss_bathy_tile_cache')",
+      ).get();
+      final swissBathyColumnNames = swissBathyCols
+          .map((c) => c.read<String>('name'))
+          .toSet();
+      if (!swissBathyColumnNames.contains('reference_level_meters')) {
+        await customStatement(
+          'ALTER TABLE swiss_bathy_tile_cache '
+          'ADD COLUMN reference_level_meters REAL NULL',
+        );
+      }
     },
   );
 }

--- a/lib/core/database/local_cache_database.dart
+++ b/lib/core/database/local_cache_database.dart
@@ -119,6 +119,22 @@ class SwissBathyTileCache extends Table {
   /// (v15), which fall back to one full re-resolution on their next check.
   TextColumn get sourceHref => text().nullable()();
 
+  /// The `SwissLakeLevel.meanLevelMeters` this tile's cached depths were
+  /// computed against (depth = referenceLevelMeters - elevation). Compared
+  /// against the CURRENT lookup's mean level on read -- a mismatch means a
+  /// correction to `swiss_lake_levels.dart` (a lake's bbox or documented
+  /// level changed) since this tile was cached, so the baked-in depths are
+  /// wrong and the row must be dropped rather than served stale. Null for
+  /// 'empty' rows and rows written before this field existed (v17), which
+  /// are ALSO treated as a mismatch (not trusted as-is): unlike
+  /// [sourceDatetime]/[checkedAt], there is no way to tell whether an old
+  /// row's baked-in level is still correct without this field, so it falls
+  /// back to one full re-resolution on its next read -- the only way to
+  /// actually correct already-wrongly-cached tiles (e.g. a coordinate that
+  /// used to resolve to a coarser neighboring lake's bbox before a
+  /// whitelist correction) rather than merely preventing new ones.
+  RealColumn get referenceLevelMeters => real().nullable()();
+
   @override
   Set<Column> get primaryKey => {tileKey};
 }
@@ -271,7 +287,7 @@ class LocalCacheDatabase extends _$LocalCacheDatabase {
   LocalCacheDatabase(super.e);
 
   @override
-  int get schemaVersion => 16;
+  int get schemaVersion => 17;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -413,6 +429,28 @@ class LocalCacheDatabase extends _$LocalCacheDatabase {
           );
         }
       }
+      // v17: the lake reference level a tile's cached depths were computed
+      // against, so a correction to the swissBATHY3D lake table (a bbox or
+      // documented level change) invalidates only the tiles it actually
+      // affects instead of either serving them stale forever or wiping the
+      // whole cache. See SwissBathyTileCache.referenceLevelMeters's doc.
+      //
+      // Column-existence checked first for the same reason as v15/v16
+      // above: v14's createTable already builds the table with the current
+      // (post-v17) column set for upgrades starting below v14.
+      if (from < 17) {
+        final cols = await customSelect(
+          "PRAGMA table_info('swiss_bathy_tile_cache')",
+        ).get();
+        final columnNames = cols.map((c) => c.read<String>('name')).toSet();
+        if (columnNames.isNotEmpty &&
+            !columnNames.contains('reference_level_meters')) {
+          await m.addColumn(
+            swissBathyTileCache,
+            swissBathyTileCache.referenceLevelMeters,
+          );
+        }
+      }
     },
     beforeOpen: (details) async {
       // Ladder-collision self-heal: a parallel branch that also claimed v7
@@ -503,6 +541,7 @@ class LocalCacheDatabase extends _$LocalCacheDatabase {
           source_datetime TEXT NULL,
           checked_at INTEGER NULL,
           source_href TEXT NULL,
+          reference_level_meters REAL NULL,
           PRIMARY KEY (tile_key)
         )
       ''');

--- a/lib/core/database/local_cache_database.dart
+++ b/lib/core/database/local_cache_database.dart
@@ -132,7 +132,10 @@ class SwissBathyTileCache extends Table {
   /// back to one full re-resolution on its next read -- the only way to
   /// actually correct already-wrongly-cached tiles (e.g. a coordinate that
   /// used to resolve to a coarser neighboring lake's bbox before a
-  /// whitelist correction) rather than merely preventing new ones.
+  /// whitelist correction) rather than merely preventing new ones. Null
+  /// only for rows written before this field existed (v17) -- every 'ok'
+  /// AND 'empty' row written since then stores its actual level, so the
+  /// mismatch check above applies uniformly to both statuses.
   RealColumn get referenceLevelMeters => real().nullable()();
 
   @override

--- a/lib/features/bathymetry/data/bathymetry_repository.dart
+++ b/lib/features/bathymetry/data/bathymetry_repository.dart
@@ -83,14 +83,27 @@ class BathymetryRepository {
     // differently must miss the old rows and refetch. Stale rows are inert
     // leftovers in this local-only cache.
     final span = BathymetryResolver.defaultSpanMeters.round();
-    if (quantumDegFor(c) <= 0) {
+    final lake = findSwissLake(c);
+    if (lake != null) {
+      // The lake's OWN mean level rides along in the key, not just
+      // selectionGeneration: _load returns a matching outer row before the
+      // resolver -- and so before SwissBathyTileCacheRepository.read's own
+      // reference-level check -- ever runs again, so a FUTURE correction
+      // to this lake's documented level (independent of any code change,
+      // and so not covered by any one-time generation bump) would
+      // otherwise keep serving the outer cache's stale depths forever
+      // (Copilot review). Folding the level in here means only the
+      // coordinates of the ACTUALLY corrected lake miss, not the whole
+      // cache, and needs no manual bump at all going forward.
+      //
       // Raw coordinate, not a quantized cell corner: needs enough decimals
       // to actually distinguish nearby sites (2 decimals is ~1 km at these
       // latitudes -- exactly the coalescing this branch exists to avoid).
       // See the class doc for the cache-coalescing this gives up, and why
       // that is deferred to issue #1511.
       return '${c.latitude.toStringAsFixed(6)},'
-          '${c.longitude.toStringAsFixed(6)}@$span$selectionGeneration';
+          '${c.longitude.toStringAsFixed(6)}@$span$selectionGeneration'
+          '@${lake.meanLevelMeters}';
     }
     final q = quantize(c);
     return '${q.lat.toStringAsFixed(2)},${q.lon.toStringAsFixed(2)}'

--- a/lib/features/bathymetry/data/bathymetry_repository.dart
+++ b/lib/features/bathymetry/data/bathymetry_repository.dart
@@ -39,7 +39,15 @@ class BathymetryRepository {
   /// rows never expire, so without this every already-visited site would
   /// keep serving the grid its old resolver chose. Old rows go inert, the
   /// same way the 4 km rows did when the span went to 8 km.
-  static const String selectionGeneration = 'v2';
+  ///
+  /// v4 here (skipping past #1756's v3, which this branch predates) so an
+  /// install that already visited #1756 -- and so already holds a v3 outer
+  /// row -- is still forced back through the resolver once this release's
+  /// inner swiss_bathy_tile_cache reference-level fix ships (Copilot
+  /// review): an unchanged v3 row would otherwise keep being served
+  /// straight from the outer cache and never reach the now-fixed inner
+  /// validation in SwissBathyTileCacheRepository.read.
+  static const String selectionGeneration = 'v4';
   static const double quantumDeg = 0.02;
 
   final LocalCacheDatabase _db;

--- a/lib/features/bathymetry/data/sources/swiss_bathy_tile_cache_repository.dart
+++ b/lib/features/bathymetry/data/sources/swiss_bathy_tile_cache_repository.dart
@@ -146,6 +146,37 @@ class SwissBathyTileCacheRepository {
     return [for (final row in rows) row.tileKey];
   }
 
+  /// Deletes [tileKey] if its stored [referenceLevelMeters] does not match
+  /// any of [currentLevels], a no-op (never deletes) when it matches one
+  /// of them or the tile is uncached. For a sweep visiting a tile whose
+  /// OWN center no longer resolves to any registered lake -- so there is
+  /// no single current lake to pass to [read]'s normal
+  /// expectedReferenceLevelMeters check -- but which may still hold a
+  /// valid row cached under a lake the fetch that found it fell back to
+  /// (see [SwissBathy3dSource.fetch]'s tileLake fallback). Matching
+  /// against every currently registered level, not just one, is looser
+  /// than [read]'s per-lookup check, but still correctly deletes a row
+  /// whose level belongs to no lake in the CURRENT table at all -- the
+  /// actual staleness signal a lake removal or a documented level
+  /// correction leaves behind.
+  Future<bool> deleteIfLevelUnknown(
+    String tileKey,
+    Iterable<double> currentLevels,
+  ) async {
+    final row = await (_db.select(
+      _db.swissBathyTileCache,
+    )..where((t) => t.tileKey.equals(tileKey))).getSingleOrNull();
+    if (row == null) return false;
+    if (row.referenceLevelMeters != null &&
+        currentLevels.contains(row.referenceLevelMeters)) {
+      return false;
+    }
+    await (_db.delete(
+      _db.swissBathyTileCache,
+    )..where((t) => t.tileKey.equals(tileKey))).go();
+    return true;
+  }
+
   Future<void> writeOk(
     String tileKey,
     BathymetryGrid grid, {

--- a/lib/features/bathymetry/data/sources/swiss_bathy_tile_cache_repository.dart
+++ b/lib/features/bathymetry/data/sources/swiss_bathy_tile_cache_repository.dart
@@ -132,14 +132,17 @@ class SwissBathyTileCacheRepository {
     return row != null;
   }
 
-  /// Every tile key with a usable ('ok') cached grid. Used by the manual
-  /// "reload map data" action, which revalidates every cached tile's
-  /// freshness immediately instead of waiting for each one's individual
-  /// [SwissBathy3dSource.staleCheckInterval] to elapse.
-  Future<List<String>> okTileKeys() async {
-    final rows = await (_db.select(
-      _db.swissBathyTileCache,
-    )..where((t) => t.status.equals('ok'))).get();
+  /// Every cached tile key, 'ok' AND 'empty' alike. Used by the manual
+  /// "reload map data" action, which revalidates every cached tile
+  /// immediately instead of waiting for each one's individual
+  /// [SwissBathy3dSource.staleCheckInterval] to elapse. Negative rows are
+  /// included, not just positive ones: a negative cached under a
+  /// reference level that no longer matches (a lake bbox/level
+  /// correction) is exactly as stale as a positive one would be, and
+  /// [read]'s mismatch check only ever runs for a tile key this sweep
+  /// actually visits.
+  Future<List<String>> allTileKeys() async {
+    final rows = await _db.select(_db.swissBathyTileCache).get();
     return [for (final row in rows) row.tileKey];
   }
 

--- a/lib/features/bathymetry/data/sources/swiss_bathy_tile_cache_repository.dart
+++ b/lib/features/bathymetry/data/sources/swiss_bathy_tile_cache_repository.dart
@@ -26,11 +26,21 @@ class SwissBathyTileCacheEntry {
   /// Null for tiles cached before this field existed (v15 and earlier).
   final String? sourceHref;
 
+  /// The lake reference level this entry's [grid] depths were computed
+  /// against — see [LocalCacheDatabase]'s `SwissBathyTileCache.
+  /// referenceLevelMeters` doc for why [read] never actually returns an
+  /// entry whose stored level does not match what the caller expects: a
+  /// mismatch (including this being null, from before the field existed)
+  /// deletes the row and returns null instead, so this field is really
+  /// only informative for a caller not passing `expectedReferenceLevelMeters`.
+  final double? referenceLevelMeters;
+
   const SwissBathyTileCacheEntry({
     required this.grid,
     this.sourceDatetime,
     this.checkedAt,
     this.sourceHref,
+    this.referenceLevelMeters,
   });
 }
 
@@ -44,10 +54,19 @@ class SwissBathyTileCacheRepository {
 
   const SwissBathyTileCacheRepository(this._db);
 
-  /// The cached entry for [tileKey], or null when uncached OR when the tile
-  /// is a cached negative ('empty'). Use [hasCachedAnswer] to tell those
-  /// apart from "never looked up".
-  Future<SwissBathyTileCacheEntry?> read(String tileKey) async {
+  /// The cached entry for [tileKey], or null when uncached, when the tile
+  /// is a cached negative ('empty'), OR when [expectedReferenceLevelMeters]
+  /// is given and does not match the level the row was actually cached
+  /// under (see `SwissBathyTileCache.referenceLevelMeters`'s doc) — the row
+  /// is deleted in that case too, exactly like corruption, so the caller
+  /// re-fetches and gets a correctly depth-converted grid instead of
+  /// silently serving stale, wrongly-converted depths forever. Passing null
+  /// (the default) skips this check entirely. Use [hasCachedAnswer] to tell
+  /// "never looked up" apart from any of these deleted-and-null outcomes.
+  Future<SwissBathyTileCacheEntry?> read(
+    String tileKey, {
+    double? expectedReferenceLevelMeters,
+  }) async {
     final row = await (_db.select(
       _db.swissBathyTileCache,
     )..where((t) => t.tileKey.equals(tileKey))).getSingleOrNull();
@@ -56,6 +75,17 @@ class SwissBathyTileCacheRepository {
     if (json == null) {
       // Inconsistent row ('ok' but no grid): delete so callers retry instead
       // of treating it as a cached negative.
+      await (_db.delete(
+        _db.swissBathyTileCache,
+      )..where((t) => t.tileKey.equals(tileKey))).go();
+      return null;
+    }
+    if (expectedReferenceLevelMeters != null &&
+        row.referenceLevelMeters != expectedReferenceLevelMeters) {
+      // A stored null (pre-v17 row) counts as a mismatch too: there is no
+      // way to tell whether its baked-in depths are still correct without
+      // this field, so it gets the same one-time re-resolution every other
+      // pre-existing-row migration in this table already falls back to.
       await (_db.delete(
         _db.swissBathyTileCache,
       )..where((t) => t.tileKey.equals(tileKey))).go();
@@ -72,6 +102,7 @@ class SwissBathyTileCacheRepository {
             ? null
             : DateTime.fromMillisecondsSinceEpoch(row.checkedAt!),
         sourceHref: row.sourceHref,
+        referenceLevelMeters: row.referenceLevelMeters,
       );
     } catch (_) {
       // Corrupt row: delete so callers retry instead of treating it as a cached negative.
@@ -108,6 +139,7 @@ class SwissBathyTileCacheRepository {
     BathymetryGrid grid, {
     String? sourceDatetime,
     String? sourceHref,
+    required double referenceLevelMeters,
   }) async {
     final now = DateTime.now().millisecondsSinceEpoch;
     await _db
@@ -121,6 +153,7 @@ class SwissBathyTileCacheRepository {
             sourceDatetime: Value(sourceDatetime),
             checkedAt: Value(now),
             sourceHref: Value(sourceHref),
+            referenceLevelMeters: Value(referenceLevelMeters),
           ),
         );
   }

--- a/lib/features/bathymetry/data/sources/swiss_bathy_tile_cache_repository.dart
+++ b/lib/features/bathymetry/data/sources/swiss_bathy_tile_cache_repository.dart
@@ -70,22 +70,31 @@ class SwissBathyTileCacheRepository {
     final row = await (_db.select(
       _db.swissBathyTileCache,
     )..where((t) => t.tileKey.equals(tileKey))).getSingleOrNull();
-    if (row == null || row.status != 'ok') return null;
-    final json = row.gridJson;
-    if (json == null) {
-      // Inconsistent row ('ok' but no grid): delete so callers retry instead
-      // of treating it as a cached negative.
+    if (row == null) return null;
+    if (expectedReferenceLevelMeters != null &&
+        row.referenceLevelMeters != expectedReferenceLevelMeters) {
+      // Checked before the status guard below, and so applies to a cached
+      // 'empty' row exactly like an 'ok' one: a lake bbox correction can
+      // turn a tile that was genuinely dry land under the OLD lake
+      // assignment into real, covered water under the new one, so a stale
+      // negative is exactly as unreliable as a stale positive would be.
+      // Without this, [hasCachedAnswer] would keep reporting the tile as
+      // definitively resolved forever, and the caller would never retry it
+      // (Copilot review). A stored null (pre-v17 row) counts as a mismatch
+      // too: there is no way to tell whether its cached answer is still
+      // correct without this field, so it gets the same one-time
+      // re-resolution every other pre-existing-row migration in this table
+      // already falls back to.
       await (_db.delete(
         _db.swissBathyTileCache,
       )..where((t) => t.tileKey.equals(tileKey))).go();
       return null;
     }
-    if (expectedReferenceLevelMeters != null &&
-        row.referenceLevelMeters != expectedReferenceLevelMeters) {
-      // A stored null (pre-v17 row) counts as a mismatch too: there is no
-      // way to tell whether its baked-in depths are still correct without
-      // this field, so it gets the same one-time re-resolution every other
-      // pre-existing-row migration in this table already falls back to.
+    if (row.status != 'ok') return null;
+    final json = row.gridJson;
+    if (json == null) {
+      // Inconsistent row ('ok' but no grid): delete so callers retry instead
+      // of treating it as a cached negative.
       await (_db.delete(
         _db.swissBathyTileCache,
       )..where((t) => t.tileKey.equals(tileKey))).go();
@@ -158,7 +167,10 @@ class SwissBathyTileCacheRepository {
         );
   }
 
-  Future<void> writeEmpty(String tileKey) async {
+  Future<void> writeEmpty(
+    String tileKey, {
+    required double referenceLevelMeters,
+  }) async {
     await _db
         .into(_db.swissBathyTileCache)
         .insertOnConflictUpdate(
@@ -166,6 +178,7 @@ class SwissBathyTileCacheRepository {
             tileKey: tileKey,
             status: 'empty',
             fetchedAt: DateTime.now().millisecondsSinceEpoch,
+            referenceLevelMeters: Value(referenceLevelMeters),
           ),
         );
   }

--- a/lib/features/bathymetry/data/sources/swissbathy3d_source.dart
+++ b/lib/features/bathymetry/data/sources/swissbathy3d_source.dart
@@ -518,7 +518,7 @@ class SwissBathy3dSource implements BathymetrySource {
   /// re-downloads that lake's zip at most once for the entire sweep, not
   /// once per affected tile.
   Future<SwissBathyRefreshSummary> refreshAllCachedTiles() async {
-    final tileKeys = await _tileCache.okTileKeys();
+    final tileKeys = await _tileCache.allTileKeys();
 
     final sharedRawGrids = <String, Future<List<RawEsriGrid>>>{};
     Future<List<RawEsriGrid>> download(String href) =>
@@ -539,18 +539,28 @@ class SwissBathy3dSource implements BathymetrySource {
       final lake = findSwissLake(
         GeoPoint(tileCenter.latitude, tileCenter.longitude),
       );
-      if (lake == null) return null; // should not happen for a real 'ok' tile
+      // Orphaned by a bbox tightened enough to no longer cover this tile
+      // at all -- inert (no future fetch() targets it either), left for a
+      // later cleanup rather than handled here.
+      if (lake == null) return null;
 
       // Computed BEFORE the read so a reference-level mismatch (the lake
       // table changed since this tile was cached) is caught here too, not
       // just on the next fetch() visit -- read() drops the row and returns
-      // null in that case, same as corruption.
+      // null in that case, same as corruption. Applies uniformly to an
+      // 'ok' row (dropped, so the next fetch() re-downloads) and an
+      // 'empty' one (dropped, so the next fetch() re-resolves instead of
+      // hasCachedAnswer() suppressing it forever) -- see allTileKeys' doc
+      // for why 'empty' tiles are included in this sweep at all. A still-
+      // valid 'empty' row also reads back null here (it never carries a
+      // grid), so this branch covers "nothing to check" and "just
+      // invalidated" alike; neither needs the freshness check below.
       final cached = await _tileCache.read(
         tileKey,
         expectedReferenceLevelMeters: lake.meanLevelMeters,
       );
       if (cached == null) {
-        return null; // evicted/corrupted/mismatched since listing
+        return null;
       }
 
       final result = await _checkAndMaybeUpdate(

--- a/lib/features/bathymetry/data/sources/swissbathy3d_source.dart
+++ b/lib/features/bathymetry/data/sources/swissbathy3d_source.dart
@@ -539,10 +539,22 @@ class SwissBathy3dSource implements BathymetrySource {
       final lake = findSwissLake(
         GeoPoint(tileCenter.latitude, tileCenter.longitude),
       );
-      // Orphaned by a bbox tightened enough to no longer cover this tile
-      // at all -- inert (no future fetch() targets it either), left for a
-      // later cleanup rather than handled here.
-      if (lake == null) return null;
+      if (lake == null) {
+        // The tile's OWN center resolves to no current lake, but the row
+        // may still be one fetch() cached under the FETCH CENTER's lake
+        // as a fallback (a real edge tile whose own center misses every
+        // registered bbox -- see fetch()'s tileLake fallback), so there is
+        // no single current lake to pass to read()'s normal per-lookup
+        // check. Delete it only if its stored level belongs to no lake in
+        // the CURRENT table at all -- the actual staleness signal a lake
+        // removal or a documented level correction leaves behind (Copilot
+        // review).
+        await _tileCache.deleteIfLevelUnknown(
+          tileKey,
+          swissLakeLevels.map((l) => l.meanLevelMeters),
+        );
+        return null;
+      }
 
       // Computed BEFORE the read so a reference-level mismatch (the lake
       // table changed since this tile was cached) is caught here too, not

--- a/lib/features/bathymetry/data/sources/swissbathy3d_source.dart
+++ b/lib/features/bathymetry/data/sources/swissbathy3d_source.dart
@@ -546,8 +546,9 @@ class SwissBathy3dSource implements BathymetrySource {
         tileKey,
         expectedReferenceLevelMeters: lake.meanLevelMeters,
       );
-      if (cached == null)
+      if (cached == null) {
         return null; // evicted/corrupted/mismatched since listing
+      }
 
       final result = await _checkAndMaybeUpdate(
         tileKey,

--- a/lib/features/bathymetry/data/sources/swissbathy3d_source.dart
+++ b/lib/features/bathymetry/data/sources/swissbathy3d_source.dart
@@ -226,7 +226,10 @@ class SwissBathy3dSource implements BathymetrySource {
   ) async {
     final tileKey = '${tileE}_$tileN';
 
-    final cached = await _tileCache.read(tileKey);
+    final cached = await _tileCache.read(
+      tileKey,
+      expectedReferenceLevelMeters: lake.meanLevelMeters,
+    );
     if (cached != null) {
       if (!_isStale(cached.checkedAt)) return cached.grid;
       return _refreshIfStale(tileKey, tileE, tileN, lake, cached);
@@ -272,6 +275,7 @@ class SwissBathy3dSource implements BathymetrySource {
       grid,
       sourceDatetime: resolved.asset.datetime,
       sourceHref: resolved.asset.href,
+      referenceLevelMeters: lake.meanLevelMeters,
     );
     return grid;
   }
@@ -477,6 +481,7 @@ class SwissBathy3dSource implements BathymetrySource {
         grid,
         sourceDatetime: resolved.asset.datetime,
         sourceHref: resolved.asset.href,
+        referenceLevelMeters: lake.meanLevelMeters,
       );
       return (grid: grid, outcome: _TileCheckOutcome.updated);
     } on SwissStacException {
@@ -519,9 +524,6 @@ class SwissBathy3dSource implements BathymetrySource {
     final outcomes = await _runBounded(tileKeys, maxConcurrentTileRequests, (
       tileKey,
     ) async {
-      final cached = await _tileCache.read(tileKey);
-      if (cached == null) return null; // evicted/corrupted since listing
-
       final parts = tileKey.split('_');
       final tileE = parts.length == 2 ? int.tryParse(parts[0]) : null;
       final tileN = parts.length == 2 ? int.tryParse(parts[1]) : null;
@@ -535,6 +537,17 @@ class SwissBathy3dSource implements BathymetrySource {
         GeoPoint(tileCenter.latitude, tileCenter.longitude),
       );
       if (lake == null) return null; // should not happen for a real 'ok' tile
+
+      // Computed BEFORE the read so a reference-level mismatch (the lake
+      // table changed since this tile was cached) is caught here too, not
+      // just on the next fetch() visit -- read() drops the row and returns
+      // null in that case, same as corruption.
+      final cached = await _tileCache.read(
+        tileKey,
+        expectedReferenceLevelMeters: lake.meanLevelMeters,
+      );
+      if (cached == null)
+        return null; // evicted/corrupted/mismatched since listing
 
       final result = await _checkAndMaybeUpdate(
         tileKey,

--- a/lib/features/bathymetry/data/sources/swissbathy3d_source.dart
+++ b/lib/features/bathymetry/data/sources/swissbathy3d_source.dart
@@ -260,7 +260,10 @@ class SwissBathy3dSource implements BathymetrySource {
       // tile once their real content was checked — deterministic for this
       // tile, so caching it avoids repeating the same lookup (and any
       // shared-href downloads) on every future visit to this coordinate.
-      await _tileCache.writeEmpty(tileKey);
+      await _tileCache.writeEmpty(
+        tileKey,
+        referenceLevelMeters: lake.meanLevelMeters,
+      );
       return null;
     }
 

--- a/test/core/database/local_cache_migration_v17_swiss_bathy_reference_level_test.dart
+++ b/test/core/database/local_cache_migration_v17_swiss_bathy_reference_level_test.dart
@@ -1,0 +1,86 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+
+void main() {
+  test(
+    'fresh database exposes reference_level_meters on swiss_bathy_tile_cache',
+    () async {
+      final db = LocalCacheDatabase(NativeDatabase.memory());
+      addTearDown(db.close);
+      expect(db.schemaVersion, greaterThanOrEqualTo(17));
+      await db
+          .into(db.swissBathyTileCache)
+          .insert(
+            SwissBathyTileCacheCompanion.insert(
+              tileKey: '2665_1212',
+              status: 'ok',
+              gridJson: const Value('{}'),
+              fetchedAt: 1753600000000,
+              sourceDatetime: const Value('2023-01-01T00:00:00Z'),
+              checkedAt: const Value(1753600000000),
+              sourceHref: const Value('https://example.org/real.zip'),
+              referenceLevelMeters: const Value(419.00),
+            ),
+          );
+      final row = await db.select(db.swissBathyTileCache).getSingle();
+      expect(row.referenceLevelMeters, 419.00);
+    },
+  );
+
+  test('upgrade from a stored v16 schema adds reference_level_meters, '
+      'nullable so existing rows survive', () async {
+    final db = LocalCacheDatabase(
+      NativeDatabase.memory(
+        setup: (raw) {
+          // Minimal v16 shape: swiss_bathy_tile_cache exists WITHOUT the
+          // v17 column, plus one pre-existing row to prove the upgrade
+          // doesn't drop data.
+          raw
+            ..execute(
+              'CREATE TABLE local_asset_cache '
+              '(media_id TEXT PRIMARY KEY, local_asset_id TEXT, '
+              'resolved_at INTEGER, resolution_method TEXT, '
+              'attempt_count INTEGER)',
+            )
+            ..execute(
+              'CREATE TABLE media_transfer_queue '
+              '(id INTEGER PRIMARY KEY AUTOINCREMENT, media_id TEXT)',
+            )
+            ..execute(
+              'CREATE TABLE media_cache_entries '
+              '(content_hash TEXT, kind TEXT, '
+              'PRIMARY KEY (content_hash, kind))',
+            )
+            ..execute(
+              'CREATE TABLE swiss_bathy_tile_cache '
+              '(tile_key TEXT NOT NULL, status TEXT NOT NULL, '
+              'grid_json TEXT NULL, fetched_at INTEGER NOT NULL, '
+              'source_datetime TEXT NULL, checked_at INTEGER NULL, '
+              'source_href TEXT NULL, '
+              'PRIMARY KEY (tile_key))',
+            )
+            ..execute(
+              "INSERT INTO swiss_bathy_tile_cache "
+              "(tile_key, status, grid_json, fetched_at, source_datetime, "
+              "checked_at, source_href) "
+              "VALUES ('2665_1212', 'ok', '{}', 1753600000000, "
+              "'2023-01-01T00:00:00Z', 1753600000000, "
+              "'https://example.org/real.zip')",
+            )
+            ..execute('PRAGMA user_version = 16');
+        },
+      ),
+    );
+    addTearDown(db.close);
+    final row = await db.select(db.swissBathyTileCache).getSingle();
+    expect(row.tileKey, '2665_1212');
+    expect(row.sourceHref, 'https://example.org/real.zip');
+    // Pre-v17 rows have no known reference level -- SwissBathyTileCacheRepository.read
+    // treats null the same as a mismatch when a caller checks it, forcing
+    // one re-resolution rather than trusting a level that might no longer
+    // be correct.
+    expect(row.referenceLevelMeters, isNull);
+  });
+}

--- a/test/core/database/local_cache_migration_v17_swiss_bathy_reference_level_test.dart
+++ b/test/core/database/local_cache_migration_v17_swiss_bathy_reference_level_test.dart
@@ -83,4 +83,43 @@ void main() {
     // be correct.
     expect(row.referenceLevelMeters, isNull);
   });
+
+  test('a database already stamped at v17 but still v16-shaped (a ladder '
+      'collision: another branch claimed user_version 17 first without '
+      'actually running this migration) is healed by the beforeOpen '
+      'backstop, not just onUpgrade -- onUpgrade never runs here since '
+      'Drift sees no version change to apply (Copilot review)', () async {
+    final db = LocalCacheDatabase(
+      NativeDatabase.memory(
+        setup: (raw) {
+          raw
+            ..execute(
+              'CREATE TABLE swiss_bathy_tile_cache '
+              '(tile_key TEXT NOT NULL, status TEXT NOT NULL, '
+              'grid_json TEXT NULL, fetched_at INTEGER NOT NULL, '
+              'source_datetime TEXT NULL, checked_at INTEGER NULL, '
+              'source_href TEXT NULL, '
+              'PRIMARY KEY (tile_key))',
+            )
+            ..execute(
+              "INSERT INTO swiss_bathy_tile_cache "
+              "(tile_key, status, grid_json, fetched_at, source_datetime, "
+              "checked_at, source_href) "
+              "VALUES ('2665_1212', 'ok', '{}', 1753600000000, "
+              "'2023-01-01T00:00:00Z', 1753600000000, "
+              "'https://example.org/real.zip')",
+            )
+            // Stamped at the CURRENT schema version despite the table
+            // still missing reference_level_meters -- the exact
+            // collision this backstop exists to heal.
+            ..execute('PRAGMA user_version = 17');
+        },
+      ),
+    );
+    addTearDown(db.close);
+    final row = await db.select(db.swissBathyTileCache).getSingle();
+    expect(row.tileKey, '2665_1212');
+    expect(row.sourceHref, 'https://example.org/real.zip');
+    expect(row.referenceLevelMeters, isNull);
+  });
 }

--- a/test/features/bathymetry/data/bathymetry_repository_test.dart
+++ b/test/features/bathymetry/data/bathymetry_repository_test.dart
@@ -115,11 +115,11 @@ void main() {
     // The key carries the request span and the selection generation, so a
     // change to either refetches instead of serving the old cached answer
     // forever.
-    expect(BathymetryRepository.keyFor(bonaire), '12.16,-68.30@8000v2');
+    expect(BathymetryRepository.keyFor(bonaire), '12.16,-68.30@8000v4');
     // Nearby coordinates share the key.
     expect(
       BathymetryRepository.keyFor(const GeoPoint(12.171, -68.281)),
-      '12.16,-68.30@8000v2',
+      '12.16,-68.30@8000v4',
     );
   });
 
@@ -310,7 +310,7 @@ void main() {
 
   test('the cache key carries the selection generation', () {
     final key = BathymetryRepository.keyFor(const GeoPoint(12.16, -68.29));
-    expect(key, endsWith('@8000v2'));
+    expect(key, endsWith('@8000v4'));
   });
 
   test('a row written under the previous generation is not reused', () {

--- a/test/features/bathymetry/data/bathymetry_repository_test.dart
+++ b/test/features/bathymetry/data/bathymetry_repository_test.dart
@@ -156,6 +156,12 @@ void main() {
         floor002(betlis.latitude),
         closeTo(floor002(murgWest.latitude), 1e-9),
       );
+
+      // The resolved lake's OWN mean level rides along in the key (Copilot
+      // review): a FUTURE correction to Walensee's documented level in
+      // swiss_lake_levels.dart automatically changes this key too, without
+      // needing a manual selectionGeneration bump for that correction.
+      expect(BathymetryRepository.keyFor(betlis), endsWith('@419.07'));
       expect(
         floor002(betlis.longitude),
         closeTo(floor002(murgWest.longitude), 1e-9),

--- a/test/features/bathymetry/data/swiss_bathy_tile_cache_repository_test.dart
+++ b/test/features/bathymetry/data/swiss_bathy_tile_cache_repository_test.dart
@@ -30,7 +30,7 @@ void main() {
         resolutionMeters: 2,
         fetchedAt: DateTime.utc(2026, 1, 1),
       );
-      await repo.writeOk('2726_1221', grid);
+      await repo.writeOk('2726_1221', grid, referenceLevelMeters: 405.92);
 
       final entry = await repo.read('2726_1221');
       expect(entry, isNotNull);
@@ -126,5 +126,115 @@ void main() {
         expect(await repo.hasCachedAnswer('2726_1221'), isTrue);
       },
     );
+
+    test(
+      'a row cached under a different reference level than expected is '
+      'deleted and read() returns null, same as corruption (regression: '
+      'a swiss_lake_levels.dart correction that changes which lake a '
+      'coordinate resolves to, or its documented mean level, must not '
+      'leave a tile serving depths computed against the old level forever)',
+      () async {
+        final grid = BathymetryGrid(
+          originLat: 47.2,
+          originLon: 9.1,
+          cellSizeLatDeg: 0.001,
+          cellSizeLonDeg: 0.001,
+          rows: 2,
+          cols: 2,
+          depthsMeters: [1.0, 2.0, 3.0, 4.0],
+          sourceId: 'swissbathy3d',
+          resolutionMeters: 2,
+          fetchedAt: DateTime.utc(2026, 1, 1),
+        );
+        await repo.writeOk(
+          '2726_1221',
+          grid,
+          referenceLevelMeters: 433.58, // e.g. Vierwaldstättersee
+        );
+
+        final entry = await repo.read(
+          '2726_1221',
+          expectedReferenceLevelMeters: 419.00, // e.g. Rotsee, post-fix
+        );
+        expect(entry, isNull);
+
+        final remaining = await (db.select(
+          db.swissBathyTileCache,
+        )..where((t) => t.tileKey.equals('2726_1221'))).get();
+        expect(remaining, isEmpty);
+        expect(await repo.hasCachedAnswer('2726_1221'), isFalse);
+      },
+    );
+
+    test(
+      'a row cached before referenceLevelMeters existed (null) is treated '
+      'as a mismatch too when a caller now expects a specific level -- '
+      'there is no way to tell whether its baked-in depths are still '
+      'correct, so it gets one re-resolution rather than being trusted',
+      () async {
+        await db
+            .into(db.swissBathyTileCache)
+            .insert(
+              SwissBathyTileCacheCompanion.insert(
+                tileKey: '2726_1221',
+                status: 'ok',
+                gridJson: const Value('{}'),
+                fetchedAt: DateTime.now().millisecondsSinceEpoch,
+              ),
+            );
+
+        final entry = await repo.read(
+          '2726_1221',
+          expectedReferenceLevelMeters: 419.00,
+        );
+        expect(entry, isNull);
+        expect(await repo.hasCachedAnswer('2726_1221'), isFalse);
+      },
+    );
+
+    test('passing no expectedReferenceLevelMeters skips the check entirely, '
+        'returning the row as-is regardless of what level it was cached '
+        'under', () async {
+      final grid = BathymetryGrid(
+        originLat: 47.2,
+        originLon: 9.1,
+        cellSizeLatDeg: 0.001,
+        cellSizeLonDeg: 0.001,
+        rows: 2,
+        cols: 2,
+        depthsMeters: [1.0, 2.0, 3.0, 4.0],
+        sourceId: 'swissbathy3d',
+        resolutionMeters: 2,
+        fetchedAt: DateTime.utc(2026, 1, 1),
+      );
+      await repo.writeOk('2726_1221', grid, referenceLevelMeters: 433.58);
+
+      final entry = await repo.read('2726_1221');
+      expect(entry, isNotNull);
+      expect(entry!.referenceLevelMeters, 433.58);
+    });
+
+    test('a matching reference level is returned normally', () async {
+      final grid = BathymetryGrid(
+        originLat: 47.2,
+        originLon: 9.1,
+        cellSizeLatDeg: 0.001,
+        cellSizeLonDeg: 0.001,
+        rows: 2,
+        cols: 2,
+        depthsMeters: [1.0, 2.0, 3.0, 4.0],
+        sourceId: 'swissbathy3d',
+        resolutionMeters: 2,
+        fetchedAt: DateTime.utc(2026, 1, 1),
+      );
+      await repo.writeOk('2726_1221', grid, referenceLevelMeters: 419.00);
+
+      final entry = await repo.read(
+        '2726_1221',
+        expectedReferenceLevelMeters: 419.00,
+      );
+      expect(entry, isNotNull);
+      expect(entry!.grid.depthAt(0, 0), 1.0);
+    });
   });
 }

--- a/test/features/bathymetry/data/swiss_bathy_tile_cache_repository_test.dart
+++ b/test/features/bathymetry/data/swiss_bathy_tile_cache_repository_test.dart
@@ -116,16 +116,59 @@ void main() {
       expect(remaining, isEmpty);
     });
 
-    test(
-      'a cached negative ("empty") row is left untouched, not deleted',
-      () async {
-        await repo.writeEmpty('2726_1221');
+    test('a cached negative ("empty") row is left untouched, not deleted, '
+        'when no expected reference level is given or it matches', () async {
+      await repo.writeEmpty('2726_1221', referenceLevelMeters: 419.00);
 
-        final entry = await repo.read('2726_1221');
-        expect(entry, isNull);
-        expect(await repo.hasCachedAnswer('2726_1221'), isTrue);
-      },
-    );
+      final entry = await repo.read('2726_1221');
+      expect(entry, isNull);
+      expect(await repo.hasCachedAnswer('2726_1221'), isTrue);
+
+      final withMatch = await repo.read(
+        '2726_1221',
+        expectedReferenceLevelMeters: 419.00,
+      );
+      expect(withMatch, isNull);
+      expect(await repo.hasCachedAnswer('2726_1221'), isTrue);
+    });
+
+    test('a cached negative ("empty") row under a different reference level '
+        'than expected is deleted, so the tile is retried instead of staying '
+        'a permanent negative (regression: a lake bbox/level correction that '
+        'turns a tile genuinely dry under the OLD lake assignment into real, '
+        'covered water under the new one must not leave it pinned "no data" '
+        'forever, exactly like the analogous "ok" row case above -- Copilot '
+        'review)', () async {
+      await repo.writeEmpty('2726_1221', referenceLevelMeters: 433.58);
+
+      final entry = await repo.read(
+        '2726_1221',
+        expectedReferenceLevelMeters: 419.00,
+      );
+      expect(entry, isNull);
+      expect(await repo.hasCachedAnswer('2726_1221'), isFalse);
+    });
+
+    test('a cached negative ("empty") row written before referenceLevelMeters '
+        'existed (null) is treated as a mismatch too when a caller now '
+        'expects a specific level', () async {
+      await db
+          .into(db.swissBathyTileCache)
+          .insert(
+            SwissBathyTileCacheCompanion.insert(
+              tileKey: '2726_1221',
+              status: 'empty',
+              fetchedAt: DateTime.now().millisecondsSinceEpoch,
+            ),
+          );
+
+      final entry = await repo.read(
+        '2726_1221',
+        expectedReferenceLevelMeters: 419.00,
+      );
+      expect(entry, isNull);
+      expect(await repo.hasCachedAnswer('2726_1221'), isFalse);
+    });
 
     test(
       'a row cached under a different reference level than expected is '

--- a/test/features/bathymetry/data/swiss_bathy_tile_cache_repository_test.dart
+++ b/test/features/bathymetry/data/swiss_bathy_tile_cache_repository_test.dart
@@ -280,4 +280,84 @@ void main() {
       expect(entry!.grid.depthAt(0, 0), 1.0);
     });
   });
+
+  group('SwissBathyTileCacheRepository.deleteIfLevelUnknown', () {
+    test('an uncached tile key is a no-op, returns false', () async {
+      final deleted = await repo.deleteIfLevelUnknown('2726_1221', [419.00]);
+      expect(deleted, isFalse);
+    });
+
+    test('a row whose stored level matches one of the current levels is left '
+        'untouched, returns false', () async {
+      await repo.writeEmpty('2726_1221', referenceLevelMeters: 419.00);
+
+      final deleted = await repo.deleteIfLevelUnknown('2726_1221', [
+        433.58,
+        419.00,
+      ]);
+
+      expect(deleted, isFalse);
+      expect(await repo.hasCachedAnswer('2726_1221'), isTrue);
+    });
+
+    test('a row whose stored level matches none of the current levels is '
+        'deleted, returns true (the fallback-cached-tile edge case: the '
+        "tile's own center resolves to no lake, so there is no single "
+        'expected level to check against)', () async {
+      await repo.writeEmpty('2726_1221', referenceLevelMeters: 419.00);
+
+      final deleted = await repo.deleteIfLevelUnknown('2726_1221', [
+        433.58,
+        405.92,
+      ]);
+
+      expect(deleted, isTrue);
+      expect(await repo.hasCachedAnswer('2726_1221'), isFalse);
+    });
+
+    test('a row with no stored level at all (pre-v17) is treated as unknown '
+        'and deleted, even against an empty currentLevels list', () async {
+      await db
+          .into(db.swissBathyTileCache)
+          .insert(
+            SwissBathyTileCacheCompanion.insert(
+              tileKey: '2726_1221',
+              status: 'empty',
+              fetchedAt: DateTime.now().millisecondsSinceEpoch,
+            ),
+          );
+
+      final deleted = await repo.deleteIfLevelUnknown(
+        '2726_1221',
+        const <double>[],
+      );
+
+      expect(deleted, isTrue);
+      expect(await repo.hasCachedAnswer('2726_1221'), isFalse);
+    });
+
+    test(
+      'also deletes a matching-status "ok" row under an unknown level',
+      () async {
+        final grid = BathymetryGrid(
+          originLat: 47.2,
+          originLon: 9.1,
+          cellSizeLatDeg: 0.001,
+          cellSizeLonDeg: 0.001,
+          rows: 2,
+          cols: 2,
+          depthsMeters: [1.0, 2.0, 3.0, 4.0],
+          sourceId: 'swissbathy3d',
+          resolutionMeters: 2,
+          fetchedAt: DateTime.utc(2026, 1, 1),
+        );
+        await repo.writeOk('2726_1221', grid, referenceLevelMeters: 419.00);
+
+        final deleted = await repo.deleteIfLevelUnknown('2726_1221', [433.58]);
+
+        expect(deleted, isTrue);
+        expect(await repo.hasCachedAnswer('2726_1221'), isFalse);
+      },
+    );
+  });
 }

--- a/test/features/bathymetry/data/swissbathy3d_source_test.dart
+++ b/test/features/bathymetry/data/swissbathy3d_source_test.dart
@@ -1953,6 +1953,125 @@ nodata_value -9999
       expect(rows.single.status, 'ok');
     });
   });
+
+  group('SwissBathy3dSource tile cache reference-level mismatch', () {
+    // Regression test for the tile-cache-staleness gap found during
+    // review of the swissBATHY3D lake whitelist correction: a coordinate
+    // whose lake assignment (or documented mean level) changes must not
+    // keep serving a cached grid whose depths were computed against the
+    // OLD reference level forever. Simulates exactly that: the tile is
+    // pre-seeded as if it had been cached under a different lake's level
+    // (433.58, e.g. Vierwaldstättersee) before Zürichsee's own entry
+    // (405.92) covered this coordinate.
+    test('a cached tile whose stored reference level does not match the '
+        'current lake is re-fetched, not served with the stale depth '
+        'conversion', () async {
+      final lv95 = Lv95Transform.fromWgs84(
+        zurichseePoint.latitude,
+        zurichseePoint.longitude,
+      );
+      final tileKey = SwissBathy3dSource.tileKeyFor(lv95);
+      await db
+          .into(db.swissBathyTileCache)
+          .insert(
+            SwissBathyTileCacheCompanion.insert(
+              tileKey: tileKey,
+              status: 'ok',
+              gridJson: const Value('{}'),
+              fetchedAt: DateTime.now().millisecondsSinceEpoch,
+              checkedAt: Value(DateTime.now().millisecondsSinceEpoch),
+              referenceLevelMeters: const Value(433.58),
+            ),
+          );
+
+      var itemCalls = 0;
+      var downloadCalls = 0;
+      final source = buildSource((req) async {
+        if (req.url.path.endsWith('/items')) {
+          itemCalls++;
+          return http.Response(
+            jsonEncode({
+              'features': [
+                {
+                  'bbox': _requestedBbox(req),
+                  'assets': {
+                    'grid': {'href': 'https://example.org/tile_grid.zip'},
+                  },
+                },
+              ],
+            }),
+            200,
+          );
+        }
+        downloadCalls++;
+        return http.Response.bytes(_zipOf('tile.asc', gridBody), 200);
+      });
+
+      final grid = await source.fetch(zurichseePoint, spanMeters: 100);
+
+      // The mismatched row forced a real re-fetch instead of an immediate
+      // cache hit.
+      expect(itemCalls, 1);
+      expect(downloadCalls, 1);
+
+      const referenceLevel = 405.92; // Zürichsee
+      expect(grid.depthAt(0, 0), closeTo(referenceLevel - 408.0, 1e-9));
+
+      final rows = await (db.select(
+        db.swissBathyTileCache,
+      )..where((t) => t.tileKey.equals(tileKey))).get();
+      expect(rows, hasLength(1));
+      expect(rows.single.referenceLevelMeters, referenceLevel);
+    });
+
+    test('a cached tile with no stored reference level at all (pre-v17 '
+        'row) is also re-fetched rather than trusted as-is', () async {
+      final lv95 = Lv95Transform.fromWgs84(
+        zurichseePoint.latitude,
+        zurichseePoint.longitude,
+      );
+      final tileKey = SwissBathy3dSource.tileKeyFor(lv95);
+      await db
+          .into(db.swissBathyTileCache)
+          .insert(
+            SwissBathyTileCacheCompanion.insert(
+              tileKey: tileKey,
+              status: 'ok',
+              gridJson: const Value('{}'),
+              fetchedAt: DateTime.now().millisecondsSinceEpoch,
+              checkedAt: Value(DateTime.now().millisecondsSinceEpoch),
+              // referenceLevelMeters intentionally absent.
+            ),
+          );
+
+      var downloadCalls = 0;
+      final source = buildSource((req) async {
+        if (req.url.path.endsWith('/items')) {
+          return http.Response(
+            jsonEncode({
+              'features': [
+                {
+                  'bbox': _requestedBbox(req),
+                  'assets': {
+                    'grid': {'href': 'https://example.org/tile_grid.zip'},
+                  },
+                },
+              ],
+            }),
+            200,
+          );
+        }
+        downloadCalls++;
+        return http.Response.bytes(_zipOf('tile.asc', gridBody), 200);
+      });
+
+      final grid = await source.fetch(zurichseePoint, spanMeters: 100);
+
+      expect(downloadCalls, 1);
+      const referenceLevel = 405.92; // Zürichsee
+      expect(grid.depthAt(0, 0), closeTo(referenceLevel - 408.0, 1e-9));
+    });
+  });
 }
 
 class _FakeFallbackSource implements BathymetrySource {

--- a/test/features/bathymetry/data/swissbathy3d_source_test.dart
+++ b/test/features/bathymetry/data/swissbathy3d_source_test.dart
@@ -1911,6 +1911,44 @@ nodata_value -9999
       expect(grid.sourceId, 'swissbathy3d');
       expect(itemCalls, 1);
     });
+
+    test("a tile whose own center CURRENTLY resolves to a different lake than "
+        "the one it was cached under is invalidated by the sweep even though "
+        "findSwissLake(tileCenter) now returns non-null (regression: verifies "
+        "the sweep's main lake!=null branch, not just the deleteIfLevelUnknown "
+        "null branch, actually catches a tile that used to belong to a "
+        "different, e.g. since-corrected-bbox lake -- Copilot review, round "
+        "3)", () async {
+      // zurichseeTileCenter's own tile (2685_1240, see the fixture header
+      // above) currently resolves to Zürichsee (405.92 m). Seeded directly
+      // as though it were still cached under Walensee's level (419.07 m)
+      // -- e.g. from before some past bbox correction moved this tile from
+      // one lake's registered bbox to another's.
+      const tileKey = '2685_1240';
+      await db
+          .into(db.swissBathyTileCache)
+          .insert(
+            SwissBathyTileCacheCompanion.insert(
+              tileKey: tileKey,
+              status: 'empty',
+              fetchedAt: DateTime.now().millisecondsSinceEpoch,
+              referenceLevelMeters: const Value(419.07),
+            ),
+          );
+
+      final source = buildSource((_) async => http.Response('', 404));
+
+      final summary = await source.refreshAllCachedTiles();
+      // Deleted via read()'s own mismatch check inside the sweep's
+      // lake!=null branch -- no network call needed for a pure local
+      // invalidation.
+      expect(summary.total, 0);
+
+      final row = await (db.select(
+        db.swissBathyTileCache,
+      )..where((t) => t.tileKey.equals(tileKey))).getSingleOrNull();
+      expect(row, isNull);
+    });
   });
 
   group('SwissBathy3dSource in the resolver chain', () {

--- a/test/features/bathymetry/data/swissbathy3d_source_test.dart
+++ b/test/features/bathymetry/data/swissbathy3d_source_test.dart
@@ -1859,6 +1859,58 @@ nodata_value -9999
       expect(summary.total, 0);
       expect(itemCalls, 1); // no extra lookup for the cached negative
     });
+
+    test('a cached negative under a STALE reference level is deleted by the '
+        'sweep, so the next fetch retries instead of staying pinned "no '
+        'data" forever (regression: allTileKeys() now includes empty rows, '
+        'but the sweep itself must actually invalidate a mismatch, not just '
+        'visit it -- Copilot review)', () async {
+      // zurichseePoint resolves to tile 2685_1240 (see gridBody's fixture
+      // header above). Seeded directly as a raw 'empty' row under a
+      // level that is NOT Zürichsee's real 405.92 m, simulating a tile
+      // that was cached before a lake table correction.
+      await db
+          .into(db.swissBathyTileCache)
+          .insert(
+            SwissBathyTileCacheCompanion.insert(
+              tileKey: '2685_1240',
+              status: 'empty',
+              fetchedAt: DateTime.now().millisecondsSinceEpoch,
+              referenceLevelMeters: const Value(433.58), // wrong lake
+            ),
+          );
+
+      var itemCalls = 0;
+      final source = buildSource((req) async {
+        if (req.url.path.endsWith('/items')) {
+          itemCalls++;
+          return http.Response(
+            jsonEncode({
+              'features': [
+                {
+                  'bbox': _requestedBbox(req),
+                  'assets': {
+                    'grid': {'href': 'https://example.org/tile_grid.zip'},
+                  },
+                },
+              ],
+            }),
+            200,
+          );
+        }
+        return http.Response.bytes(_zipOf('tile.asc', gridBody), 200);
+      });
+
+      final summary = await source.refreshAllCachedTiles();
+      expect(summary.total, 0); // deleted, not counted as a freshness hit
+      expect(itemCalls, 0); // pure local invalidation, no network call
+
+      // The stale negative is gone, so a real fetch retries it instead
+      // of hasCachedAnswer() suppressing it.
+      final grid = await source.fetch(zurichseePoint, spanMeters: 100);
+      expect(grid.sourceId, 'swissbathy3d');
+      expect(itemCalls, 1);
+    });
   });
 
   group('SwissBathy3dSource in the resolver chain', () {


### PR DESCRIPTION
## Summary

Closes #1761.

Follow-up to the swissBATHY3D lake whitelist correction (#1756), scoped as its own PR since a schema migration deserves its own review rather than a rushed addition to an already-broad change.

`SwissBathyTileCacheRepository` has never had any version/generation concept, independent of any specific whitelist change. A cached tile's depths are computed as `referenceLevelMeters - elevation` at write time and baked into the stored grid, but nothing recorded which lake (or level) that was, and nothing checked it back against the current lookup on read.

Concretely: Vierwaldstättersee's bbox has always been more generous than its real STAC coverage and sweeps over the real Rotsee location. Before Rotsee existed in the whitelist, a coordinate there resolved to Vierwaldstättersee, and swissBATHY3D successfully cached the real tile there — depth-converted using Vierwaldstättersee's 433.58 m instead of Rotsee's own 419.00 m, a ~14.6 m error. Any already-cached install keeps that wrong tile forever: the outer `BathymetryRepository` cache's `selectionGeneration` bump (#1756) does not help, since this inner cache is checked first and returns its stale grid without ever re-resolving through the outer cache/resolver.

## Changes

- Adds `SwissBathyTileCache.referenceLevelMeters` (schema v17, migration + `beforeOpen` backstop following the exact v15/v16 idiom already used for this same table).
- `writeOk` now records it; `read` takes a new optional `expectedReferenceLevelMeters` parameter and checks it. A mismatch — including a stored null, since pre-v17 rows have no way to tell whether their baked-in level is still correct — deletes the row and returns null, exactly like the repository already does for corruption, so the caller re-fetches with a correctly depth-converted grid.
- Threaded through both `_fetchTile` (the per-visit path) and `refreshAllCachedTiles`'s sweep (reordered there to compute the current lake before reading, so the manual "reload map data" action catches mismatches too, not just a fresh `fetch()` visit).

## Test plan

- [x] `dart analyze` clean on all touched files
- [x] `dart format` applied
- [x] Full bathymetry suite (236 tests) and full database suite (783 tests) passing
- [x] New migration test (fresh install + upgrade-from-v16 paths)
- [x] New repository tests: mismatch deletes and returns null, null-stored-level treated as mismatch, no-expected-level skips the check, matching level returns normally
- [x] New end-to-end regression tests in `swissbathy3d_source_test.dart` simulating the exact Rotsee/Vierwaldstättersee scenario (both with an explicit wrong stored level and with a pre-v17 null level)