### PR TITLE
fix(uddf): restore dive guides and every per-dive role on import

### DIFF
--- a/lib/core/services/export/uddf/uddf_buddy_roles.dart
+++ b/lib/core/services/export/uddf/uddf_buddy_roles.dart
@@ -1,0 +1,163 @@
+import 'package:xml/xml.dart';
+
+import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
+
+/// Per-dive buddy roles in UDDF (issue #1737).
+///
+/// Standard UDDF has one leader field, `<divemaster>`, which holds names,
+/// and links every other participant as a plain buddy. Import resolves
+/// those names back to people and links them as dive guides. Submersion's
+/// own export also writes each person's exact role on each dive to the
+/// private `<buddyroles>` block, which import applies on top.
+///
+/// The dive map keys this produces are consumed by
+/// `UddfEntityImporter._linkBuddiesToDive`.
+abstract final class UddfBuddyRoles {
+  /// Dive map key holding exact roles: a list of
+  /// `{'buddyRef': <buddy uddf id>, 'roleId': <dive role id>}`.
+  static const roleRefsKey = 'buddyRoleRefs';
+
+  static const _buddyRefsKey = 'buddyRefs';
+  static const _guideRefsKey = 'diveGuideRefs';
+  static const _guideNamesKey = 'unmatchedDiveGuideNames';
+
+  /// Splits the comma-joined names of a `<divemaster>` element and
+  /// resolves each against the people the document declares ([buddies],
+  /// keyed by `<buddy id>`), case-insensitively.
+  ///
+  /// The export joins names with ", " and a name may itself contain a
+  /// comma ("Lee, Ann"), so the longest run of fragments naming a declared
+  /// person wins. A name repeated in [text] reaches the next declared
+  /// person of that name. Names matching nobody are returned once each in
+  /// [unmatched].
+  static ({List<String> refs, List<String> unmatched}) resolveLeaderNames(
+    String text,
+    Map<String, Map<String, dynamic>> buddies,
+  ) {
+    final refsByName = <String, List<String>>{};
+    for (final entry in buddies.entries) {
+      final name = entry.value['name'];
+      if (name is String && name.trim().isNotEmpty) {
+        refsByName.putIfAbsent(_normalized(name), () => []).add(entry.key);
+      }
+    }
+
+    final parts = _fragments(text);
+    final refs = <String>[];
+    final unmatched = <String>[];
+    var i = 0;
+    while (i < parts.length) {
+      var taken = 1;
+      List<String>? candidates;
+      for (var end = parts.length; end > i; end--) {
+        candidates = refsByName[parts.sublist(i, end).join(', ').toLowerCase()];
+        if (candidates != null) {
+          taken = end - i;
+          break;
+        }
+      }
+      if (candidates == null) {
+        final name = parts[i];
+        if (!unmatched.any((n) => n.toLowerCase() == name.toLowerCase())) {
+          unmatched.add(name);
+        }
+      } else {
+        // Every declared person of this name already taken means the text
+        // repeats a leader; there is no one new to link.
+        final next = candidates.where((r) => !refs.contains(r)).firstOrNull;
+        if (next != null) refs.add(next);
+      }
+      i += taken;
+    }
+    return (refs: refs, unmatched: unmatched);
+  }
+
+  /// Records the dive's `<divemaster>` [text] on [dive] as dive guide
+  /// links: refs to declared people, and names to find or create.
+  static void applyLeaderNames(
+    Map<String, dynamic> dive,
+    String text,
+    Map<String, Map<String, dynamic>> buddies,
+  ) {
+    final leaders = resolveLeaderNames(text, buddies);
+    if (leaders.refs.isNotEmpty) dive[_guideRefsKey] = leaders.refs;
+    if (leaders.unmatched.isNotEmpty) dive[_guideNamesKey] = leaders.unmatched;
+  }
+
+  /// The private `<buddyroles>` block: per dive ref, each person's role.
+  static Map<String, List<Map<String, String>>> parse(XmlElement block) => {
+    for (final dive in block.findElements('dive'))
+      if (dive.getAttribute('ref') case final ref? when ref.isNotEmpty)
+        ref: [
+          for (final row in dive.findElements('buddy'))
+            if ((row.getAttribute('ref'), row.getAttribute('role')) case (
+              final buddy?,
+              final role?,
+            ) when buddy.isNotEmpty && role.isNotEmpty)
+              {'buddyRef': buddy, 'roleId': role},
+        ],
+  };
+
+  /// Records one dive's exact roles ([rows] from [parse]) on [dive].
+  ///
+  /// A row is used only when its person is declared ([declaredBuddies])
+  /// and its role is built in or declared ([declaredRoleIds]); anything
+  /// else leaves that person to the standard elements. When a used row is
+  /// a leader, the dive's `<divemaster>` text was written from these rows,
+  /// so the guides inferred from it are dropped as superseded.
+  static void applyExactRoles(
+    Map<String, dynamic> dive,
+    List<Map<String, String>> rows, {
+    required Set<String> declaredBuddies,
+    required Set<String> declaredRoleIds,
+  }) {
+    final usable = [
+      for (final row in rows)
+        if (declaredBuddies.contains(row['buddyRef']) &&
+            (DiveRole.builtInIds.contains(row['roleId']) ||
+                declaredRoleIds.contains(row['roleId'])))
+          row,
+    ];
+    if (usable.isEmpty) return;
+    dive[roleRefsKey] = usable;
+    if (usable.any((row) => DiveRole.leaderIds.contains(row['roleId']))) {
+      dive
+        ..remove(_guideRefsKey)
+        ..remove(_guideNamesKey);
+    }
+  }
+
+  /// Leaves each person in [dive] holding one role: whoever is linked as
+  /// a guide or with an exact role is taken out of the plain buddy links
+  /// (Submersion's export links every participant, leaders included).
+  ///
+  /// Runs once every other step has recorded its links, so no step has to
+  /// undo another's removal.
+  static void settle(Map<String, dynamic> dive) {
+    final buddyRefs = dive[_buddyRefsKey];
+    if (buddyRefs is! List) return;
+    final elsewhere = <Object?>{
+      ...?(dive[_guideRefsKey] as List?),
+      for (final row in (dive[roleRefsKey] as List?) ?? const [])
+        if (row is Map) row['buddyRef'],
+    };
+    if (elsewhere.isEmpty) return;
+    final kept = <String>[
+      for (final ref in buddyRefs)
+        if (ref is String && !elsewhere.contains(ref)) ref,
+    ];
+    if (kept.isEmpty) {
+      dive.remove(_buddyRefsKey);
+    } else {
+      dive[_buddyRefsKey] = kept;
+    }
+  }
+
+  static List<String> _fragments(String text) => [
+    for (final part in text.split(','))
+      if (part.trim().isNotEmpty) part.trim(),
+  ];
+
+  static String _normalized(String name) =>
+      _fragments(name).join(', ').toLowerCase();
+}

--- a/lib/core/services/export/uddf/uddf_buddy_roles.dart
+++ b/lib/core/services/export/uddf/uddf_buddy_roles.dart
@@ -21,6 +21,10 @@ abstract final class UddfBuddyRoles {
   static const _guideRefsKey = 'diveGuideRefs';
   static const _guideNamesKey = 'unmatchedDiveGuideNames';
 
+  /// Transient: the raw `<divemaster>` text, held until [settle] can weigh
+  /// it against the exact roles. [settle] removes it.
+  static const _leaderTextKey = '_leaderText';
+
   /// Splits the comma-joined names of a `<divemaster>` element and
   /// resolves each against the people the document declares ([buddies],
   /// keyed by `<buddy id>`), case-insensitively.
@@ -33,6 +37,14 @@ abstract final class UddfBuddyRoles {
   static ({List<String> refs, List<String> unmatched}) resolveLeaderNames(
     String text,
     Map<String, Map<String, dynamic>> buddies,
+  ) => _links(_resolve(text, buddies));
+
+  /// Each leader named in [text], in order, with the declared person it
+  /// resolves to. A null [ref] on a [declared] name is a repeat with no
+  /// declared person of that name left to link.
+  static List<({String name, String? ref, bool declared})> _resolve(
+    String text,
+    Map<String, Map<String, dynamic>> buddies,
   ) {
     final refsByName = <String, List<String>>{};
     for (final entry in buddies.entries) {
@@ -43,8 +55,8 @@ abstract final class UddfBuddyRoles {
     }
 
     final parts = _fragments(text);
-    final refs = <String>[];
-    final unmatched = <String>[];
+    final used = <String>{};
+    final leaders = <({String name, String? ref, bool declared})>[];
     var i = 0;
     while (i < parts.length) {
       var taken = 1;
@@ -56,33 +68,35 @@ abstract final class UddfBuddyRoles {
           break;
         }
       }
-      if (candidates == null) {
-        final name = parts[i];
-        if (!unmatched.any((n) => n.toLowerCase() == name.toLowerCase())) {
-          unmatched.add(name);
-        }
-      } else {
-        // Every declared person of this name already taken means the text
-        // repeats a leader; there is no one new to link.
-        final next = candidates.where((r) => !refs.contains(r)).firstOrNull;
-        if (next != null) refs.add(next);
-      }
+      final name = parts.sublist(i, i + taken).join(', ');
+      final ref = candidates?.where((r) => !used.contains(r)).firstOrNull;
+      if (ref != null) used.add(ref);
+      leaders.add((name: name, ref: ref, declared: candidates != null));
       i += taken;
+    }
+    return leaders;
+  }
+
+  static ({List<String> refs, List<String> unmatched}) _links(
+    Iterable<({String name, String? ref, bool declared})> leaders,
+  ) {
+    final refs = <String>[];
+    final unmatched = <String>[];
+    for (final leader in leaders) {
+      if (leader.ref case final ref?) {
+        refs.add(ref);
+      } else if (!leader.declared &&
+          !unmatched.any((n) => _normalized(n) == _normalized(leader.name))) {
+        unmatched.add(leader.name);
+      }
     }
     return (refs: refs, unmatched: unmatched);
   }
 
-  /// Records the dive's `<divemaster>` [text] on [dive] as dive guide
-  /// links: refs to declared people, and names to find or create.
-  static void applyLeaderNames(
-    Map<String, dynamic> dive,
-    String text,
-    Map<String, Map<String, dynamic>> buddies,
-  ) {
-    final leaders = resolveLeaderNames(text, buddies);
-    if (leaders.refs.isNotEmpty) dive[_guideRefsKey] = leaders.refs;
-    if (leaders.unmatched.isNotEmpty) dive[_guideNamesKey] = leaders.unmatched;
-  }
+  /// Holds the dive's `<divemaster>` [text] on [dive] for [settle], which
+  /// turns it into dive guide links once the exact roles are known.
+  static void recordLeaderText(Map<String, dynamic> dive, String text) =>
+      dive[_leaderTextKey] = text;
 
   /// The private `<buddyroles>` block: per dive ref, each person's role.
   static Map<String, List<Map<String, String>>> parse(XmlElement block) => {
@@ -102,9 +116,7 @@ abstract final class UddfBuddyRoles {
   ///
   /// A row is used only when its person is declared ([declaredBuddies])
   /// and its role is built in or declared ([declaredRoleIds]); anything
-  /// else leaves that person to the standard elements. When a used row is
-  /// a leader, the dive's `<divemaster>` text was written from these rows,
-  /// so the guides inferred from it are dropped as superseded.
+  /// else leaves that person to the standard elements.
   static void applyExactRoles(
     Map<String, dynamic> dive,
     List<Map<String, String>> rows, {
@@ -118,22 +130,51 @@ abstract final class UddfBuddyRoles {
                 declaredRoleIds.contains(row['roleId'])))
           row,
     ];
-    if (usable.isEmpty) return;
-    dive[roleRefsKey] = usable;
-    if (usable.any((row) => DiveRole.leaderIds.contains(row['roleId']))) {
-      dive
-        ..remove(_guideRefsKey)
-        ..remove(_guideNamesKey);
-    }
+    if (usable.isNotEmpty) dive[roleRefsKey] = usable;
   }
 
-  /// Leaves each person in [dive] holding one role: whoever is linked as
-  /// a guide or with an exact role is taken out of the plain buddy links
-  /// (Submersion's export links every participant, leaders included).
+  /// Settles [dive]'s role links once every source has been read.
   ///
-  /// Runs once every other step has recorded its links, so no step has to
-  /// undo another's removal.
-  static void settle(Map<String, dynamic> dive) {
+  /// The recorded `<divemaster>` text becomes dive guide links, except
+  /// for the names the exact roles already cover: Submersion writes that
+  /// text from its leader rows, so each leader row with an exact role
+  /// accounts for one name, matched by name ([buddies] gives each
+  /// person's), since the text may have resolved a namesake instead. Then
+  /// whoever holds a guide or exact role leaves the plain buddy links, as
+  /// Submersion's export links every participant, leaders included.
+  ///
+  /// Nothing earlier removes a link, so no step has to undo another's.
+  static void settle(
+    Map<String, dynamic> dive,
+    Map<String, Map<String, dynamic>> buddies,
+  ) {
+    final leaderText = dive.remove(_leaderTextKey);
+    if (leaderText is String) {
+      final covered = <String, int>{};
+      for (final row in (dive[roleRefsKey] as List?) ?? const []) {
+        if (row is! Map || !DiveRole.leaderIds.contains(row['roleId'])) {
+          continue;
+        }
+        final name = buddies[row['buddyRef']]?['name'];
+        if (name is String) {
+          covered.update(_normalized(name), (n) => n + 1, ifAbsent: () => 1);
+        }
+      }
+      final uncovered = <({String name, String? ref, bool declared})>[];
+      for (final leader in _resolve(leaderText, buddies)) {
+        final key = _normalized(leader.name);
+        final left = covered[key] ?? 0;
+        if (left > 0) {
+          covered[key] = left - 1;
+        } else {
+          uncovered.add(leader);
+        }
+      }
+      final links = _links(uncovered);
+      if (links.refs.isNotEmpty) dive[_guideRefsKey] = links.refs;
+      if (links.unmatched.isNotEmpty) dive[_guideNamesKey] = links.unmatched;
+    }
+
     final buddyRefs = dive[_buddyRefsKey];
     if (buddyRefs is! List) return;
     final elsewhere = <Object?>{

--- a/lib/core/services/export/uddf/uddf_export_builders.dart
+++ b/lib/core/services/export/uddf/uddf_export_builders.dart
@@ -112,21 +112,17 @@ class UddfExportBuilders {
   }) {
     // Separate buddies by role for UDDF export. Leaders map to UDDF leader
     // elements; every other role (including custom roles) exports as a plain
-    // buddy. Solo exports as neither.
-    const leaderRoleIds = {
-      DiveRole.diveGuideId,
-      DiveRole.diveMasterId,
-      DiveRole.instructorId,
-    };
+    // buddy. Solo exports as neither. The exact role of each person rides in
+    // the private <buddyroles> block (see buildApplicationData).
     final regularBuddies = diveBuddyList
         .where(
           (b) =>
-              !leaderRoleIds.contains(b.role.id) &&
+              !DiveRole.leaderIds.contains(b.role.id) &&
               b.role.id != DiveRole.soloId,
         )
         .toList();
     final guidesAndDivemasters = diveBuddyList
-        .where((b) => leaderRoleIds.contains(b.role.id))
+        .where((b) => DiveRole.leaderIds.contains(b.role.id))
         .toList();
 
     // Find the trip this dive belongs to
@@ -898,6 +894,7 @@ class UddfExportBuilders {
     Map<String, String?> dataSourceDumps = const {},
     List<EquipmentComponent>? components,
     List<Dive>? gearLinkDives,
+    Map<String, List<BuddyWithRole>>? diveBuddies,
   }) {
     // Gear provenance per dive (issue #1487): only rows attached through
     // an assembly or applied from a set are worth a link; the standard
@@ -906,10 +903,21 @@ class UddfExportBuilders {
       for (final d in gearLinkDives ?? const <Dive>[])
         if (d.gear.any(_hasProvenance)) d,
     ];
+    // Exact per-dive roles (issue #1737): the standard sections flatten
+    // every leader into <divemaster> text and every other role into a
+    // plain buddy link, so each row whose role is not plain buddy is
+    // recorded here to be restored exactly.
+    final roleRows = <String, List<BuddyWithRole>>{
+      for (final entry in (diveBuddies ?? const {}).entries)
+        if (entry.value.where((b) => b.role.id != DiveRole.buddyId).toList()
+            case final rows when rows.isNotEmpty)
+          entry.key: rows,
+    };
     final hasData =
         (equipment?.isNotEmpty ?? false) ||
         (components?.isNotEmpty ?? false) ||
         linkDives.isNotEmpty ||
+        roleRows.isNotEmpty ||
         (certifications?.isNotEmpty ?? false) ||
         (diveCenters?.isNotEmpty ?? false) ||
         (species?.isNotEmpty ?? false) ||
@@ -1469,6 +1477,31 @@ class UddfExportBuilders {
                                 'via': 'equip_${g.viaEquipmentId}',
                               if (g.viaSetId != null)
                                 'set': 'set_${g.viaSetId}',
+                            },
+                          );
+                        }
+                      },
+                    );
+                  }
+                },
+              );
+            }
+
+            if (roleRows.isNotEmpty) {
+              builder.element(
+                'buddyroles',
+                nest: () {
+                  for (final entry in roleRows.entries) {
+                    builder.element(
+                      'dive',
+                      attributes: {'ref': 'dive_${entry.key}'},
+                      nest: () {
+                        for (final row in entry.value) {
+                          builder.element(
+                            'buddy',
+                            attributes: {
+                              'ref': 'buddy_${row.buddy.id}',
+                              'role': row.role.id,
                             },
                           );
                         }

--- a/lib/core/services/export/uddf/uddf_full_export_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_export_service.dart
@@ -464,6 +464,7 @@ class UddfFullExportService {
           dataSourceDumps: encodedById,
           components: components,
           gearLinkDives: dives,
+          diveBuddies: diveBuddies,
         );
 
         // The UDDF specification places <divecomputercontrol> last, so this
@@ -489,6 +490,9 @@ class UddfFullExportService {
   Future<String> generateAllDataXmlForTest({
     required List<Dive> dives,
     Diver? owner,
+    List<Buddy>? buddies,
+    Map<String, List<BuddyWithRole>>? diveBuddies,
+    List<DiveRole>? customDiveRoles,
     List<EquipmentItem>? equipment,
     List<EquipmentSet>? equipmentSets,
     List<EquipmentComponent>? components,
@@ -498,6 +502,9 @@ class UddfFullExportService {
   }) => _generateAllDataXml(
     dives: dives,
     owner: owner,
+    buddies: buddies,
+    diveBuddies: diveBuddies,
+    customDiveRoles: customDiveRoles,
     equipment: equipment,
     equipmentSets: equipmentSets,
     components: components,

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -517,7 +517,9 @@ class UddfFullImportService {
 
     // Every source of role links has now been read, so each person can be
     // left holding exactly one role per dive.
-    dives.forEach(UddfBuddyRoles.settle);
+    for (final dive in dives) {
+      UddfBuddyRoles.settle(dive, buddyMap);
+    }
 
     _applyTripDateRanges(trips, dives);
 
@@ -976,7 +978,7 @@ class UddfFullImportService {
         'divemaster',
       );
       if (leaderNames != null) {
-        UddfBuddyRoles.applyLeaderNames(diveData, leaderNames, buddies);
+        UddfBuddyRoles.recordLeaderText(diveData, leaderNames);
       }
 
       final diveTypeElements = beforeElement.findElements('divetype').toList();

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -5,6 +5,7 @@ import 'package:xml/xml.dart';
 import 'package:submersion/core/constants/enums.dart' as enums;
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/export/models/uddf_import_result.dart';
+import 'package:submersion/core/services/export/uddf/uddf_buddy_roles.dart';
 import 'package:submersion/core/services/export/uddf/uddf_dump_codec.dart';
 import 'package:submersion/core/services/export/uddf/uddf_import_parsers.dart';
 import 'package:submersion/core/services/export/uddf/uddf_normalizer.dart';
@@ -452,6 +453,29 @@ class UddfFullImportService {
           }
         }
 
+        // Exact per-dive roles (issue #1737), matched the same way. Parsed
+        // after <diveroles>, so a custom role the file declares is known.
+        final buddyRolesSection = submersionElement
+            .findElements('buddyroles')
+            .firstOrNull;
+        if (buddyRolesSection != null) {
+          final byDive = UddfBuddyRoles.parse(buddyRolesSection);
+          final declaredRoleIds = {
+            for (final role in customDiveRoles)
+              if (role['id'] is String) role['id'] as String,
+          };
+          for (final dive in dives) {
+            final rows = byDive[dive['sourceUuid']];
+            if (rows == null || rows.isEmpty) continue;
+            UddfBuddyRoles.applyExactRoles(
+              dive,
+              rows,
+              declaredBuddies: buddyMap.keys.toSet(),
+              declaredRoleIds: declaredRoleIds,
+            );
+          }
+        }
+
         // Parse courses
         final coursesSection = submersionElement
             .findElements('courses')
@@ -490,6 +514,10 @@ class UddfFullImportService {
         }
       }
     }
+
+    // Every source of role links has now been read, so each person can be
+    // left holding exactly one role per dive.
+    dives.forEach(UddfBuddyRoles.settle);
 
     _applyTripDateRanges(trips, dives);
 
@@ -941,10 +969,15 @@ class UddfFullImportService {
         .findElements('informationbeforedive')
         .firstOrNull;
     if (beforeElement != null) {
-      diveData['diveMaster'] = UddfImportParsers.getElementText(
+      // The names in <divemaster> become dive guide links rather than
+      // free text on the dive (issue #1737).
+      final leaderNames = UddfImportParsers.getElementText(
         beforeElement,
         'divemaster',
       );
+      if (leaderNames != null) {
+        UddfBuddyRoles.applyLeaderNames(diveData, leaderNames, buddies);
+      }
 
       final diveTypeElements = beforeElement.findElements('divetype').toList();
       if (diveTypeElements.isNotEmpty) {

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1764,6 +1764,7 @@ class UddfEntityImporter {
     final diveIdByIndex = <int, String>{};
     final diveIdBySourceUuid = <String, String>{};
     final inlineBuddyIds = <String>{};
+    final roleExists = <String, bool>{};
 
     // Sort selected indices by dateTime (oldest first) for sequential
     // numbering. An undated dive is stored at [now] further down, so it has
@@ -2376,6 +2377,8 @@ class UddfEntityImporter {
         diverId,
         buddyIdMapping,
         repos.buddyRepository,
+        roleRepository: repos.diveRoleRepository,
+        roleExists: roleExists,
       );
       inlineBuddyIds.addAll(linkedIds);
 
@@ -2629,8 +2632,10 @@ class UddfEntityImporter {
     String diveId,
     String diverId,
     Map<String, String> buddyIdMapping,
-    BuddyRepository repository,
-  ) async {
+    BuddyRepository repository, {
+    DiveRoleRepository? roleRepository,
+    required Map<String, bool> roleExists,
+  }) async {
     // Link referenced buddies (from pre-imported buddy entities)
     final buddyRefsValue = diveData['buddyRefs'];
     final buddyRefs = buddyRefsValue is List
@@ -2688,7 +2693,42 @@ class UddfEntityImporter {
       inlineIds.add(guide.id);
     }
 
+    // Exact roles from Submersion's private <buddyroles> block (issue
+    // #1737). Applied last: addBuddyToDive keeps one row per person, so
+    // these override any role inferred from the standard elements. A role
+    // this database lacks can only be a custom role whose definition never
+    // arrived, which the standard elements carried as a plain buddy.
+    final roleRefsValue = diveData['buddyRoleRefs'];
+    final roleRefs = roleRefsValue is List ? roleRefsValue : const [];
+    for (final entry in roleRefs) {
+      if (entry is! Map) continue;
+      final buddyRef = entry['buddyRef'];
+      final roleId = entry['roleId'];
+      if (buddyRef is! String || roleId is! String || roleId.isEmpty) continue;
+      final newBuddyId = buddyIdMapping[buddyRef];
+      if (newBuddyId == null) continue;
+      final known = await _roleExists(roleId, roleRepository, roleExists);
+      await repository.addBuddyToDive(
+        diveId,
+        newBuddyId,
+        known ? roleId : DiveRole.buddyId,
+      );
+    }
+
     return inlineIds;
+  }
+
+  /// Whether [roleId] names a role in this database: built in, or custom
+  /// and already present or restored ahead of the dives. Memoized in
+  /// [cache] across one import.
+  Future<bool> _roleExists(
+    String roleId,
+    DiveRoleRepository? repository,
+    Map<String, bool> cache,
+  ) async {
+    if (DiveRole.builtInIds.contains(roleId)) return true;
+    if (repository == null) return false;
+    return cache[roleId] ??= await repository.getDiveRoleById(roleId) != null;
   }
 
   Future<void> _linkTagsToDive(

--- a/lib/features/dive_roles/domain/entities/dive_role.dart
+++ b/lib/features/dive_roles/domain/entities/dive_role.dart
@@ -45,6 +45,14 @@ class DiveRole extends Equatable {
     safetyDiverId,
   ];
 
+  /// Roles that lead the dive. Interchange formats with a single leader
+  /// field (UDDF and Subsurface `<divemaster>`) carry these people there.
+  static const Set<String> leaderIds = {
+    diveGuideId,
+    diveMasterId,
+    instructorId,
+  };
+
   /// Placeholder for a role id with no dive_roles row (legacy or
   /// not-yet-synced data). Displays the raw slug instead of silently
   /// renaming it to Buddy.

--- a/lib/features/import_wizard/data/adapters/universal_adapter.dart
+++ b/lib/features/import_wizard/data/adapters/universal_adapter.dart
@@ -1375,6 +1375,12 @@ class UniversalAdapter implements ImportSourceAdapter {
       equipmentSets: payload.entitiesOf(ui.ImportEntityType.equipmentSets),
       courses: payload.entitiesOf(ui.ImportEntityType.courses),
       serviceRecords: payload.entitiesOf(ui.ImportEntityType.serviceRecords),
+      customDiveRoles: [
+        for (final role
+            in (payload.metadata[ImportPayload.customDiveRolesKey] as List?) ??
+                const [])
+          if (role is Map<String, dynamic>) role,
+      ],
     );
   }
 }

--- a/lib/features/universal_import/data/models/import_payload.dart
+++ b/lib/features/universal_import/data/models/import_payload.dart
@@ -24,6 +24,12 @@ class ImportPayload extends Equatable {
   /// Metadata about the import source.
   final Map<String, dynamic> metadata;
 
+  /// [metadata] key for custom dive role definitions (a list of maps with
+  /// `id`, `name`, `sortOrder`, `isBuiltIn`). They have no review step, so
+  /// they ride here rather than as an entity type, and are restored ahead
+  /// of the dive links that reference them.
+  static const customDiveRolesKey = 'customDiveRoles';
+
   const ImportPayload({
     required this.entities,
     this.warnings = const [],

--- a/lib/features/universal_import/data/parsers/uddf_import_parser.dart
+++ b/lib/features/universal_import/data/parsers/uddf_import_parser.dart
@@ -73,6 +73,8 @@ class UddfImportParser implements ImportParser {
         metadata: {
           'sourceApp': options?.sourceApp.displayName ?? 'UDDF',
           'summary': result.summary,
+          if (result.customDiveRoles.isNotEmpty)
+            ImportPayload.customDiveRolesKey: result.customDiveRoles,
         },
       );
     } on FormatException catch (e) {

--- a/lib/features/universal_import/data/services/payload_merger.dart
+++ b/lib/features/universal_import/data/services/payload_merger.dart
@@ -52,6 +52,10 @@ class PayloadMerger {
   static const _gearLinkRefFields = ['itemRef', 'viaRef', 'setRef'];
   static const _componentRefFields = ['componentRef'];
 
+  /// Reference field inside a dive's `buddyRoleRefs` entries (issue #1737):
+  /// the person holding each exact role.
+  static const _buddyRoleRefFields = ['buddyRef'];
+
   /// Rewrites the string reference [fields] of every map in [item]'s
   /// [key] list through [rewrite], copying rather than mutating the
   /// nested maps. A null reference stays null; a map without the list is
@@ -93,9 +97,19 @@ class PayloadMerger {
     final aliases = <String, String>{};
     // entity type -> fold key -> surviving map (already in `entities`)
     final survivors = <ImportEntityType, Map<String, Map<String, dynamic>>>{};
+    // Custom dive role definitions by id (issue #1737). Ids are device-minted
+    // UUIDs referenced verbatim by dive links, so they are never namespaced,
+    // and the same id in two files is the same role.
+    final customDiveRoles = <String, Map<String, dynamic>>{};
 
     for (final input in inputs) {
       warnings.addAll(input.payload.warnings);
+      final roles = input.payload.metadata[ImportPayload.customDiveRolesKey];
+      for (final role in roles is List ? roles : const []) {
+        if (role is Map<String, dynamic> && role['id'] is String) {
+          customDiveRoles.putIfAbsent(role['id'] as String, () => role);
+        }
+      }
 
       // Dives are appended without folding, so each file's dive indices shift
       // by the number of dives already collected. Captured BEFORE this input's
@@ -170,6 +184,8 @@ class PayloadMerger {
       metadata: {
         'batchFileCount': inputs.length,
         'sourceFiles': [for (final i in inputs) i.fileName],
+        if (customDiveRoles.isNotEmpty)
+          ImportPayload.customDiveRolesKey: customDiveRoles.values.toList(),
       },
     );
   }
@@ -219,6 +235,12 @@ class PayloadMerger {
         item,
         'gearLinks',
         _gearLinkRefFields,
+        (ref) => '$fileId:$ref',
+      );
+      _rewriteNested(
+        item,
+        'buddyRoleRefs',
+        _buddyRoleRefFields,
         (ref) => '$fileId:$ref',
       );
     }
@@ -310,6 +332,7 @@ class PayloadMerger {
         }
       }
       _rewriteNested(dive, 'gearLinks', _gearLinkRefFields, resolve);
+      _rewriteNested(dive, 'buddyRoleRefs', _buddyRoleRefFields, resolve);
     }
 
     for (final item in entities[ImportEntityType.equipment] ?? const []) {

--- a/test/core/services/export/uddf/uddf_buddy_roles_round_trip_test.dart
+++ b/test/core/services/export/uddf/uddf_buddy_roles_round_trip_test.dart
@@ -1,0 +1,213 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/export_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_export_service.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/dive_import/data/services/uddf_entity_importer.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/dive_roles/data/repositories/dive_role_repository.dart';
+import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
+
+import '../../../../helpers/test_database.dart';
+import 'uddf_raw_data_round_trip_test.dart'
+    show buildRepositories, createTestDiver;
+
+/// Issue #1737: a full UDDF backup restored onto a clean database must
+/// attribute every dive to its guides, divemasters and instructors again,
+/// so no leader's profile drops to zero dives.
+void main() {
+  setUp(() async {
+    await setUpTestDatabase();
+  });
+
+  tearDown(() async => tearDownTestDatabase());
+
+  Future<void> restore(String xml) async {
+    final diverId = await createTestDiver();
+    final parsed = await ExportService().importAllDataFromUddf(xml);
+    await UddfEntityImporter().import(
+      data: parsed,
+      selections: UddfImportSelections.selectAll(parsed),
+      repositories: buildRepositories(),
+      diverId: diverId,
+    );
+  }
+
+  /// Role id per person name on the [index]th dive in time order.
+  Future<Map<String, String>> rolesOn(int index) async {
+    final dives = await DiveRepository().getAllDives();
+    final dive = ([
+      ...dives,
+    ]..sort((a, b) => a.dateTime.compareTo(b.dateTime))).elementAt(index);
+    return {
+      for (final b in await BuddyRepository().getBuddiesForDive(dive.id))
+        b.buddy.name: b.role.id,
+    };
+  }
+
+  Future<int> diveCountFor(String name) async {
+    final buddy = (await BuddyRepository().getAllBuddies()).singleWhere(
+      (b) => b.name == name,
+    );
+    return BuddyRepository().getDiveCountForBuddy(buddy.id);
+  }
+
+  test('every per-dive role survives export and restore', () async {
+    final diverId = await createTestDiver();
+    final custom = await DiveRoleRepository().createDiveRole(
+      name: 'Photographer',
+      diverId: diverId,
+    );
+    final buddies = BuddyRepository();
+    final now = DateTime.now();
+    Future<Buddy> person(String name) => buddies.createBuddy(
+      Buddy(id: '', name: name, createdAt: now, updatedAt: now),
+    );
+    final guide = await person('Nicol Sorin');
+    final master = await person('Ana Reyes');
+    final instructor = await person('Tom Lee');
+    final student = await person('Sam Park');
+    final photographer = await person('Pat Kim');
+    final plain = await person('Joe Bloggs');
+
+    final dives = DiveRepository();
+    await dives.createDive(
+      domain.Dive(id: 'd1', dateTime: DateTime(2026, 3, 1, 9)),
+    );
+    await dives.createDive(
+      domain.Dive(id: 'd2', dateTime: DateTime(2026, 3, 1, 14)),
+    );
+    await buddies.addBuddyToDive('d1', guide.id, DiveRole.diveGuideId);
+    await buddies.addBuddyToDive('d1', master.id, DiveRole.diveMasterId);
+    await buddies.addBuddyToDive('d1', instructor.id, DiveRole.instructorId);
+    await buddies.addBuddyToDive('d1', student.id, DiveRole.studentId);
+    await buddies.addBuddyToDive('d1', photographer.id, custom.id);
+    await buddies.addBuddyToDive('d1', plain.id, DiveRole.buddyId);
+    await buddies.addBuddyToDive('d2', guide.id, DiveRole.diveGuideId);
+
+    final allDives = await dives.getAllDives();
+    final xml = await UddfFullExportService().generateAllDataXmlForTest(
+      dives: allDives,
+      buddies: await buddies.getAllBuddies(),
+      diveBuddies: await buddies.getBuddiesForDives([
+        for (final d in allDives) d.id,
+      ]),
+      customDiveRoles: [
+        for (final r in await DiveRoleRepository().getAllDiveRoles(
+          diverId: diverId,
+        ))
+          if (!r.isBuiltIn) r,
+      ],
+    );
+
+    // A clean database, as a restore onto a new device would be.
+    await tearDownTestDatabase();
+    await setUpTestDatabase();
+    await restore(xml);
+
+    expect(await rolesOn(0), {
+      'Nicol Sorin': DiveRole.diveGuideId,
+      'Ana Reyes': DiveRole.diveMasterId,
+      'Tom Lee': DiveRole.instructorId,
+      'Sam Park': DiveRole.studentId,
+      'Pat Kim': custom.id,
+      'Joe Bloggs': DiveRole.buddyId,
+    });
+    expect(await rolesOn(1), {'Nicol Sorin': DiveRole.diveGuideId});
+    expect(
+      (await DiveRoleRepository().getDiveRoleById(custom.id))?.name,
+      'Photographer',
+      reason: 'the custom role the link points at is restored too',
+    );
+    expect(await diveCountFor('Nicol Sorin'), 2);
+    expect(
+      await BuddyRepository().getAllBuddies(),
+      hasLength(6),
+      reason: 'a leader named in <divemaster> is not minted a second time',
+    );
+    for (final d in await DiveRepository().getAllDives()) {
+      expect(d.diveMaster, isNull, reason: 'no guide name left as bare text');
+    }
+  });
+
+  test('an exact role the database lacks falls back to buddy', () async {
+    // A custom role whose definition did not arrive (the file lost it, or
+    // a caller dropped it) must not leave a link naming a role that does
+    // not exist: the UI would show its raw id as the role name.
+    final diverId = await createTestDiver();
+    const parsed = UddfImportResult(
+      buddies: [
+        {'uddfId': 'buddy_p', 'name': 'Pat Kim'},
+        {'uddfId': 'buddy_s', 'name': 'Sam Park'},
+      ],
+      dives: [
+        {
+          'sourceUuid': 'dive_1',
+          'buddyRoleRefs': [
+            {'buddyRef': 'buddy_p', 'roleId': 'role-never-restored'},
+            {'buddyRef': 'buddy_s', 'roleId': DiveRole.studentId},
+          ],
+        },
+      ],
+    );
+
+    await UddfEntityImporter().import(
+      data: parsed,
+      selections: UddfImportSelections.selectAll(parsed),
+      repositories: buildRepositories(),
+      diverId: diverId,
+    );
+
+    expect(await rolesOn(0), {
+      'Pat Kim': DiveRole.buddyId,
+      'Sam Park': DiveRole.studentId,
+    });
+  });
+
+  test('a backup written before <buddyroles> restores its guides', () async {
+    // The shape of every full export made before this fix: the guide is a
+    // declared <buddy>, linked from the dive like any buddy, and named as
+    // the leader only in <divemaster>. The second dive has no link, as a
+    // third-party file naming the same person would.
+    const xml = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<uddf version="3.2.0">
+  <diver>
+    <buddy id="buddy_n">
+      <personal><firstname>Nicol</firstname><lastname>Sorin</lastname></personal>
+    </buddy>
+  </diver>
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive_1">
+        <informationbeforedive>
+          <datetime>2026-03-01T09:00:00</datetime>
+          <divemaster>Nicol Sorin</divemaster>
+          <link ref="buddy_n"/>
+        </informationbeforedive>
+      </dive>
+      <dive id="dive_2">
+        <informationbeforedive>
+          <datetime>2026-03-01T14:00:00</datetime>
+          <divemaster>Nicol Sorin, Walk In Guide</divemaster>
+        </informationbeforedive>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+
+    await restore(xml);
+
+    expect(await diveCountFor('Nicol Sorin'), 2);
+    expect(await diveCountFor('Walk In Guide'), 1);
+    expect(await rolesOn(0), {'Nicol Sorin': DiveRole.diveGuideId});
+    expect(await rolesOn(1), {
+      'Nicol Sorin': DiveRole.diveGuideId,
+      'Walk In Guide': DiveRole.diveGuideId,
+    });
+    expect(await BuddyRepository().getAllBuddies(), hasLength(2));
+  });
+}

--- a/test/core/services/export/uddf/uddf_buddy_roles_test.dart
+++ b/test/core/services/export/uddf/uddf_buddy_roles_test.dart
@@ -1,0 +1,393 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/uddf/uddf_export_builders.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_import_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_buddy_roles.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
+import 'package:xml/xml.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Issue #1737: dive guides, divemasters and every other per-dive role
+/// must survive a UDDF export and import instead of collapsing into the
+/// `<divemaster>` text and a plain buddy link.
+final _epoch = DateTime(2024, 1, 1);
+
+Buddy _buddy(String id, String name) =>
+    Buddy(id: id, name: name, createdAt: _epoch, updatedAt: _epoch);
+
+DiveRole _role(String id) =>
+    DiveRole(id: id, name: id, createdAt: _epoch, updatedAt: _epoch);
+
+String _applicationData(Map<String, List<BuddyWithRole>> diveBuddies) {
+  final builder = XmlBuilder();
+  builder.element(
+    'uddf',
+    nest: () {
+      UddfExportBuilders.buildApplicationData(
+        builder,
+        diveBuddies: diveBuddies,
+      );
+    },
+  );
+  return builder.buildDocument().toXmlString();
+}
+
+/// A document declaring [buddies] (id to full name) and one dive per
+/// entry of [dives] (dive id to the XML inside its informationbeforedive),
+/// plus an optional private [submersion] block.
+String _document({
+  Map<String, String> buddies = const {},
+  required Map<String, String> dives,
+  String submersion = '',
+}) {
+  final diverSection = buddies.isEmpty
+      ? ''
+      : '''
+  <diver>
+${buddies.entries.map((e) {
+          final parts = e.value.split(' ');
+          final last = parts.length > 1 ? '<lastname>${parts.sublist(1).join(' ')}</lastname>' : '';
+          return '    <buddy id="${e.key}"><personal>'
+              '<firstname>${parts.first}</firstname>$last'
+              '</personal></buddy>';
+        }).join('\n')}
+  </diver>''';
+  final diveSection = dives.entries
+      .map(
+        (e) =>
+            '''
+      <dive id="${e.key}">
+        <informationbeforedive>
+          <datetime>2025-03-19T08:19:54</datetime>
+          ${e.value}
+        </informationbeforedive>
+      </dive>''',
+      )
+      .join('\n');
+  final appData = submersion.isEmpty
+      ? ''
+      : '''
+  <applicationdata>
+    <submersion version="1.0">
+$submersion
+    </submersion>
+  </applicationdata>''';
+  return '''
+<?xml version="1.0" encoding="UTF-8"?>
+<uddf version="3.2.0">
+$diverSection
+  <profiledata>
+    <repetitiongroup>
+$diveSection
+    </repetitiongroup>
+  </profiledata>
+$appData
+</uddf>
+''';
+}
+
+Future<Map<String, dynamic>> _importSingleDive(String xml) async {
+  final result = await UddfFullImportService().importAllDataFromUddf(xml);
+  return result.dives.single;
+}
+
+void main() {
+  group('export: <buddyroles>', () {
+    test('writes every non-buddy role per dive, keyed by dive ref', () {
+      final xml = _applicationData({
+        'd1': [
+          BuddyWithRole(
+            buddy: _buddy('b1', 'Nicol Sorin'),
+            role: _role(DiveRole.diveMasterId),
+          ),
+          BuddyWithRole(
+            buddy: _buddy('b2', 'Joe Bloggs'),
+            role: _role(DiveRole.buddyId),
+          ),
+          BuddyWithRole(
+            buddy: _buddy('b3', 'Pat Kim'),
+            role: _role('custom-uuid'),
+          ),
+        ],
+      });
+
+      final dive = XmlDocument.parse(
+        xml,
+      ).findAllElements('buddyroles').single.findElements('dive').single;
+      expect(dive.getAttribute('ref'), 'dive_d1');
+      final rows = {
+        for (final e in dive.findElements('buddy'))
+          e.getAttribute('ref'): e.getAttribute('role'),
+      };
+      expect(rows, {
+        'buddy_b1': DiveRole.diveMasterId,
+        'buddy_b3': 'custom-uuid',
+      });
+    });
+
+    test('writes no block when every dive has only plain buddies', () {
+      final xml = _applicationData({
+        'd1': [
+          BuddyWithRole(
+            buddy: _buddy('b2', 'Joe Bloggs'),
+            role: _role(DiveRole.buddyId),
+          ),
+        ],
+      });
+
+      expect(xml, isNot(contains('buddyroles')));
+    });
+  });
+
+  group('import', () {
+    setUp(() async {
+      await setUpTestDatabase();
+    });
+
+    tearDown(() async {
+      await tearDownTestDatabase();
+    });
+
+    group('<divemaster> without a <buddyroles> block', () {
+      test('resolves a declared person to a dive guide ref', () async {
+        // Submersion's own export also links every participant, leaders
+        // included, so the guide arrives as a buddy link as well.
+        final dive = await _importSingleDive(
+          _document(
+            buddies: {'buddy_n': 'Nicol Sorin', 'buddy_j': 'Joe Bloggs'},
+            dives: {
+              'dive_1':
+                  '<link ref="buddy_n"/><link ref="buddy_j"/>'
+                  '<divemaster>nicol sorin</divemaster>',
+            },
+          ),
+        );
+
+        expect(dive['diveGuideRefs'], ['buddy_n']);
+        expect(dive['buddyRefs'], [
+          'buddy_j',
+        ], reason: 'the guide holds one role, not a buddy link as well');
+        expect(dive.containsKey('unmatchedDiveGuideNames'), isFalse);
+        expect(
+          dive['diveMaster'],
+          isNull,
+          reason: 'a name that became a guide link is not also kept as text',
+        );
+      });
+
+      test('passes an undeclared name on to be found or created', () async {
+        final dive = await _importSingleDive(
+          _document(
+            buddies: {'buddy_n': 'Nicol Sorin'},
+            dives: {
+              'dive_1': '<divemaster>Nicol Sorin, Walk In Guide</divemaster>',
+            },
+          ),
+        );
+
+        expect(dive['diveGuideRefs'], ['buddy_n']);
+        expect(dive['unmatchedDiveGuideNames'], ['Walk In Guide']);
+        expect(dive['diveMaster'], isNull);
+      });
+
+      test('keeps a declared name that contains a comma whole', () async {
+        final dive = await _importSingleDive(
+          _document(
+            buddies: {'buddy_d': 'Doe, Jane', 'buddy_n': 'Nicol Sorin'},
+            dives: {
+              'dive_1': '<divemaster>Doe, Jane, Nicol Sorin</divemaster>',
+            },
+          ),
+        );
+
+        expect(dive['diveGuideRefs'], ['buddy_d', 'buddy_n']);
+        expect(dive.containsKey('unmatchedDiveGuideNames'), isFalse);
+      });
+    });
+
+    group('<buddyroles> block', () {
+      test(
+        'carries exact roles and supersedes the text it came from',
+        () async {
+          final dive = await _importSingleDive(
+            _document(
+              buddies: {
+                'buddy_n': 'Nicol Sorin',
+                'buddy_s': 'Sam Park',
+                'buddy_j': 'Joe Bloggs',
+              },
+              dives: {
+                'dive_1':
+                    '<link ref="buddy_s"/><link ref="buddy_j"/>'
+                    '<divemaster>Nicol Sorin</divemaster>',
+              },
+              submersion: '''
+      <buddyroles>
+        <dive ref="dive_1">
+          <buddy ref="buddy_n" role="diveMaster"/>
+          <buddy ref="buddy_s" role="student"/>
+        </dive>
+      </buddyroles>''',
+            ),
+          );
+
+          expect(dive['buddyRoleRefs'], [
+            {'buddyRef': 'buddy_n', 'roleId': 'diveMaster'},
+            {'buddyRef': 'buddy_s', 'roleId': 'student'},
+          ]);
+          expect(dive['buddyRefs'], [
+            'buddy_j',
+          ], reason: 'a person with an exact role is not also linked as buddy');
+          expect(
+            dive.containsKey('diveGuideRefs'),
+            isFalse,
+            reason: 'the <divemaster> text was generated from the leader rows',
+          );
+          expect(dive['diveMaster'], isNull);
+        },
+      );
+
+      test('a namesake of the leader keeps their buddy link', () async {
+        // Text matching picks the first "Chris Diver", but the block says
+        // the other one led. The first stays the plain buddy they were.
+        final dive = await _importSingleDive(
+          _document(
+            buddies: {'buddy_a': 'Chris Diver', 'buddy_b': 'Chris Diver'},
+            dives: {
+              'dive_1':
+                  '<link ref="buddy_a"/><link ref="buddy_b"/>'
+                  '<divemaster>Chris Diver</divemaster>',
+            },
+            submersion: '''
+      <buddyroles>
+        <dive ref="dive_1">
+          <buddy ref="buddy_b" role="diveGuide"/>
+        </dive>
+      </buddyroles>''',
+          ),
+        );
+
+        expect(dive['buddyRefs'], ['buddy_a']);
+        expect(dive['buddyRoleRefs'], [
+          {'buddyRef': 'buddy_b', 'roleId': 'diveGuide'},
+        ]);
+        expect(dive.containsKey('diveGuideRefs'), isFalse);
+      });
+
+      test(
+        'keeps text-derived guides when the block names no leader',
+        () async {
+          // A dive with no leader rows exports its legacy free-text
+          // divemaster instead, so that text is still the only source.
+          final dive = await _importSingleDive(
+            _document(
+              buddies: {'buddy_s': 'Sam Park'},
+              dives: {
+                'dive_1':
+                    '<link ref="buddy_s"/>'
+                    '<divemaster>Old Text Guide</divemaster>',
+              },
+              submersion: '''
+      <buddyroles>
+        <dive ref="dive_1">
+          <buddy ref="buddy_s" role="student"/>
+        </dive>
+      </buddyroles>''',
+            ),
+          );
+
+          expect(dive['unmatchedDiveGuideNames'], ['Old Text Guide']);
+          expect(dive['buddyRoleRefs'], [
+            {'buddyRef': 'buddy_s', 'roleId': 'student'},
+          ]);
+        },
+      );
+
+      test('accepts a custom role the file declares', () async {
+        final dive = await _importSingleDive(
+          _document(
+            buddies: {'buddy_p': 'Pat Kim'},
+            dives: {'dive_1': '<link ref="buddy_p"/>'},
+            submersion: '''
+      <diveroles>
+        <diverole id="custom-uuid">
+          <name>Photographer</name>
+          <sortorder>10</sortorder>
+          <isbuiltin>false</isbuiltin>
+        </diverole>
+      </diveroles>
+      <buddyroles>
+        <dive ref="dive_1">
+          <buddy ref="buddy_p" role="custom-uuid"/>
+        </dive>
+      </buddyroles>''',
+          ),
+        );
+
+        expect(dive['buddyRoleRefs'], [
+          {'buddyRef': 'buddy_p', 'roleId': 'custom-uuid'},
+        ]);
+        expect(dive.containsKey('buddyRefs'), isFalse);
+      });
+
+      test('ignores unknown roles and undeclared people', () async {
+        final dive = await _importSingleDive(
+          _document(
+            buddies: {'buddy_p': 'Pat Kim'},
+            dives: {'dive_1': '<link ref="buddy_p"/>'},
+            submersion: '''
+      <buddyroles>
+        <dive ref="dive_1">
+          <buddy ref="buddy_p" role="no-such-role"/>
+          <buddy ref="buddy_ghost" role="diveGuide"/>
+        </dive>
+      </buddyroles>''',
+          ),
+        );
+
+        expect(dive.containsKey('buddyRoleRefs'), isFalse);
+        expect(dive['buddyRefs'], [
+          'buddy_p',
+        ], reason: 'an entry that cannot be honoured leaves the standard link');
+      });
+    });
+  });
+
+  group('UddfBuddyRoles.resolveLeaderNames', () {
+    final declared = {
+      'buddy_a': {'name': 'Chris Diver'},
+      'buddy_b': {'name': 'Chris Diver'},
+      'buddy_c': {'name': 'Lee, Ann'},
+    };
+
+    test('splits on commas and trims blanks', () {
+      final r = UddfBuddyRoles.resolveLeaderNames(' X ,, Y ', const {});
+
+      expect(r.refs, isEmpty);
+      expect(r.unmatched, ['X', 'Y']);
+    });
+
+    test('a repeated name reaches the next declared person of that name', () {
+      final r = UddfBuddyRoles.resolveLeaderNames(
+        'Chris Diver, Chris Diver',
+        declared,
+      );
+
+      expect(r.refs, ['buddy_a', 'buddy_b']);
+    });
+
+    test('rejoins fragments that together name a declared person', () {
+      final r = UddfBuddyRoles.resolveLeaderNames('lee, ann', declared);
+
+      expect(r.refs, ['buddy_c']);
+      expect(r.unmatched, isEmpty);
+    });
+
+    test('an undeclared name is listed once', () {
+      final r = UddfBuddyRoles.resolveLeaderNames('Zed, Zed', declared);
+
+      expect(r.unmatched, ['Zed']);
+    });
+  });
+}

--- a/test/core/services/export/uddf/uddf_buddy_roles_test.dart
+++ b/test/core/services/export/uddf/uddf_buddy_roles_test.dart
@@ -174,6 +174,11 @@ void main() {
           isNull,
           reason: 'a name that became a guide link is not also kept as text',
         );
+        expect(
+          dive.keys.where((k) => k.startsWith('_')),
+          isEmpty,
+          reason: 'the held <divemaster> text does not reach the importer',
+        );
       });
 
       test('passes an undeclared name on to be found or created', () async {
@@ -274,6 +279,40 @@ void main() {
         ]);
         expect(dive.containsKey('diveGuideRefs'), isFalse);
       });
+
+      test(
+        'a leader the block cannot use still comes back as a guide',
+        () async {
+          // The block covers Nicol, but its row for the second leader names
+          // a person the file never declares. That leader's name in the text
+          // is then the only record of them, so it must not be dropped along
+          // with the names the block does cover.
+          final dive = await _importSingleDive(
+            _document(
+              buddies: {'buddy_n': 'Nicol Sorin'},
+              dives: {
+                'dive_1':
+                    '<link ref="buddy_n"/>'
+                    '<divemaster>Nicol Sorin, Ghost Leader</divemaster>',
+              },
+              submersion: '''
+      <buddyroles>
+        <dive ref="dive_1">
+          <buddy ref="buddy_n" role="diveGuide"/>
+          <buddy ref="buddy_ghost" role="diveMaster"/>
+        </dive>
+      </buddyroles>''',
+            ),
+          );
+
+          expect(dive['buddyRoleRefs'], [
+            {'buddyRef': 'buddy_n', 'roleId': 'diveGuide'},
+          ]);
+          expect(dive['unmatchedDiveGuideNames'], ['Ghost Leader']);
+          expect(dive.containsKey('diveGuideRefs'), isFalse);
+          expect(dive.containsKey('buddyRefs'), isFalse);
+        },
+      );
 
       test(
         'keeps text-derived guides when the block names no leader',

--- a/test/core/services/export/uddf/uddf_raw_data_round_trip_test.dart
+++ b/test/core/services/export/uddf/uddf_raw_data_round_trip_test.dart
@@ -19,6 +19,7 @@ import 'package:submersion/features/dive_log/data/repositories/dive_repository_i
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain_dive;
+import 'package:submersion/features/dive_roles/data/repositories/dive_role_repository.dart';
 import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
 import 'package:submersion/features/dive_types/data/repositories/dive_type_repository.dart';
 import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
@@ -41,6 +42,7 @@ ImportRepositories buildRepositories() => ImportRepositories(
   certificationRepository: CertificationRepository(),
   tagRepository: TagRepository(),
   diveTypeRepository: DiveTypeRepository(),
+  diveRoleRepository: DiveRoleRepository(),
   siteRepository: SiteRepository(),
   diveRepository: DiveRepository(),
   tankPressureRepository: TankPressureRepository(),

--- a/test/features/import_wizard/data/adapters/universal_adapter_test.dart
+++ b/test/features/import_wizard/data/adapters/universal_adapter_test.dart
@@ -35,12 +35,14 @@ import 'package:submersion/features/dive_log/data/services/dive_merge_snapshot.d
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_roles/data/repositories/dive_role_repository.dart';
 import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/dive_types/data/repositories/dive_type_repository.dart';
 import 'package:submersion/features/dive_types/domain/entities/dive_type_entity.dart';
 import 'package:submersion/features/dive_types/presentation/providers/dive_type_providers.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/equipment/domain/entities/gear_link.dart';
@@ -2414,6 +2416,64 @@ void main() {
           expect(result.errorMessage, isNull);
         },
       );
+    });
+
+    testWidgets('custom dive roles in the metadata are restored', (
+      tester,
+    ) async {
+      // Issue #1737: a restored dive links people by custom role id, so
+      // the role definitions the file carried have to land as well.
+      await setUpTestDatabase();
+      addTearDown(tearDownTestDatabase);
+      await tester.runAsync(() => DiverRepository().createDiver(_testDiver()));
+
+      final payload = ImportPayload(
+        entities: {
+          ui.ImportEntityType.dives: [
+            {
+              'dateTime': DateTime(2026, 3, 15, 10, 0),
+              'maxDepth': 20.0,
+              'runtime': const Duration(minutes: 30),
+            },
+          ],
+        },
+        metadata: {
+          ImportPayload.customDiveRolesKey: [
+            {
+              'id': 'custom-uuid',
+              'name': 'Photographer',
+              'sortOrder': 10,
+              'isBuiltIn': false,
+            },
+          ],
+        },
+      );
+
+      final mockTankPresetRepo = MockTankPresetRepository();
+      when(mockTankPresetRepo.getPresetById(any)).thenAnswer((_) async => null);
+
+      await _runWithAdapter(
+        tester,
+        overrides: _fullOverrides(
+          payload: payload,
+          diver: _testDiver(),
+          mockTankPresetRepo: mockTankPresetRepo,
+        ),
+        callback: (adapter) async {
+          await tester.runAsync(() async {
+            final bundle = await adapter.buildBundle();
+            final result = await adapter.performImport(bundle, {
+              wizard.ImportEntityType.dives: {0},
+            }, {});
+            expect(result.errorMessage, isNull);
+          });
+        },
+      );
+
+      final role = await tester.runAsync(
+        () => DiveRoleRepository().getDiveRoleById('custom-uuid'),
+      );
+      expect(role?.name, 'Photographer');
     });
 
     testWidgets(

--- a/test/features/universal_import/data/parsers/uddf_import_parser_test.dart
+++ b/test/features/universal_import/data/parsers/uddf_import_parser_test.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/universal_import/data/models/import_payload.dart';
+import 'package:submersion/features/universal_import/data/parsers/uddf_import_parser.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  setUp(() async {
+    await setUpTestDatabase();
+  });
+
+  tearDown(() async => tearDownTestDatabase());
+
+  test('carries custom dive role definitions in the metadata', () async {
+    // Issue #1737: per-dive links name custom roles by id, so the wizard
+    // must restore the definitions too, or the links point at nothing.
+    const uddf = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<uddf version="3.2.0">
+  <applicationdata>
+    <submersion>
+      <diveroles>
+        <diverole id="custom-uuid">
+          <name>Photographer</name>
+          <sortorder>10</sortorder>
+          <isbuiltin>false</isbuiltin>
+        </diverole>
+      </diveroles>
+    </submersion>
+  </applicationdata>
+</uddf>
+''';
+
+    final payload = await UddfImportParser().parse(
+      Uint8List.fromList(utf8.encode(uddf)),
+    );
+
+    final roles = payload.metadata[ImportPayload.customDiveRolesKey] as List;
+    expect(roles, hasLength(1));
+    expect((roles.single as Map)['id'], 'custom-uuid');
+    expect((roles.single as Map)['name'], 'Photographer');
+  });
+}

--- a/test/features/universal_import/data/services/payload_merger_test.dart
+++ b/test/features/universal_import/data/services/payload_merger_test.dart
@@ -138,6 +138,69 @@ void main() {
       expect(dives[0]['buddyRefs'], ['f0:b1']);
     });
 
+    test('keeps every file\'s custom dive roles, once per id', () {
+      // Role ids are UUIDs minted on one device, so the same id in two
+      // backups is the same role and must not be restored twice.
+      ImportPayload withRoles(List<String> ids) => ImportPayload(
+        entities: const {},
+        metadata: {
+          ImportPayload.customDiveRolesKey: [
+            for (final id in ids) {'id': id, 'name': 'Role $id'},
+          ],
+        },
+      );
+
+      final merged = merger.merge([
+        FilePayload(
+          fileId: 'f0',
+          fileName: 'a.uddf',
+          payload: withRoles(['r1', 'r2']),
+        ),
+        FilePayload(
+          fileId: 'f1',
+          fileName: 'b.uddf',
+          payload: withRoles(['r2', 'r3']),
+        ),
+      ]);
+
+      final roles = merged.metadata[ImportPayload.customDiveRolesKey] as List;
+      expect([for (final r in roles) (r as Map)['id']], ['r1', 'r2', 'r3']);
+    });
+
+    test('rewrites the person in each exact buddy role (issue #1737)', () {
+      final a = payloadWith(
+        buddies: [
+          {'uddfId': 'b1', 'name': 'Alice'},
+        ],
+      );
+      final b = payloadWith(
+        buddies: [
+          {'uddfId': 'b7', 'name': 'ALICE'},
+          {'uddfId': 'b8', 'name': 'Bob'},
+        ],
+        dives: [
+          {
+            'dateTime': DateTime(2026, 2, 1, 9),
+            'buddyRoleRefs': [
+              {'buddyRef': 'b7', 'roleId': 'diveMaster'},
+              {'buddyRef': 'b8', 'roleId': 'student'},
+            ],
+          },
+        ],
+      );
+
+      final merged = merger.merge([
+        FilePayload(fileId: 'f0', fileName: 'a.uddf', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.uddf', payload: b),
+      ]);
+
+      final dives = merged.entitiesOf(ImportEntityType.dives);
+      expect(dives[0]['buddyRoleRefs'], [
+        {'buddyRef': 'f0:b1', 'roleId': 'diveMaster'},
+        {'buddyRef': 'f1:b8', 'roleId': 'student'},
+      ]);
+    });
+
     test('never folds dives, even identical ones', () {
       final dive = {'dateTime': DateTime(2026, 1, 1, 9), 'maxDepth': 18.0};
       final merged = merger.merge([


### PR DESCRIPTION
## Summary

Fixes #1737. A full UDDF backup lost every per-dive role on restore. The export flattened each dive's leaders (guide, divemaster, instructor) into `<divemaster>` text and linked every participant, leaders included, as a plain buddy. Import put the text into the free-text Dive Master field, so everyone came back as a plain buddy. Guides, divemasters, instructors, students, rear guards and custom roles all lost their role.

The issue suggested restoring leaders as dive guides from the `<divemaster>` text. This PR does that, and also preserves the exact role through a Submersion-private block, so a divemaster comes back as a divemaster and a custom-role person keeps their custom role.

## Changes

- **Export:** a new private `<applicationdata><submersion><buddyroles>` block records each dive participant whose role is not plain buddy, keyed by dive ref (same convention as `<gearlinks>`). The standard `<divemaster>` text and `<link>` elements are unchanged for other apps.
- **Import, `<divemaster>`:** names are split and resolved to declared `<buddy>` records first, case-insensitively. A declared name containing a comma ("Lee, Ann") is kept whole. Unmatched names fall back to find-or-create, the same as the CSV and Subsurface importers. All become dive guide links, and the names are no longer also kept as Dive Master free text.
- **Import, `<buddyroles>`:** exact roles are applied on top. When the block names a leader, the guides inferred from the text are dropped, since that text was written from the same rows. A row is used only when its person is declared and its role is built in or declared by the file.
- **One role per person:** a final settle step removes people who hold a guide or exact role from the plain buddy links. Nothing earlier removes anything, so no step undoes another (covered by a test with two people sharing the leader's name).
- **Importer guard:** an exact role naming a role the database lacks falls back to plain buddy, so no link can point at a nonexistent role (the UI would otherwise show its raw id).
- **Wizard, pre-existing gap:** `UniversalAdapter._payloadToUddfResult` rebuilt `UddfImportResult` without `customDiveRoles`, so custom role definitions never reached the database through the import UI (the #551 restore only worked on the direct service path). They now travel in `ImportPayload.metadata` under `ImportPayload.customDiveRolesKey`, and `PayloadMerger` merges them once per id across files.
- `DiveRole.leaderIds` is now the one definition of which roles UDDF writes as `<divemaster>`, shared by export and import.

Backups made before this change restore their leaders as dive guides, which is as much as the old format records.

## Test Plan

- [x] New `uddf_buddy_roles_round_trip_test.dart`: every role (guide, divemaster, instructor, student, custom, plain buddy) survives export plus a clean-database restore; the guide's dive count is back to 2; no duplicate people; no Dive Master text left. Also covers the issue's reproduction (an existing backup without `<buddyroles>`, with and without the buddy link) and the missing-role fallback.
- [x] New `uddf_buddy_roles_test.dart`: export block shape, text resolution (comma names, repeated names, undeclared names), block precedence, namesake safety, and validation of unknown roles and undeclared people.
- [x] Payload merger: nested `buddyRef` namespacing and alias rewriting; custom roles merged once per id.
- [x] Universal UDDF parser and adapter: custom role definitions reach the database through `performImport`.
- [x] Each new test was watched failing before the fix. The issue's reproduction failed with the guide at 0 dives.
- [x] `flutter test` on export, dive_import, universal_import, import_wizard, buddies, dive_roles and the integration UDDF round trip: 3,857 passed.
- [x] `flutter analyze` passes (whole project).
- [x] Manual testing on: not run (no UI changes; covered by the DB-backed round-trip and wizard tests).
