### PR TITLE
fix(dive-log): give the cylinder name room beside its consumption rates

### DIFF
--- a/lib/features/dive_log/presentation/widgets/cylinders_card.dart
+++ b/lib/features/dive_log/presentation/widgets/cylinders_card.dart
@@ -194,6 +194,12 @@ class CylindersCard extends ConsumerWidget {
       formatFixedForDisplay(workingPpO2, 1),
       mndDepth,
     );
+    final consumptionRow = _consumptionRow(
+      context.l10n,
+      theme,
+      cylinderSac,
+      sourceName,
+    );
 
     return ListTile(
       contentPadding: EdgeInsets.zero,
@@ -212,7 +218,7 @@ class CylindersCard extends ConsumerWidget {
             '$startP ${units.pressureSymbol} → '
             '$endP ${units.pressureSymbol}$used',
           ),
-          ?_consumptionRow(context.l10n, theme, cylinderSac, sourceName),
+          ?consumptionRow,
           Text(
             modMndText,
             style: theme.textTheme.bodySmall?.copyWith(
@@ -245,7 +251,9 @@ class CylindersCard extends ConsumerWidget {
             ),
         ],
       ),
-      isThreeLine: serial != null,
+      // Either extra subtitle row makes the tile tall, and M3 centres the
+      // leading icon on a tall two-line tile, away from the name.
+      isThreeLine: serial != null || consumptionRow != null,
       trailing: _checkInButton(tank),
     );
   }

--- a/lib/features/dive_log/presentation/widgets/cylinders_card.dart
+++ b/lib/features/dive_log/presentation/widgets/cylinders_card.dart
@@ -31,7 +31,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// Replaces the former Tanks card and SAC by Cylinder block. Occupies the
 /// [DiveDetailSectionId.tanks] slot on the dive detail page. Per-tank SAC
 /// is shown whenever it is computable, regardless of tank count; the
-/// trailing block is omitted entirely when it is not.
+/// consumption row is omitted entirely when it is not.
 class CylindersCard extends ConsumerWidget {
   const CylindersCard({
     super.key,
@@ -150,9 +150,7 @@ class CylindersCard extends ConsumerWidget {
         ? pressures.$1! - pressures.$2!
         : null;
     // The pressure drop and the gas volume are one fact in two units, so
-    // they read together. It also keeps the trailing slot to the rates:
-    // ListTile caps leading and trailing at 56px minus the density
-    // adjustment, which is 48px on desktop, and three lines do not fit.
+    // they read together on one line.
     final gasUsedLiters = cylinderSac?.gasUsedLiters;
     final volumeUsed = gasUsedLiters != null
         ? ' / ${units.convertVolume(gasUsedLiters).round()} '
@@ -214,6 +212,7 @@ class CylindersCard extends ConsumerWidget {
             '$startP ${units.pressureSymbol} → '
             '$endP ${units.pressureSymbol}$used',
           ),
+          ?_consumptionRow(context.l10n, theme, cylinderSac, sourceName),
           Text(
             modMndText,
             style: theme.textTheme.bodySmall?.copyWith(
@@ -247,37 +246,25 @@ class CylindersCard extends ConsumerWidget {
         ],
       ),
       isThreeLine: serial != null,
-      trailing: _trailingWithCheckIn(
-        context,
-        tank: tank,
-        block: _trailingBlock(context.l10n, theme, cylinderSac, sourceName),
-      ),
+      trailing: _checkInButton(tank),
     );
   }
 
   /// A cylinder that is a gear item (the registry wrote its equipment link)
-  /// gets the check-in chip ahead of the SAC block; any other cylinder keeps
-  /// the block alone. The item loads through its own provider so the row
-  /// never blocks on it.
-  Widget _trailingWithCheckIn(
-    BuildContext context, {
-    required DiveTank tank,
-    required Widget? block,
-  }) {
+  /// gets the check-in button; any other cylinder has no trailing widget.
+  /// Trailing holds only this fixed-width icon button: ListTile lays trailing
+  /// out first and gives the title what is left, so anything carrying text
+  /// there starves the tank name on a narrow card (#935). The item loads
+  /// through its own provider so the row never blocks on it.
+  Widget? _checkInButton(DiveTank tank) {
     final equipmentId = tank.equipmentId;
-    if (equipmentId == null) return block ?? const SizedBox.shrink();
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Consumer(
-          builder: (context, ref, _) {
-            final item = ref.watch(equipmentItemProvider(equipmentId)).value;
-            if (item == null) return const SizedBox.shrink();
-            return ObservationStatusChip(equipment: item, dive: dive);
-          },
-        ),
-        ?block,
-      ],
+    if (equipmentId == null) return null;
+    return Consumer(
+      builder: (context, ref, _) {
+        final item = ref.watch(equipmentItemProvider(equipmentId)).value;
+        if (item == null) return const SizedBox.shrink();
+        return ObservationStatusChip(equipment: item, dive: dive);
+      },
     );
   }
 
@@ -299,36 +286,32 @@ class CylindersCard extends ConsumerWidget {
     );
   }
 
-  /// Trailing column: attribution badge and one consumption line per
-  /// visible lane. Returns null when there is nothing to show so the tile
-  /// keeps its natural width. The gas used lives in the subtitle, beside
-  /// the pressure drop it restates: ListTile caps this slot at two lines on
-  /// desktop, and Both already needs both of them.
-  Widget? _trailingBlock(
+  /// Subtitle row under the pressure line: attribution badge and one
+  /// consumption item per visible lane, wrapping onto a second line when the
+  /// card is too narrow for them side by side. Returns null when there is
+  /// nothing to show.
+  Widget? _consumptionRow(
     AppLocalizations l10n,
     ThemeData theme,
     CylinderSac? cylinderSac,
     String? sourceName,
   ) {
-    final hasSac = cylinderSac != null && cylinderSac.hasValidSac;
-    if (!hasSac && sourceName == null) return null;
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      mainAxisAlignment: MainAxisAlignment.center,
-      crossAxisAlignment: CrossAxisAlignment.end,
-      children: [
-        if (sourceName != null) FieldAttributionBadge(sourceName: sourceName),
-        if (hasSac) ...[
-          for (final line in _consumptionLines(l10n, cylinderSac))
-            Text(
-              line,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-                color: theme.colorScheme.primary,
-              ),
-            ),
-        ],
-      ],
+    final style = theme.textTheme.bodyMedium?.copyWith(
+      fontWeight: FontWeight.bold,
+      color: theme.colorScheme.primary,
+    );
+    final children = [
+      if (sourceName != null) FieldAttributionBadge(sourceName: sourceName),
+      if (cylinderSac != null && cylinderSac.hasValidSac)
+        for (final line in _consumptionLines(l10n, cylinderSac))
+          Text(line, style: style),
+    ];
+    if (children.isEmpty) return null;
+    return Wrap(
+      spacing: 12,
+      runSpacing: 2,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: children,
     );
   }
 

--- a/test/features/dive_log/presentation/widgets/cylinders_card_test.dart
+++ b/test/features/dive_log/presentation/widgets/cylinders_card_test.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/gas_consumption_display.dart';
 import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/icons/mdi_icons.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/cylinder_sac.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
@@ -310,27 +311,72 @@ void main() {
       expect(find.text('RMV 22.2 L/min'), findsOneWidget);
     });
 
-    testWidgets('both fits its lanes at desktop density', (tester) async {
-      // The lanes used to live in ListTile's trailing slot, whose height the
-      // tile caps at 56px minus the density adjustment. Desktop defaults to
-      // compact, making that 48px: exactly 8px short of the three lines
-      // Both rendered there (SAC, RMV, gas used), which is what the macOS
-      // screenshot run reported. Widget tests run at standard density, so
-      // the default harness never saw it. The lanes and the gas used now
-      // live in the subtitle, which grows with its content.
+    testWidgets('the tank icon stays level with the name on a row with rates', (
+      tester,
+    ) async {
+      // The rates add a subtitle row, so the tile is tall. ListTile's M3
+      // alignment centres leading and trailing on the whole tile unless
+      // isThreeLine is set, which left the icon floating below the name.
       await tester.pumpWidget(
         _buildCard(
           dive: _makeDive([_makeTank()]),
           cylinderSacs: [_makeSac()],
           display: GasConsumptionDisplay.both,
-          visualDensity: VisualDensity.compact,
         ),
       );
       await tester.pumpAndSettle();
 
+      final iconTop = tester.getTopLeft(find.byIcon(MdiIcons.divingScubaTank));
+      final nameTop = tester.getTopLeft(find.text('Tank 1 (EAN32)'));
+      expect((iconTop.dy - nameTop.dy).abs(), lessThan(8));
+    });
+
+    testWidgets('both fits everything at desktop density', (tester) async {
+      // ListTile caps the trailing slot's height at 56px minus the density
+      // adjustment. Desktop defaults to compact, making that 48px, which the
+      // macOS screenshot run found too short for the lines trailing used to
+      // hold. Widget tests run at standard density, so the default harness
+      // never saw it. This row carries all of it at once (source badge, both
+      // lanes, gas used, check-in button); a vertical overflow anywhere
+      // would fail the test through FlutterError.
+      final item = EquipmentItem(
+        id: 'al80',
+        name: 'AL80 #4',
+        type: EquipmentType.tank,
+        createdAt: DateTime(2026),
+      );
+      await tester.pumpWidget(
+        _buildCard(
+          dive: _makeDive([
+            _makeTank(computerId: 'comp-1', equipmentId: 'al80'),
+          ]),
+          cylinderSacs: [_makeSac()],
+          dataSources: [
+            _makeSource(
+              id: 'src-1',
+              computerId: 'comp-1',
+              isPrimary: true,
+              computerModel: 'Perdix 2',
+            ),
+            _makeSource(id: 'src-2', computerId: 'comp-2'),
+          ],
+          display: GasConsumptionDisplay.both,
+          visualDensity: VisualDensity.compact,
+          extraOverrides: [
+            equipmentItemProvider('al80').overrideWith((ref) async => item),
+            observationsForDiveProvider(
+              'dive-1',
+            ).overrideWith((ref) async => const []),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Perdix 2'), findsOneWidget);
       expect(find.text('SAC 2.0 bar/min'), findsOneWidget);
       expect(find.text('RMV 22.2 L/min'), findsOneWidget);
       expect(find.textContaining('(150 bar / 1665 L used)'), findsOneWidget);
+      expect(find.byType(ObservationStatusChip), findsOneWidget);
     });
 
     group('on a narrow card', () {
@@ -352,7 +398,8 @@ void main() {
             dive: _makeDive([tank ?? _makeTank()]),
             cylinderSacs: [_makeSac()],
             display: GasConsumptionDisplay.both,
-            locale: locale,
+            // Pinned, so the English finders do not depend on the host.
+            locale: locale ?? const Locale('en'),
             extraOverrides: extraOverrides,
           ),
         );

--- a/test/features/dive_log/presentation/widgets/cylinders_card_test.dart
+++ b/test/features/dive_log/presentation/widgets/cylinders_card_test.dart
@@ -12,7 +12,10 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/dive_log/presentation/providers/gas_analysis_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/cylinders_card.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/field_attribution_badge.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/equipment/presentation/providers/equipment_observation_providers.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
+import 'package:submersion/features/equipment/presentation/widgets/observation_status_chip.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/transmitters/domain/entities/transmitter.dart';
 import 'package:submersion/features/transmitters/presentation/providers/transmitter_providers.dart';
@@ -107,6 +110,7 @@ Widget _buildCard({
   VisualDensity? visualDensity,
   List<Transmitter> registry = const [],
   List<dynamic> extraOverrides = const [],
+  Locale? locale,
 }) {
   final card = CylindersCard(
     dive: dive,
@@ -137,6 +141,7 @@ Widget _buildCard({
   );
   return testAppRouter(
     router: router,
+    locale: locale,
     overrides: [
       cylinderSacProvider.overrideWith((ref, id) async => cylinderSacs),
       tankPressuresProvider.overrideWith((ref, id) async => tankPressures),
@@ -305,16 +310,14 @@ void main() {
       expect(find.text('RMV 22.2 L/min'), findsOneWidget);
     });
 
-    testWidgets('both fits its two trailing lanes at desktop density', (
-      tester,
-    ) async {
-      // The trailing block lives in a ListTile slot whose height the tile
-      // caps at 56px minus the density adjustment. Desktop defaults to
+    testWidgets('both fits its lanes at desktop density', (tester) async {
+      // The lanes used to live in ListTile's trailing slot, whose height the
+      // tile caps at 56px minus the density adjustment. Desktop defaults to
       // compact, making that 48px: exactly 8px short of the three lines
-      // Both used to render (SAC, RMV, gas used), which is what the macOS
+      // Both rendered there (SAC, RMV, gas used), which is what the macOS
       // screenshot run reported. Widget tests run at standard density, so
-      // the default harness never saw it. The gas used now lives in the
-      // subtitle, so the slot holds only the two lanes.
+      // the default harness never saw it. The lanes and the gas used now
+      // live in the subtitle, which grows with its content.
       await tester.pumpWidget(
         _buildCard(
           dive: _makeDive([_makeTank()]),
@@ -328,6 +331,91 @@ void main() {
       expect(find.text('SAC 2.0 bar/min'), findsOneWidget);
       expect(find.text('RMV 22.2 L/min'), findsOneWidget);
       expect(find.textContaining('(150 bar / 1665 L used)'), findsOneWidget);
+    });
+
+    group('on a narrow card', () {
+      // ListTile lays trailing out against the full tile width and gives the
+      // title what is left (#935). With the rates in trailing, Both left the
+      // tank name about 20px of a 300px tile, on a phone or half of a paired
+      // row. The test font sets every glyph a full em wide, so 150px is a
+      // floor for "has room", not the width a real font needs.
+      Future<void> pumpNarrow(
+        WidgetTester tester, {
+        DiveTank? tank,
+        Locale? locale,
+        List<dynamic> extraOverrides = const [],
+      }) async {
+        await tester.binding.setSurfaceSize(const Size(340, 800));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await tester.pumpWidget(
+          _buildCard(
+            dive: _makeDive([tank ?? _makeTank()]),
+            cylinderSacs: [_makeSac()],
+            display: GasConsumptionDisplay.both,
+            locale: locale,
+            extraOverrides: extraOverrides,
+          ),
+        );
+        await tester.pumpAndSettle();
+      }
+
+      testWidgets('the tank name keeps its width beside both rates', (
+        tester,
+      ) async {
+        await pumpNarrow(tester);
+
+        expect(
+          tester.getSize(find.text('Tank 1 (EAN32)')).width,
+          greaterThan(150),
+        );
+        expect(find.text('SAC 2.0 bar/min'), findsOneWidget);
+        expect(find.text('RMV 22.2 L/min'), findsOneWidget);
+      });
+
+      testWidgets('the tank name keeps its width in German', (tester) async {
+        // "Druckverbrauch" is the #935 shape: a translated lane label far
+        // wider than the English "SAC".
+        await pumpNarrow(tester, locale: const Locale('de'));
+
+        expect(
+          tester.getSize(find.text('Flasche 1 (EAN32)')).width,
+          greaterThan(150),
+        );
+        expect(find.textContaining('Druckverbrauch '), findsOneWidget);
+        expect(find.textContaining('AMV '), findsOneWidget);
+      });
+
+      testWidgets('a linked cylinder keeps its check-in button and the name '
+          'keeps its width', (tester) async {
+        // The check-in button is the one widget trailing still holds, so the
+        // tank has no volume and so no volume chip: the name has the title
+        // row to itself, and what is measured is only what trailing leaves.
+        // The rates still come from the SAC fixture's own cylinder volume.
+        final item = EquipmentItem(
+          id: 'al80',
+          name: 'AL80 #4',
+          type: EquipmentType.tank,
+          createdAt: DateTime(2026),
+        );
+        await pumpNarrow(
+          tester,
+          tank: _makeTank(equipmentId: 'al80', volume: null),
+          extraOverrides: [
+            equipmentItemProvider('al80').overrideWith((ref) async => item),
+            observationsForDiveProvider(
+              'dive-1',
+            ).overrideWith((ref) async => const []),
+          ],
+        );
+
+        expect(find.byType(ObservationStatusChip), findsOneWidget);
+        expect(
+          tester.getSize(find.text('Tank 1 (EAN32)')).width,
+          greaterThan(150),
+        );
+        expect(find.text('SAC 2.0 bar/min'), findsOneWidget);
+        expect(find.text('RMV 22.2 L/min'), findsOneWidget);
+      });
     });
 
     testWidgets('both omits the RMV line for a cylinder without a volume', (


### PR DESCRIPTION
## Summary

On a narrow Cylinders card (a phone, or half of a paired row on the dive detail page) the tank name was squeezed to almost nothing. `_RenderListTile` lays `trailing` out against the full tile width first and gives the title what is left, and `trailing` held the per-cylinder consumption lines ("SAC 2.0 bar/min", plus "RMV 22.2 L/min" under Both) and the source badge.

Measured in widget tests at 340px with Both:

| Case | Tank name width, before | After |
| --- | --- | --- |
| English | 0px (silent, no assert) | > 150px |
| German | framework assert: "Trailing widget consumes the entire tile width" | > 150px |
| Cylinder linked to gear | 0px | > 150px |

The German case is the #935 shape: the SAC lane label "Druckverbrauch" is far wider than "SAC". The fix follows #1026: nothing text-bearing stays in `trailing`.

## Changes

- The consumption lanes and the attribution badge move into the subtitle as one bold row under the pressure line, wrapping onto a second line when the card is too narrow. Lanes stay labelled and still follow the unit settings and the SAC/RMV/Both preference.
- `trailing` now holds only the check-in button (`ObservationStatusChip`, a fixed-width compact `IconButton`) for cylinders linked to equipment, and is `null` otherwise, so an unlinked cylinder's title also gets back the trailing gap.
- This also retires the 48px trailing-height cap at desktop density as a concern for the rates: the subtitle grows with its content.
- Comments that described the old trailing layout are updated, including the desktop-density test's name and comment (its assertions are unchanged).

Note for merging: #1776 turns the title row into a `Wrap` on the same `ListTile` and adds a narrow-card test at the same spot in `cylinders_card_test.dart`, so whichever merges second gets a small mechanical conflict. Its comment "The trailing rates take their width first" will no longer be true after this lands.

## Test Plan

- [x] New narrow-card tests (English, German, linked cylinder) written first and seen failing on the old layout; re-run against the original file after the fixture change to confirm they still catch it
- [x] `flutter test test/features/dive_log/presentation/widgets` (1321 passed)
- [x] `flutter test test/features/dive_log/presentation/pages` (424 passed, 1 skipped)
- [x] `flutter analyze` passes
- [x] `dart format .` clean
- [ ] Manual testing on: not yet run on a device

The linked-cylinder test uses a tank without a volume, so there is no volume chip: with the chip, today's `Row` title gives the chip its width first and the name measures 115px, which is the title-row squeeze #1776 addresses rather than trailing starvation.
