### PR TITLE
ci(test): run the test suite on 16 file shards instead of 8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -280,11 +280,15 @@ jobs:
         # already fans out ~10-11 non-test jobs (analyze + 5 builds + scripts +
         # timezone + integration) that share the pool AND gate ci-success, so
         # oversharding queues the builds and makes total CI slower, not
-        # faster. 8 keeps us under the cap while roughly halving test
-        # wall-clock.
-        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+        # faster. The org is on GitHub Team (60 concurrent jobs; it was 8
+        # shards under Free's 20). Each shard pays ~4s per test file (almost
+        # all of it load + coverage, not assertions) plus ~2 min of fixed
+        # setup, so at ~3000 files 16 shards bring a shard to ~14 min, under
+        # the ~19 min Android build that then sets the critical path. More
+        # shards would not shorten CI until that build does.
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     env:
-      TOTAL_SHARDS: 8
+      TOTAL_SHARDS: 16
     steps:
       - uses: actions/checkout@v7
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,27 +3,27 @@
 
 codecov:
   notify:
-    # Coverage arrives as 9 separate uploads: the 8 file-sharded test jobs
-    # (flags shard-0..7) plus the scripts job (flag scripts). Tests are sharded
+    # Coverage arrives as 17 separate uploads: the 16 file-sharded test jobs
+    # (flags shard-0..15) plus the scripts job (flag scripts). Tests are sharded
     # BY FILE (ci.yaml), so each shard's lcov only marks the lines its subset
     # executed and Codecov must union them. Without waiting, Codecov computes
     # the patch/project STATUS after the first upload lands -- and a shard that
     # touched only part of a PR's diff then posts a misleadingly low patch %
     # (e.g. 12.5% when the fully-merged coverage is 100%), which sticks. Hold
-    # the status until all 9 uploads arrive, then compute once on the merge.
+    # the status until all 17 uploads arrive, then compute once on the merge.
     # Both upload steps run `if: always()` (empty shards upload an empty lcov),
-    # so exactly 9 uploads occur.
+    # so exactly 17 uploads occur.
     #
     # THIS MUST EQUAL (ci.yaml shard count + 1) for the scripts job. If the
     # `codecov/patch` status is made a REQUIRED check in branch protection, a
     # stale count here means the status never settles and NO PR can merge --
     # so bump this in lockstep whenever you change the shard matrix.
-    after_n_builds: 9
+    after_n_builds: 17
     wait_for_ci: true
 
 comment:
   # Same rationale: don't post/update the PR comment until every upload is in.
-  after_n_builds: 9
+  after_n_builds: 17
 
 coverage:
   status:


### PR DESCRIPTION
## Summary

Test shards are the CI critical path. On the latest main run (34665616941) the 8 shards took 23-27 min each, while every platform build finished within ~19 min of codegen. Doubling the shards should put a shard at ~14 min, which makes the Android build the critical path and brings end-to-end CI from ~37 min to roughly 28.

The 8-shard cap came from the Free plan's 20 concurrent job limit. The org is now on GitHub Team, which allows 60.

## Changes

- `ci.yaml`: test matrix `0..15`, `TOTAL_SHARDS: 16`, and an updated comment explaining the cap and why going past 16 would not help until the Android build gets faster.
- `codecov.yml`: `after_n_builds` 9 to 17 (16 shards plus the scripts job), so Codecov still waits for every partial lcov before posting status.

## Why more shards helps

Each shard spends ~1,530s in `Run tests` for ~371 files, about 4s per file. Almost all of that is per-file load and `--coverage` overhead rather than assertions. Sharding by file (already in place) divides that cost linearly, so halving the files per shard roughly halves the step. Setup (Flutter install, caches, pub get) is ~2 min per shard and does not divide.

Verified locally that the 16-way `awk` split is disjoint and complete: 185-186 files per shard, 2,967 total, 2,967 unique. The only required status check on `main` is `CI Success`, so adding shard jobs cannot leave a required check pending.

## Test Plan

- [x] All 16 `Test (shard N)` jobs run and pass on this PR
- [x] Each shard's `Run tests` step is ~12-14 min
- [x] Codecov posts patch/project status only after all 17 uploads arrive
- [x] `flutter analyze` passes (pre-push hook)
