### PR TITLE
docs(readme): lead with the generated brand banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-<h1>
-<img src="assets/icon/icon.png" alt="Submersion logo" width="72" align="left" hspace="14">
-Submersion<br>
-<sub><sub><sup><em>Own your dive log. Free and open-source, forever.</em></sup></sub></sub><br>&nbsp;
-</h1>
+<img src="assets/brand/readme-banner.png" alt="Submersion: Dive safe. Log everything." width="100%">
 
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/submersion-app/submersion/ci.yaml?branch=main&label=CI&logo=githubactions&logoColor=white)](https://github.com/submersion-app/submersion/actions/workflows/ci.yaml)


### PR DESCRIPTION
## Summary

The README header now uses the generated brand banner instead of the hand-built icon, title and tagline. `assets/brand/readme-banner.png` is the preset the brand generator (#1780) draws for this spot.

## Changes

- Replace the header `<h1>` (icon floated left, "Submersion" title, nested `<sub>`/`<sup>` tagline) with `assets/brand/readme-banner.png` at full width
- Drop the old tagline "Own your dive log. Free and open-source, forever." in favor of the banner's slogan, "Dive safe. Log everything."; the intro paragraph still says the app is free and open source
- The alt text carries the name and slogan, since the image now holds all of the header's text

The banner is opaque, so it reads the same in GitHub's light and dark themes. Markdownlint already allows inline HTML (MD033) and a first line that is not a heading (MD041), and nothing links to the old `#submersion` anchor.

## Test Plan

- [x] `flutter analyze` passes (pre-push hook)
- [x] No Dart changes, so `flutter test` is not affected
- [x] Check the rendered README on the branch in light and dark themes
