### PR TITLE
fix(deco-calculator): show gas warning ppO2 in bar, not the tank pressure unit

### DIFF
--- a/lib/features/deco_calculator/presentation/widgets/gas_warnings_display.dart
+++ b/lib/features/deco_calculator/presentation/widgets/gas_warnings_display.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/number_display.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -65,7 +67,11 @@ class GasWarningsDisplay extends ConsumerWidget {
                   child: _buildMetric(
                     context,
                     label: 'ppO₂',
-                    value: units.formatPressure(ppO2),
+                    // ppO2 is always shown in bar, never the diver's tank
+                    // pressure unit, matching the planner's ppO2 warnings.
+                    value:
+                        '${formatFixedForDisplay(ppO2, 2)} '
+                        '${PressureUnit.bar.symbol}',
                     status: ppO2Status,
                     tooltip: _getPpO2Tooltip(context, ppO2),
                   ),

--- a/test/features/deco_calculator/presentation/widgets/gas_warnings_display_test.dart
+++ b/test/features/deco_calculator/presentation/widgets/gas_warnings_display_test.dart
@@ -29,6 +29,7 @@ Future<WidgetRef> _pump(
         settingsProvider.overrideWith((ref) => _TestSettingsNotifier(settings)),
       ],
       child: MaterialApp(
+        locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
@@ -47,6 +48,15 @@ Future<WidgetRef> _pump(
 }
 
 void main() {
+  // The number helpers read the process-global Intl.defaultLocale rather than
+  // MaterialApp.locale, so pin it per test; the German test overrides it.
+  String? previousLocale;
+  setUp(() {
+    previousLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en_US';
+  });
+  tearDown(() => Intl.defaultLocale = previousLocale);
+
   testWidgets('a psi diver sees ppO2 in bar, not converted to psi', (
     tester,
   ) async {
@@ -87,10 +97,7 @@ void main() {
   });
 
   testWidgets('ppO2 uses the locale decimal separator', (tester) async {
-    // The number helpers read the process-global Intl.defaultLocale.
-    final previousLocale = Intl.defaultLocale;
     Intl.defaultLocale = 'de';
-    addTearDown(() => Intl.defaultLocale = previousLocale);
 
     final ref = await _pump(
       tester,

--- a/test/features/deco_calculator/presentation/widgets/gas_warnings_display_test.dart
+++ b/test/features/deco_calculator/presentation/widgets/gas_warnings_display_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/deco_calculator/presentation/providers/deco_calculator_providers.dart';
+import 'package:submersion/features/deco_calculator/presentation/widgets/gas_warnings_display.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier(super.settings);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Pumps the card and hands back a ref so a test can drive the inputs.
+Future<WidgetRef> _pump(
+  WidgetTester tester, {
+  AppSettings settings = const AppSettings(),
+}) async {
+  late WidgetRef captured;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        settingsProvider.overrideWith((ref) => _TestSettingsNotifier(settings)),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Consumer(
+            builder: (context, ref, _) {
+              captured = ref;
+              return const GasWarningsDisplay();
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return captured;
+}
+
+void main() {
+  testWidgets('a psi diver sees ppO2 in bar, not converted to psi', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    final ref = await _pump(
+      tester,
+      settings: const AppSettings(pressureUnit: PressureUnit.psi),
+    );
+
+    // EAN32 at 30 m: 4.0 bar ambient x 0.32 = 1.28 bar, which formatPressure
+    // would have shown as "19 psi".
+    ref.read(calcDepthProvider.notifier).state = 30;
+    ref.read(calcO2Provider.notifier).state = 32;
+    await tester.pumpAndSettle();
+
+    expect(find.text('1.28 bar'), findsOneWidget);
+    expect(find.textContaining('psi'), findsNothing);
+
+    // The tooltip is a status word and carries no pressure value or unit.
+    expect(find.byTooltip('ppO2 Safe'), findsOneWidget);
+
+    // The screen reader label is built from the displayed value, so it must
+    // say bar as well.
+    expect(find.bySemanticsLabel(RegExp(r'ppO₂: 1\.28 bar\.')), findsOneWidget);
+    expect(find.bySemanticsLabel(RegExp('psi')), findsNothing);
+
+    semantics.dispose();
+  });
+
+  testWidgets('ppO2 keeps two decimals rather than rounding to whole bar', (
+    tester,
+  ) async {
+    // Defaults: air at 18 m is 2.8 bar ambient x 0.21 = 0.588 bar, which the
+    // zero-decimal pressure formatting rendered as "1 bar".
+    await _pump(tester);
+
+    expect(find.text('0.59 bar'), findsOneWidget);
+  });
+
+  testWidgets('ppO2 uses the locale decimal separator', (tester) async {
+    // The number helpers read the process-global Intl.defaultLocale.
+    final previousLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'de';
+    addTearDown(() => Intl.defaultLocale = previousLocale);
+
+    final ref = await _pump(
+      tester,
+      settings: const AppSettings(pressureUnit: PressureUnit.psi),
+    );
+    ref.read(calcDepthProvider.notifier).state = 30;
+    ref.read(calcO2Provider.notifier).state = 32;
+    await tester.pumpAndSettle();
+
+    expect(find.text('1,28 bar'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

The ppO2 metric on the deco calculator's gas safety card was formatted with `UnitFormatter.formatPressure`, which converts bar into the diver's tank pressure unit and rounds to whole numbers. A diver with pressure set to psi saw a ppO2 of 1.28 bar as "19 psi", and a bar diver saw 0.59 bar as "1 bar".

Everywhere else the app shows ppO2 in bar regardless of the pressure unit (`divePlanner_warning_ppO2High`, `divePlanner_warning_ppO2Critical`, `diveLog_detail_collapsed_cnsMaxPpO2AtTime`, `settings_decompression_ppO2LimitsSubtitle`, and the equipment condition cell sentences). This brings the gas warning card in line.

## Changes

- `gas_warnings_display.dart`: render ppO2 as `formatFixedForDisplay(ppO2, 2)` plus the bar symbol. Two decimals match the planner's ppO2 warnings; the locale decimal separator is kept, so German shows "1,28 bar", consistent with the MOD and END tiles beside it.
- The status colours and thresholds were already correct, since `calcPpO2Provider` returns bar and the 1.4 / 1.6 / 0.16 checks compare against bar. Only the display was wrong.
- Tooltip (`_getPpO2Tooltip`): checked, no change needed. It returns status words ("ppO2 Safe", "ppO2 Caution", ...) with no value or unit. The screen reader label is built from the displayed value, so it previously read "ppO₂: 19 psi" and now says bar as well.
- New `gas_warnings_display_test.dart` with three widget tests, each confirmed failing against the unfixed code before the fix:
  - a psi diver sees "1.28 bar" in the text and the semantics label, no "psi" anywhere, and the tooltip is the plain status word
  - default settings (air at 18 m) show "0.59 bar", not "1 bar"
  - under the de locale the value renders "1,28 bar"

## Test Plan

- [x] `flutter test` passes for `test/features/deco_calculator` and `test/features/planning` (the pages that embed the calculator); full suite left to CI
- [x] `flutter analyze` passes (scoped run plus the pre-push hook)
- [ ] Manual testing on: not run; covered by widget tests
