### PR TITLE
fix(sync): stage the parent dive for registry backfills and dive re-parses

### DIFF
--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -4,6 +4,7 @@ import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/features/dive_computer/data/services/libdc_dive_mode.dart';
 import 'package:submersion/features/dive_log/data/repositories/profile_series_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_series_repository.dart';
@@ -46,6 +47,7 @@ class ReparseService {
     ProfileSeriesRepository? profileSeries,
     TankPressureSeriesRepository? tankSeries,
   }) : _transmitterMatcherLoader = transmitterMatcherLoader,
+       _sync = SyncRepository(database: db),
        _profileSeries =
            profileSeries ??
            ProfileSeriesRepository(
@@ -59,6 +61,7 @@ class ReparseService {
              syncRepository: SyncRepository(database: db),
            );
 
+  final SyncRepository _sync;
   final ProfileSeriesRepository _profileSeries;
   final TankPressureSeriesRepository _tankSeries;
 
@@ -80,6 +83,12 @@ class ReparseService {
   ///
   /// Returns whether the dive's profile strand was left untouched because
   /// this source does not own it -- see [_sourceOwnsProfileStrand].
+  ///
+  /// The dive row and its source row, tanks, events and gas switches all
+  /// export only through the dive's HLC, so the dive is staged for sync
+  /// whatever this re-parse wrote, and every child row it removes is
+  /// tombstoned: a peer's import only upserts those, so a row deleted here
+  /// without one would linger there beside its replacement.
   Future<({bool profilePreserved})> applyParsedUpdate({
     required String diveId,
     required String sourceRowId,
@@ -91,7 +100,7 @@ class ReparseService {
     Uint8List? rawData,
     Uint8List? rawFingerprint,
   }) async {
-    return db.transaction(() async {
+    final outcome = await db.transaction(() async {
       final now = DateTime.now();
 
       // ------------------------------------------------------------------
@@ -173,12 +182,27 @@ class ReparseService {
       // one original had one, so the ownership guard applies here too --
       // otherwise the merge's own surface-gap markers are deleted (#1164).
       if (!isMultiSource && ownsStrand) {
+        final oldEvents = await (db.select(
+          db.diveProfileEvents,
+        )..where((t) => t.diveId.equals(diveId))).get();
         await (db.delete(
           db.diveProfileEvents,
         )..where((t) => t.diveId.equals(diveId))).go();
+        for (final event in oldEvents) {
+          await _sync.logDeletion(
+            entityType: 'diveProfileEvents',
+            recordId: event.id,
+          );
+        }
+        final oldSwitches = await (db.select(
+          db.gasSwitches,
+        )..where((t) => t.diveId.equals(diveId))).get();
         await (db.delete(
           db.gasSwitches,
         )..where((t) => t.diveId.equals(diveId))).go();
+        for (final sw in oldSwitches) {
+          await _sync.logDeletion(entityType: 'gasSwitches', recordId: sw.id);
+        }
         await _tankSeries.deleteForDive(diveId);
 
         // Re-insert events from parsed data
@@ -215,8 +239,18 @@ class ReparseService {
         );
       }
 
+      // Unconditional: even a non-primary re-parse rewrote its source row,
+      // which rides the dive's clock like the rest.
+      await _sync.markRecordPending(
+        entityType: 'dives',
+        recordId: diveId,
+        localUpdatedAt: now.millisecondsSinceEpoch,
+      );
+
       return (profilePreserved: !ownsStrand);
     });
+    SyncEventBus.notifyLocalChange();
+    return outcome;
   }
 
   /// Whether [row] is the sole author of its `(dive_id, computer_id)` profile
@@ -822,6 +856,7 @@ class ReparseService {
         await (db.delete(
           db.diveTanks,
         )..where((t) => t.id.equals(existing.id))).go();
+        await _sync.logDeletion(entityType: 'diveTanks', recordId: existing.id);
       }
     }
 

--- a/lib/features/transmitters/data/repositories/transmitter_repository.dart
+++ b/lib/features/transmitters/data/repositories/transmitter_repository.dart
@@ -185,6 +185,7 @@ class TransmitterRepository {
   /// Retroactive fill for the tanks that carry [t]'s key: empty size,
   /// working pressure, material, preset, gear link and name are filled; the
   /// role is replaced only while it is still the uninformed backGas default.
+  /// Each updated tank and its parent dive are staged for sync.
   /// One transaction; a failure leaves no half-applied dive.
   Future<ApplyToExistingResult> applyToExistingDives(Transmitter t) async {
     final candidates = await _tanksForEntry(t);
@@ -235,6 +236,16 @@ class TransmitterRepository {
         );
         touchedDives.add(row.diveId);
         tanks++;
+      }
+      // Tanks export only through their parent dive's HLC (diveTanks has no
+      // clock of its own), so each touched dive is staged too or the filled
+      // fields never reach a peer.
+      for (final diveId in touchedDives) {
+        await _syncRepository.markRecordPending(
+          entityType: 'dives',
+          recordId: diveId,
+          localUpdatedAt: now,
+        );
       }
     });
     if (tanks > 0) SyncEventBus.notifyLocalChange();

--- a/test/features/dive_computer/data/services/reparse_service_sync_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_sync_test.dart
@@ -1,0 +1,258 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
+import 'package:submersion/features/dive_computer/data/services/reparse_service.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// A re-parse rewrites the dive row, its source row, its tanks, events and
+/// gas switches. Every one of those exports only through the dive's HLC, so
+/// the dive has to be staged, and the rows the re-parse removes have to be
+/// tombstoned, or a peer never sees the change (and, once the dive does
+/// publish, keeps the replaced events and switches beside the new ones).
+void main() {
+  late AppDatabase db;
+  late ReparseService service;
+  late SyncDataSerializer serializer;
+
+  const nowMs = 1768471200000; // 2026-01-15 10:00 UTC
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    service = ReparseService(db: db);
+    serializer = SyncDataSerializer();
+  });
+
+  tearDown(() async => tearDownTestDatabase());
+
+  /// A single-computer dive with a tank the next parse keeps, a tank it
+  /// drops, one event and one gas switch, all already published.
+  Future<void> seedPublishedDive({bool primary = true}) async {
+    await db
+        .into(db.dives)
+        .insert(
+          const DivesCompanion(
+            id: Value('d1'),
+            diveDateTime: Value(nowMs),
+            createdAt: Value(nowMs),
+            updatedAt: Value(nowMs),
+          ),
+        );
+    await db
+        .into(db.diveComputers)
+        .insert(
+          const DiveComputersCompanion(
+            id: Value('c1'),
+            name: Value('Perdix'),
+            createdAt: Value(nowMs),
+            updatedAt: Value(nowMs),
+          ),
+        );
+    final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+    await db
+        .into(db.diveDataSources)
+        .insert(
+          DiveDataSourcesCompanion(
+            id: const Value('src-1'),
+            diveId: const Value('d1'),
+            computerId: const Value('c1'),
+            isPrimary: Value(primary),
+            sourceFormat: const Value('dive_computer'),
+            importedAt: Value(now),
+            createdAt: Value(now),
+          ),
+        );
+    for (final (id, index) in [('kept', 0), ('gone', 5)]) {
+      await db
+          .into(db.diveTanks)
+          .insert(
+            DiveTanksCompanion(
+              id: Value(id),
+              diveId: const Value('d1'),
+              computerId: const Value('c1'),
+              tankOrder: Value(index),
+              sourceTankIndex: Value(index),
+              startPressure: const Value(180),
+            ),
+          );
+    }
+    await db
+        .into(db.diveProfileEvents)
+        .insert(
+          const DiveProfileEventsCompanion(
+            id: Value('old-event'),
+            diveId: Value('d1'),
+            computerId: Value('c1'),
+            timestamp: Value(30),
+            eventType: Value('bookmark'),
+            createdAt: Value(nowMs),
+          ),
+        );
+    await db
+        .into(db.gasSwitches)
+        .insert(
+          const GasSwitchesCompanion(
+            id: Value('old-switch'),
+            diveId: Value('d1'),
+            timestamp: Value(10),
+            tankId: Value('kept'),
+            createdAt: Value(nowMs),
+          ),
+        );
+    await SyncRepository(
+      database: db,
+    ).markRecordPending(entityType: 'dives', recordId: 'd1', localUpdatedAt: 1);
+  }
+
+  /// Records the watermark a device keeps after publishing everything so
+  /// far, and clears what that publish staged.
+  Future<String> publishEverything() async {
+    final base = await serializer.exportChangeset(
+      deviceId: 'test-device',
+      hlcWatermark: null,
+      deletions: await db.select(db.deletionLog).get(),
+    );
+    await db.customStatement('DELETE FROM sync_records');
+    return base.toHlc!;
+  }
+
+  Future<SyncPayload> nextChangeset(String watermark) async =>
+      serializer.exportChangeset(
+        deviceId: 'test-device',
+        hlcWatermark: watermark,
+        deletions: await db.select(db.deletionLog).get(),
+      );
+
+  pigeon.ParsedDive parsedDive() => pigeon.ParsedDive(
+    fingerprint: 'fp',
+    dateTimeYear: 2026,
+    dateTimeMonth: 1,
+    dateTimeDay: 15,
+    dateTimeHour: 10,
+    dateTimeMinute: 0,
+    dateTimeSecond: 0,
+    maxDepthMeters: 25,
+    avgDepthMeters: 14,
+    durationSeconds: 3000,
+    gasMixes: [
+      pigeon.GasMix(index: 0, o2Percent: 32, hePercent: 0),
+      pigeon.GasMix(index: 1, o2Percent: 99, hePercent: 0),
+    ],
+    tanks: [
+      pigeon.TankInfo(
+        index: 0,
+        gasMixIndex: 0,
+        startPressureBar: 200,
+        endPressureBar: 50,
+      ),
+    ],
+    samples: [
+      pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0, gasMixIndex: 0),
+      pigeon.ProfileSample(timeSeconds: 120, depthMeters: 25, gasMixIndex: 0),
+      pigeon.ProfileSample(timeSeconds: 180, depthMeters: 6, gasMixIndex: 1),
+      pigeon.ProfileSample(timeSeconds: 240, depthMeters: 5, gasMixIndex: 1),
+    ],
+    events: [pigeon.DiveEvent(timeSeconds: 60, type: 'bookmark')],
+  );
+
+  Future<void> reparse() => service.applyParsedUpdate(
+    diveId: 'd1',
+    sourceRowId: 'src-1',
+    parsed: parsedDive(),
+    descriptorVendor: null,
+    descriptorProduct: null,
+    descriptorModel: null,
+    libdivecomputerVersion: null,
+  );
+
+  Future<String?> diveHlc() async =>
+      (await db
+              .customSelect("SELECT hlc FROM dives WHERE id = 'd1'")
+              .getSingle())
+          .read<String?>('hlc');
+
+  test('stages the dive, so the rewritten rows reach peers in the next '
+      'changeset', () async {
+    await seedPublishedDive();
+    final watermark = await publishEverything();
+
+    await reparse();
+
+    final pending = await db.select(db.syncRecords).get();
+    expect(
+      pending.where((r) => r.entityType == 'dives').map((r) => r.recordId),
+      ['d1'],
+    );
+    expect((await diveHlc())!.compareTo(watermark), greaterThan(0));
+
+    final data = (await nextChangeset(watermark)).data;
+    expect(data.dives.map((d) => d['id']), ['d1']);
+    expect(data.diveDataSources.map((s) => s['id']), ['src-1']);
+    final tanks = {for (final t in data.diveTanks) t['id']: t};
+    expect(tanks.keys, contains('kept'));
+    expect(tanks['kept']!['startPressure'], 200);
+    final events = await db.select(db.diveProfileEvents).get();
+    expect(
+      data.diveProfileEvents.map((e) => e['id']).toSet(),
+      events.map((e) => e.id).toSet(),
+    );
+    final switches = await db.select(db.gasSwitches).get();
+    expect(switches, isNotEmpty);
+    expect(
+      data.gasSwitches.map((s) => s['id']).toSet(),
+      switches.map((s) => s.id).toSet(),
+    );
+  });
+
+  test('tombstones the tank, event and gas switch it removes', () async {
+    await seedPublishedDive();
+    final watermark = await publishEverything();
+
+    await reparse();
+
+    expect(
+      await (db.select(
+        db.diveTanks,
+      )..where((t) => t.id.equals('gone'))).getSingleOrNull(),
+      isNull,
+      reason: 'the parse no longer reports tank 5',
+    );
+    final deletions = (await nextChangeset(watermark)).deletions;
+    List<String> ids(String entity) =>
+        (deletions[entity] ?? const []).map((d) => d.id).toList();
+    expect(ids('diveTanks'), ['gone']);
+    expect(ids('diveProfileEvents'), ['old-event']);
+    expect(ids('gasSwitches'), ['old-switch']);
+  });
+
+  test('a non-primary source still stages the dive, since its source row '
+      'rides the same clock', () async {
+    await seedPublishedDive(primary: false);
+    final watermark = await publishEverything();
+
+    await reparse();
+
+    expect((await diveHlc())!.compareTo(watermark), greaterThan(0));
+    final data = (await nextChangeset(watermark)).data;
+    expect(data.diveDataSources.map((s) => s['id']), ['src-1']);
+  });
+
+  test('announces the change, so an auto-sync publishes it', () async {
+    // A non-primary re-parse writes no series, so the series repositories'
+    // own announcements never fire for it.
+    await seedPublishedDive(primary: false);
+    var notifications = 0;
+    final subscription = SyncEventBus.changes.listen((_) => notifications++);
+    addTearDown(subscription.cancel);
+
+    await reparse();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(notifications, 1);
+  });
+}

--- a/test/features/transmitters/data/repositories/transmitter_repository_test.dart
+++ b/test/features/transmitters/data/repositories/transmitter_repository_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/database/database.dart' show DiveTanksCompanion;
 import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
@@ -230,6 +231,62 @@ void main() {
       expect(k3.volume, isNull, reason: 'another serial is untouched');
     },
   );
+
+  test('applyToExistingDives stages each touched dive so its tanks reach '
+      'peers in the next changeset', () async {
+    // Tanks export only through their parent dive's HLC, and diveTanks has
+    // no clock of its own, so a backfill that stages only the tanks never
+    // leaves this device in an incremental changeset.
+    await seedDiverAndDive();
+    await seedDiverAndDive(diveId: 'd2');
+    await seedTank(id: 'k1', diveId: 'd1', serial: '180777');
+    await seedTank(id: 'k2', diveId: 'd1', serial: '180777', order: 1);
+    await seedTank(id: 'k3', diveId: 'd2', serial: '109623');
+    final entry = await repo.create(_entry());
+    final db = DatabaseService.instance.database;
+    final serializer = SyncDataSerializer();
+    // Everything so far has been published: record the watermark a device
+    // keeps after a base export and clear the staged records.
+    final base = await serializer.exportChangeset(
+      deviceId: 'test-device',
+      hlcWatermark: null,
+      deletions: const [],
+    );
+    final watermark = base.toHlc;
+    expect(watermark, isNotNull);
+    await db.customStatement('DELETE FROM sync_records');
+    Future<String?> diveHlc(String id) async =>
+        (await db
+                .customSelect(
+                  'SELECT hlc FROM dives WHERE id = ?',
+                  variables: [Variable<String>(id)],
+                )
+                .getSingle())
+            .read<String?>('hlc');
+    final d2HlcBefore = await diveHlc('d2');
+
+    final result = await repo.applyToExistingDives(entry);
+
+    expect(result, (tanksUpdated: 2, divesUpdated: 1));
+    final pending = await db.select(db.syncRecords).get();
+    expect(
+      pending.where((r) => r.entityType == 'dives').map((r) => r.recordId),
+      ['d1'],
+      reason: 'one mark per touched dive, none for an untouched one',
+    );
+    expect((await diveHlc('d1'))!.compareTo(watermark!), greaterThan(0));
+    expect(await diveHlc('d2'), d2HlcBefore);
+
+    final changeset = await serializer.exportChangeset(
+      deviceId: 'test-device',
+      hlcWatermark: watermark,
+      deletions: const [],
+    );
+    final tanks = {for (final t in changeset.data.diveTanks) t['id']: t};
+    expect(tanks.keys.toSet(), {'k1', 'k2'});
+    expect(tanks['k1']!['volume'], 2.0);
+    expect(tanks['k1']!['tankRole'], 'oxygenSupply');
+  });
 
   test(
     'applyToExistingDives matches a channel entry on the source index',


### PR DESCRIPTION
## Summary

`dive_tanks`, `dive_data_sources`, `dive_profile_events` and `gas_switches` have no clock of their own. `SyncDataSerializer` exports them only for dives whose `hlc` is newer than the watermark, and none of them is in `SyncRepository.hlcTargets`, so `markRecordPending('diveTanks', ...)` stamps nothing. Two writers edited these rows without staging the parent dive, so their changes never reached a peer in an incremental changeset.

1. **Transmitter registry backfill** (`TransmitterRepository.applyToExistingDives`) filled volume, working pressure, material, preset, gear link, name and role onto matching tanks and staged only the tanks. It now stages each distinct touched dive once, inside the same transaction. This follows the same approach as #1769 did for `EquipmentRepository.deleteEquipment`.
2. **Dive re-parse** (`ReparseService.applyParsedUpdate`) rewrote the dive row, its source row, tanks, events and gas switches and staged nothing at all. It also deleted events, gas switches and dropped tanks without tombstones. A peer's import only upserts those rows, so staging the dive alone would have left every replaced event and switch on the peer beside its re-inserted copy. The fix therefore does both.

## Changes

- `TransmitterRepository.applyToExistingDives`: `markRecordPending('dives', ...)` once per touched dive after the per-tank marks.
- `ReparseService.applyParsedUpdate`:
  - stages the dive at the end of the transaction, unconditionally. A non-primary re-parse still rewrites its `dive_data_sources` row, which rides the same clock.
  - tombstones every event and gas switch it clears, and every tank it drops.
  - calls `SyncEventBus.notifyLocalChange()` after commit. A non-primary re-parse writes no series, so nothing announced it before.
- New `reparse_service_sync_test.dart`, kept separate because `reparse_service_test.dart` is already over 4,000 lines.

I audited every other `dive_tanks` writer (dive repository single and bulk paths, split, uncombine, merge, consolidation, tank pressure source exchange, dive computer import and merge). Each one already stages the parent dive.

## Test Plan

- [x] New tests record the watermark from a base export, run the write, then check the incremental changeset. For the backfill: only the touched dive is staged, an untouched dive's HLC does not move, and the filled tank rows are exported. For the re-parse: the dive, source row, tanks, events and gas switches are exported; tombstones for the removed tank, event and gas switch ride the changeset; a non-primary re-parse still advances the dive's HLC; the change is announced.
- [x] Each new test failed before its fix. Mutation checks (dropping the event tombstones, dropping the gas switch tombstones, or gating the dive mark on `isPrimary`) each turn one test red.
- [x] `flutter test` on the dive computer, transmitter, sync, consolidation, merge and re-parse menu suites: 1,481 passed
- [x] `flutter analyze` passes
- [ ] Manual testing on: not run; the change is data-layer only
