### PR TITLE
fix(import): restore a dive's entry and exit GPS from UDDF backups

### DIFF
--- a/lib/core/services/export/models/uddf_import_result.dart
+++ b/lib/core/services/export/models/uddf_import_result.dart
@@ -143,6 +143,23 @@ class UddfImportResult {
     return parts.isEmpty ? 'No data' : parts.join(', ');
   }
 
+  /// The entries in [byDiveRef] belonging to the dive whose `<dive id>` the
+  /// parser kept as [diveRef] (its `sourceUuid`).
+  ///
+  /// Submersion's own export writes `<dive id="dive_<uuid>">` and the parser
+  /// keeps that attribute verbatim, so the ref is already prefixed. A file
+  /// whose dive ids are bare needs the prefix added. Both shapes are tried
+  /// rather than assuming either, and in one place, so the parser attaching
+  /// entries to a dive and the importer reading them cannot resolve a dive
+  /// differently.
+  static List<Map<String, dynamic>> sourcesForDive(
+    Map<String, List<Map<String, dynamic>>> byDiveRef,
+    String? diveRef,
+  ) {
+    if (diveRef == null) return const [];
+    return byDiveRef[diveRef] ?? byDiveRef['dive_$diveRef'] ?? const [];
+  }
+
   /// Returns a copy with [sourceFileName] replaced.
   UddfImportResult copyWithSourceFileName(String? sourceFileName) {
     return UddfImportResult(

--- a/lib/core/services/export/uddf/uddf_export_builders.dart
+++ b/lib/core/services/export/uddf/uddf_export_builders.dart
@@ -98,6 +98,24 @@ class UddfExportBuilders {
     );
   }
 
+  /// A dive's own entry or exit fix, as `<{side}latitude>` and
+  /// `<{side}longitude>` (the names the `<source>` record already uses).
+  ///
+  /// UDDF has coordinates only under `<divesite><geography>`, so these are
+  /// custom elements like `entrytype` and `exittype` beside them. They are
+  /// the only place a fix that lives on the dive row alone (GPS track
+  /// matching, a manual edit) reaches the file at all; without them a
+  /// restore drops it (#1735). Both exporters call this so neither can drift.
+  static void buildDiveGpsElements(
+    XmlBuilder builder,
+    String side,
+    GeoPoint? fix,
+  ) {
+    if (fix == null) return;
+    builder.element('${side}latitude', nest: fix.latitude.toString());
+    builder.element('${side}longitude', nest: fix.longitude.toString());
+  }
+
   static void buildDiveElement(
     XmlBuilder builder,
     Dive dive,
@@ -280,6 +298,7 @@ class UddfExportBuilders {
             if (dive.entryMethod != null) {
               builder.element('entrytype', nest: dive.entryMethod!.name);
             }
+            buildDiveGpsElements(builder, 'entry', dive.entryLocation);
             // Link to buddy records in diver section
             for (final buddyWithRole in diveBuddyList) {
               builder.element(
@@ -657,6 +676,7 @@ class UddfExportBuilders {
             if (dive.exitMethod != null) {
               builder.element('exittype', nest: dive.exitMethod!.name);
             }
+            buildDiveGpsElements(builder, 'exit', dive.exitLocation);
             // Weight system
             if (dive.weightAmount != null) {
               builder.element(

--- a/lib/core/services/export/uddf/uddf_export_service.dart
+++ b/lib/core/services/export/uddf/uddf_export_service.dart
@@ -263,6 +263,11 @@ class UddfExportService {
                                 nest: dive.entryMethod!.name,
                               );
                             }
+                            UddfExportBuilders.buildDiveGpsElements(
+                              builder,
+                              'entry',
+                              dive.entryLocation,
+                            );
                           },
                         );
 
@@ -471,6 +476,11 @@ class UddfExportService {
                                 nest: dive.exitMethod!.name,
                               );
                             }
+                            UddfExportBuilders.buildDiveGpsElements(
+                              builder,
+                              'exit',
+                              dive.exitLocation,
+                            );
                             // Weight system
                             if (dive.weightAmount != null) {
                               builder.element(

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -495,6 +495,19 @@ class UddfFullImportService {
 
     final sources = _parseDataSources(uddfElement);
 
+    // Each dive's <source> entries also ride on its own map as `dataSources`,
+    // like `gearLinks` above. The import wizard flattens this result into
+    // entity lists and rebuilds it without dataSourcesByDiveRef, so a restore
+    // through it otherwise saw no sources at all: no restored source rows,
+    // and no GPS for a backup that kept it only there (#1735).
+    for (final dive in dives) {
+      final entries = UddfImportResult.sourcesForDive(
+        sources.byDiveRef,
+        dive['sourceUuid'] as String?,
+      );
+      if (entries.isNotEmpty) dive['dataSources'] = entries;
+    }
+
     return UddfImportResult(
       dataSourcesByDiveRef: sources.byDiveRef,
       unpairedDumps: sources.unpaired,

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -964,6 +964,14 @@ class UddfFullImportService {
         );
       }
 
+      // The dive's own entry fix, under the keys every other import format
+      // uses for it (#1735).
+      if (UddfImportParsers.parseDiveGps(beforeElement, 'entry')
+          case final fix?) {
+        diveData['latitude'] = fix.latitude;
+        diveData['longitude'] = fix.longitude;
+      }
+
       // Parse dive mode
       final diveMode = UddfImportParsers.parseDiveModeIn(beforeElement);
       if (diveMode != null) {
@@ -1148,6 +1156,12 @@ class UddfFullImportService {
           exitType,
           enums.EntryMethod.values,
         );
+      }
+
+      if (UddfImportParsers.parseDiveGps(afterElement, 'exit')
+          case final fix?) {
+        diveData['exitLatitude'] = fix.latitude;
+        diveData['exitLongitude'] = fix.longitude;
       }
 
       // Parse weight used

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -118,6 +118,26 @@ class UddfImportParsers {
     return value;
   }
 
+  /// Reads a dive's own entry or exit fix, the `<{side}latitude>` and
+  /// `<{side}longitude>` pair `UddfExportBuilders.buildDiveGpsElements`
+  /// writes into [parent].
+  ///
+  /// Returns null unless both halves are present, finite and on the globe. A
+  /// lone latitude is not a position, and treating it as one would also stop
+  /// the importer falling back to the dive's `<source>` coordinates.
+  static ({double latitude, double longitude})? parseDiveGps(
+    XmlElement parent,
+    String side,
+  ) {
+    final latitude = parseUddfDouble(getElementText(parent, '${side}latitude'));
+    final longitude = parseUddfDouble(
+      getElementText(parent, '${side}longitude'),
+    );
+    if (latitude == null || longitude == null) return null;
+    if (latitude.abs() > 90 || longitude.abs() > 180) return null;
+    return (latitude: latitude, longitude: longitude);
+  }
+
   static void assignGasMixToTankIfMissing({
     required List<Map<String, dynamic>> tanks,
     required int tankIndex,

--- a/lib/core/services/export/uddf/uddf_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_import_service.dart
@@ -228,6 +228,13 @@ class UddfImportService {
         diveData['diveNumber'] = UddfImportParsers.parseUddfInt(diveNumText);
       }
 
+      // The dive's own entry fix, as both UDDF exporters write it (#1735).
+      if (UddfImportParsers.parseDiveGps(beforeElement, 'entry')
+          case final fix?) {
+        diveData['latitude'] = fix.latitude;
+        diveData['longitude'] = fix.longitude;
+      }
+
       final airTempText = _getElementText(beforeElement, 'airtemperature');
       if (airTempText != null) {
         // UDDF stores temps in Kelvin
@@ -697,6 +704,12 @@ class UddfImportService {
       final maxDepthText = _getElementText(afterElement, 'greatestdepth');
       if (maxDepthText != null) {
         diveData['maxDepth'] = double.tryParse(maxDepthText);
+      }
+
+      if (UddfImportParsers.parseDiveGps(afterElement, 'exit')
+          case final fix?) {
+        diveData['exitLatitude'] = fix.latitude;
+        diveData['exitLongitude'] = fix.longitude;
       }
 
       final avgDepthText = _getElementText(afterElement, 'averagedepth');

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1520,21 +1520,25 @@ class UddfEntityImporter {
 
   /// The `<source>` entries belonging to one parsed dive.
   ///
-  /// Submersion's own export writes `<dive id="dive_<uuid>">`, and the parser
-  /// keeps that attribute verbatim as `sourceUuid`, so the ref is already
-  /// prefixed. A file whose dive ids are bare needs the prefix added. Both
-  /// shapes are tried rather than assuming either, and this lives in one
-  /// place so the restore and the computer registration cannot resolve a dive
+  /// Read from the dive's own map first, where the parser attaches them as
+  /// `dataSources`: that is the only copy the import wizard keeps, because
+  /// it rebuilds the result from entity lists and drops
+  /// [dataSourcesByDiveRef] (#1735). The map is the fallback for a caller
+  /// that builds a result by hand. This lives in one place so the restore,
+  /// the GPS fallback and the computer registration cannot resolve a dive
   /// differently.
   static List<Map<String, dynamic>> _entriesForDive(
     Map<String, dynamic> diveData,
     Map<String, List<Map<String, dynamic>>> dataSourcesByDiveRef,
   ) {
-    final sourceUuid = diveData['sourceUuid'] as String?;
-    if (sourceUuid == null) return const [];
-    return dataSourcesByDiveRef[sourceUuid] ??
-        dataSourcesByDiveRef['dive_$sourceUuid'] ??
-        const [];
+    final carried = diveData['dataSources'];
+    if (carried is List && carried.isNotEmpty) {
+      return carried.cast<Map<String, dynamic>>();
+    }
+    return UddfImportResult.sourcesForDive(
+      dataSourcesByDiveRef,
+      diveData['sourceUuid'] as String?,
+    );
   }
 
   /// The registration key for a model and serial pair.

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -2087,6 +2087,7 @@ class UddfEntityImporter {
           : null;
 
       final diveName = (diveData['name'] as String?)?.trim();
+      final gps = _diveGps(diveData, dataSourcesByDiveRef);
       var dive = Dive(
         id: diveId,
         diverId: diverId,
@@ -2141,11 +2142,8 @@ class UddfEntityImporter {
         altitude: asDoubleOrNull(diveData['altitude']),
         // Entry/exit GPS, so file-imported dives become eligible for the
         // existing site matcher.
-        entryLocation: _geoPoint(diveData['latitude'], diveData['longitude']),
-        exitLocation: _geoPoint(
-          diveData['exitLatitude'],
-          diveData['exitLongitude'],
-        ),
+        entryLocation: gps.entry,
+        exitLocation: gps.exit,
         // Dive mode and rebreather fields
         diveMode: diveMode,
         isPlanned: isPlanned,
@@ -2480,6 +2478,61 @@ class UddfEntityImporter {
     final lngVal = asDoubleOrNull(lng);
     if (latVal == null || lngVal == null) return null;
     return GeoPoint(latVal, lngVal);
+  }
+
+  /// The entry and exit fixes to store on an imported dive.
+  ///
+  /// The dive's own coordinates win, and win as a pair: a dive that carries
+  /// either fix is restored exactly as it was, so it never gains an exit
+  /// borrowed from a source that the diver's dive row did not have.
+  ///
+  /// Only a dive carrying no fix at all falls back to its `<source>` entries,
+  /// primary first, then file order. That is the only place a Submersion
+  /// backup written before #1735 kept GPS, so without it restoring one of
+  /// those drops every Surface GPS card. Foreign files carry no `<source>`
+  /// entries, so for them this is exactly the dive's own coordinates.
+  ({GeoPoint? entry, GeoPoint? exit}) _diveGps(
+    Map<String, dynamic> diveData,
+    Map<String, List<Map<String, dynamic>>> dataSourcesByDiveRef,
+  ) {
+    final entry = _geoPoint(diveData['latitude'], diveData['longitude']);
+    final exit = _geoPoint(diveData['exitLatitude'], diveData['exitLongitude']);
+    if (entry != null || exit != null) return (entry: entry, exit: exit);
+
+    final sources = _entriesForDive(diveData, dataSourcesByDiveRef);
+    final primaryFirst = [
+      ...sources.where((s) => s['isPrimary'] == true),
+      ...sources.where((s) => s['isPrimary'] != true),
+    ];
+    for (final source in primaryFirst) {
+      final sourceEntry = _sourceFix(
+        source['entryLatitude'],
+        source['entryLongitude'],
+      );
+      final sourceExit = _sourceFix(
+        source['exitLatitude'],
+        source['exitLongitude'],
+      );
+      if (sourceEntry != null || sourceExit != null) {
+        return (entry: sourceEntry, exit: sourceExit);
+      }
+    }
+    return (entry: null, exit: null);
+  }
+
+  /// A `<source>` coordinate pair as a fix, or null unless it is finite and
+  /// on the globe. The source parser keeps whatever `double.tryParse`
+  /// accepts, NaN included, and one bad source must not hide a good one.
+  GeoPoint? _sourceFix(dynamic lat, dynamic lng) {
+    final fix = _geoPoint(lat, lng);
+    if (fix == null ||
+        !fix.latitude.isFinite ||
+        !fix.longitude.isFinite ||
+        fix.latitude.abs() > 90 ||
+        fix.longitude.abs() > 180) {
+      return null;
+    }
+    return fix;
   }
 
   List<DiveTank> _buildTanks(Map<String, dynamic> diveData) {

--- a/test/core/services/export/uddf/uddf_dive_gps_round_trip_test.dart
+++ b/test/core/services/export/uddf/uddf_dive_gps_round_trip_test.dart
@@ -1,0 +1,414 @@
+// Issue #1735: a dive's entry and exit GPS must survive a real UDDF export
+// followed by a real import into a clean database.
+//
+// Two gaps lost it. The exporters wrote coordinates only onto each
+// `<source>` record, never onto the `<dive>`, so a fix that lives only on the
+// dive row (GPS track matching, a manual edit) never reached the file. And
+// the importer read the `<source>` coordinates into the data source rows
+// only, never onto the dive, so even a fix that did reach the file was not
+// shown after a restore.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/export/export_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_export_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_export_service.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/certifications/data/repositories/certification_repository.dart';
+import 'package:submersion/features/courses/data/repositories/course_repository.dart';
+import 'package:submersion/features/dive_centers/data/repositories/dive_center_repository.dart';
+import 'package:submersion/features/dive_import/data/services/uddf_entity_importer.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain_dive;
+import 'package:submersion/features/dive_log/domain/entities/dive_source_export.dart';
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart'
+    show GeoPoint;
+import 'package:submersion/features/dive_types/data/repositories/dive_type_repository.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart'
+    as domain;
+import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_set_repository_impl.dart';
+import 'package:submersion/features/equipment/domain/entities/gear_link.dart';
+import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
+import 'package:submersion/features/trips/data/repositories/trip_repository.dart';
+import 'package:xml/xml.dart';
+
+import '../../../../helpers/test_database.dart';
+
+const _diverId = 'diver-gps-round-trip';
+const _diveId = 'dive-gps-1';
+
+ImportRepositories _repositories() => ImportRepositories(
+  tripRepository: TripRepository(),
+  equipmentRepository: EquipmentRepository(),
+  equipmentSetRepository: EquipmentSetRepository(),
+  buddyRepository: BuddyRepository(),
+  diveCenterRepository: DiveCenterRepository(),
+  certificationRepository: CertificationRepository(),
+  tagRepository: TagRepository(),
+  diveTypeRepository: DiveTypeRepository(),
+  siteRepository: SiteRepository(),
+  diveRepository: DiveRepository(),
+  tankPressureRepository: TankPressureRepository(),
+  courseRepository: CourseRepository(),
+  diveComputerRepository: DiveComputerRepository(),
+);
+
+Future<void> _createDiver() async {
+  final now = DateTime.now();
+  await DiverRepository().createDiver(
+    domain.Diver(
+      id: _diverId,
+      name: 'Test Diver',
+      isDefault: true,
+      createdAt: now,
+      updatedAt: now,
+    ),
+  );
+}
+
+domain_dive.Dive _dive({GeoPoint? entry, GeoPoint? exit}) => domain_dive.Dive(
+  id: _diveId,
+  diveNumber: 1,
+  dateTime: DateTime(2025, 10, 13, 11, 24),
+  bottomTime: const Duration(minutes: 45),
+  maxDepth: 24.0,
+  entryLocation: entry,
+  exitLocation: exit,
+  tanks: const [],
+  profile: const [],
+  gear: looseGear(const []),
+  notes: '',
+  photoIds: const [],
+  sightings: const [],
+  weights: const [],
+  tags: const [],
+);
+
+DiveSourceExport _source({
+  required String id,
+  required int ordinal,
+  required bool isPrimary,
+  double? entryLatitude,
+  double? entryLongitude,
+  double? exitLatitude,
+  double? exitLongitude,
+}) {
+  final stamp = DateTime(2025, 10, 13, 18);
+  return DiveSourceExport(
+    id: id,
+    diveId: _diveId,
+    ordinal: ordinal,
+    isPrimary: isPrimary,
+    importedAt: stamp,
+    createdAt: stamp.add(Duration(seconds: ordinal)),
+    computerModel: 'Computer $ordinal',
+    computerSerial: 'SN-$ordinal',
+    mergeSourceSlot: ordinal,
+    entryLatitude: entryLatitude,
+    entryLongitude: entryLongitude,
+    exitLatitude: exitLatitude,
+    exitLongitude: exitLongitude,
+  );
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    await _createDiver();
+  });
+
+  tearDown(() async => tearDownTestDatabase());
+
+  /// Imports [xml] into a clean database, the way a restore onto a new
+  /// device would, and returns the single restored dive row.
+  Future<Dive> restore(String xml) async {
+    await tearDownTestDatabase();
+    db = await setUpTestDatabase();
+    await _createDiver();
+
+    final parsed = await ExportService().importAllDataFromUddf(xml);
+    await UddfEntityImporter().import(
+      data: parsed,
+      selections: const UddfImportSelections(dives: {0}),
+      repositories: _repositories(),
+      diverId: _diverId,
+    );
+    return (db.select(db.dives)..limit(1)).getSingle();
+  }
+
+  Future<String> fullBackup(
+    domain_dive.Dive dive, [
+    List<DiveSourceExport> sources = const [],
+  ]) => UddfFullExportService().generateAllDataXmlForTest(
+    dives: [dive],
+    dataSources: sources,
+  );
+
+  group('export', () {
+    test('writes the dive GPS beside entrytype and exittype', () async {
+      final xml = await fullBackup(
+        _dive(
+          entry: const GeoPoint(29.500852, 34.917877),
+          exit: const GeoPoint(29.501234, 34.918765),
+        ),
+      );
+      final dive = XmlDocument.parse(xml).findAllElements('dive').single;
+      final before = dive.findElements('informationbeforedive').single;
+      final after = dive.findElements('informationafterdive').single;
+
+      expect(before.getElement('entrylatitude')?.innerText, '29.500852');
+      expect(before.getElement('entrylongitude')?.innerText, '34.917877');
+      expect(after.getElement('exitlatitude')?.innerText, '29.501234');
+      expect(after.getElement('exitlongitude')?.innerText, '34.918765');
+      // Each fix belongs to one side of the dive only, so a reader that
+      // looks in the wrong container cannot pass by finding both there.
+      expect(before.getElement('exitlatitude'), isNull);
+      expect(after.getElement('entrylatitude'), isNull);
+    });
+
+    test('writes no GPS elements for a dive without a fix', () async {
+      final xml = await fullBackup(_dive());
+      final dive = XmlDocument.parse(xml).findAllElements('dive').single;
+      for (final name in const [
+        'entrylatitude',
+        'entrylongitude',
+        'exitlatitude',
+        'exitlongitude',
+      ]) {
+        expect(dive.findAllElements(name), isEmpty, reason: name);
+      }
+    });
+  });
+
+  group('restore', () {
+    test(
+      'a fix that lives only on the dive row survives a full backup',
+      () async {
+        // Track matching and manual edits write the dive row and no source
+        // row, so before the fix nothing in the file carried this at all.
+        final restored = await restore(
+          await fullBackup(
+            _dive(
+              entry: const GeoPoint(29.500852, 34.917877),
+              exit: const GeoPoint(29.501234, 34.918765),
+            ),
+          ),
+        );
+
+        expect(restored.entryLatitude, closeTo(29.500852, 1e-9));
+        expect(restored.entryLongitude, closeTo(34.917877, 1e-9));
+        expect(restored.exitLatitude, closeTo(29.501234, 1e-9));
+        expect(restored.exitLongitude, closeTo(34.918765, 1e-9));
+      },
+    );
+
+    test('a dives-only export carries the dive GPS too', () async {
+      final xml = await UddfExportService().generateDivesUddfContent([
+        _dive(
+          entry: const GeoPoint(-8.274, 115.593),
+          exit: const GeoPoint(-8.275, 115.594),
+        ),
+      ]);
+
+      final restored = await restore(xml);
+
+      expect(restored.entryLatitude, closeTo(-8.274, 1e-9));
+      expect(restored.entryLongitude, closeTo(115.593, 1e-9));
+      expect(restored.exitLatitude, closeTo(-8.275, 1e-9));
+      expect(restored.exitLongitude, closeTo(115.594, 1e-9));
+    });
+
+    test('a backup whose dive carries no GPS takes it from the primary '
+        'source', () async {
+      // Every backup written before the fix has this shape: coordinates on
+      // the <source> records only. The secondary is listed first and holds
+      // different coordinates, so taking the first entry instead of the
+      // primary one fails here.
+      final restored = await restore(
+        await fullBackup(_dive(), [
+          _source(
+            id: 'src-secondary',
+            ordinal: 0,
+            isPrimary: false,
+            entryLatitude: 10.0,
+            entryLongitude: 20.0,
+            exitLatitude: 10.5,
+            exitLongitude: 20.5,
+          ),
+          _source(
+            id: 'src-primary',
+            ordinal: 1,
+            isPrimary: true,
+            entryLatitude: 29.500852584838867,
+            entryLongitude: 34.917877197265625,
+            exitLatitude: 29.5012,
+            exitLongitude: 34.9187,
+          ),
+        ]),
+      );
+
+      expect(restored.entryLatitude, closeTo(29.500852584838867, 1e-12));
+      expect(restored.entryLongitude, closeTo(34.917877197265625, 1e-12));
+      expect(restored.exitLatitude, closeTo(29.5012, 1e-12));
+      expect(restored.exitLongitude, closeTo(34.9187, 1e-12));
+    });
+
+    test(
+      'a source fix still applies when the primary source has none',
+      () async {
+        final restored = await restore(
+          await fullBackup(_dive(), [
+            _source(id: 'src-primary', ordinal: 0, isPrimary: true),
+            _source(
+              id: 'src-secondary',
+              ordinal: 1,
+              isPrimary: false,
+              entryLatitude: 10.0,
+              entryLongitude: 20.0,
+            ),
+          ]),
+        );
+
+        expect(restored.entryLatitude, closeTo(10.0, 1e-12));
+        expect(restored.entryLongitude, closeTo(20.0, 1e-12));
+        expect(restored.exitLatitude, isNull);
+        expect(restored.exitLongitude, isNull);
+      },
+    );
+
+    test("the dive's own GPS is restored as it was, never topped up from a "
+        'source', () async {
+      // The diver corrected the entry pin and has no exit on the dive row.
+      // The source still holds the computer's original entry and an exit;
+      // restoring either would show a fix the diver never had.
+      final restored = await restore(
+        await fullBackup(_dive(entry: const GeoPoint(29.6, 34.95)), [
+          _source(
+            id: 'src-primary',
+            ordinal: 0,
+            isPrimary: true,
+            entryLatitude: 29.5,
+            entryLongitude: 34.9,
+            exitLatitude: 29.51,
+            exitLongitude: 34.91,
+          ),
+        ]),
+      );
+
+      expect(restored.entryLatitude, closeTo(29.6, 1e-12));
+      expect(restored.entryLongitude, closeTo(34.95, 1e-12));
+      expect(restored.exitLatitude, isNull);
+      expect(restored.exitLongitude, isNull);
+    });
+
+    test('the restored source rows keep their own coordinates', () async {
+      await restore(
+        await fullBackup(_dive(entry: const GeoPoint(29.6, 34.95)), [
+          _source(
+            id: 'src-primary',
+            ordinal: 0,
+            isPrimary: true,
+            entryLatitude: 29.5,
+            entryLongitude: 34.9,
+          ),
+        ]),
+      );
+
+      final source = await db.select(db.diveDataSources).getSingle();
+      expect(source.entryLatitude, closeTo(29.5, 1e-12));
+      expect(source.entryLongitude, closeTo(34.9, 1e-12));
+    });
+
+    test('a half-written dive fix is ignored rather than stored', () async {
+      // A latitude with no longitude is not a position. It must not count as
+      // "the dive has GPS" either, or it would block the source fallback.
+      final xml =
+          (await fullBackup(_dive(), [
+            _source(
+              id: 'src-primary',
+              ordinal: 0,
+              isPrimary: true,
+              entryLatitude: 29.5,
+              entryLongitude: 34.9,
+            ),
+          ])).replaceFirst(
+            '</informationbeforedive>',
+            '<entrylatitude>12.0</entrylatitude></informationbeforedive>',
+          );
+
+      final restored = await restore(xml);
+
+      expect(restored.entryLatitude, closeTo(29.5, 1e-12));
+      expect(restored.entryLongitude, closeTo(34.9, 1e-12));
+    });
+  });
+
+  group('validation', () {
+    Future<String> withDiveFix(String latitude, String longitude) async =>
+        (await fullBackup(_dive())).replaceFirst(
+          '</informationbeforedive>',
+          '<entrylatitude>$latitude</entrylatitude>'
+              '<entrylongitude>$longitude</entrylongitude>'
+              '</informationbeforedive>',
+        );
+
+    for (final (label, lat, lng) in const [
+      ('a latitude past a pole', '90.5', '10.0'),
+      ('a longitude past the antimeridian', '10.0', '-180.5'),
+      ('a NaN latitude', 'NaN', '10.0'),
+      ('an infinite longitude', '10.0', 'Infinity'),
+      ('a non-numeric latitude', 'north', '10.0'),
+    ]) {
+      test('a dive fix with $label is not stored', () async {
+        final restored = await restore(await withDiveFix(lat, lng));
+        expect(restored.entryLatitude, isNull);
+        expect(restored.entryLongitude, isNull);
+      });
+    }
+
+    test('a dive fix on the poles and the antimeridian is kept', () async {
+      final restored = await restore(await withDiveFix('-90', '180'));
+      expect(restored.entryLatitude, -90);
+      expect(restored.entryLongitude, 180);
+    });
+
+    test('an out-of-range source fix is skipped for the next one', () async {
+      final restored = await restore(
+        await fullBackup(_dive(), [
+          _source(
+            id: 'src-primary',
+            ordinal: 0,
+            isPrimary: true,
+            entryLatitude: 200.0,
+            entryLongitude: 20.0,
+          ),
+          _source(
+            id: 'src-secondary',
+            ordinal: 1,
+            isPrimary: false,
+            entryLatitude: 12.0,
+            entryLongitude: 22.0,
+          ),
+        ]),
+      );
+
+      expect(restored.entryLatitude, closeTo(12.0, 1e-12));
+      expect(restored.entryLongitude, closeTo(22.0, 1e-12));
+    });
+  });
+
+  test('restored GPS reaches the Dive the Surface GPS card reads', () async {
+    await restore(await fullBackup(_dive(entry: const GeoPoint(29.5, 34.9))));
+
+    final dive = (await DiveRepository().getAllDives(diverId: _diverId)).single;
+    expect(dive.entryLocation, const GeoPoint(29.5, 34.9));
+    expect(dive.exitLocation, isNull);
+  });
+}

--- a/test/core/services/export/uddf/uddf_dive_gps_round_trip_test.dart
+++ b/test/core/services/export/uddf/uddf_dive_gps_round_trip_test.dart
@@ -7,6 +7,9 @@
 // the importer read the `<source>` coordinates into the data source rows
 // only, never onto the dive, so even a fix that did reach the file was not
 // shown after a restore.
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/export/export_service.dart';
@@ -35,6 +38,8 @@ import 'package:submersion/features/equipment/data/repositories/equipment_set_re
 import 'package:submersion/features/equipment/domain/entities/gear_link.dart';
 import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
 import 'package:submersion/features/trips/data/repositories/trip_repository.dart';
+import 'package:submersion/features/universal_import/data/models/import_enums.dart';
+import 'package:submersion/features/universal_import/data/parsers/uddf_import_parser.dart';
 import 'package:xml/xml.dart';
 
 import '../../../../helpers/test_database.dart';
@@ -401,6 +406,70 @@ void main() {
 
       expect(restored.entryLatitude, closeTo(12.0, 1e-12));
       expect(restored.entryLongitude, closeTo(22.0, 1e-12));
+    });
+  });
+
+  group('import wizard path', () {
+    test('a pre-fix backup restores GPS and sources from the dive maps '
+        'alone', () async {
+      // The wizard hands the importer ImportPayload entity lists and
+      // rebuilds UddfImportResult from them, so anything kept only on the
+      // result (dataSourcesByDiveRef) never reaches a real restore. This is
+      // that shape: the real parser, then nothing but the dive list.
+      final xml = await fullBackup(_dive(), [
+        _source(
+          id: 'src-primary',
+          ordinal: 0,
+          isPrimary: true,
+          entryLatitude: 29.5,
+          entryLongitude: 34.9,
+        ),
+        _source(id: 'src-secondary', ordinal: 1, isPrimary: false),
+      ]);
+      await tearDownTestDatabase();
+      db = await setUpTestDatabase();
+      await _createDiver();
+
+      final payload = await UddfImportParser().parse(
+        Uint8List.fromList(utf8.encode(xml)),
+      );
+      await UddfEntityImporter().import(
+        data: UddfImportResult(
+          dives: payload.entitiesOf(ImportEntityType.dives),
+        ),
+        selections: const UddfImportSelections(dives: {0}),
+        repositories: _repositories(),
+        diverId: _diverId,
+      );
+
+      final restored = await db.select(db.dives).getSingle();
+      expect(restored.entryLatitude, closeTo(29.5, 1e-12));
+      expect(restored.entryLongitude, closeTo(34.9, 1e-12));
+      expect(
+        await db.select(db.diveDataSources).get(),
+        hasLength(2),
+        reason: 'both exported sources come back, not one synthesised row',
+      );
+    });
+  });
+
+  group('simple dives import', () {
+    test('reads the dive GPS a dives-only export writes', () async {
+      final xml = await UddfExportService().generateDivesUddfContent([
+        _dive(
+          entry: const GeoPoint(-8.274, 115.593),
+          exit: const GeoPoint(-8.275, 115.594),
+        ),
+      ]);
+
+      final dive = (await ExportService().importDivesFromUddf(
+        xml,
+      ))['dives']!.single;
+
+      expect(dive['latitude'], closeTo(-8.274, 1e-12));
+      expect(dive['longitude'], closeTo(115.593, 1e-12));
+      expect(dive['exitLatitude'], closeTo(-8.275, 1e-12));
+      expect(dive['exitLongitude'], closeTo(115.594, 1e-12));
     });
   });
 

--- a/test/features/import_wizard/data/adapters/universal_adapter_test.dart
+++ b/test/features/import_wizard/data/adapters/universal_adapter_test.dart
@@ -15,6 +15,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:riverpod/src/framework.dart' as riverpod show Override;
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_export_service.dart';
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
@@ -34,6 +35,7 @@ import 'package:submersion/features/dive_log/data/services/dive_consolidation_se
 import 'package:submersion/features/dive_log/data/services/dive_merge_snapshot.dart';
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_source_export.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
@@ -75,6 +77,7 @@ import 'package:submersion/features/universal_import/data/models/import_options.
 import 'package:submersion/features/universal_import/data/models/import_payload.dart';
 import 'package:submersion/features/universal_import/data/models/picked_import_file.dart';
 import 'package:submersion/features/universal_import/data/parsers/subsurface_xml_parser.dart';
+import 'package:submersion/features/universal_import/data/parsers/uddf_import_parser.dart';
 import 'package:submersion/features/universal_import/presentation/providers/universal_import_providers.dart';
 
 @GenerateNiceMocks([
@@ -2474,6 +2477,94 @@ void main() {
             expect(result.importedCounts[ImportEntityType.dives], 1);
           },
         );
+      },
+    );
+
+    testWidgets(
+      'a backup whose GPS lives on its <source> records restores it (#1735)',
+      (tester) async {
+        // The wizard rebuilds UddfImportResult from entity lists, so the
+        // per-dive source entries have to survive on the dive maps. Every
+        // backup written before #1735 kept GPS only on those entries.
+        await setUpTestDatabase();
+        addTearDown(tearDownTestDatabase);
+
+        final payload = (await tester.runAsync(() async {
+          final stamp = DateTime(2025, 10, 13, 18);
+          final xml = await UddfFullExportService().generateAllDataXmlForTest(
+            dives: [
+              Dive(
+                id: 'dive-gps',
+                diveNumber: 1,
+                dateTime: DateTime(2025, 10, 13, 11, 24),
+                bottomTime: const Duration(minutes: 45),
+                maxDepth: 24.0,
+              ),
+            ],
+            dataSources: [
+              DiveSourceExport(
+                id: 'src-primary',
+                diveId: 'dive-gps',
+                ordinal: 0,
+                isPrimary: true,
+                importedAt: stamp,
+                createdAt: stamp,
+                entryLatitude: 29.5,
+                entryLongitude: 34.9,
+              ),
+              DiveSourceExport(
+                id: 'src-secondary',
+                diveId: 'dive-gps',
+                ordinal: 1,
+                isPrimary: false,
+                importedAt: stamp,
+                createdAt: stamp,
+              ),
+            ],
+          );
+          return UddfImportParser().parse(Uint8List.fromList(utf8.encode(xml)));
+        }))!;
+
+        final mockDiveRepo = MockDiveRepository();
+        when(
+          mockDiveRepo.createDive(any),
+        ).thenAnswer((inv) async => inv.positionalArguments[0] as Dive);
+        final mockTankPresetRepo = MockTankPresetRepository();
+        when(
+          mockTankPresetRepo.getPresetById(any),
+        ).thenAnswer((_) async => null);
+
+        await _runWithAdapter(
+          tester,
+          overrides: _fullOverrides(
+            payload: payload,
+            diver: _testDiver(),
+            mockDiveRepo: mockDiveRepo,
+            mockTankPresetRepo: mockTankPresetRepo,
+          ),
+          callback: (adapter) async {
+            await tester.runAsync(() async {
+              final bundle = await adapter.buildBundle();
+              final result = await adapter.performImport(bundle, {
+                wizard.ImportEntityType.dives: {0},
+              }, {});
+              expect(result.errorMessage, isNull);
+            });
+          },
+        );
+
+        final dive =
+            verify(mockDiveRepo.createDive(captureAny)).captured.single as Dive;
+        expect(dive.entryLocation, const GeoPoint(29.5, 34.9));
+        // Both exported sources are restored rather than one synthesised
+        // row, which is the same entries reaching the importer.
+        final readings =
+            verify(
+                  mockDiveRepo.saveComputerReadings(captureAny),
+                ).captured.single
+                as List;
+        expect(readings, hasLength(2));
+        verifyNever(mockDiveRepo.saveComputerReading(any));
       },
     );
   });


### PR DESCRIPTION
## Summary

Fixes #1735. Restoring a full UDDF backup dropped every dive's entry and exit GPS, so the Surface GPS card disappeared from all of them.

The issue traced the **import** gap. There was also an **export** gap: neither UDDF exporter ever wrote the dive's own coordinates. They reached the file only on each `<source>` record. That means a fix that lives on the dive row alone (GPS track matching via `setDiveGps`, or a manual edit) was never backed up at all, and no import-side fallback could have brought it back.

## Changes

- **Export:** a new shared `UddfExportBuilders.buildDiveGpsElements` writes `<entrylatitude>`/`<entrylongitude>` in `<informationbeforedive>` and `<exitlatitude>`/`<exitlongitude>` in `<informationafterdive>`, beside the existing `entrytype`/`exittype` extensions and with the same names the `<source>` record uses. Both the full backup and the dives-only export call it.
- **Parse:** `UddfImportParsers.parseDiveGps` reads a pair back only when both halves are present, finite, and on the globe. `UddfFullImportService` maps it to the `latitude`/`longitude`/`exitLatitude`/`exitLongitude` keys every other import format already uses.
- **Import fallback for existing backups:** when a dive carries no fix of its own (every backup written before this PR), `UddfEntityImporter` takes the first valid `<source>` fix, primary source first. A dive that does carry a fix is restored exactly as it was and never topped up from a source, so it can't gain an exit pin its dive row never had.
- **Import wizard:** the wizard rebuilt `UddfImportResult` from entity lists without `dataSourcesByDiveRef`, so a real restore never saw any `<source>` entries. The fallback above could not run, and exported source rows were replaced by one synthesised row (an older gap from #228). Each dive's entries now ride on its own map as `dataSources`, the same way `gearLinks` already does, and the importer reads them from there. `UddfImportResult.sourcesForDive` is now the one place that resolves a dive ref.
- **Simple import API:** `UddfImportService` (`ExportService.importDivesFromUddf`) reads the dive-level GPS too.

Out of scope: Subsurface XML keeps GPS on the site, not the dive, so it has no equivalent dive-level gap.

## Test Plan

- [x] New `test/core/services/export/uddf/uddf_dive_gps_round_trip_test.dart` (17 tests) runs real export into a clean database and real import. It covers: dive-row-only GPS through a full backup and through a dives-only export; a pre-fix backup shape restored from the primary source; a secondary-source fallback; the no-top-up rule; source rows keeping their own coordinates; and rejection of half, non-finite, non-numeric, or out-of-range fixes (poles and antimeridian are kept).
- [x] `UniversalAdapter.performImport` regression with a real `UddfImportParser` payload; it fails with the ride-along removed.
- [x] Saw the new-behavior tests fail before the fix. Mutation-tested each guard: removing the range checks, the primary-first ordering, or the pair rule each turns its test red.
- [x] `flutter test test/core/services/ test/features/dive_import/ test/features/universal_import/ test/features/import_wizard/ test/integration/uddf_round_trip_test.dart` passes (5,794 tests)
- [x] `flutter analyze` passes
- [ ] Manual testing: not run on a device

