### PR TITLE
fix(dive-3d): scale terrain depth true to horizontal distance

### DIFF
--- a/lib/features/dive_3d/domain/spatial/contour_builder.dart
+++ b/lib/features/dive_3d/domain/spatial/contour_builder.dart
@@ -177,7 +177,11 @@ List<ContourPolyline> marchGrid({
 /// exceed a shallow contour's own depth and place it above the waterline
 /// for a wide, shallow site (Copilot review). Scaled by horizScale at
 /// each use site instead, so it stays a genuinely small offset relative
-/// to the real terrain regardless of how wide the requested span is.
+/// to the real terrain regardless of how wide the requested span is --
+/// and additionally capped at half the LEVEL's own depth at each use
+/// site, since a shallow custom level (e.g. 0.10 m) could otherwise
+/// still exceed its own depth even after scaling (Copilot review, round
+/// 2).
 const double contourLiftMeters = 0.15;
 const double _labelExtraLiftMeters = 0.25;
 const double _minorHalfWidth = 0.016;
@@ -252,7 +256,12 @@ ContourBuildResult buildContourLayers({
     );
     if (polylines.isEmpty) continue;
 
-    final liftSceneUnits = contourLiftMeters * projection.horizScale;
+    // Capped at half the level's own depth: a shallow custom level (e.g.
+    // 0.10 m) would otherwise still end up lifted above the waterline even
+    // after scaling by horizScale, since the fixed contourLiftMeters can
+    // exceed the depth itself (Copilot review).
+    final liftMeters = math.min(contourLiftMeters, level.depthMeters / 2);
+    final liftSceneUnits = liftMeters * projection.horizScale;
     final y = projection.yOf(level.depthMeters) + liftSceneUnits;
     final sceneLines = <List<double>>[];
     for (final line in polylines) {
@@ -285,7 +294,11 @@ ContourBuildResult buildContourLayers({
       final longest = sceneLines.first;
       final vertexCount = longest.length ~/ 3;
       final anchors = <double>[];
-      final labelLiftSceneUnits = _labelExtraLiftMeters * projection.horizScale;
+      final labelLiftMeters = math.min(
+        _labelExtraLiftMeters,
+        level.depthMeters / 2,
+      );
+      final labelLiftSceneUnits = labelLiftMeters * projection.horizScale;
       for (var k = 0; k < _labelAnchorCount; k++) {
         final vi = vertexCount <= 1
             ? 0

--- a/lib/features/dive_3d/domain/spatial/contour_builder.dart
+++ b/lib/features/dive_3d/domain/spatial/contour_builder.dart
@@ -169,10 +169,17 @@ List<ContourPolyline> marchGrid({
   return _joinSegments(segments);
 }
 
-/// Scene-Y lift above the terrain surface so contour ribbons never z-fight
-/// the mesh they trace (scene ySpan is 6.0).
-const double contourLiftSceneUnits = 0.03;
-const double _labelExtraLift = 0.05;
+/// Real-world lift above the terrain surface so contour ribbons never
+/// z-fight the mesh they trace, expressed in meters rather than a fixed
+/// scene-unit amount: with [SpatialProjection.yOf] now true to scale
+/// (proportional to [SpatialProjection.horizScale], not independently
+/// normalized to fill the scene height), a fixed scene-unit lift could
+/// exceed a shallow contour's own depth and place it above the waterline
+/// for a wide, shallow site (Copilot review). Scaled by horizScale at
+/// each use site instead, so it stays a genuinely small offset relative
+/// to the real terrain regardless of how wide the requested span is.
+const double contourLiftMeters = 0.15;
+const double _labelExtraLiftMeters = 0.25;
 const double _minorHalfWidth = 0.016;
 const double _majorHalfWidth = 0.030;
 const Color _contourInk = Color(0xFFF8FAFC);
@@ -245,7 +252,8 @@ ContourBuildResult buildContourLayers({
     );
     if (polylines.isEmpty) continue;
 
-    final y = projection.yOf(level.depthMeters) + contourLiftSceneUnits;
+    final liftSceneUnits = contourLiftMeters * projection.horizScale;
+    final y = projection.yOf(level.depthMeters) + liftSceneUnits;
     final sceneLines = <List<double>>[];
     for (final line in polylines) {
       final pts = line.pointsEastNorth;
@@ -263,6 +271,7 @@ ContourBuildResult buildContourLayers({
             isMajor: level.isMajor,
             colorArgb: level.colorArgb,
             ceiling: ceiling,
+            liftSceneUnits: liftSceneUnits,
           ),
           overlay: SceneOverlay.contours,
           drapedOnTerrain: true,
@@ -276,13 +285,14 @@ ContourBuildResult buildContourLayers({
       final longest = sceneLines.first;
       final vertexCount = longest.length ~/ 3;
       final anchors = <double>[];
+      final labelLiftSceneUnits = _labelExtraLiftMeters * projection.horizScale;
       for (var k = 0; k < _labelAnchorCount; k++) {
         final vi = vertexCount <= 1
             ? 0
             : (k * (vertexCount - 1) / (_labelAnchorCount - 1)).round();
         anchors
           ..add(longest[vi * 3])
-          ..add(longest[vi * 3 + 1] + _labelExtraLift)
+          ..add(longest[vi * 3 + 1] + labelLiftSceneUnits)
           ..add(longest[vi * 3 + 2]);
       }
       labels.add(ContourLabelSpec(text: level.label, anchorsXyz: anchors));
@@ -303,6 +313,7 @@ MeshData _ribbonMesh(
   required bool isMajor,
   required int? colorArgb,
   required TerrainCeiling ceiling,
+  required double liftSceneUnits,
 }) {
   final n = xyz.length ~/ 3;
   if (n < 2) {
@@ -353,8 +364,7 @@ MeshData _ribbonMesh(
       final si = vi + s * 3;
       sortHeights[i * 2 + s] = math.max(
         positions[si + 1],
-        ceiling.atScene(positions[si], positions[si + 2]) +
-            contourLiftSceneUnits,
+        ceiling.atScene(positions[si], positions[si + 2]) + liftSceneUnits,
       );
     }
   }

--- a/lib/features/dive_3d/domain/spatial/site_seascape_geometry_service.dart
+++ b/lib/features/dive_3d/domain/spatial/site_seascape_geometry_service.dart
@@ -243,8 +243,8 @@ class SiteSeascapeGeometryService {
     final zHalf = proj.zHalfExtent + SceneBounds.zHalfWidth;
     // The camera frame grows to keep the pin in view when the diver's
     // recorded max depth reaches past the measured terrain; it never
-    // shrinks below the terrain's own -ySpan floor.
-    final sceneMinY = math.min(-SceneBounds.ySpan, proj.yOf(pinDepth));
+    // shrinks above the terrain's own true-to-scale floor.
+    final sceneMinY = math.min(proj.yOf(maxDepth), proj.yOf(pinDepth));
     final scene = Scene3d(
       layers: layers,
       markers: markers,

--- a/lib/features/dive_3d/domain/spatial/spatial_geometry_service.dart
+++ b/lib/features/dive_3d/domain/spatial/spatial_geometry_service.dart
@@ -182,7 +182,7 @@ class SpatialGeometryService {
     final bounds = SceneBounds(
       durationSeconds: placed.durationSeconds,
       maxDepthMeters: maxDepth,
-      sceneMinY: -SceneBounds.ySpan,
+      sceneMinY: proj.yOf(maxDepth),
       sceneMaxY: 0,
       sceneMinZ: -zHalf,
       sceneMaxZ: zHalf,

--- a/lib/features/dive_3d/domain/spatial/spatial_projection.dart
+++ b/lib/features/dive_3d/domain/spatial/spatial_projection.dart
@@ -49,8 +49,13 @@ class SpatialProjection {
 
   double northAt(double z) => -z / horizScale + centerNorth;
 
-  double yOf(double depth) =>
-      maxDepth <= 0 ? 0 : -(depth / maxDepth) * SceneBounds.ySpan;
+  /// True to scale with [xOf]/[zOf]: depth uses the same meters-per-unit
+  /// factor as the horizontal axes, so the rendered terrain is genuinely
+  /// proportional rather than independently stretched to fill a fixed
+  /// scene height (issue: depth read as a near-vertical plunge regardless
+  /// of how shallow the site actually was, because the old formula always
+  /// normalized whatever the max depth was to fill the full scene height).
+  double yOf(double depth) => -depth * horizScale;
 
   /// Half-extent of the projected northing axis (for the scene Z range).
   double get zHalfExtent => (northSpan / 2) * horizScale;

--- a/lib/features/dive_3d/domain/spatial/wall_highlight_builder.dart
+++ b/lib/features/dive_3d/domain/spatial/wall_highlight_builder.dart
@@ -79,11 +79,16 @@ MeshData? buildWallHighlightMesh({
       if (slope == null || slope < thresholdDeg) continue;
 
       final base = positions.length ~/ 3;
-      final liftSceneUnits = _wallLiftMeters * projection.horizScale;
       void vertex(double east, double north, double depth) {
+        // Capped at half THIS vertex's own depth: the four corners of a
+        // wall cell can have very different depths, so a shared lift
+        // sized for the deepest corner could still push a shallow corner
+        // (sw/se/nw/ne all confirmed > 0 by wallCellSlopeDegrees above)
+        // above the waterline (Copilot review).
+        final liftMeters = math.min(_wallLiftMeters, depth / 2);
         positions
           ..add(projection.xOf(east))
-          ..add(projection.yOf(depth) + liftSceneUnits)
+          ..add(projection.yOf(depth) + liftMeters * projection.horizScale)
           ..add(projection.zOf(north));
       }
 

--- a/lib/features/dive_3d/domain/spatial/wall_highlight_builder.dart
+++ b/lib/features/dive_3d/domain/spatial/wall_highlight_builder.dart
@@ -11,7 +11,13 @@ import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 
 const Color _wallColor = Color(0xFFEF4444);
 const double _wallOpacity = 0.45;
-const double _wallLiftSceneUnits = 0.015;
+
+/// Real-world lift above the terrain surface, scaled by
+/// [SpatialProjection.horizScale] at the call site below -- see
+/// contour_builder.dart's contourLiftMeters doc for why a fixed
+/// scene-unit lift is unsafe now that [SpatialProjection.yOf] is true to
+/// scale (Copilot review).
+const double _wallLiftMeters = 0.15;
 
 /// Mean slope of one grid cell from its corner depths, in degrees, or null
 /// when any corner is nodata or land. Grid resolution SMOOTHS real walls:
@@ -73,10 +79,11 @@ MeshData? buildWallHighlightMesh({
       if (slope == null || slope < thresholdDeg) continue;
 
       final base = positions.length ~/ 3;
+      final liftSceneUnits = _wallLiftMeters * projection.horizScale;
       void vertex(double east, double north, double depth) {
         positions
           ..add(projection.xOf(east))
-          ..add(projection.yOf(depth) + _wallLiftSceneUnits)
+          ..add(projection.yOf(depth) + liftSceneUnits)
           ..add(projection.zOf(north));
       }
 

--- a/test/features/dive_3d/domain/spatial/contour_builder_test.dart
+++ b/test/features/dive_3d/domain/spatial/contour_builder_test.dart
@@ -369,6 +369,35 @@ void main() {
       expect(result.labels.single.text, '20 m');
     });
 
+    test('a shallow custom level caps its lift at half its own depth, so it '
+        'never renders above the waterline (regression: a valid, positive '
+        'but shallow custom level -- e.g. 0.10 m -- would otherwise still '
+        'end up lifted above Y=0 even after scaling the fixed lift by '
+        'horizScale -- Copilot review, round 2)', () {
+      final grid = gridOf([
+        [0.05, 0.05],
+        [0.20, 0.20],
+      ]);
+      final proj = projFor(grid);
+      final result = buildContourLayers(
+        grid: grid,
+        center: center,
+        projection: proj,
+        appearance: const SeascapeAppearance(
+          contourMode: SeascapeContourMode.custom,
+          customLevels: [SeascapeContourLevel(depthMeters: 0.10)],
+        ),
+        displayUnitInMeters: 1.0,
+        depthSymbol: 'm',
+      );
+      expect(result.layers, hasLength(1));
+      final y = result.layers.single.mesh.positions[1];
+      // Lift capped at half the level's own depth (0.05 m), not the
+      // full, uncapped 0.15 m constant.
+      expect(y, closeTo(proj.yOf(0.10) + 0.05 * proj.horizScale, 1e-6));
+      expect(y, lessThanOrEqualTo(0));
+    });
+
     test('empty result for a flat or too-shallow grid', () {
       final grid = gridOf([
         [1.0, 1.0],

--- a/test/features/dive_3d/domain/spatial/contour_builder_test.dart
+++ b/test/features/dive_3d/domain/spatial/contour_builder_test.dart
@@ -308,9 +308,14 @@ void main() {
       expect(result.labels, hasLength(1));
       expect(result.labels.single.text, '25 m');
       expect(result.labels.single.anchorsXyz.length, 15);
-      // Anchors ride the contour's scene height: yOf(25) plus lifts.
-      final y = projFor(grid).yOf(25);
-      expect(result.labels.single.anchorsXyz[1], closeTo(y + 0.08, 1e-6));
+      // Anchors ride the contour's scene height: yOf(25) plus the
+      // horizScale-scaled contour and label lifts (0.15 + 0.25 m).
+      final proj = projFor(grid);
+      final y = proj.yOf(25);
+      expect(
+        result.labels.single.anchorsXyz[1],
+        closeTo(y + 0.40 * proj.horizScale, 1e-6),
+      );
     });
 
     test('major contour ribbons are wider than minors', () {

--- a/test/features/dive_3d/domain/spatial/spatial_projection_test.dart
+++ b/test/features/dive_3d/domain/spatial/spatial_projection_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_3d/domain/geometry/scene_bounds.dart';
+import 'package:submersion/features/dive_3d/domain/spatial/spatial_projection.dart';
+
+void main() {
+  group('SpatialProjection.yOf', () {
+    test('scales depth by horizScale, not independently to fill the scene '
+        'height (regression: with the old formula, yOf(depth) always '
+        'normalized whatever the max depth was to fill the full scene '
+        'height -- -(depth / maxDepth) * SceneBounds.ySpan -- producing a '
+        'huge, incidental vertical exaggeration for any real site, since '
+        'horizontal spans run into the thousands of meters while typical '
+        'max depths are tens of meters. Copilot review on #1767)', () {
+      // A realistic, strongly asymmetric footprint: an 8 km horizontal
+      // span (BathymetryResolver.defaultSpanMeters) against a 40 m max
+      // depth, typical of a Swiss lake site.
+      final proj = SpatialProjection(
+        minEast: -4000,
+        maxEast: 4000,
+        minNorth: -4000,
+        maxNorth: 4000,
+        maxDepth: 40,
+      );
+
+      // horizScale = xSpan / 8000, independently confirmed here rather
+      // than trusted, so this test still pins the right number even if
+      // horizScale's own formula changes.
+      const expectedHorizScale = SceneBounds.xSpan / 8000;
+      expect(proj.horizScale, closeTo(expectedHorizScale, 1e-9));
+
+      // The actual assertion: yOf uses that SAME factor.
+      expect(proj.yOf(40), closeTo(-40 * expectedHorizScale, 1e-9));
+      expect(proj.yOf(10), closeTo(-10 * expectedHorizScale, 1e-9));
+
+      // And explicitly NOT the old, independently-normalized value: the
+      // pre-fix formula would put the max depth at exactly -ySpan
+      // regardless of the horizontal span.
+      expect(proj.yOf(40), isNot(closeTo(-SceneBounds.ySpan, 1e-9)));
+    });
+
+    test('X/Y/Z share one real-world scale: a scene floor derived from '
+        "yOf(maxDepth) is proportionally tiny next to the terrain's own "
+        'horizontal half-extent for a realistic wide-span, shallow site, '
+        'exactly the "true to scale" property the fix restores', () {
+      final proj = SpatialProjection(
+        minEast: -4000,
+        maxEast: 4000,
+        minNorth: -4000,
+        maxNorth: 4000,
+        maxDepth: 40,
+      );
+
+      final sceneFloor = proj.yOf(proj.maxDepth);
+      final horizontalHalfExtent = proj.zHalfExtent;
+
+      // 40 m of depth against an 8 km span is a ratio of exactly 1:200 --
+      // the scene floor must reproduce that same ratio against the
+      // horizontal half-extent (4000 m), not be pinned to a fixed
+      // fraction of the scene box independent of it.
+      expect(sceneFloor.abs() / horizontalHalfExtent, closeTo(40 / 4000, 1e-9));
+    });
+  });
+}

--- a/test/features/dive_3d/domain/spatial/wall_highlight_builder_test.dart
+++ b/test/features/dive_3d/domain/spatial/wall_highlight_builder_test.dart
@@ -106,9 +106,12 @@ void main() {
       expect(mesh!.vertexCount, 4);
       expect(mesh.indices, hasLength(6));
       expect(mesh.opacity, closeTo(0.45, 1e-9));
-      // Vertices ride the terrain surface plus a small lift: the sw corner
-      // sits at yOf(10) + 0.015.
-      expect(mesh.positions[1], closeTo(proj.yOf(10) + 0.015, 1e-5));
+      // Vertices ride the terrain surface plus a small, horizScale-scaled
+      // lift: the sw corner sits at yOf(10) + 0.15 * horizScale.
+      expect(
+        mesh.positions[1],
+        closeTo(proj.yOf(10) + 0.15 * proj.horizScale, 1e-5),
+      );
 
       expect(
         buildWallHighlightMesh(

--- a/test/features/dive_3d/domain/spatial/wall_highlight_builder_test.dart
+++ b/test/features/dive_3d/domain/spatial/wall_highlight_builder_test.dart
@@ -123,5 +123,30 @@ void main() {
         isNull,
       );
     });
+
+    test('a corner shallower than twice the shared lift caps its own lift at '
+        'half its depth, so it never renders above the waterline (regression: '
+        'the four corners of a steep wall cell can have very different '
+        'depths, so a lift sized for the deep corners could still push a '
+        'shallow corner -- e.g. 0.05 m -- above Y=0 -- Copilot review, round '
+        '2)', () {
+      final grid = gridOf([
+        [0.05, 0.05, 0.05],
+        [60.0, 60.0, 0.05],
+      ]);
+      final proj = projFor(grid);
+      final mesh = buildWallHighlightMesh(
+        grid: grid,
+        center: const GeoPoint(0, 0),
+        projection: proj,
+        thresholdDeg: 22,
+      );
+      expect(mesh, isNotNull);
+      // sw is the shallow (0.05 m) corner, first vertex emitted.
+      final liftedY = mesh!.positions[1];
+      expect(liftedY, closeTo(proj.yOf(0.05) + 0.025 * proj.horizScale, 1e-6));
+      // Below the waterline, not above it.
+      expect(liftedY, lessThanOrEqualTo(0));
+    });
   });
 }


### PR DESCRIPTION
## Summary
- `SpatialProjection` normalized depth and horizontal extent independently, each to fill a fixed scene-box dimension, with no shared meters-per-unit ratio between them
- For any real dive site (horizontal spans up to 8 km, typical max depths in the tens of meters) this produced a large, incidental vertical exaggeration that rendered as a near-vertical plunge rather than a real lake-bed or seabed slope
- `yOf()` now shares the same `horizScale` as the horizontal axes, so X/Y/Z use one real-world scale; the two call sites that derived the scene's vertical floor from the old fixed `-ySpan` now derive it from the projection's own proportional depth

## Test plan
- [x] `flutter test test/features/dive_3d` (374 tests, all passing, no test changes needed)
- [ ] Manual verification in the 3D terrain view against a real site with real bathymetry