### PR TITLE
fix(dive-profile): stop the zoomed profile chart corrupting frames on macOS

### DIFF
--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -1038,6 +1038,13 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   // getTouchedSpotIndicator during paint. See [velocityIndicatorSuppression].
   List<({double x, double y})> _suppressedDepthIndicatorSpots = const [];
 
+  // The spots of the latest touch response. fl_chart keeps each touched
+  // spot's index across rebuilds, and once the series under it is
+  // re-decimated (a zoomed pan crossing a decimation bucket) that index names
+  // a different sample; getTouchedSpotIndicator only draws a marker whose
+  // spot is still one of these.
+  List<({double x, double y})> _touchedIndicatorSpots = const [];
+
   // Memoized lineBarsData. The chart's series builders are pure w.r.t.
   // interaction state, so the assembled bars are reused across playback / hover
   // / zoom rebuilds and only reconstructed when the underlying data, units,
@@ -3310,7 +3317,9 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                     if (index < 0 || index >= barData.spots.length)
                       null
                     else if (suppressed.isNotEmpty &&
-                        _isSuppressedIndicatorSpot(barData, index, suppressed))
+                        _isSpotAt(barData, index, suppressed))
+                      null
+                    else if (!_isSpotAt(barData, index, _touchedIndicatorSpots))
                       null
                     else
                       defaultTouchedIndicators(barData, [index]).first,
@@ -3343,6 +3352,9 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                 // depth dot, independently of the external selection/tooltip
                 // callbacks below (so the built-in indicator is de-cluttered
                 // even when neither callback is wired).
+                _touchedIndicatorSpots = active
+                    ? [for (final s in spots) (x: s.x, y: s.y)]
+                    : const [];
                 _suppressedDepthIndicatorSpots = active
                     ? DiveProfileChart.velocityIndicatorSuppression([
                         for (final s in spots)
@@ -4729,20 +4741,21 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     return [0 - leadIn];
   }
 
-  /// Whether the built-in focus indicator for [barData]'s spot at [index]
-  /// should be hidden because velocity colouring already shows the depth dot on
-  /// another band (see [velocityIndicatorSuppression]). Matches on the spot
-  /// coordinate because fl_chart hands the indicator callback a copied bar
-  /// without its position in the bar list.
-  bool _isSuppressedIndicatorSpot(
+  /// Whether [barData]'s spot at [index] is one of [spots]. Matches on the
+  /// spot coordinate because fl_chart hands the indicator callback a copied
+  /// bar without its position in the bar list. Used both to hide the focus
+  /// indicator velocity colouring already shows on another band (see
+  /// [velocityIndicatorSuppression]) and to drop a stale touched index (see
+  /// [_touchedIndicatorSpots]).
+  bool _isSpotAt(
     LineChartBarData barData,
     int index,
-    List<({double x, double y})> suppressed,
+    List<({double x, double y})> spots,
   ) {
     if (index < 0 || index >= barData.spots.length) return false;
     final spot = barData.spots[index];
     const epsilon = 1e-6;
-    for (final s in suppressed) {
+    for (final s in spots) {
       if ((s.x - spot.x).abs() < epsilon && (s.y - spot.y).abs() < epsilon) {
         return true;
       }

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -34,6 +34,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/o2_cell_spread
 import 'package:submersion/features/dive_log/presentation/widgets/profile_decimator.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_metric_band.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_metric_bands.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/profile_bar_window.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_metric_colors.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/range_selection_overlay.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/gas_colors.dart';
@@ -1039,11 +1040,17 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   List<({double x, double y})> _suppressedDepthIndicatorSpots = const [];
 
   // The spots of the latest touch response. fl_chart keeps each touched
-  // spot's index across rebuilds, and once the series under it is
-  // re-decimated (a zoomed pan crossing a decimation bucket) that index names
-  // a different sample; getTouchedSpotIndicator only draws a marker whose
-  // spot is still one of these.
+  // spot's index across rebuilds, and once the series under it is re-cut (a
+  // pan, see [_windowedBars]) or re-decimated that index names a different
+  // sample; getTouchedSpotIndicator only draws a marker whose spot is still
+  // one of these.
   List<({double x, double y})> _touchedIndicatorSpots = const [];
+
+  // The bars last handed to fl_chart, cut to the visible window when zoomed,
+  // and the inputs they were cut for (see [_windowedBars]).
+  WindowedBars _barWindow = const WindowedBars([], []);
+  List<LineChartBarData>? _barWindowSource;
+  ({double minX, double maxX, double minY})? _barWindowRange;
 
   // Memoized lineBarsData. The chart's series builders are pure w.r.t.
   // interaction state, so the assembled bars are reused across playback / hover
@@ -1340,7 +1347,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     // synthetic vertex should read the first sample, not suppress the tooltip.
     final index = touched == null
         ? -1
-        : math.max(0, starts[touched.barIndex] + touched.spotIndex);
+        : math.max(0, starts[touched.barIndex] + _sourceSpotIndex(touched));
     if (touched == null || index < 0 || index >= widget.profile.length) {
       widget.onTooltipData!(null);
       return;
@@ -1350,7 +1357,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     // On the lead-in vertex the cursor is before the first sample, so the
     // readout must describe t=0 rather than repeat the first sample's values.
     final onLeadIn =
-        touched.spotIndex == 0 &&
+        _sourceSpotIndex(touched) == 0 &&
         starts[touched.barIndex] < 0 &&
         shouldDrawSurfaceLeadIn(widget.profile);
     final point = onLeadIn
@@ -3093,184 +3100,195 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
             // invalidation; the combined key memoizes the concatenation so a
             // playback-only rebuild returns the identical outer list (fl_chart
             // listEquals short-circuits on identity).
-            lineBarsData: _barsCache.series(
-              'combined',
-              _sigOf([
-                _baseSig,
-                _sacSig,
-                _ascentSig,
-                _analysisSig,
-                _markersSig,
-                _overlaysSig,
-              ]),
-              () => [
-                ..._barsCache.series(
-                  'base',
+            lineBarsData: _windowedBars(
+              visibleMinX: visibleMinX,
+              visibleRangeX: visibleRangeX,
+              chartMinY: -visibleMaxDepth,
+              _barsCache.series(
+                'combined',
+                _sigOf([
                   _baseSig,
-                  () => [
-                    // Depth line segments (colored by active gas if present)
-                    ..._buildGasColoredDepthLines(colorScheme, units),
+                  _sacSig,
+                  _ascentSig,
+                  _analysisSig,
+                  _markersSig,
+                  _overlaysSig,
+                ]),
+                () => [
+                  ..._barsCache.series(
+                    'base',
+                    _baseSig,
+                    () => [
+                      // Depth line segments (colored by active gas if present)
+                      ..._buildGasColoredDepthLines(colorScheme, units),
 
-                    // Gas switch markers (if showing and data available)
-                    if (_showGasSwitchMarkers) ..._buildGasSwitchMarkers(units),
+                      // Gas switch markers (if showing and data available)
+                      if (_showGasSwitchMarkers)
+                        ..._buildGasSwitchMarkers(units),
 
-                    // Temperature line(s) (if showing) — one per visible
-                    // computer when multi-computer profiles are present, else
-                    // a single curve from the primary profile.
-                    if (_showTemperature &&
-                        hasTemperatureData &&
-                        minTemp != null &&
-                        maxTemp != null)
-                      ..._buildTemperatureLines(
-                        colorScheme,
+                      // Temperature line(s) (if showing) — one per visible
+                      // computer when multi-computer profiles are present, else
+                      // a single curve from the primary profile.
+                      if (_showTemperature &&
+                          hasTemperatureData &&
+                          minTemp != null &&
+                          maxTemp != null)
+                        ..._buildTemperatureLines(
+                          colorScheme,
+                          metricBand,
+                          minTemp,
+                          maxTemp,
+                          units,
+                        ),
+
+                      // Multi-tank pressure lines (per-tank visibility controlled
+                      // inside _buildMultiTankPressureLines via _showTankPressure)
+                      if (_hasMultiTankPressure)
+                        ..._buildMultiTankPressureLines(metricBand),
+
+                      // Heart rate line (if showing)
+                      if (_showHeartRate &&
+                          hasHeartRateData &&
+                          minHR != null &&
+                          maxHR != null)
+                        _buildHeartRateLine(
+                          heartRateColor,
+                          metricBand,
+                          minHR,
+                          maxHR,
+                        ),
+                    ],
+                  ),
+                  ..._barsCache.series(
+                    'sac',
+                    _sacSig,
+                    () => [
+                      // SAC curve line (if showing)
+                      if (_showSac &&
+                          hasSacData &&
+                          minSac != null &&
+                          maxSac != null)
+                        _buildSacLine(metricBand, minSac, maxSac),
+                    ],
+                  ),
+                  ..._barsCache.series(
+                    'ascent',
+                    _ascentSig,
+                    () => [
+                      // Ascent-rate magnitude line (separate overlay; signed
+                      // m/min)
+                      if (_showAscentRateLine && widget.ascentRates != null)
+                        _buildAscentRateLine(metricBand),
+                    ],
+                  ),
+                  ..._barsCache.series(
+                    'analysis',
+                    _analysisSig,
+                    () => [
+                      // Deco stop band, drawn before the ceiling line so the
+                      // dashed curve stays legible on top of the fill.
+                      if (_showDecoStops && widget.decoStopCurve != null)
+                        buildDecoStopBand(
+                          decoStopCurve: widget.decoStopCurve!,
+                          timestamps: [
+                            for (final p in widget.profile) p.timestamp,
+                          ],
+                          units: units,
+                        ),
+                      // Ceiling line (if showing and data available)
+                      if (_showCeiling && widget.ceilingCurve != null)
+                        _buildCeilingLine(units),
+
+                      // NDL line (if showing)
+                      if (_showNdl && widget.ndlCurve != null)
+                        _buildNdlLine(metricBand),
+
+                      // ppO2 line (if showing)
+                      if (_showPpO2 && widget.ppO2Curve != null)
+                        _buildPpO2Line(metricBand),
+
+                      // ppN2 line (if showing)
+                      if (_showPpN2 && widget.ppN2Curve != null)
+                        _buildPpN2Line(metricBand),
+
+                      // ppHe line (if showing and has helium data)
+                      if (_showPpHe &&
+                          widget.ppHeCurve != null &&
+                          widget.ppHeCurve!.any((v) => v > 0.001))
+                        _buildPpHeLine(metricBand),
+
+                      // O2 cell agreement rug plus one millivolt line per cell
+                      if (_showO2CellMv && widget.o2CellMvCurves != null) ...[
+                        ..._buildO2CellRug(metricBand),
+                        ..._buildO2CellMvLines(metricBand, units),
+                      ],
+
+                      // MOD line (if showing)
+                      if (_showMod && widget.modCurve != null)
+                        _buildModLine(units),
+
+                      // Gas density line (if showing)
+                      if (_showDensity && widget.densityCurve != null)
+                        _buildDensityLine(metricBand),
+
+                      // GF% line (if showing)
+                      if (_showGf && widget.gfCurve != null)
+                        _buildGfLine(metricBand),
+
+                      // Surface GF line (if showing)
+                      if (_showSurfaceGf && widget.surfaceGfCurve != null)
+                        _buildSurfaceGfLine(metricBand),
+
+                      // Mean depth line (if showing)
+                      if (_showMeanDepth && widget.meanDepthCurve != null)
+                        _buildMeanDepthLine(units),
+
+                      // TTS line (if showing)
+                      if (_showTts && widget.ttsCurve != null)
+                        _buildTtsLine(metricBand),
+
+                      // GTR line (if showing)
+                      if (_showGtr && widget.gtrCurve != null)
+                        _buildGtrLine(metricBand),
+
+                      // CNS% curve (if showing)
+                      if (_showCns && widget.cnsCurve != null)
+                        _buildCnsLine(metricBand),
+
+                      // OTU curve (if showing)
+                      if (_showOtu && widget.otuCurve != null)
+                        _buildOtuLine(metricBand),
+                    ],
+                  ),
+                  ..._barsCache.series(
+                    'markers',
+                    _markersSig,
+                    () => [
+                      // Profile markers (max depth, pressure thresholds)
+                      ..._buildMarkerLines(
+                        units,
+                        metricBand,
+                        minPressure: minPressure,
+                        maxPressure: maxPressure,
+                      ),
+                    ],
+                  ),
+                  ..._barsCache.series(
+                    'overlays',
+                    _overlaysSig,
+                    () => [
+                      // Overlaid comparison sources — LAST, so depth bars keep
+                      // occupying the leading barIndex range (_depthBarCount).
+                      ..._buildOverlayLines(
+                        units,
                         metricBand,
                         minTemp,
                         maxTemp,
-                        units,
                       ),
-
-                    // Multi-tank pressure lines (per-tank visibility controlled
-                    // inside _buildMultiTankPressureLines via _showTankPressure)
-                    if (_hasMultiTankPressure)
-                      ..._buildMultiTankPressureLines(metricBand),
-
-                    // Heart rate line (if showing)
-                    if (_showHeartRate &&
-                        hasHeartRateData &&
-                        minHR != null &&
-                        maxHR != null)
-                      _buildHeartRateLine(
-                        heartRateColor,
-                        metricBand,
-                        minHR,
-                        maxHR,
-                      ),
-                  ],
-                ),
-                ..._barsCache.series(
-                  'sac',
-                  _sacSig,
-                  () => [
-                    // SAC curve line (if showing)
-                    if (_showSac &&
-                        hasSacData &&
-                        minSac != null &&
-                        maxSac != null)
-                      _buildSacLine(metricBand, minSac, maxSac),
-                  ],
-                ),
-                ..._barsCache.series(
-                  'ascent',
-                  _ascentSig,
-                  () => [
-                    // Ascent-rate magnitude line (separate overlay; signed
-                    // m/min)
-                    if (_showAscentRateLine && widget.ascentRates != null)
-                      _buildAscentRateLine(metricBand),
-                  ],
-                ),
-                ..._barsCache.series(
-                  'analysis',
-                  _analysisSig,
-                  () => [
-                    // Deco stop band, drawn before the ceiling line so the
-                    // dashed curve stays legible on top of the fill.
-                    if (_showDecoStops && widget.decoStopCurve != null)
-                      buildDecoStopBand(
-                        decoStopCurve: widget.decoStopCurve!,
-                        timestamps: [
-                          for (final p in widget.profile) p.timestamp,
-                        ],
-                        units: units,
-                      ),
-                    // Ceiling line (if showing and data available)
-                    if (_showCeiling && widget.ceilingCurve != null)
-                      _buildCeilingLine(units),
-
-                    // NDL line (if showing)
-                    if (_showNdl && widget.ndlCurve != null)
-                      _buildNdlLine(metricBand),
-
-                    // ppO2 line (if showing)
-                    if (_showPpO2 && widget.ppO2Curve != null)
-                      _buildPpO2Line(metricBand),
-
-                    // ppN2 line (if showing)
-                    if (_showPpN2 && widget.ppN2Curve != null)
-                      _buildPpN2Line(metricBand),
-
-                    // ppHe line (if showing and has helium data)
-                    if (_showPpHe &&
-                        widget.ppHeCurve != null &&
-                        widget.ppHeCurve!.any((v) => v > 0.001))
-                      _buildPpHeLine(metricBand),
-
-                    // O2 cell agreement rug plus one millivolt line per cell
-                    if (_showO2CellMv && widget.o2CellMvCurves != null) ...[
-                      ..._buildO2CellRug(metricBand),
-                      ..._buildO2CellMvLines(metricBand, units),
                     ],
-
-                    // MOD line (if showing)
-                    if (_showMod && widget.modCurve != null)
-                      _buildModLine(units),
-
-                    // Gas density line (if showing)
-                    if (_showDensity && widget.densityCurve != null)
-                      _buildDensityLine(metricBand),
-
-                    // GF% line (if showing)
-                    if (_showGf && widget.gfCurve != null)
-                      _buildGfLine(metricBand),
-
-                    // Surface GF line (if showing)
-                    if (_showSurfaceGf && widget.surfaceGfCurve != null)
-                      _buildSurfaceGfLine(metricBand),
-
-                    // Mean depth line (if showing)
-                    if (_showMeanDepth && widget.meanDepthCurve != null)
-                      _buildMeanDepthLine(units),
-
-                    // TTS line (if showing)
-                    if (_showTts && widget.ttsCurve != null)
-                      _buildTtsLine(metricBand),
-
-                    // GTR line (if showing)
-                    if (_showGtr && widget.gtrCurve != null)
-                      _buildGtrLine(metricBand),
-
-                    // CNS% curve (if showing)
-                    if (_showCns && widget.cnsCurve != null)
-                      _buildCnsLine(metricBand),
-
-                    // OTU curve (if showing)
-                    if (_showOtu && widget.otuCurve != null)
-                      _buildOtuLine(metricBand),
-                  ],
-                ),
-                ..._barsCache.series(
-                  'markers',
-                  _markersSig,
-                  () => [
-                    // Profile markers (max depth, pressure thresholds)
-                    ..._buildMarkerLines(
-                      units,
-                      metricBand,
-                      minPressure: minPressure,
-                      maxPressure: maxPressure,
-                    ),
-                  ],
-                ),
-                ..._barsCache.series(
-                  'overlays',
-                  _overlaysSig,
-                  () => [
-                    // Overlaid comparison sources — LAST, so depth bars keep
-                    // occupying the leading barIndex range (_depthBarCount).
-                    ..._buildOverlayLines(units, metricBand, minTemp, maxTemp),
-                  ],
-                ),
-              ],
+                  ),
+                ],
+              ),
             ),
             rangeAnnotations: RangeAnnotations(
               verticalRangeAnnotations: _buildHighlightRangeAnnotations(
@@ -3383,7 +3401,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                             profile: widget.profile,
                             depthBarStarts: starts,
                             barIndex: depthSpot.barIndex,
-                            spotIndex: depthSpot.spotIndex,
+                            spotIndex: _sourceSpotIndex(depthSpot),
                             spotX: depthSpot.x,
                             multiComputer: false,
                           );
@@ -3437,7 +3455,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                           profile: widget.profile,
                           depthBarStarts: depthBarStarts,
                           barIndex: depthSpot.barIndex,
-                          spotIndex: depthSpot.spotIndex,
+                          spotIndex: _sourceSpotIndex(depthSpot),
                           spotX: depthSpot.x,
                           multiComputer: false,
                         );
@@ -3451,7 +3469,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                   // readout must describe t=0, not repeat the first sample.
                   final onLeadIn =
                       depthSpot != null &&
-                      depthSpot.spotIndex == 0 &&
+                      _sourceSpotIndex(depthSpot) == 0 &&
                       depthBarStarts[depthSpot.barIndex] < 0 &&
                       shouldDrawSurfaceLeadIn(widget.profile);
 
@@ -4762,6 +4780,44 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     }
     return false;
   }
+
+  /// The bars fl_chart is handed: [bars] cut to the visible window when
+  /// zoomed, so no path runs far off screen (see [windowBars]). Memoized on
+  /// the source list and the snapped window: a horizontal pan that stays
+  /// inside one eighth-window step hands fl_chart the identical list, which
+  /// keeps its touched spot indices valid and lets its listEquals
+  /// short-circuit. [chartMinY] is in the key too, since the cut bars' fill
+  /// gradients are placed against it.
+  List<LineChartBarData> _windowedBars(
+    List<LineChartBarData> bars, {
+    required double visibleMinX,
+    required double visibleRangeX,
+    required double chartMinY,
+  }) {
+    final snapped = snappedBarWindow(minX: visibleMinX, width: visibleRangeX);
+    final range = _viewport.isZoomed
+        ? (minX: snapped.minX, maxX: snapped.maxX, minY: chartMinY)
+        : null;
+    if (identical(bars, _barWindowSource) && range == _barWindowRange) {
+      return _barWindow.bars;
+    }
+    _barWindowSource = bars;
+    _barWindowRange = range;
+    _barWindow = range == null
+        ? WindowedBars.unwindowed(bars)
+        : windowBars(
+            bars,
+            minX: range.minX,
+            maxX: range.maxX,
+            chartMinY: range.minY,
+          );
+    return _barWindow.bars;
+  }
+
+  /// [spot]'s index in its source bar, before [_windowedBars] cut it.
+  /// fl_chart reports touches against the cut bars it was handed.
+  int _sourceSpotIndex(LineBarSpot spot) =>
+      _barWindow.sourceSpotIndex(spot.barIndex, spot.spotIndex);
 
   /// Build every overlaid source's lines: dashed depth, dimmed temperature
   /// (when the temperature metric is enabled), and computer-reported

--- a/lib/features/dive_log/presentation/widgets/profile_bar_window.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_bar_window.dart
@@ -1,0 +1,209 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+
+/// The profile chart's bars cut down to one visible X window, plus where each
+/// cut bar starts inside the bar it came from.
+///
+/// fl_chart builds a path over every spot it is given and only clips at
+/// raster time. Zoomed in, that path runs many plot-widths past the visible
+/// window, and on macOS the Impeller (MetalSDF) renderer corrupts the frame
+/// once it gets big enough: blanked series, stray triangles, smeared glyphs.
+/// Handing fl_chart only the window keeps every path about one plot wide at
+/// any zoom.
+///
+/// fl_chart reports touches as `(barIndex, spotIndex)` against the bars it
+/// was given, so any code that reads a touched spot's index back into the
+/// source data must go through [sourceSpotIndex].
+@immutable
+class WindowedBars {
+  const WindowedBars(this.bars, this.offsets);
+
+  /// The bars as given, uncut: offsets are all zero.
+  WindowedBars.unwindowed(this.bars)
+    : offsets = List<int>.filled(bars.length, 0);
+
+  final List<LineChartBarData> bars;
+
+  /// Index of each cut bar's first spot within its source bar's spot list.
+  final List<int> offsets;
+
+  /// Maps a spot index fl_chart reported against [bars] back to the index of
+  /// the same spot in the source bar.
+  int sourceSpotIndex(int barIndex, int spotIndex) =>
+      barIndex >= 0 && barIndex < offsets.length
+      ? offsets[barIndex] + spotIndex
+      : spotIndex;
+}
+
+/// Cuts each bar down to the spots inside [minX, maxX], keeping [margin] real
+/// (non-gap) samples beyond each edge so lines and curves still run off the
+/// plot exactly as before. Two neighbours keep a curved segment that crosses
+/// an edge identical: its control points come from the samples either side.
+///
+/// A bar whose x values ever decrease (a shape that doubles back, such as a
+/// closed band) is passed through whole, since cutting a prefix and suffix
+/// would change its outline. A bar that already fits is returned as the same
+/// instance.
+///
+/// [chartMinY] is the chart's current minY, the bottom edge fl_chart sizes a
+/// below-area gradient to (see [_remappedFill]).
+WindowedBars windowBars(
+  List<LineChartBarData> bars, {
+  required double minX,
+  required double maxX,
+  required double chartMinY,
+  int margin = 2,
+}) {
+  final out = <LineChartBarData>[];
+  final offsets = <int>[];
+  for (final bar in bars) {
+    final range = _windowRange(bar.spots, minX, maxX, margin);
+    if (range == null ||
+        (range.start == 0 && range.end == bar.spots.length - 1)) {
+      out.add(bar);
+      offsets.add(0);
+    } else {
+      final cut = bar.copyWith(
+        spots: bar.spots.sublist(range.start, range.end + 1),
+      );
+      out.add(_remappedFill(bar, cut, chartMinY));
+      offsets.add(range.start);
+    }
+  }
+  return WindowedBars(out, offsets);
+}
+
+/// [cut] with its below-area gradient moved back to where it sat on [source].
+///
+/// fl_chart stretches a below-area gradient over the bar's own bounds: its
+/// leftmost to rightmost spot, and its topmost spot down to the chart's minY.
+/// Cutting the bar shrinks those bounds, which would slide the fill's shading
+/// around as the window moves. The mapping from data to pixels is linear, so
+/// re-expressing each alignment against the cut bounds, all in data units,
+/// puts every colour back on the same depth.
+LineChartBarData _remappedFill(
+  LineChartBarData source,
+  LineChartBarData cut,
+  double chartMinY,
+) {
+  final fill = cut.belowBarData;
+  final gradient = fill.gradient;
+  if (!fill.show || gradient is! LinearGradient) return cut;
+  final begin = gradient.begin;
+  final end = gradient.end;
+  if (begin is! Alignment || end is! Alignment) return cut;
+
+  final srcLeft = source.mostLeftSpot.x;
+  final srcRight = source.mostRightSpot.x;
+  final srcTop = source.mostTopSpot.y;
+  final cutLeft = cut.mostLeftSpot.x;
+  final cutRight = cut.mostRightSpot.x;
+  final cutTop = cut.mostTopSpot.y;
+  if (!(cutRight > cutLeft) || !(cutTop > chartMinY)) return cut;
+
+  // An alignment runs -1..1 across a rect edge to edge; y runs top (larger
+  // data y) to bottom (chartMinY), matching the chart's inverted pixel axis.
+  double remap(
+    double a,
+    double srcFrom,
+    double srcTo,
+    double from,
+    double to,
+  ) => 2 * (srcFrom + (a + 1) / 2 * (srcTo - srcFrom) - from) / (to - from) - 1;
+  Alignment moved(Alignment a) => Alignment(
+    remap(a.x, srcLeft, srcRight, cutLeft, cutRight),
+    remap(a.y, srcTop, chartMinY, cutTop, chartMinY),
+  );
+
+  return cut.copyWith(
+    belowBarData: BarAreaData(
+      show: fill.show,
+      color: fill.color,
+      gradient: LinearGradient(
+        begin: moved(begin),
+        end: moved(end),
+        colors: gradient.colors,
+        stops: gradient.stops,
+        tileMode: gradient.tileMode,
+        transform: gradient.transform,
+      ),
+      spotsLine: fill.spotsLine,
+      cutOffY: fill.cutOffY,
+      applyCutOffY: fill.applyCutOffY,
+    ),
+  );
+}
+
+/// Inclusive spot range to keep, or null to keep the bar whole.
+({int start, int end})? _windowRange(
+  List<FlSpot> spots,
+  double minX,
+  double maxX,
+  int margin,
+) {
+  if (spots.isEmpty || !_isOrderedByX(spots)) return null;
+
+  var first = 0; // first real spot at or after minX
+  while (first < spots.length &&
+      (spots[first].isNull() || spots[first].x < minX)) {
+    first++;
+  }
+  var last = spots.length - 1; // last real spot at or before maxX
+  while (last >= 0 && (spots[last].isNull() || spots[last].x > maxX)) {
+    last--;
+  }
+
+  var start = first;
+  for (var kept = 0, i = first - 1; i >= 0 && kept < margin; i--) {
+    if (spots[i].isNull()) continue;
+    start = i;
+    kept++;
+  }
+  var end = last;
+  for (var kept = 0, i = last + 1; i < spots.length && kept < margin; i++) {
+    if (spots[i].isNull()) continue;
+    end = i;
+    kept++;
+  }
+
+  if (start >= spots.length) start = spots.length - 1;
+  if (end < 0) end = 0;
+  if (end < start) return null;
+  return (start: start, end: end);
+}
+
+/// Whether the real spots' x values never decrease, memoized per spot list:
+/// the chart's bars are memoized too, so this runs once per bar, not once
+/// per pan frame.
+bool _isOrderedByX(List<FlSpot> spots) => _orderedByX[spots] ??= () {
+  var prev = double.negativeInfinity;
+  for (final s in spots) {
+    if (s.isNull()) continue;
+    if (s.x < prev) return false;
+    prev = s.x;
+  }
+  return true;
+}();
+
+final Expando<bool> _orderedByX = Expando<bool>('orderedByX');
+
+/// The window starting at [minX] and [width] wide, widened to whole
+/// eighth-window steps.
+///
+/// Snapping keeps the cut bars (and so fl_chart's touched spot indices)
+/// unchanged while a pan stays inside one step, instead of shifting on every
+/// frame. The result is at most a quarter of a window wider than asked.
+/// [width] is taken rather than derived from a max so one zoom level always
+/// yields the exact same step.
+({double minX, double maxX}) snappedBarWindow({
+  required double minX,
+  required double width,
+}) {
+  final step = width / 8;
+  if (!(step > 0)) return (minX: minX, maxX: minX + width);
+  return (
+    minX: (minX / step).floorToDouble() * step,
+    maxX: ((minX + width) / step).ceilToDouble() * step,
+  );
+}

--- a/lib/features/dive_log/presentation/widgets/profile_bar_window.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_bar_window.dart
@@ -58,20 +58,68 @@ WindowedBars windowBars(
   final out = <LineChartBarData>[];
   final offsets = <int>[];
   for (final bar in bars) {
-    final range = _windowRange(bar.spots, minX, maxX, margin);
+    final clip = _canClipAtEdges(bar);
+    final range = _windowRange(bar.spots, minX, maxX, clip ? 1 : margin);
+    final kept = range == null
+        ? null
+        : bar.spots.sublist(range.start, range.end + 1);
+    final spots = kept != null && clip
+        ? _clippedToEdges(kept, minX, maxX)
+        : kept;
     if (range == null ||
-        (range.start == 0 && range.end == bar.spots.length - 1)) {
+        (range.start == 0 &&
+            range.end == bar.spots.length - 1 &&
+            identical(spots, kept))) {
       out.add(bar);
       offsets.add(0);
     } else {
-      final cut = bar.copyWith(
-        spots: bar.spots.sublist(range.start, range.end + 1),
-      );
+      final cut = bar.copyWith(spots: spots);
       out.add(_remappedFill(bar, cut, chartMinY));
       offsets.add(range.start);
     }
   }
   return WindowedBars(out, offsets);
+}
+
+/// Whether [bar]'s edge samples can be moved onto the window edges without
+/// changing what is drawn: a straight line joins its samples (no curve, whose
+/// shape depends on the samples either side, and no steps), and no dots mark
+/// where the samples are.
+bool _canClipAtEdges(LineChartBarData bar) =>
+    !bar.isCurved && !bar.isStepLineChart && !bar.dotData.show;
+
+/// [spots] with a first sample left of [minX], and a last one right of
+/// [maxX], moved along their segment onto that edge. A span from a
+/// full-dive series (the O2 cell rug is two points, start to end) would
+/// otherwise stay the width of the whole dive. A sample whose neighbour is a
+/// gap has no segment into the window and stays put. Only the end samples
+/// move, so spot indices into the cut are unchanged.
+List<FlSpot> _clippedToEdges(List<FlSpot> spots, double minX, double maxX) {
+  if (spots.length < 2) return spots;
+  FlSpot onEdge(FlSpot from, FlSpot to, double x) =>
+      FlSpot(x, from.y + (to.y - from.y) * (x - from.x) / (to.x - from.x));
+
+  final first = spots.first;
+  final second = spots[1];
+  final last = spots.last;
+  final beforeLast = spots[spots.length - 2];
+  final clipFirst =
+      !first.isNull() && !second.isNull() && first.x < minX && second.x > minX;
+  final clipLast =
+      !last.isNull() &&
+      !beforeLast.isNull() &&
+      last.x > maxX &&
+      beforeLast.x < maxX;
+  if (!clipFirst && !clipLast) return spots;
+  return [
+    for (var i = 0; i < spots.length; i++)
+      if (i == 0 && clipFirst)
+        onEdge(first, second, minX)
+      else if (i == spots.length - 1 && clipLast)
+        onEdge(beforeLast, last, maxX)
+      else
+        spots[i],
+  ];
 }
 
 /// [cut] with its below-area gradient moved back to where it sat on [source].

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -4216,7 +4216,10 @@ void main() {
         expect(bars.length, greaterThanOrEqualTo(3));
 
         // Drive the touch pipeline directly: three depth bands under the cursor
-        // at distinct interior samples (barIndex 0/1/2).
+        // at distinct interior samples (barIndex 0/1/2), plus another line.
+        // fl_chart only asks for indicators on spots it reported touched, so
+        // the other line's spot is part of the response too.
+        final overlay = LineChartBarData(spots: const [FlSpot(0, 0)]);
         data.lineTouchData.touchCallback!(
           FlPanDownEvent(DragDownDetails()),
           LineTouchResponse(
@@ -4226,6 +4229,7 @@ void main() {
               TouchLineBarSpot(bars[0], 0, bars[0].spots[1], 0),
               TouchLineBarSpot(bars[1], 1, bars[1].spots[1], 0),
               TouchLineBarSpot(bars[2], 2, bars[2].spots[1], 0),
+              TouchLineBarSpot(overlay, bars.length, overlay.spots[0], 0),
             ],
           ),
         );
@@ -4237,7 +4241,6 @@ void main() {
         expect(indicator(bars[1], const [1]).single, isNull);
         expect(indicator(bars[2], const [1]).single, isNull);
         // A line whose sample is not the resolved point keeps its dot.
-        final overlay = LineChartBarData(spots: const [FlSpot(0, 0)]);
         expect(
           indicator(overlay, const [0]).single,
           isNotNull,
@@ -4267,6 +4270,38 @@ void main() {
       expect(() => indicator(bar, [bar.spots.length + 685]), returnsNormally);
       expect(indicator(bar, [bar.spots.length + 685]).single, isNull);
       expect(indicator(bar, const [-1]).single, isNull);
+    });
+
+    testWidgets('touched spot indicator skips an index that went stale', (
+      tester,
+    ) async {
+      // Regression: fl_chart keeps a touched spot's index across rebuilds.
+      // Once the series under it is rebuilt with different spots (zoomed
+      // analysis curves re-decimate as a pan crosses a bucket), the index
+      // names another sample, and the marker was drawn at the wrong time,
+      // splitting away from the cursor. Only the touched spot is drawn.
+      final profile = _makeProfile(points: 12);
+      await tester.pumpWidget(
+        buildWithLegend(profile: profile, ascentRates: const []),
+      );
+      await tester.pumpAndSettle();
+
+      final data = primaryChartData(tester);
+      final bar = data.lineBarsData.first;
+      data.lineTouchData.touchCallback!(
+        FlPanDownEvent(DragDownDetails()),
+        LineTouchResponse(
+          touchLocation: Offset.zero,
+          touchChartCoordinate: Offset.zero,
+          lineBarSpots: <TouchLineBarSpot>[
+            TouchLineBarSpot(bar, 0, bar.spots[5], 5),
+          ],
+        ),
+      );
+
+      final indicator = data.lineTouchData.getTouchedSpotIndicator;
+      expect(indicator(bar, const [5]).single, isNotNull);
+      expect(indicator(bar, const [6]).single, isNull);
     });
 
     testWidgets('tooltip builds when hovering a non-first velocity segment', (

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_zoom_window_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_zoom_window_test.dart
@@ -1,0 +1,272 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// Zoomed-in rendering of the profile chart.
+///
+/// fl_chart only clips at raster time, so it builds a path over every spot it
+/// is given. Zoomed in, those paths ran many plot-widths off screen, and the
+/// macOS Impeller (MetalSDF) renderer corrupted whole frames while panning.
+/// The chart now hands fl_chart only the visible window (see
+/// profile_bar_window.dart); these tests pin that down, and pin the touch
+/// paths that read fl_chart's spot indices back into the profile.
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// 600 samples, 5 s apart: a 50-minute dive with a W-shaped profile.
+const _sampleSeconds = 5;
+
+List<DiveProfilePoint> _profile() => List.generate(600, (i) {
+  final phase = (i % 200) / 200.0;
+  return DiveProfilePoint(
+    timestamp: i * _sampleSeconds,
+    depth: 5 + 25 * (phase < 0.5 ? phase * 2 : (1 - phase) * 2),
+    temperature: 20.0 - i * 0.005,
+  );
+});
+
+Widget _buildChart({void Function(List<TooltipRow>? rows)? onTooltipData}) {
+  return ProviderScope(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SizedBox(
+          width: 800,
+          height: 500,
+          child: DiveProfileChart(
+            profile: _profile(),
+            tooltipBelow: onTooltipData != null,
+            onTooltipData: onTooltipData,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+LineChartData _chartData(WidgetTester tester) =>
+    tester.widget<LineChart>(find.byType(LineChart).first).data;
+
+/// Mouse-wheel zoom anchored at the chart centre: 1.1x per click.
+Future<void> _wheelZoomIn(WidgetTester tester, {required int clicks}) async {
+  final center = tester.getCenter(find.byType(LineChart).first);
+  for (var i = 0; i < clicks; i++) {
+    await tester.sendEventToBinding(
+      PointerScrollEvent(position: center, scrollDelta: const Offset(0, -100)),
+    );
+    await tester.pump();
+  }
+}
+
+/// Mouse click-drag pan by [dx] pixels.
+Future<void> _dragPan(WidgetTester tester, double dx) async {
+  final center = tester.getCenter(find.byType(LineChart).first);
+  final drag = await tester.createGesture(kind: PointerDeviceKind.mouse);
+  await drag.down(center);
+  for (var i = 0; i < 10; i++) {
+    await drag.moveBy(Offset(dx / 10, 0));
+    await tester.pump();
+  }
+  await drag.up();
+  // A mouse stays attached after the button is released; detach it so a
+  // later hover gesture can add the device again.
+  await drag.removePointer();
+  await tester.pump();
+}
+
+/// Hovers the mouse at [position] and returns the external tooltip rows.
+Future<List<TooltipRow>?> _hover(
+  WidgetTester tester,
+  Offset position,
+  List<TooltipRow>? Function() rows,
+) async {
+  final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+  await mouse.addPointer(location: position - const Offset(4, 0));
+  addTearDown(mouse.removePointer);
+  await tester.pump();
+  await mouse.moveTo(position);
+  await tester.pump();
+  return rows();
+}
+
+int _timeRowSeconds(List<TooltipRow> rows) {
+  final parts = rows.first.value.split(':');
+  return int.parse(parts[0]) * 60 + int.parse(parts[1]);
+}
+
+void _ignoreOverflowErrors() {
+  final origOnError = FlutterError.onError;
+  FlutterError.onError = (details) {
+    if (details.toString().contains('overflowed')) return;
+    origOnError?.call(details);
+  };
+  addTearDown(() => FlutterError.onError = origOnError);
+}
+
+void main() {
+  testWidgets('zoomed in, no series reaches much past the visible window', (
+    tester,
+  ) async {
+    _ignoreOverflowErrors();
+    await tester.pumpWidget(_buildChart());
+    await tester.pumpAndSettle();
+
+    await _wheelZoomIn(tester, clicks: 20); // ~6.7x
+    await _dragPan(tester, -150);
+
+    final data = _chartData(tester);
+    final width = data.maxX - data.minX;
+    expect(width, lessThan(3000 / 5), reason: 'the chart must be zoomed in');
+
+    // Eighth-window snapping widens the window by at most a quarter of a
+    // window, plus the two real neighbours kept past each edge.
+    final slack = width * 0.25 + 2 * _sampleSeconds;
+    for (final bar in data.lineBarsData) {
+      final xs = [
+        for (final s in bar.spots)
+          if (!s.isNull()) s.x,
+      ];
+      if (xs.length < 2) continue;
+      expect(
+        xs.first,
+        greaterThanOrEqualTo(data.minX - slack),
+        reason:
+            'a series starting at ${xs.first}s runs far left of the '
+            'visible window [${data.minX}, ${data.maxX}]',
+      );
+      expect(
+        xs.last,
+        lessThanOrEqualTo(data.maxX + slack),
+        reason:
+            'a series ending at ${xs.last}s runs far right of the '
+            'visible window [${data.minX}, ${data.maxX}]',
+      );
+    }
+  });
+
+  testWidgets('panning keeps the depth fill shading on the same depths', (
+    tester,
+  ) async {
+    // fl_chart stretches the fill gradient from the bar's topmost spot to the
+    // chart's minY, so a cut bar needs its gradient remapped; otherwise the
+    // shading slides whenever a pan re-cuts the series.
+    _ignoreOverflowErrors();
+    await tester.pumpWidget(_buildChart());
+    await tester.pumpAndSettle();
+    await _wheelZoomIn(tester, clicks: 20);
+
+    // Data y where the gradient's first colour sits.
+    double gradientTopY() {
+      final data = _chartData(tester);
+      final depth = data.lineBarsData.first;
+      final begin =
+          (depth.belowBarData.gradient! as LinearGradient).begin as Alignment;
+      final top = depth.mostTopSpot.y;
+      return top + (begin.y + 1) / 2 * (data.minY - top);
+    }
+
+    await _dragPan(tester, -60);
+    final before = gradientTopY();
+    final cutTopBefore = _chartData(tester).lineBarsData.first.mostTopSpot.y;
+    await _dragPan(tester, -200);
+    final cutTopAfter = _chartData(tester).lineBarsData.first.mostTopSpot.y;
+
+    expect(
+      cutTopAfter,
+      isNot(cutTopBefore),
+      reason: 'the pan must re-cut the depth series for this to test anything',
+    );
+    expect(gradientTopY(), closeTo(before, 1e-6));
+  });
+
+  testWidgets('unzoomed, every series keeps all of its samples', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildChart());
+    await tester.pumpAndSettle();
+
+    final depth = _chartData(tester).lineBarsData.first;
+    expect(depth.spots.where((s) => !s.isNull()), hasLength(600));
+  });
+
+  testWidgets('zoomed in, hovering reads the sample under the cursor', (
+    tester,
+  ) async {
+    _ignoreOverflowErrors();
+    List<TooltipRow>? rows;
+    await tester.pumpWidget(_buildChart(onTooltipData: (r) => rows = r));
+    await tester.pumpAndSettle();
+
+    await _wheelZoomIn(tester, clicks: 20);
+    await _dragPan(tester, -150);
+
+    final data = _chartData(tester);
+    final got = await _hover(
+      tester,
+      tester.getCenter(find.byType(LineChart).first),
+      () => rows,
+    );
+
+    expect(got, isNotNull);
+    final seconds = _timeRowSeconds(got!);
+    expect(
+      seconds,
+      inInclusiveRange(data.minX, data.maxX),
+      reason:
+          'the readout must describe a sample inside the visible '
+          'window, not one offset by the trimmed-off spots',
+    );
+  });
+
+  testWidgets('a focus marker whose spot index went stale is not drawn', (
+    tester,
+  ) async {
+    _ignoreOverflowErrors();
+    List<TooltipRow>? rows;
+    await tester.pumpWidget(_buildChart(onTooltipData: (r) => rows = r));
+    await tester.pumpAndSettle();
+
+    await _wheelZoomIn(tester, clicks: 20);
+    final got = await _hover(
+      tester,
+      tester.getCenter(find.byType(LineChart).first),
+      () => rows,
+    );
+    expect(got, isNotNull);
+    final touchedX = _timeRowSeconds(got!).toDouble();
+
+    final data = _chartData(tester);
+    final depth = data.lineBarsData.first;
+    final touched = depth.spots.indexWhere((s) => s.x == touchedX);
+    expect(touched, isNonNegative);
+    final indicator = data.lineTouchData.getTouchedSpotIndicator;
+
+    // fl_chart keeps the touched spot's index across rebuilds. Once the
+    // series under it is re-cut (a pan) or re-decimated, that index names a
+    // different sample, and drawing it puts the marker at the wrong time.
+    expect(indicator(depth, [touched]).single, isNotNull);
+    expect(indicator(depth, [touched + 5]).single, isNull);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/profile_bar_window_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_bar_window_test.dart
@@ -1,0 +1,205 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/presentation/widgets/profile_bar_window.dart';
+
+LineChartBarData _bar(List<double> xs) =>
+    LineChartBarData(spots: [for (final x in xs) FlSpot(x, x * 2)]);
+
+List<double> _xs(LineChartBarData bar) => [
+  for (final s in bar.spots) s.isNull() ? double.nan : s.x,
+];
+
+void main() {
+  group('windowBars', () {
+    final ramp = _bar([for (var i = 0; i <= 100; i++) i.toDouble()]);
+
+    test('keeps the window plus two real neighbours on each side', () {
+      final w = windowBars([ramp], minX: 40, maxX: 50, chartMinY: -1000);
+
+      expect(_xs(w.bars.single), [for (var i = 38; i <= 52; i++) i.toDouble()]);
+      expect(w.offsets, [38]);
+    });
+
+    test('maps a windowed spot index back to its source index', () {
+      final w = windowBars([ramp], minX: 40, maxX: 50, chartMinY: -1000);
+
+      expect(w.sourceSpotIndex(0, 0), 38);
+      expect(w.sourceSpotIndex(0, 5), 43);
+      expect(ramp.spots[w.sourceSpotIndex(0, 5)], w.bars.single.spots[5]);
+    });
+
+    test('keeps the samples bracketing a window that falls between them', () {
+      // Sparse samples: nothing lies inside [12, 18], but the segment from
+      // 10 to 20 still crosses the whole window and must stay drawn.
+      final sparse = _bar([0, 10, 20, 30, 40]);
+
+      final w = windowBars([sparse], minX: 12, maxX: 18, chartMinY: -1000);
+
+      expect(_xs(w.bars.single), [0, 10, 20, 30]);
+      expect(w.offsets, [0]);
+    });
+
+    test('does not count gap spots as neighbours', () {
+      final gappy = LineChartBarData(
+        spots: const [
+          FlSpot(0, 0),
+          FlSpot(1, 1),
+          FlSpot.nullSpot,
+          FlSpot(2, 2),
+          FlSpot.nullSpot,
+          FlSpot(5, 5),
+          FlSpot(6, 6),
+          FlSpot(7, 7),
+          FlSpot(8, 8),
+          FlSpot(9, 9),
+        ],
+      );
+
+      final w = windowBars([gappy], minX: 5, maxX: 6, chartMinY: -1000);
+
+      // Two real samples before the window (1 and 2) are kept even though a
+      // gap sits between them; the gaps travel along unchanged.
+      expect(w.offsets, [1]);
+      expect(w.bars.single.spots.first, const FlSpot(1, 1));
+      expect(w.bars.single.spots.last, const FlSpot(8, 8));
+    });
+
+    test('leaves a bar that is not ordered by x untouched', () {
+      // A shape that doubles back in x (a closed band) cannot be trimmed by
+      // cutting a prefix and suffix without changing its outline.
+      final band = _bar([0, 10, 20, 30, 20, 10, 0]);
+
+      final w = windowBars([band], minX: 12, maxX: 18, chartMinY: -1000);
+
+      expect(identical(w.bars.single, band), isTrue);
+      expect(w.offsets, [0]);
+    });
+
+    test('returns a bar that already fits the window as the same instance', () {
+      final w = windowBars([ramp], minX: -10, maxX: 200, chartMinY: -1000);
+
+      expect(identical(w.bars.single, ramp), isTrue);
+      expect(w.offsets, [0]);
+    });
+
+    test('keeps the tail of a bar that ends before the window', () {
+      final early = _bar([0, 1, 2, 3, 4]);
+
+      final w = windowBars([early], minX: 50, maxX: 60, chartMinY: -1000);
+
+      expect(_xs(w.bars.single), [3, 4]);
+      expect(w.offsets, [3]);
+    });
+
+    test('passes an empty bar through', () {
+      final empty = LineChartBarData(spots: const []);
+
+      final w = windowBars([empty], minX: 0, maxX: 1, chartMinY: -1000);
+
+      expect(identical(w.bars.single, empty), isTrue);
+      expect(w.offsets, [0]);
+    });
+
+    test('windows every bar independently and preserves bar order', () {
+      final a = _bar([for (var i = 0; i <= 100; i++) i.toDouble()]);
+      final b = _bar([for (var i = 0; i <= 100; i += 10) i.toDouble()]);
+
+      final w = windowBars([a, b], minX: 40, maxX: 50, chartMinY: -1000);
+
+      expect(w.bars, hasLength(2));
+      expect(w.offsets, [38, 2]);
+      expect(_xs(w.bars[1]), [20, 30, 40, 50, 60, 70]);
+    });
+  });
+
+  group('windowBars fill gradient', () {
+    // fl_chart sizes a below-area gradient to the bar's own bounds: its most
+    // left/right spots across, and from its topmost spot down to the chart's
+    // minY. Cutting the bar moves those bounds, so the gradient is remapped to
+    // keep every colour at the same place on the chart.
+    LineChartBarData filled(List<FlSpot> spots) => LineChartBarData(
+      spots: spots,
+      belowBarData: BarAreaData(
+        show: true,
+        gradient: const LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [Color(0x0D0000FF), Color(0x4D0000FF)],
+        ),
+      ),
+    );
+
+    // Depth is plotted negative: y 0 is the surface, -50 the deepest sample.
+    final dive = filled([
+      for (var i = 0; i <= 100; i++)
+        FlSpot(i.toDouble(), i <= 50 ? -i.toDouble() : -(100 - i).toDouble()),
+    ]);
+
+    test('keeps the gradient on the same depths after a cut', () {
+      // Window 38..42 keeps spots 36..44: topmost y is -36, not 0.
+      final w = windowBars([dive], minX: 38, maxX: 42, chartMinY: -60);
+
+      final g = w.bars.single.belowBarData.gradient! as LinearGradient;
+      final begin = g.begin as Alignment;
+      final end = g.end as Alignment;
+      // Source rect runs y 0 (top) to -60 (bottom); the cut rect runs -36 to
+      // -60. y 0 sits 36 above the cut top on a 24-tall rect: 2*36/24 = 3
+      // half-heights above its top edge.
+      expect(begin.y, closeTo(-4, 1e-9));
+      expect(end.y, closeTo(1, 1e-9));
+      // Both ends stay in one column, so the gradient stays vertical.
+      expect(begin.x, closeTo(end.x, 1e-9));
+      expect(g.colors, (dive.belowBarData.gradient! as LinearGradient).colors);
+    });
+
+    test('leaves the gradient alone when the bar is not cut', () {
+      final w = windowBars([dive], minX: -10, maxX: 200, chartMinY: -60);
+
+      expect(identical(w.bars.single, dive), isTrue);
+    });
+
+    test('leaves a solid-colour fill alone', () {
+      final solid = LineChartBarData(
+        spots: [for (var i = 0; i <= 100; i++) FlSpot(i.toDouble(), -1)],
+        belowBarData: BarAreaData(show: true, color: const Color(0xFF0000FF)),
+      );
+
+      final w = windowBars([solid], minX: 40, maxX: 50, chartMinY: -60);
+
+      expect(w.bars.single.belowBarData.gradient, isNull);
+      expect(w.bars.single.belowBarData.color, const Color(0xFF0000FF));
+    });
+  });
+
+  group('snappedBarWindow', () {
+    test('contains the requested window', () {
+      final s = snappedBarWindow(minX: 13.3, width: 10);
+
+      expect(s.minX, lessThanOrEqualTo(13.3));
+      expect(s.maxX, greaterThanOrEqualTo(23.3));
+    });
+
+    test('grows the window by at most a quarter of its width', () {
+      final s = snappedBarWindow(minX: 13.3, width: 10);
+
+      expect(s.maxX - s.minX, lessThanOrEqualTo(10 * 1.25 + 1e-9));
+    });
+
+    test('is stable while a pan stays inside one eighth-window step', () {
+      // Width 10 -> step 1.25; both windows start inside [12.5, 13.75).
+      final a = snappedBarWindow(minX: 12.6, width: 10);
+      final b = snappedBarWindow(minX: 13.7, width: 10);
+
+      expect(b.minX, a.minX);
+    });
+
+    test('moves once a pan crosses an eighth-window step', () {
+      final a = snappedBarWindow(minX: 12.6, width: 10);
+      final b = snappedBarWindow(minX: 13.8, width: 10);
+
+      expect(b.minX, greaterThan(a.minX));
+    });
+  });
+}

--- a/test/features/dive_log/presentation/widgets/profile_bar_window_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_bar_window_test.dart
@@ -114,6 +114,78 @@ void main() {
     });
   });
 
+  group('windowBars straight spans', () {
+    // A straight, dot-less series can be cut exactly: its segments crossing
+    // the window edges are clipped to them, so even a two-point span over
+    // the whole dive (the O2 cell rug) stays about one window wide.
+    LineChartBarData straight(List<FlSpot> spots) =>
+        LineChartBarData(spots: spots, dotData: const FlDotData(show: false));
+
+    test('clips a two-point span that brackets the window to its edges', () {
+      final rug = straight(const [FlSpot(0, 7), FlSpot(100, 7)]);
+
+      final w = windowBars([rug], minX: 40, maxX: 50, chartMinY: -1000);
+
+      expect(w.bars.single.spots, const [FlSpot(40, 7), FlSpot(50, 7)]);
+      expect(w.offsets, [0]);
+    });
+
+    test('clips the segments crossing each edge on their own line', () {
+      final line = straight([
+        for (var i = 0; i <= 100; i += 10) FlSpot(i.toDouble(), i * 2.0),
+      ]);
+
+      final w = windowBars([line], minX: 42, maxX: 58, chartMinY: -1000);
+
+      final spots = w.bars.single.spots;
+      expect(spots.first.x, 42);
+      expect(spots.first.y, closeTo(84, 1e-9));
+      expect(spots[1], const FlSpot(50, 100));
+      expect(spots.last.x, 58);
+      expect(spots.last.y, closeTo(116, 1e-9));
+      expect(spots, hasLength(3));
+      expect(w.offsets, [4]);
+    });
+
+    test('keeps a neighbour whose segment is broken by a gap', () {
+      final gappy = straight(const [
+        FlSpot(0, 0),
+        FlSpot(30, 30),
+        FlSpot.nullSpot,
+        FlSpot(45, 45),
+        FlSpot(60, 60),
+      ]);
+
+      final w = windowBars([gappy], minX: 40, maxX: 50, chartMinY: -1000);
+
+      // No line joins 30 to 45, so 30 must not be dragged to the edge.
+      expect(w.bars.single.spots.first, const FlSpot(30, 30));
+      expect(w.bars.single.spots.last, const FlSpot(50, 50));
+    });
+
+    test('leaves points alone on a series that draws its dots', () {
+      final dotted = LineChartBarData(
+        spots: const [FlSpot(0, 7), FlSpot(100, 7)],
+      );
+
+      final w = windowBars([dotted], minX: 40, maxX: 50, chartMinY: -1000);
+
+      expect(identical(w.bars.single, dotted), isTrue);
+    });
+
+    test('leaves points alone on a curved series', () {
+      final curved = LineChartBarData(
+        spots: const [FlSpot(0, 7), FlSpot(100, 7)],
+        isCurved: true,
+        dotData: const FlDotData(show: false),
+      );
+
+      final w = windowBars([curved], minX: 40, maxX: 50, chartMinY: -1000);
+
+      expect(identical(w.bars.single, curved), isTrue);
+    });
+  });
+
   group('windowBars fill gradient', () {
     // fl_chart sizes a below-area gradient to the bar's own bounds: its most
     // left/right spots across, and from its topmost spot down to the chart's


### PR DESCRIPTION
## Summary

On macOS, the fullscreen dive profile chart drew garbage while zoomed in and panning or zooming: series blanked out, large stray triangles appeared, text smeared across the window, the transport bar and zoom hint vanished, and a digit could stay corrupted in the readout until relaunch.

fl_chart builds a path over every spot it is given and only clips when drawing, so zoomed in, each series became a path zoom times the plot width. Flutter 3.47 made Impeller's MetalSDF renderer the macOS default, and it corrupts the frame once that geometry gets large enough (from about 5x in a typical window). The same frames render correctly on Skia, and trimming the off-screen samples made the corruption go away on real hardware with a trackpad.

The chart now hands fl_chart only the visible window when zoomed. A second, smaller fix stops the hover markers splitting away from the cursor while panning.

## Changes

- **Series cut to the visible window** (new `profile_bar_window.dart`). When zoomed, each series keeps only the samples in the visible window plus two real samples past each edge, so lines and curves still run off the plot unchanged. The window snaps to eighth-window steps, so a pan inside one step reuses the same bars. Series whose x values double back are left whole. Unzoomed, the bars pass through untouched.
- **Touched spot indices mapped back through the cut.** fl_chart reports touches against the bars it was given, so every read of a touched depth spot's index (external readout, tooltip, point selection, the surface lead-in check) now maps to the source sample.
- **Depth fill gradient kept in place.** fl_chart stretches the fill gradient from the bar's topmost spot to the chart's minY. A cut bar's gradient is remapped, in data units, so the shading stays on the same depths while panning.
- **Focus markers drawn only on the touched spot** (separate commit). fl_chart keeps touched spot indices across rebuilds. When zoomed analysis curves re-decimate during a pan, a kept index names another sample, and the NDL line or tank dot was drawn at the wrong time. The touch callback now records the touched spots, and the indicator callback skips any index whose spot is no longer one of them.

## Notes for review

- On Flutter 3.47 macOS, SDF rendering cannot be disabled without disabling Impeller entirely (`enableSDFs` is hard-coded on in the embedder), so a chart-side fix was preferred over opting macOS out of Impeller.
- The raw diff of `dive_profile_chart.dart` is mostly re-indentation from wrapping `lineBarsData`; `git diff -w` shows the substance.
- One existing test (velocity colouring shows one depth focus dot) now includes the overlay line's spot in its synthetic touch response, since fl_chart only asks for indicators on spots it reported touched.

## Test Plan

- [x] `flutter test` passes (full suite locally, 26,938 tests, before the rebase onto current main; the pre-push hook's affected tests after it)
- [x] `flutter analyze` passes (whole project, no issues)
- [x] Manual testing on: macOS (Apple silicon, built-in Retina display), trackpad pinch and pan at about 5x and above on a real dive, in a profile build. Corruption gone; hover markers and depth fill shading correct while panning.

New tests cover the windowing (neighbours, sparse samples, gaps, doubled-back series, pass-through, offsets, snapping) and the gradient remap, plus chart-level tests for the geometry bound when zoomed, the hover readout reading the sample under the cursor, fill shading staying put across a pan, and stale focus markers. The index-mapping and gradient tests were mutation-checked: each fails with the corresponding piece of the fix removed.
