### PR TITLE
ci: cache build_runner state per commit and stop the no-op SDK caches

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -150,12 +150,6 @@ jobs:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: stable
 
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: build-all-${{ steps.setup-flutter.outputs.CACHE-KEY }}
-
       - name: Cache pub dependencies
         uses: actions/cache@v6
         with:
@@ -436,12 +430,6 @@ jobs:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: stable
 
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: build-all-${{ steps.setup-flutter.outputs.CACHE-KEY }}
-
       - name: Cache pub dependencies
         uses: actions/cache@v6
         with:
@@ -588,12 +576,6 @@ jobs:
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: stable
-
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: build-all-${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
@@ -763,12 +745,6 @@ jobs:
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: stable
-
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: build-all-${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
@@ -952,12 +928,6 @@ jobs:
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: stable
-
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: build-all-${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -35,14 +35,30 @@ jobs:
           REF: refs/pull/${{ github.event.pull_request.number }}/merge
         run: |
           set -uo pipefail
-          ids=$(gh cache list --ref "$REF" --limit 100 --json id --jq '.[].id')
-          if [ -z "$ids" ]; then
-            echo "No caches for $REF."
-            exit 0
-          fi
-          # A cache GitHub already evicted (or a concurrent run deleted) makes
-          # delete fail; that is fine, so report it but keep going.
-          for id in $ids; do
-            gh cache delete "$id" || echo "::warning::could not delete cache $id"
+          deleted=0
+          # ci.yaml saves one build_runner entry per commit, so a long-lived PR
+          # can exceed one listing page. Delete in passes of up to 100 until the
+          # ref is empty; the pass cap stops a cache that keeps refusing to
+          # delete from looping forever.
+          for pass in $(seq 1 20); do
+            # A failed listing must fail the job, not read as "nothing left".
+            if ! ids=$(gh cache list --ref "$REF" --limit 100 --json id --jq '.[].id'); then
+              echo "::error::could not list caches for $REF"
+              exit 1
+            fi
+            if [ -z "$ids" ]; then
+              echo "Deleted $deleted cache(s) for $REF in $((pass - 1)) pass(es)."
+              exit 0
+            fi
+            # A cache GitHub already evicted (or a concurrent run deleted) makes
+            # delete fail; that is fine, so report it but keep going.
+            for id in $ids; do
+              if gh cache delete "$id"; then
+                deleted=$((deleted + 1))
+              else
+                echo "::warning::could not delete cache $id"
+              fi
+            done
           done
-          echo "Processed $(echo "$ids" | wc -w) cache(s) for $REF."
+          echo "::error::caches still listed for $REF after 20 passes ($deleted deleted)"
+          exit 1

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -10,6 +10,10 @@ name: PR cache cleanup
 # pull_request_target, not pull_request: a fork PR's pull_request token is
 # read-only, so it could not delete its own caches. This workflow never checks
 # out or runs PR code; it only calls the cache API for the PR's ref.
+#
+# pull_request_target also runs the workflow as it exists on main, so it only
+# covers PRs that close after this file lands there. Caches from PRs closed
+# before then are left to GitHub's LRU eviction, as they always were.
 on:
   pull_request_target:
     types: [closed]

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,44 @@
+name: PR cache cleanup
+
+# The repo shares one 10 GB Actions cache, and every PR run saves entries
+# scoped to its own merge ref (refs/pull/N/merge): pub, pods, nuget and the
+# per-commit build_runner state from ci.yaml. Nothing can restore those once
+# the PR closes, but they still count against the limit until GitHub evicts
+# them, pushing out the main-branch entries every new PR restores from. Delete
+# them as soon as the PR closes (merged or not).
+#
+# pull_request_target, not pull_request: a fork PR's pull_request token is
+# read-only, so it could not delete its own caches. This workflow never checks
+# out or runs PR code; it only calls the cache API for the PR's ref.
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: Delete closed PR caches
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete caches for this PR's merge ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          set -uo pipefail
+          ids=$(gh cache list --ref "$REF" --limit 100 --json id --jq '.[].id')
+          if [ -z "$ids" ]; then
+            echo "No caches for $REF."
+            exit 0
+          fi
+          # A cache GitHub already evicted (or a concurrent run deleted) makes
+          # delete fail; that is fine, so report it but keep going.
+          for id in $ids; do
+            gh cache delete "$id" || echo "::warning::could not delete cache $id"
+          done
+          echo "Processed $(echo "$ids" | wc -w) cache(s) for $REF."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,12 +134,6 @@ jobs:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: 'stable'
 
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
-
       - name: Cache pub dependencies
         uses: actions/cache@v6
         with:
@@ -155,6 +149,28 @@ jobs:
 
       - name: Install dependencies
         run: flutter pub get
+
+      # build_runner keeps its incremental state (asset graph, compiled build
+      # script, hidden outputs) in .dart_tool/build, and restoring a recent
+      # copy turns a ~350s full build into a ~45-70s incremental one. The pub
+      # cache above also carries a .dart_tool/build, but its key only changes
+      # with pubspec.lock and an exact hit is never re-saved, so that copy
+      # drifts further behind main with every merge (hits measured 43s to
+      # 325s). Drop it and restore a per-commit copy instead: every run saves
+      # its own state (~12 MB compressed) and restore-keys picks the newest one
+      # for the same lockfile and SDK, preferring this PR's own ref, then main.
+      # A lockfile or SDK change starts cold, as build_runner would discard
+      # the graph anyway.
+      - name: Drop stale build_runner state from the pub cache
+        run: rm -rf .dart_tool/build
+
+      - name: Cache build_runner state
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/.dart_tool/build
+          key: build-runner-${{ runner.os }}-${{ steps.flutter-ver.outputs.version }}-${{ hashFiles('pubspec.lock', 'build.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            build-runner-${{ runner.os }}-${{ steps.flutter-ver.outputs.version }}-${{ hashFiles('pubspec.lock', 'build.yaml') }}-
 
       - name: Run code generation
         run: dart run build_runner build --delete-conflicting-outputs
@@ -198,12 +214,6 @@ jobs:
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: 'stable'
-
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
@@ -299,12 +309,6 @@ jobs:
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: 'stable'
-
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
@@ -403,12 +407,6 @@ jobs:
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: 'stable'
-
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
@@ -677,12 +675,6 @@ jobs:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: 'stable'
 
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
-
       - name: Cache pub dependencies
         uses: actions/cache@v6
         with:
@@ -754,12 +746,6 @@ jobs:
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: 'stable'
-
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
@@ -837,12 +823,6 @@ jobs:
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: 'stable'
-
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
@@ -971,12 +951,6 @@ jobs:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: 'stable'
 
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
-
       - name: Cache pub dependencies
         uses: actions/cache@v6
         with:
@@ -1093,12 +1067,6 @@ jobs:
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: 'stable'
-
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
@@ -1243,12 +1211,6 @@ jobs:
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: 'stable'
-
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,6 +161,11 @@ jobs:
       # for the same lockfile and SDK, preferring this PR's own ref, then main.
       # A lockfile or SDK change starts cold, as build_runner would discard
       # the graph anyway.
+      # The generated sources themselves (*.g.dart etc., gitignored) are NOT
+      # cached and a fresh checkout has none of them; build_runner rewrites
+      # missing outputs from the restored graph. The old pub-cache path relied
+      # on the same thing: run 34671403450 restored only the graph, wrote 104
+      # outputs in 43s, packaged all 40 generated files and passed.
       - name: Drop stale build_runner state from the pub cache
         run: rm -rf .dart_tool/build
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -48,12 +48,6 @@ jobs:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: stable
 
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
-
       - name: Cache pub dependencies
         uses: actions/cache@v6
         with:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -62,12 +62,6 @@ jobs:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: stable
 
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
-
       - name: Cache pub dependencies
         uses: actions/cache@v6
         with:
@@ -196,12 +190,6 @@ jobs:
         with:
           flutter-version: ${{ steps.flutter-ver.outputs.version }}
           channel: stable
-
-      - name: Cache Flutter SDK
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6


### PR DESCRIPTION
## Summary

Code Generation gates every other CI job, and its build_runner step swings from ~45s to ~350s depending on whether build_runner's incremental state (`.dart_tool/build`) survived from an earlier run. This PR makes that state reliably fresh and frees the cache space it was losing.

Evidence from the 13 most recent CI runs:

| Pub cache | build_runner | Outputs written |
|---|---|---|
| Miss (4 runs, incl. the latest main push) | 243-446s | ~10,360 (full) |
| Hit, recent graph | 43-72s | 104-4,832 |
| Hit, stale graph | 224-325s | 5,665-7,379 |

Two causes:

1. **Staleness.** The state only travelled inside the pub cache, keyed on `pubspec.lock`. An exact hit is never re-saved, so the restored graph drifts further behind main with every merge.
2. **Eviction.** The repo cache sits at 9.84 GB of its 10 GB limit and the oldest entry was a few hours old, so entries get evicted almost as soon as they are written.

## Changes

- **Per-commit build_runner cache** (`ci.yaml`, codegen job): key `build-runner-<os>-<flutter>-<lockhash>-<sha>` with restore-keys on the prefix, so every run saves its state and the next run restores the newest one (this PR's own ref first, then main). The stale copy the pub cache restores is dropped first. The state is ~12 MB compressed (measured locally: 111 MB raw).
- **Remove all 18 "Cache Flutter SDK" steps** (`ci.yaml` 10, `build-all.yml` 5, `screenshots.yml` 2, `performance.yml` 1). Each ran *after* `subosito/flutter-action` (with `cache: false`) had already downloaded Flutter, so it restored 1.6-2.1 GB over a finished install. Verified in run 34671898415: the install finished at 04:03:36, then the SDK cache restore ran from 04:03:36 to 04:03:55. That costs ~20s to restore plus ~14s to save per job, for no benefit, and holds 5.5 GB of the 10 GB cache.
- **New `cache-cleanup.yml`**: on `pull_request_target` `closed`, deletes every cache scoped to that PR's merge ref. It uses `pull_request_target` so fork PRs get a token that can delete; it never checks out or runs PR code.

## Expected effect

- Codegen should consistently land in the ~45-70s range instead of ~350s on a miss, taking up to ~5 min off the critical path on those runs.
- Every job loses ~34s of pointless SDK cache restore/save.
- About 5.5 GB of cache is freed for pub, gradle (Android is the slowest build) and the build_runner state.

Complements #1783 (16 test shards). The two PRs touch different parts of `ci.yaml`.

## Test Plan

- [x] First run: `Cache build_runner state` misses (new key prefix), codegen runs a full build and saves an 11 MB entry on `refs/pull/1784/merge`
- [x] A second push restores that entry (run 34676243070): build_runner **24s, 40 outputs** (the 40 gitignored sources, rewritten from the graph), all 40 packaged; whole Code Generation job **110s** vs ~500s on the latest cold main run
- [x] All downstream jobs pass without the SDK cache steps
- [x] After merge, closing any PR removes its `refs/pull/N/merge` caches (check the `PR cache cleanup` run)
- [x] YAML parses; `actionlint` reports only an existing SC2129 style note elsewhere in `ci.yaml`
- [x] `flutter analyze` passes (pre-push hook)