### PR TITLE
fix(suunto-cloud): import the exit surface GPS fix (#1736)

### DIFF
--- a/lib/core/services/suunto_cloud/suunto_dive_parser.dart
+++ b/lib/core/services/suunto_cloud/suunto_dive_parser.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:submersion/core/services/suunto_cloud/suunto_cloud_event_map.dart';
 import 'package:submersion/features/dive_computer/domain/entities/downloaded_dive.dart';
 
@@ -97,6 +99,15 @@ class SuuntoDiveParser {
 
     final tanks = _buildTanks(diving, profileResult.gasSwitchOrder);
 
+    // Suunto takes a surface fix before the descent and another after the
+    // ascent, and keeps the pair in the dive footer's DiveLocation block
+    // (hoisted onto the header by [SuuntoSmlNormalizer]). A dive may hold
+    // either fix alone. The samples' DiveRouteOrigin repeats the entry fix
+    // and is the fallback for exports whose footer has no Start.
+    final diveLocation = header['DiveLocation'] as Map<String, dynamic>?;
+    final entryFix = _surfaceFix(diveLocation?['Start']);
+    final exitFix = _surfaceFix(diveLocation?['Stop']);
+
     final dive = DownloadedDive(
       startTime: startTime,
       durationSeconds: durationSeconds,
@@ -104,8 +115,10 @@ class SuuntoDiveParser {
       avgDepth: avgDepth,
       minTemperature: minTemperature,
       maxTemperature: maxTemperature,
-      entryLatitude: firstPass.latitude,
-      entryLongitude: firstPass.longitude,
+      entryLatitude: entryFix?.latitude ?? firstPass.latitude,
+      entryLongitude: entryFix?.longitude ?? firstPass.longitude,
+      exitLatitude: exitFix?.latitude,
+      exitLongitude: exitFix?.longitude,
       profile: profileResult.samples,
       tanks: tanks,
       gasSwitches: profileResult.gasSwitches,
@@ -496,6 +509,29 @@ class SuuntoDiveParser {
 
   static double _kelvinToCelsius(double kelvin) => kelvin - 273.15;
 
+  /// Reads one `DiveLocation` fix (`Start` or `Stop`), whose coordinates are
+  /// radians, into degrees.
+  ///
+  /// Returns null for a fix that is absent, incomplete, at null island, or
+  /// whose converted coordinates fall off the globe -- the last of which
+  /// catches a fix that was in degrees already, rather than importing it
+  /// scaled by 180/pi as a plausible-looking position somewhere else.
+  static _SurfaceFix? _surfaceFix(dynamic fix) {
+    if (fix is! Map) return null;
+    final latRadians = _asDouble(fix['Latitude']);
+    final lonRadians = _asDouble(fix['Longitude']);
+    if (latRadians == null || lonRadians == null) return null;
+    if (latRadians == 0 && lonRadians == 0) return null;
+
+    final latitude = _radiansToDegrees(latRadians);
+    final longitude = _radiansToDegrees(lonRadians);
+    if (latitude.abs() > 90 || longitude.abs() > 180) return null;
+
+    return _SurfaceFix(latitude, longitude);
+  }
+
+  static double _radiansToDegrees(double radians) => radians * 180.0 / math.pi;
+
   static double? _asDouble(dynamic value) => (value as num?)?.toDouble();
 
   static int? _parseTimestampMs(Map<String, dynamic> sample) {
@@ -580,6 +616,13 @@ class _PressureReading {
   const _PressureReading(this.tankIndex, this.pressureBar);
   final int tankIndex;
   final double pressureBar;
+}
+
+/// One surface GPS fix, in degrees.
+class _SurfaceFix {
+  const _SurfaceFix(this.latitude, this.longitude);
+  final double latitude;
+  final double longitude;
 }
 
 /// First pass over the raw samples: collects temperature readings (matched

--- a/lib/core/services/suunto_cloud/suunto_sml_normalizer.dart
+++ b/lib/core/services/suunto_cloud/suunto_sml_normalizer.dart
@@ -64,7 +64,9 @@ class SuuntoSmlNormalizer {
   ///  - `Summary.Samples[]` with an `Attributes['suunto/sml']['Header']`
   ///    entry and an `Attributes['suunto/sml']['DiveHeader']` entry (which
   ///    holds the real Gases list, as plain percentages, not the 0.0-1.0
-  ///    fractions the DeviceLog shape uses).
+  ///    fractions the DeviceLog shape uses), and an
+  ///    `Attributes['suunto/sml']['DiveFooter']` entry (which holds the
+  ///    dive's surface GPS fixes in `DiveLocation`).
   ///  - `Data.Samples[]` each wraps the per-instant fields (Depth, Ceiling,
   ///    NoDecTime, Cylinders, DiveEvents, Events, Temperature, ...) one level
   ///    deeper, in `Attributes['suunto/sml']['Sample']`.
@@ -116,6 +118,17 @@ class SuuntoSmlNormalizer {
       diving['GfHigh'] = diveHeader['HighGf'];
     }
     if (diving.isNotEmpty) header['Diving'] = diving;
+
+    // The surface GPS pair (Start = entry, Stop = exit, both in radians)
+    // lives in the dive footer rather than the header or the samples. The
+    // dive parser only sees (header, samples), so hoist it onto the header.
+    final diveFooterVal = _summaryType(root, 'DiveFooter');
+    if (diveFooterVal is Map) {
+      final diveLocation = diveFooterVal['DiveLocation'];
+      if (diveLocation is Map) {
+        header['DiveLocation'] = Map<String, dynamic>.from(diveLocation);
+      }
+    }
 
     final samples = <Map<String, dynamic>>[];
     final dataSamples =

--- a/test/core/services/suunto_cloud/suunto_dive_parser_test.dart
+++ b/test/core/services/suunto_cloud/suunto_dive_parser_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/suunto_cloud/suunto_dive_parser.dart';
 
@@ -757,5 +759,171 @@ void main() {
         );
       },
     );
+  });
+
+  // Suunto records a surface fix before the descent and another after the
+  // ascent, and stores the pair in the dive footer's DiveLocation block as
+  // radians. The samples' DiveRouteOrigin carries only the entry fix (in
+  // degrees), so it is a fallback for dives whose footer has no Start.
+  group('surface GPS fixes', () {
+    double rad(double degrees) => degrees * math.pi / 180.0;
+
+    Map<String, dynamic> fix(double latDegrees, double lonDegrees) => {
+      'Latitude': rad(latDegrees),
+      'Longitude': rad(lonDegrees),
+      'Ehpe': 4.5,
+    };
+
+    Map<String, dynamic> headerWithLocation(Map<String, dynamic> location) => {
+      ..._header(),
+      'DiveLocation': location,
+    };
+
+    test('reads entry from Start and exit from Stop, converted to degrees', () {
+      final result = SuuntoDiveParser.parse(
+        header: headerWithLocation({
+          'Start': fix(34.5, 35.25),
+          'Stop': fix(34.502, 35.253),
+        }),
+        samples: const [],
+      );
+
+      expect(result.dive.entryLatitude, closeTo(34.5, 1e-9));
+      expect(result.dive.entryLongitude, closeTo(35.25, 1e-9));
+      expect(result.dive.exitLatitude, closeTo(34.502, 1e-9));
+      expect(result.dive.exitLongitude, closeTo(35.253, 1e-9));
+    });
+
+    test('handles southern and western hemispheres', () {
+      final result = SuuntoDiveParser.parse(
+        header: headerWithLocation({
+          'Start': fix(-16.75, -122.4),
+          'Stop': fix(-16.751, -122.402),
+        }),
+        samples: const [],
+      );
+
+      expect(result.dive.entryLatitude, closeTo(-16.75, 1e-9));
+      expect(result.dive.entryLongitude, closeTo(-122.4, 1e-9));
+      expect(result.dive.exitLatitude, closeTo(-16.751, 1e-9));
+      expect(result.dive.exitLongitude, closeTo(-122.402, 1e-9));
+    });
+
+    test('imports a dive that holds only an exit fix', () {
+      final result = SuuntoDiveParser.parse(
+        header: headerWithLocation({'Stop': fix(34.502, 35.253)}),
+        samples: const [],
+      );
+
+      expect(result.dive.entryLatitude, isNull);
+      expect(result.dive.entryLongitude, isNull);
+      expect(result.dive.exitLatitude, closeTo(34.502, 1e-9));
+      expect(result.dive.exitLongitude, closeTo(35.253, 1e-9));
+    });
+
+    test('imports a dive that holds only an entry fix', () {
+      final result = SuuntoDiveParser.parse(
+        header: headerWithLocation({'Start': fix(34.5, 35.25)}),
+        samples: const [],
+      );
+
+      expect(result.dive.entryLatitude, closeTo(34.5, 1e-9));
+      expect(result.dive.exitLatitude, isNull);
+      expect(result.dive.exitLongitude, isNull);
+    });
+
+    test('falls back to DiveRouteOrigin for entry when Start is absent', () {
+      final result = SuuntoDiveParser.parse(
+        header: headerWithLocation({'Stop': fix(34.502, 35.253)}),
+        samples: const [
+          {
+            'TimeISO8601': '2024-05-01T10:00:00.000Z',
+            'Depth': 0.5,
+            'DiveEvents': {'DiveStatus': true},
+            'DiveRouteOrigin': {'Latitude': 34.5, 'Longitude': 35.25},
+          },
+        ],
+      );
+
+      expect(result.dive.entryLatitude, closeTo(34.5, 1e-9));
+      expect(result.dive.entryLongitude, closeTo(35.25, 1e-9));
+      expect(result.dive.exitLatitude, closeTo(34.502, 1e-9));
+    });
+
+    test('prefers the footer Start over DiveRouteOrigin', () {
+      final result = SuuntoDiveParser.parse(
+        header: headerWithLocation({'Start': fix(34.5, 35.25)}),
+        samples: const [
+          {
+            'TimeISO8601': '2024-05-01T10:00:00.000Z',
+            'Depth': 0.5,
+            'DiveEvents': {'DiveStatus': true},
+            'DiveRouteOrigin': {'Latitude': 12.0, 'Longitude': 13.0},
+          },
+        ],
+      );
+
+      expect(result.dive.entryLatitude, closeTo(34.5, 1e-9));
+      expect(result.dive.entryLongitude, closeTo(35.25, 1e-9));
+    });
+
+    test('keeps DiveRouteOrigin when the footer has no location at all', () {
+      final result = SuuntoDiveParser.parse(
+        header: _header(),
+        samples: const [
+          {
+            'TimeISO8601': '2024-05-01T10:00:00.000Z',
+            'Depth': 0.5,
+            'DiveEvents': {'DiveStatus': true},
+            'DiveRouteOrigin': {'Latitude': 34.5, 'Longitude': 35.25},
+          },
+        ],
+      );
+
+      expect(result.dive.entryLatitude, closeTo(34.5, 1e-9));
+      expect(result.dive.entryLongitude, closeTo(35.25, 1e-9));
+      expect(result.dive.exitLatitude, isNull);
+    });
+
+    test('ignores a null-island fix', () {
+      final result = SuuntoDiveParser.parse(
+        header: headerWithLocation({
+          'Start': {'Latitude': 0.0, 'Longitude': 0.0},
+          'Stop': fix(34.502, 35.253),
+        }),
+        samples: const [],
+      );
+
+      expect(result.dive.entryLatitude, isNull);
+      expect(result.dive.exitLatitude, closeTo(34.502, 1e-9));
+    });
+
+    test('ignores a fix missing one of its two coordinates', () {
+      final result = SuuntoDiveParser.parse(
+        header: headerWithLocation({
+          'Start': {'Latitude': rad(34.5)},
+          'Stop': {'Longitude': rad(35.253)},
+        }),
+        samples: const [],
+      );
+
+      expect(result.dive.entryLatitude, isNull);
+      expect(result.dive.exitLatitude, isNull);
+    });
+
+    // A value that only makes sense as degrees would land far outside the
+    // globe once multiplied by 180/pi, so rejecting out-of-range results
+    // stops a mis-scaled fix being imported as a plausible-looking position.
+    test('rejects a fix that is out of range once converted', () {
+      final result = SuuntoDiveParser.parse(
+        header: headerWithLocation({
+          'Start': {'Latitude': 34.5, 'Longitude': 35.25},
+        }),
+        samples: const [],
+      );
+
+      expect(result.dive.entryLatitude, isNull);
+      expect(result.dive.entryLongitude, isNull);
+    });
   });
 }

--- a/test/core/services/suunto_cloud/suunto_sml_normalizer_test.dart
+++ b/test/core/services/suunto_cloud/suunto_sml_normalizer_test.dart
@@ -114,6 +114,35 @@ void main() {
       expect(export.header['Diving']['GfHigh'], 85);
     });
 
+    // The dive footer holds the surface GPS pair (entry and exit); it sits in
+    // its own Summary block, so the header has to carry it over for the dive
+    // parser, which only ever sees (header, samples).
+    test('carries the dive footer location onto the header', () {
+      final fixture = _cloudFixture();
+      (fixture['Summary'] as Map)['Samples'].add({
+        'Attributes': {
+          'suunto/sml': {
+            'DiveFooter': {
+              'DiveLocation': {
+                'Start': {'Latitude': 0.6021385919, 'Longitude': 0.6152631256},
+                'Stop': {'Latitude': 0.6021396642, 'Longitude': 0.6152677321},
+              },
+            },
+          },
+        },
+      });
+
+      final export = SuuntoSmlNormalizer.parse(fixture);
+      final location = export.header['DiveLocation'] as Map<String, dynamic>;
+      expect(location['Start']['Latitude'], 0.6021385919);
+      expect(location['Stop']['Longitude'], 0.6152677321);
+    });
+
+    test('leaves DiveLocation absent when the footer has none', () {
+      final export = SuuntoSmlNormalizer.parse(_cloudFixture());
+      expect(export.header.containsKey('DiveLocation'), isFalse);
+    });
+
     test('omits Diving.Gases when no gas has a filled tank', () {
       final fixture = _cloudFixture();
       (((fixture['Summary'] as Map)['Samples'] as List)[1]


### PR DESCRIPTION
## Summary

Suunto records a surface fix before the descent and another after the ascent, but the
Suunto Cloud importer only ever read one position and assigned it to entry, so
`exitLatitude`/`exitLongitude` were never populated for any Suunto dive -- and dives where
the watch holds only the exit fix imported with no position at all.

The pair is not in the sample stream. `DiveRouteOrigin`, which the parser was reading,
repeats the entry fix alone; the real pair lives in the dive footer as
`DiveLocation.Start` and `.Stop`, in radians.

## Changes

- `SuuntoSmlNormalizer` hoists `DiveFooter.DiveLocation` onto the header, the same way it
  already hoists gases and gradient factors -- the footer sits in its own `Summary` block
  and the parser only ever sees `(header, samples)`.
- `SuuntoDiveParser` reads entry from `Start` (falling back to `DiveRouteOrigin` when the
  footer has no `Start`) and exit from `Stop`, converting radians to degrees.
- A fix is rejected when it is incomplete, at null island, or lands off the globe once
  converted; that last check stops a coordinate that was already in degrees being imported
  as a plausible-looking position 57x away.
- Tests for both conversion directions, entry-only and exit-only dives, the
  `DiveRouteOrigin` fallback and its precedence, and each rejection case.

Nothing downstream needed changing: the import service already writes the exit columns
from a downloaded dive, and the Surface GPS card already draws the exit marker and the
entry-to-exit drift.

Related: #1735 is the same information being lost on the UDDF side; it is a separate
defect in the UDDF importer and is not addressed here.

## Test Plan

- [x] `flutter test` passes -- ran the 20 affected test files (329 tests, all green)
      rather than the full suite
- [x] `flutter analyze` passes
- [ ] Manual testing on: not run -- no Suunto Cloud account to sync against

Fixes #1736
