### PR TITLE
fix(selection): keep the leading element visible beside the checkbox

### DIFF
--- a/lib/features/buddies/presentation/widgets/buddy_list_tile.dart
+++ b/lib/features/buddies/presentation/widgets/buddy_list_tile.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/dive_roles/presentation/providers/dive_role_
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/buddies/presentation/buddy_certification_l10n.dart';
+import 'package:submersion/shared/selection/selection_inset.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
 import 'package:submersion/shared/widgets/entity_card/card_slot_resolver.dart';
 import 'package:submersion/shared/widgets/entity_card/entity_card_extra_fields.dart';
@@ -157,14 +158,14 @@ class BuddyListTile extends ConsumerWidget {
               children: [
                 Row(
                   children: [
-                    SizedBox(
-                      width: 40,
-                      height: 40,
-                      child: Center(
-                        child: SelectionLeading(
-                          isSelectionMode: isSelectionMode,
-                          isChecked: isChecked,
-                          onChanged: (_) => onTap?.call(),
+                    SelectionLeading(
+                      isSelectionMode: isSelectionMode,
+                      isChecked: isChecked,
+                      onChanged: (_) => onTap?.call(),
+                      child: SizedBox(
+                        width: 40,
+                        height: 40,
+                        child: Center(
                           child: _BuddyAvatar(
                             buddy: buddy,
                             ringColor: agencyColor,
@@ -214,10 +215,9 @@ class BuddyListTile extends ConsumerWidget {
                   ],
                 ),
                 const SizedBox(height: 6),
-                Padding(
-                  padding: const EdgeInsetsDirectional.only(
-                    start: _contentInset,
-                  ),
+                SelectionInset(
+                  isSelectionMode: isSelectionMode,
+                  start: _contentInset,
                   child: Wrap(
                     crossAxisAlignment: WrapCrossAlignment.center,
                     spacing: 16,
@@ -230,10 +230,9 @@ class BuddyListTile extends ConsumerWidget {
                 ),
                 if (trailer.isNotEmpty) ...[
                   const SizedBox(height: 6),
-                  Padding(
-                    padding: const EdgeInsetsDirectional.only(
-                      start: _contentInset,
-                    ),
+                  SelectionInset(
+                    isSelectionMode: isSelectionMode,
+                    start: _contentInset,
                     child: Wrap(
                       crossAxisAlignment: WrapCrossAlignment.center,
                       spacing: 8,
@@ -244,10 +243,9 @@ class BuddyListTile extends ConsumerWidget {
                 ],
                 if (config.extraFields.isNotEmpty) ...[
                   const SizedBox(height: 4),
-                  Padding(
-                    padding: const EdgeInsetsDirectional.only(
-                      start: _contentInset,
-                    ),
+                  SelectionInset(
+                    isSelectionMode: isSelectionMode,
+                    start: _contentInset,
                     child:
                         EntityCardExtraFields<BuddyWithDiveCount, BuddyField>(
                           adapter: adapter,

--- a/lib/features/courses/presentation/widgets/course_card.dart
+++ b/lib/features/courses/presentation/widgets/course_card.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/courses/domain/entities/course.dart';
 import 'package:submersion/features/courses/presentation/course_status_colors.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
+import 'package:submersion/shared/widgets/card_icon_label.dart';
 import 'package:submersion/features/certifications/presentation/certification_agency_display.dart';
 
 /// Card widget for displaying a course in a list
@@ -95,36 +96,20 @@ class CourseCard extends ConsumerWidget {
                         overflow: TextOverflow.ellipsis,
                       ),
                       const SizedBox(height: 4),
-                      Row(
+                      // A Wrap, not a Row: the start date drops onto its own
+                      // line when a narrow card, or the checkbox column in
+                      // selection mode, leaves too little width for both.
+                      Wrap(
+                        spacing: 12,
+                        runSpacing: 4,
                         children: [
-                          Icon(
-                            Icons.business,
-                            size: 14,
-                            color: colorScheme.onSurfaceVariant,
+                          CardIconLabel(
+                            icon: Icons.business,
+                            text: course.agency.localizedName(context.l10n),
                           ),
-                          const SizedBox(width: 4),
-                          Flexible(
-                            child: Text(
-                              course.agency.localizedName(context.l10n),
-                              style: Theme.of(context).textTheme.bodySmall
-                                  ?.copyWith(
-                                    color: colorScheme.onSurfaceVariant,
-                                  ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Icon(
-                            Icons.calendar_today,
-                            size: 14,
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            startDateStr,
-                            style: Theme.of(context).textTheme.bodySmall
-                                ?.copyWith(color: colorScheme.onSurfaceVariant),
+                          CardIconLabel(
+                            icon: Icons.calendar_today,
+                            text: startDateStr,
                           ),
                         ],
                       ),

--- a/lib/features/dive_computer/presentation/pages/device_list_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_list_page.dart
@@ -16,6 +16,7 @@ import 'package:submersion/shared/selection/selection_leading.dart';
 import 'package:submersion/shared/selection/selection_app_bar.dart';
 import 'package:submersion/shared/selection/selection_controller.dart';
 import 'package:submersion/shared/selection/selection_state.dart';
+import 'package:submersion/shared/widgets/card_icon_label.dart';
 
 /// Page displaying a list of saved dive computers.
 class DeviceListPage extends ConsumerStatefulWidget {
@@ -466,37 +467,25 @@ class _ComputerCard extends ConsumerWidget {
                         ),
                       ),
                       const SizedBox(height: 8),
-                      Row(
+                      // A Wrap, not a Row: the two stats drop onto their own
+                      // lines when a narrow card, or the checkbox column in
+                      // selection mode, leaves too little width for both.
+                      Wrap(
+                        spacing: 16,
+                        runSpacing: 4,
                         children: [
-                          Icon(
-                            Icons.scuba_diving,
-                            size: 14,
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            context.l10n.diveComputer_list_diveCount(
+                          CardIconLabel(
+                            icon: Icons.scuba_diving,
+                            text: context.l10n.diveComputer_list_diveCount(
                               computer.diveCount,
                             ),
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: colorScheme.onSurfaceVariant,
-                            ),
                           ),
-                          const SizedBox(width: 16),
-                          Icon(
-                            Icons.access_time,
-                            size: 14,
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            formatLastDownload(
+                          CardIconLabel(
+                            icon: Icons.access_time,
+                            text: formatLastDownload(
                               context,
                               computer.lastDownload,
                               units: units,
-                            ),
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: colorScheme.onSurfaceVariant,
                             ),
                           ),
                         ],

--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -41,6 +41,7 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 import 'package:submersion/features/tags/domain/entities/tag.dart';
 import 'package:submersion/features/tags/presentation/widgets/tag_input_widget.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/selection/selection_inset.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
 import 'package:submersion/shared/utils/ink_centered_text_style.dart';
 import 'package:submersion/shared/widgets/debounced_search_results.dart';
@@ -917,31 +918,28 @@ class DiveListTile extends ConsumerWidget {
                 // Top row: avatar/checkbox, text info, chart, chevron
                 Row(
                   children: [
-                    // Selection checkbox or dive number badge
-                    SizedBox(
-                      width: 40,
-                      height: 40,
-                      child: Center(
-                        child: SelectionLeading(
-                          isSelectionMode: isSelectionMode,
-                          isChecked: isChecked,
-                          onChanged: (_) => onTap?.call(),
-                          child: CircleAvatar(
-                            backgroundColor: colorScheme.primaryContainer,
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 4,
-                              ),
-                              child: FittedBox(
-                                fit: BoxFit.scaleDown,
-                                child: Text(
-                                  '#$diveNumber',
-                                  maxLines: 1,
-                                  style: TextStyle(
-                                    color: colorScheme.onPrimaryContainer,
-                                    fontWeight: FontWeight.bold,
-                                    fontSize: 12,
-                                  ),
+                    // Dive number badge, with the selection checkbox ahead
+                    // of it in selection mode (never in place of it).
+                    SelectionLeading(
+                      isSelectionMode: isSelectionMode,
+                      isChecked: isChecked,
+                      onChanged: (_) => onTap?.call(),
+                      child: SizedBox(
+                        width: 40,
+                        height: 40,
+                        child: CircleAvatar(
+                          backgroundColor: colorScheme.primaryContainer,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 4),
+                            child: FittedBox(
+                              fit: BoxFit.scaleDown,
+                              child: Text(
+                                '#$diveNumber',
+                                maxLines: 1,
+                                style: TextStyle(
+                                  color: colorScheme.onPrimaryContainer,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 12,
                                 ),
                               ),
                             ),
@@ -1109,8 +1107,9 @@ class DiveListTile extends ConsumerWidget {
                 // neither can squeeze the other -- DiveTypeBadgeRow still
                 // collapses into a single "+N" badge if the stat row alone
                 // leaves it little room.
-                Padding(
-                  padding: const EdgeInsetsDirectional.only(start: 52),
+                SelectionInset(
+                  isSelectionMode: isSelectionMode,
+                  start: 52,
                   child: Row(
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
@@ -1157,8 +1156,9 @@ class DiveListTile extends ConsumerWidget {
                 // is itself capped with an ellipsis as a defensive backstop).
                 if (tags.isNotEmpty && detailedConfig.showTags) ...[
                   const SizedBox(height: 4),
-                  Padding(
-                    padding: const EdgeInsetsDirectional.only(start: 52),
+                  SelectionInset(
+                    isSelectionMode: isSelectionMode,
+                    start: 52,
                     child: TagChips(tags: tags, maxTags: 3),
                   ),
                 ],
@@ -1166,8 +1166,9 @@ class DiveListTile extends ConsumerWidget {
                 if (extraFields.isNotEmpty &&
                     (fullDive != null || summary != null)) ...[
                   const SizedBox(height: 4),
-                  Padding(
-                    padding: const EdgeInsets.only(left: 52),
+                  SelectionInset(
+                    isSelectionMode: isSelectionMode,
+                    start: 52,
                     child: LayoutBuilder(
                       builder: (context, innerConstraints) {
                         final useOneColumn = innerConstraints.maxWidth < 250;

--- a/lib/features/dive_log/presentation/widgets/compact_dive_list_tile.dart
+++ b/lib/features/dive_log/presentation/widgets/compact_dive_list_tile.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/dive_mode_badg
 import 'package:submersion/features/dive_log/presentation/widgets/dive_type_badge_row.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/selection/selection_inset.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
 
 /// Two-line compact card tile for the dive list.
@@ -287,14 +288,14 @@ class CompactDiveListTile extends ConsumerWidget {
                   // Line 1: dive number, title slot, date slot, chevron
                   Row(
                     children: [
-                      SizedBox(
-                        width: 36,
-                        child: Align(
-                          alignment: Alignment.centerLeft,
-                          child: SelectionLeading(
-                            isSelectionMode: isSelectionMode,
-                            isChecked: isChecked,
-                            onChanged: (_) => onTap?.call(),
+                      SelectionLeading(
+                        isSelectionMode: isSelectionMode,
+                        isChecked: isChecked,
+                        onChanged: (_) => onTap?.call(),
+                        child: SizedBox(
+                          width: 36,
+                          child: Align(
+                            alignment: Alignment.centerLeft,
                             child: FittedBox(
                               fit: BoxFit.scaleDown,
                               alignment: Alignment.centerLeft,
@@ -362,8 +363,9 @@ class CompactDiveListTile extends ConsumerWidget {
                     ],
                   ),
                   // Line 2: stat1 and stat2 slots
-                  Padding(
-                    padding: const EdgeInsetsDirectional.only(start: 44),
+                  SelectionInset(
+                    isSelectionMode: isSelectionMode,
+                    start: 44,
                     child: Row(
                       children: [
                         ExcludeSemantics(

--- a/lib/features/dive_sites/presentation/widgets/site_list_tile.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_tile.dart
@@ -17,6 +17,7 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 import 'package:submersion/features/site_scape/presentation/site_feature_glyph.dart';
 import 'package:submersion/features/site_scape/presentation/site_feature_sheet.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/selection/selection_inset.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
 import 'package:submersion/shared/widgets/entity_card/card_slot_resolver.dart';
 import 'package:submersion/shared/widgets/entity_card/entity_card_extra_fields.dart';
@@ -166,22 +167,20 @@ class _SiteListTileState extends ConsumerState<SiteListTile> {
           children: [
             Row(
               children: [
-                SizedBox(
-                  width: 40,
-                  height: 40,
-                  child: Center(
-                    child: SelectionLeading(
-                      isSelectionMode: widget.isSelectionMode,
-                      isChecked: widget.isChecked,
-                      onChanged: (_) => widget.onTap?.call(),
-                      child: CircleAvatar(
-                        backgroundColor:
-                            accent?.withValues(alpha: 0.15) ??
-                            colorScheme.secondaryContainer,
-                        child: Icon(
-                          Icons.location_on,
-                          color: accent ?? colorScheme.onSecondaryContainer,
-                        ),
+                SelectionLeading(
+                  isSelectionMode: widget.isSelectionMode,
+                  isChecked: widget.isChecked,
+                  onChanged: (_) => widget.onTap?.call(),
+                  child: SizedBox(
+                    width: 40,
+                    height: 40,
+                    child: CircleAvatar(
+                      backgroundColor:
+                          accent?.withValues(alpha: 0.15) ??
+                          colorScheme.secondaryContainer,
+                      child: Icon(
+                        Icons.location_on,
+                        color: accent ?? colorScheme.onSecondaryContainer,
                       ),
                     ),
                   ),
@@ -253,8 +252,9 @@ class _SiteListTileState extends ConsumerState<SiteListTile> {
               ],
             ),
             const SizedBox(height: 6),
-            Padding(
-              padding: const EdgeInsetsDirectional.only(start: _contentInset),
+            SelectionInset(
+              isSelectionMode: widget.isSelectionMode,
+              start: _contentInset,
               child: Wrap(
                 crossAxisAlignment: WrapCrossAlignment.center,
                 spacing: 16,
@@ -264,15 +264,17 @@ class _SiteListTileState extends ConsumerState<SiteListTile> {
             ),
             if (chips.isNotEmpty) ...[
               const SizedBox(height: 6),
-              Padding(
-                padding: const EdgeInsetsDirectional.only(start: _contentInset),
+              SelectionInset(
+                isSelectionMode: widget.isSelectionMode,
+                start: _contentInset,
                 child: Wrap(spacing: 6, runSpacing: 4, children: chips),
               ),
             ],
             if (config.extraFields.isNotEmpty) ...[
               const SizedBox(height: 4),
-              Padding(
-                padding: const EdgeInsetsDirectional.only(start: _contentInset),
+              SelectionInset(
+                isSelectionMode: widget.isSelectionMode,
+                start: _contentInset,
                 child: EntityCardExtraFields<SiteWithDiveCount, SiteField>(
                   adapter: adapter,
                   entity: entry,

--- a/lib/features/trips/presentation/widgets/trip_list_content.dart
+++ b/lib/features/trips/presentation/widgets/trip_list_content.dart
@@ -29,6 +29,7 @@ import 'package:submersion/features/trips/presentation/providers/trip_providers.
 import 'package:submersion/features/trips/presentation/widgets/compact_trip_list_tile.dart';
 import 'package:submersion/features/trips/presentation/widgets/dense_trip_list_tile.dart';
 import 'package:submersion/features/trips/presentation/widgets/upcoming_trip_banner.dart';
+import 'package:submersion/shared/widgets/card_icon_label.dart';
 import 'package:submersion/shared/widgets/feature_accent.dart';
 
 /// Content widget for the trip list, used in master-detail layout.
@@ -910,37 +911,26 @@ class TripListTile extends ConsumerWidget {
                   ),
                 ),
               const SizedBox(height: 4),
-              Row(
+              // A Wrap, not a Row: the runtime drops onto its own line when a
+              // narrow tile, or the checkbox column in selection mode, leaves
+              // too little width for both.
+              Wrap(
+                spacing: 12,
+                runSpacing: 4,
                 children: [
-                  Icon(
-                    Icons.scuba_diving,
-                    size: 14,
-                    color: theme.colorScheme.primary,
-                  ),
-                  const SizedBox(width: 4),
-                  Text(
-                    context.l10n.trips_list_tile_diveCount(
+                  CardIconLabel(
+                    icon: Icons.scuba_diving,
+                    text: context.l10n.trips_list_tile_diveCount(
                       tripWithStats.diveCount,
                     ),
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.primary,
-                    ),
+                    color: theme.colorScheme.primary,
                   ),
-                  if (tripWithStats.totalRuntime > 0) ...[
-                    const SizedBox(width: 12),
-                    Icon(
-                      Icons.timer,
-                      size: 14,
+                  if (tripWithStats.totalRuntime > 0)
+                    CardIconLabel(
+                      icon: Icons.timer,
+                      text: tripWithStats.formattedRuntime,
                       color: theme.colorScheme.primary,
                     ),
-                    const SizedBox(width: 4),
-                    Text(
-                      tripWithStats.formattedRuntime,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.primary,
-                      ),
-                    ),
-                  ],
                 ],
               ),
             ],

--- a/lib/shared/selection/selection_checkbox_slot.dart
+++ b/lib/shared/selection/selection_checkbox_slot.dart
@@ -5,11 +5,11 @@ import 'package:submersion/shared/selection/selection_leading.dart';
 /// A checkbox inserted at the start of a row that has no leading element.
 ///
 /// Tiles that own a leading widget -- a dive number badge, a site avatar --
-/// use [SelectionLeading] to swap it for the checkbox. Compact and dense tiles
-/// start their row with the entity name and have nothing to swap, so the
-/// checkbox has to be inserted instead. This keeps that insertion inside the
-/// tile's own padding, so the checkbox reads as part of the card rather than
-/// floating beside it.
+/// wrap it in [SelectionLeading], which puts the checkbox ahead of it. Compact
+/// and dense tiles start their row with the entity name and have no leading
+/// widget to wrap, so this slot supplies the checkbox on its own. It sits
+/// inside the tile's own padding, so the checkbox reads as part of the card
+/// rather than floating beside it.
 ///
 /// Nothing is reserved when selection mode is off: the slot collapses to zero
 /// width, and the gap collapses with it rather than leaving the row's first
@@ -35,28 +35,15 @@ class SelectionCheckboxSlot extends StatelessWidget {
     this.gap = 12,
   });
 
-  static const Duration _gapDuration = Duration(milliseconds: 150);
-
   @override
   Widget build(BuildContext context) {
-    final showCheckbox = isSelectionMode && isSelectable;
-
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        SelectionLeading(
-          isSelectionMode: isSelectionMode,
-          isChecked: isChecked,
-          isSelectable: isSelectable,
-          onChanged: onChanged,
-          child: const SizedBox.shrink(),
-        ),
-        // The gap belongs to the checkbox, so it collapses with it.
-        AnimatedSize(
-          duration: _gapDuration,
-          child: SizedBox(width: showCheckbox ? gap : 0),
-        ),
-      ],
+    return SelectionLeading(
+      isSelectionMode: isSelectionMode,
+      isChecked: isChecked,
+      isSelectable: isSelectable,
+      onChanged: onChanged,
+      gap: gap,
+      child: const SizedBox.shrink(),
     );
   }
 }

--- a/lib/shared/selection/selection_inset.dart
+++ b/lib/shared/selection/selection_inset.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/shared/selection/selection_leading.dart';
+
+/// Start padding for a card line that sits under the first line's content.
+///
+/// Card tiles put their leading element on the first line and indent the lines
+/// below it by a fixed [start] so they align with the title. In selection mode
+/// [SelectionLeading] inserts a checkbox column ahead of that leading element,
+/// pushing the title along; this inset grows by the same width, over the same
+/// slide, so the lower lines stay under the title instead of drifting left of
+/// it.
+class SelectionInset extends StatelessWidget {
+  final bool isSelectionMode;
+
+  /// The indent outside selection mode: the leading element plus its gap.
+  final double start;
+
+  final Widget child;
+
+  const SelectionInset({
+    super.key,
+    required this.isSelectionMode,
+    required this.start,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedPadding(
+      duration: SelectionLeading.slideDuration,
+      padding: EdgeInsetsDirectional.only(
+        start:
+            start +
+            SelectionLeading.columnWidth(isSelectionMode: isSelectionMode),
+      ),
+      child: child,
+    );
+  }
+}

--- a/lib/shared/selection/selection_leading.dart
+++ b/lib/shared/selection/selection_leading.dart
@@ -1,10 +1,16 @@
 import 'package:flutter/material.dart';
 
-/// A row's leading slot, which becomes a checkbox in selection mode.
+/// A row's leading slot, which gains a checkbox ahead of it in selection mode.
 ///
-/// The swap is animated so entering and leaving the mode does not jolt the
-/// list. Non-selectable rows keep their [child] and render no checkbox, which
-/// is what tells the user at a glance that the row cannot be acted on.
+/// The checkbox is inserted, never swapped in: the leading element often
+/// carries identifying data (a dive number, an avatar's initials), and a user
+/// picking rows for a bulk action needs to see it (issue #1717). The checkbox
+/// column slides in and out so entering and leaving the mode does not jolt the
+/// list.
+///
+/// Non-selectable rows keep a blank column where the checkbox would be. The
+/// missing checkbox tells the user at a glance that the row cannot be acted
+/// on, and the blank keeps its leading element aligned with its neighbours.
 class SelectionLeading extends StatelessWidget {
   /// The row's normal leading element: dive number badge, avatar, gear icon.
   final Widget child;
@@ -17,6 +23,9 @@ class SelectionLeading extends StatelessWidget {
 
   final ValueChanged<bool>? onChanged;
 
+  /// Space between the checkbox column and [child] in selection mode.
+  final double gap;
+
   const SelectionLeading({
     super.key,
     required this.child,
@@ -24,30 +33,49 @@ class SelectionLeading extends StatelessWidget {
     required this.isChecked,
     this.isSelectable = true,
     this.onChanged,
+    this.gap = 8,
   });
 
-  static const Duration _swapDuration = Duration(milliseconds: 150);
+  /// How long the checkbox column takes to slide in or out. Content that has
+  /// to move with it, such as `SelectionInset`, animates over the same span.
+  static const Duration slideDuration = Duration(milliseconds: 150);
+
+  /// Width of the checkbox below: a shrink-wrapped tap target (40) with the
+  /// compact density adjustment (-8). A non-selectable row reserves exactly
+  /// this, width only, so it lines up without growing taller.
+  static const double _checkboxExtent = 32;
+
+  /// The width the checkbox column adds ahead of [child], with [gap].
+  static double columnWidth({required bool isSelectionMode, double gap = 8}) =>
+      isSelectionMode ? _checkboxExtent + gap : 0;
 
   @override
   Widget build(BuildContext context) {
-    final showCheckbox = isSelectionMode && isSelectable;
-
-    return AnimatedSwitcher(
-      duration: _swapDuration,
-      child: showCheckbox
-          ? Checkbox(
-              key: const ValueKey('selection_leading_checkbox'),
-              value: isChecked,
-              visualDensity: VisualDensity.compact,
-              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              onChanged: onChanged == null
-                  ? null
-                  : (value) => onChanged!(value ?? false),
-            )
-          : KeyedSubtree(
-              key: const ValueKey('selection_leading_child'),
-              child: child,
-            ),
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AnimatedSize(
+          duration: slideDuration,
+          alignment: AlignmentDirectional.centerStart,
+          child: isSelectionMode
+              ? Padding(
+                  padding: EdgeInsetsDirectional.only(end: gap),
+                  child: isSelectable
+                      ? Checkbox(
+                          value: isChecked,
+                          visualDensity: VisualDensity.compact,
+                          materialTapTargetSize:
+                              MaterialTapTargetSize.shrinkWrap,
+                          onChanged: onChanged == null
+                              ? null
+                              : (value) => onChanged!(value ?? false),
+                        )
+                      : const SizedBox(width: _checkboxExtent),
+                )
+              : const SizedBox.shrink(),
+        ),
+        child,
+      ],
     );
   }
 }

--- a/lib/shared/widgets/card_icon_label.dart
+++ b/lib/shared/widgets/card_icon_label.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+/// A small icon followed by a one-line secondary label, for a card's stat line.
+///
+/// Built to sit in a [Wrap] with its siblings: the pair stays together and
+/// moves to its own line when the card is too narrow for both, and a label
+/// still wider than the card ellipsizes instead of overflowing it.
+class CardIconLabel extends StatelessWidget {
+  final IconData icon;
+  final String text;
+
+  /// Tint for both the icon and the label. Defaults to the theme's secondary
+  /// text color ([ColorScheme.onSurfaceVariant]).
+  final Color? color;
+
+  const CardIconLabel({
+    super.key,
+    required this.icon,
+    required this.text,
+    this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = this.color ?? theme.colorScheme.onSurfaceVariant;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 14, color: color),
+        const SizedBox(width: 4),
+        Flexible(
+          child: Text(
+            text,
+            style: theme.textTheme.bodySmall?.copyWith(color: color),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/buddies/presentation/widgets/buddy_list_tile_test.dart
+++ b/test/features/buddies/presentation/widgets/buddy_list_tile_test.dart
@@ -260,4 +260,68 @@ void main() {
       reason: 'the lower lines move with the checkbox column',
     );
   });
+
+  testWidgets('keeps the extra fields under the title in selection mode', (
+    tester,
+  ) async {
+    const withExtras = EntityCardViewConfig<BuddyField>(
+      slots: [
+        EntityCardSlotConfig(slotId: 'title', field: BuddyField.buddyName),
+        EntityCardSlotConfig(slotId: 'subtitle', field: BuddyField.email),
+        EntityCardSlotConfig(slotId: 'stat1', field: BuddyField.diveCount),
+        EntityCardSlotConfig(slotId: 'stat2', field: BuddyField.lastDive),
+      ],
+      extraFields: [BuddyField.phone],
+    );
+
+    Future<double> extraOffsetFromTitle({required bool selecting}) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: await _overrides(config: withExtras),
+          locale: const Locale('en'),
+          child: BuddyListTile(
+            entry: BuddyWithDiveCount(buddy: _buddy(), diveCount: 23),
+            isSelectionMode: selecting,
+            isChecked: false,
+            onTap: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return tester.getTopLeft(find.text('+1 555 0100')).dx -
+          tester.getTopLeft(find.text('Jane Doe')).dx;
+    }
+
+    final normal = await extraOffsetFromTitle(selecting: false);
+    final selecting = await extraOffsetFromTitle(selecting: true);
+    expect(selecting, normal);
+  });
+
+  testWidgets('tapping the checkbox toggles the row', (tester) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      testApp(
+        overrides: await _overrides(),
+        child: BuddyListTile(
+          entry: BuddyWithDiveCount(buddy: _buddy(), diveCount: 1),
+          isSelectionMode: true,
+          isChecked: false,
+          onTap: () => taps++,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<Checkbox>(find.byType(Checkbox)).onChanged,
+      isNotNull,
+      reason: 'a disabled checkbox would read as an unselectable row',
+    );
+    await tester.tap(find.byType(Checkbox));
+    expect(
+      taps,
+      1,
+      reason: 'the checkbox claims the tap, so the row toggles exactly once',
+    );
+  });
 }

--- a/test/features/buddies/presentation/widgets/buddy_list_tile_test.dart
+++ b/test/features/buddies/presentation/widgets/buddy_list_tile_test.dart
@@ -204,4 +204,60 @@ void main() {
 
     expect(find.byType(Checkbox), findsOneWidget);
   });
+
+  testWidgets('keeps the avatar initials beside the checkbox in selection '
+      'mode', (tester) async {
+    await tester.pumpWidget(
+      testApp(
+        overrides: await _overrides(),
+        child: BuddyListTile(
+          entry: BuddyWithDiveCount(buddy: _buddy(), diveCount: 1),
+          isSelectionMode: true,
+          isChecked: false,
+          onTap: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('JD'),
+      findsOneWidget,
+      reason: 'the checkbox is inserted ahead of the avatar (issue #1717)',
+    );
+    expect(
+      tester.getTopRight(find.byType(Checkbox)).dx,
+      lessThanOrEqualTo(tester.getTopLeft(find.text('JD')).dx),
+    );
+  });
+
+  testWidgets('keeps the stat line under the title in selection mode', (
+    tester,
+  ) async {
+    Future<double> statOffsetFromTitle({required bool selecting}) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: await _overrides(),
+          locale: const Locale('en'),
+          child: BuddyListTile(
+            entry: BuddyWithDiveCount(buddy: _buddy(), diveCount: 23),
+            isSelectionMode: selecting,
+            isChecked: false,
+            onTap: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return tester.getTopLeft(find.text('23 dives')).dx -
+          tester.getTopLeft(find.text('Jane Doe')).dx;
+    }
+
+    final normal = await statOffsetFromTitle(selecting: false);
+    final selecting = await statOffsetFromTitle(selecting: true);
+    expect(
+      selecting,
+      normal,
+      reason: 'the lower lines move with the checkbox column',
+    );
+  });
 }

--- a/test/features/courses/presentation/widgets/course_card_test.dart
+++ b/test/features/courses/presentation/widgets/course_card_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/courses/domain/entities/course.dart';
+import 'package:submersion/features/courses/presentation/widgets/course_card.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_app.dart';
+
+final _course = Course(
+  id: 'c1',
+  diverId: 'd1',
+  name: 'Advanced Open Water Diver',
+  agency: CertificationAgency.padi,
+  startDate: DateTime(2025, 12, 28),
+  instructorName: 'Maximiliane Schwarzenberger-Hoffmann',
+  createdAt: DateTime(2026),
+  updatedAt: DateTime(2026),
+);
+
+void main() {
+  // Selection mode puts the checkbox ahead of the status icon rather than in
+  // its place (issue #1717), so the info column loses 40px. Its agency and
+  // start-date line must still fit a phone-width card.
+  for (final selecting in [false, true]) {
+    testWidgets('fits a phone-width card '
+        '${selecting ? 'in' : 'outside'} selection mode', (tester) async {
+      tester.view.physicalSize = const Size(353, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        testApp(
+          overrides: await getBaseOverrides(),
+          locale: const Locale('en'),
+          child: CourseCard(
+            course: _course,
+            isSelectionMode: selecting,
+            onTap: () {},
+            onCheckChanged: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(Checkbox), selecting ? findsOneWidget : findsNothing);
+    });
+  }
+}

--- a/test/features/dive_computer/presentation/pages/device_list_page_test.dart
+++ b/test/features/dive_computer/presentation/pages/device_list_page_test.dart
@@ -111,6 +111,50 @@ void main() {
 
       expect(find.byKey(const ValueKey('enter_selection')), findsOneWidget);
     });
+
+    // Selection mode puts the checkbox ahead of the connection icon rather
+    // than in its place (issue #1717), so the info column loses 40px. The
+    // stats line must still fit a phone-width card.
+    for (final selecting in [false, true]) {
+      testWidgets('fits a phone-width card '
+          '${selecting ? 'in' : 'outside'} selection mode', (tester) async {
+        tester.view.physicalSize = const Size(353, 800);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(
+          testApp(
+            overrides: [
+              allDiveComputersProvider.overrideWith(
+                (ref) async => [
+                  DiveComputer(
+                    id: 'c1',
+                    name: 'Perdix',
+                    manufacturer: 'Shearwater',
+                    model: 'Perdix 2',
+                    diveCount: 1234,
+                    lastDownload: DateTime(2025, 12, 28, 18, 45),
+                    createdAt: DateTime(2026),
+                    updatedAt: DateTime(2026),
+                  ),
+                ],
+              ),
+            ],
+            locale: const Locale('en'),
+            child: const DeviceListPage(),
+          ),
+        );
+        await tester.pumpAndSettle();
+        if (selecting) {
+          await tester.tap(find.byKey(const ValueKey('enter_selection')));
+          await tester.pumpAndSettle();
+          expect(find.byType(Checkbox), findsWidgets);
+        }
+
+        expect(tester.takeException(), isNull);
+        expect(find.text('1234 dives'), findsOneWidget);
+      });
+    }
   });
 }
 

--- a/test/features/dive_log/presentation/widgets/dive_list_item_channels_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_item_channels_test.dart
@@ -93,7 +93,7 @@ void main() {
       expect(find.byKey(const ValueKey('dive_row_highlight')), findsNothing);
     });
 
-    testWidgets('the checkbox replaces the dive number in selection mode', (
+    testWidgets('the dive number stays visible beside the checkbox', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -104,9 +104,15 @@ void main() {
       expect(find.byType(Checkbox), findsOneWidget);
       expect(
         find.text('#412'),
-        findsNothing,
+        findsOneWidget,
         reason:
-            'the checkbox replaces the leading element, it does not badge it',
+            'the number is what a diver picks dives by during a bulk edit, so '
+            'the checkbox must not hide it (issue #1717)',
+      );
+      expect(
+        tester.getTopRight(find.byType(Checkbox)).dx,
+        lessThanOrEqualTo(tester.getTopLeft(find.text('#412')).dx),
+        reason: 'the checkbox sits ahead of the number, not on top of it',
       );
     });
   });

--- a/test/features/dive_log/presentation/widgets/dive_tile_selection_number_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_tile_selection_number_test.dart
@@ -35,45 +35,51 @@ class _TestCardConfigNotifier extends CardViewConfigNotifier {
 }
 
 void main() {
-  Widget compact({required bool isSelectionMode, bool isChecked = false}) =>
-      testApp(
-        overrides: [
-          settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
-        ],
-        child: CompactDiveListTile(
-          diveId: 'd1',
-          diveNumber: 125,
-          dateTime: DateTime(2025, 7, 19, 12, 24),
-          siteName: 'Centeen SCUBA park',
-          maxDepth: 10.6,
-          duration: const Duration(minutes: 28),
-          isSelectionMode: isSelectionMode,
-          isChecked: isChecked,
-          onTap: () {},
-        ),
-      );
+  Widget compact({
+    required bool isSelectionMode,
+    bool isChecked = false,
+    VoidCallback? onTap,
+  }) => testApp(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+    ],
+    child: CompactDiveListTile(
+      diveId: 'd1',
+      diveNumber: 125,
+      dateTime: DateTime(2025, 7, 19, 12, 24),
+      siteName: 'Centeen SCUBA park',
+      maxDepth: 10.6,
+      duration: const Duration(minutes: 28),
+      isSelectionMode: isSelectionMode,
+      isChecked: isChecked,
+      onTap: onTap ?? () {},
+    ),
+  );
 
-  Widget detailed({required bool isSelectionMode, bool isChecked = false}) =>
-      testApp(
-        overrides: [
-          settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
-          detailedCardConfigProvider.overrideWith(
-            (ref) => _TestCardConfigNotifier(),
-          ),
-        ],
-        child: DiveListTile(
-          diveId: 'd1',
-          diveNumber: 125,
-          dateTime: DateTime(2025, 7, 19, 12, 24),
-          siteName: 'Centeen SCUBA park',
-          siteLocation: 'Ontario, Canada',
-          maxDepth: 10.6,
-          duration: const Duration(minutes: 28),
-          isSelectionMode: isSelectionMode,
-          isChecked: isChecked,
-          onTap: () {},
-        ),
-      );
+  Widget detailed({
+    required bool isSelectionMode,
+    bool isChecked = false,
+    VoidCallback? onTap,
+  }) => testApp(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+      detailedCardConfigProvider.overrideWith(
+        (ref) => _TestCardConfigNotifier(),
+      ),
+    ],
+    child: DiveListTile(
+      diveId: 'd1',
+      diveNumber: 125,
+      dateTime: DateTime(2025, 7, 19, 12, 24),
+      siteName: 'Centeen SCUBA park',
+      siteLocation: 'Ontario, Canada',
+      maxDepth: 10.6,
+      duration: const Duration(minutes: 28),
+      isSelectionMode: isSelectionMode,
+      isChecked: isChecked,
+      onTap: onTap ?? () {},
+    ),
+  );
 
   /// Narrow phone width, matching the screenshots on issue #1717.
   Future<void> usePhoneWidth(WidgetTester tester) async {
@@ -84,7 +90,12 @@ void main() {
 
   void selectionNumberTests(
     String name,
-    Widget Function({required bool isSelectionMode, bool isChecked}) build,
+    Widget Function({
+      required bool isSelectionMode,
+      bool isChecked,
+      VoidCallback? onTap,
+    })
+    build,
   ) {
     group('$name in selection mode', () {
       for (final checked in [false, true]) {
@@ -124,6 +135,27 @@ void main() {
 
         expect(find.byType(Checkbox), findsNothing);
         expect(find.text('#125'), findsOneWidget);
+      });
+
+      testWidgets('tapping the checkbox toggles the row', (tester) async {
+        var taps = 0;
+        await tester.pumpWidget(
+          build(isSelectionMode: true, onTap: () => taps++),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.widget<Checkbox>(find.byType(Checkbox)).onChanged,
+          isNotNull,
+          reason: 'a disabled checkbox would read as an unselectable row',
+        );
+        await tester.tap(find.byType(Checkbox));
+        expect(
+          taps,
+          1,
+          reason:
+              'the checkbox claims the tap, so the row toggles exactly once',
+        );
       });
 
       for (final selecting in [false, true]) {

--- a/test/features/dive_log/presentation/widgets/dive_tile_selection_number_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_tile_selection_number_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_list_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/compact_dive_list_tile.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// Issue #1717: selecting dives hid every dive number.
+///
+/// Both card tiles used to swap the `#N` badge for the selection checkbox, so
+/// a diver picking dives for a bulk edit lost the one field they pick by. The
+/// checkbox now slides in ahead of the badge. These tests pin the number, the
+/// checkbox's position, and that the wider leading slot still fits a phone.
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// The detailed tile reads its slot config through a provider chain that
+/// reaches SharedPreferences, so the config is pinned to the default here.
+class _TestCardConfigNotifier extends CardViewConfigNotifier {
+  _TestCardConfigNotifier() : super.withMode(ListViewMode.detailed);
+}
+
+void main() {
+  Widget compact({required bool isSelectionMode, bool isChecked = false}) =>
+      testApp(
+        overrides: [
+          settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+        ],
+        child: CompactDiveListTile(
+          diveId: 'd1',
+          diveNumber: 125,
+          dateTime: DateTime(2025, 7, 19, 12, 24),
+          siteName: 'Centeen SCUBA park',
+          maxDepth: 10.6,
+          duration: const Duration(minutes: 28),
+          isSelectionMode: isSelectionMode,
+          isChecked: isChecked,
+          onTap: () {},
+        ),
+      );
+
+  Widget detailed({required bool isSelectionMode, bool isChecked = false}) =>
+      testApp(
+        overrides: [
+          settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+          detailedCardConfigProvider.overrideWith(
+            (ref) => _TestCardConfigNotifier(),
+          ),
+        ],
+        child: DiveListTile(
+          diveId: 'd1',
+          diveNumber: 125,
+          dateTime: DateTime(2025, 7, 19, 12, 24),
+          siteName: 'Centeen SCUBA park',
+          siteLocation: 'Ontario, Canada',
+          maxDepth: 10.6,
+          duration: const Duration(minutes: 28),
+          isSelectionMode: isSelectionMode,
+          isChecked: isChecked,
+          onTap: () {},
+        ),
+      );
+
+  /// Narrow phone width, matching the screenshots on issue #1717.
+  Future<void> usePhoneWidth(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(353, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+  }
+
+  void selectionNumberTests(
+    String name,
+    Widget Function({required bool isSelectionMode, bool isChecked}) build,
+  ) {
+    group('$name in selection mode', () {
+      for (final checked in [false, true]) {
+        testWidgets('keeps the dive number visible when '
+            '${checked ? 'checked' : 'unchecked'}', (tester) async {
+          await tester.pumpWidget(
+            build(isSelectionMode: true, isChecked: checked),
+          );
+          await tester.pumpAndSettle();
+
+          expect(tester.widget<Checkbox>(find.byType(Checkbox)).value, checked);
+          expect(
+            find.text('#125'),
+            findsOneWidget,
+            reason: 'the checkbox must not replace the dive number',
+          );
+        });
+      }
+
+      testWidgets('places the checkbox ahead of the dive number', (
+        tester,
+      ) async {
+        await tester.pumpWidget(build(isSelectionMode: true));
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getTopRight(find.byType(Checkbox)).dx,
+          lessThanOrEqualTo(tester.getTopLeft(find.text('#125')).dx),
+        );
+      });
+
+      testWidgets('keeps the number where it was outside selection mode', (
+        tester,
+      ) async {
+        await tester.pumpWidget(build(isSelectionMode: false));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(Checkbox), findsNothing);
+        expect(find.text('#125'), findsOneWidget);
+      });
+
+      for (final selecting in [false, true]) {
+        testWidgets('keeps the stat line under the title when '
+            '${selecting ? '' : 'not '}selecting', (tester) async {
+          await tester.pumpWidget(build(isSelectionMode: selecting));
+          await tester.pumpAndSettle();
+
+          expect(
+            tester.getTopLeft(find.byIcon(Icons.arrow_downward)).dx,
+            tester.getTopLeft(find.text('Centeen SCUBA park')).dx,
+            reason:
+                'the lines below the title are indented to sit under it, so '
+                'they must move with the checkbox column',
+          );
+        });
+      }
+
+      testWidgets('fits a phone-width row without overflowing', (tester) async {
+        await usePhoneWidth(tester);
+        await tester.pumpWidget(build(isSelectionMode: true));
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(find.text('#125'), findsOneWidget);
+      });
+    });
+  }
+
+  selectionNumberTests('CompactDiveListTile', compact);
+  selectionNumberTests('DiveListTile', detailed);
+}

--- a/test/features/dive_sites/presentation/widgets/site_list_tile_test.dart
+++ b/test/features/dive_sites/presentation/widgets/site_list_tile_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/theme/feature_accent_colors.dart';
 import 'package:submersion/features/dive_sites/domain/constants/site_field.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/domain/entities/site_with_dive_count.dart';
@@ -225,5 +226,61 @@ void main() {
 
     expect(find.byType(FlutterMap), findsWidgets);
     expect(find.text('Located Reef'), findsOneWidget);
+  });
+
+  testWidgets('tapping the checkbox toggles the row', (tester) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      testApp(
+        overrides: await _overrides(),
+        child: SiteListTile(
+          entry: _richEntry,
+          isSelectionMode: true,
+          isChecked: false,
+          onTap: () => taps++,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<Checkbox>(find.byType(Checkbox)).onChanged,
+      isNotNull,
+      reason: 'a disabled checkbox would read as an unselectable row',
+    );
+    await tester.tap(find.byType(Checkbox));
+    expect(
+      taps,
+      1,
+      reason: 'the checkbox claims the tap, so the row toggles exactly once',
+    );
+  });
+
+  testWidgets('tints the avatar with the sites accent when list accents are '
+      'on', (tester) async {
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...await _overrides(),
+          accentListIconsProvider.overrideWithValue(true),
+        ],
+        child: Builder(
+          builder: (context) => Theme(
+            data: Theme.of(
+              context,
+            ).copyWith(extensions: const [FeatureAccentColors.light]),
+            child: SiteListTile(entry: _richEntry, onTap: () {}),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final accent = FeatureAccentColors.light.of('sites')!;
+    expect(
+      tester.widget<CircleAvatar>(find.byType(CircleAvatar)).backgroundColor,
+      accent.withValues(alpha: 0.15),
+    );
+    expect(tester.widget<Icon>(find.byIcon(Icons.location_on)).color, accent);
   });
 }

--- a/test/features/dive_sites/presentation/widgets/site_list_tile_test.dart
+++ b/test/features/dive_sites/presentation/widgets/site_list_tile_test.dart
@@ -147,6 +147,63 @@ void main() {
     expect(find.byType(Checkbox), findsOneWidget);
   });
 
+  testWidgets('keeps the avatar beside the checkbox in selection mode', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      testApp(
+        overrides: await _overrides(),
+        child: SiteListTile(
+          entry: _richEntry,
+          isSelectionMode: true,
+          isChecked: false,
+          onTap: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byIcon(Icons.location_on),
+      findsOneWidget,
+      reason: 'the checkbox is inserted ahead of the avatar (issue #1717)',
+    );
+    expect(
+      tester.getTopRight(find.byType(Checkbox)).dx,
+      lessThanOrEqualTo(tester.getTopLeft(find.byType(CircleAvatar)).dx),
+    );
+  });
+
+  testWidgets('keeps the stat line under the title in selection mode', (
+    tester,
+  ) async {
+    Future<double> statOffsetFromTitle({required bool selecting}) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: await _overrides(),
+          locale: const Locale('en'),
+          child: SiteListTile(
+            entry: _richEntry,
+            isSelectionMode: selecting,
+            isChecked: false,
+            onTap: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return tester.getTopLeft(find.text('5-50m')).dx -
+          tester.getTopLeft(find.text('Blue Hole')).dx;
+    }
+
+    final normal = await statOffsetFromTitle(selecting: false);
+    final selecting = await statOffsetFromTitle(selecting: true);
+    expect(
+      selecting,
+      normal,
+      reason: 'the lower lines move with the checkbox column',
+    );
+  });
+
   testWidgets('renders a FlutterMap background for a located site', (
     tester,
   ) async {

--- a/test/features/trips/presentation/widgets/trip_list_tile_layout_test.dart
+++ b/test/features/trips/presentation/widgets/trip_list_tile_layout_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/trips/domain/entities/trip.dart';
+import 'package:submersion/features/trips/presentation/widgets/trip_list_content.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// The tile's subtree watches [settingsProvider]; the real notifier reaches for
+/// SharedPreferences, so stand in with a fixed [AppSettings].
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final _trip = TripWithStats(
+  trip: Trip(
+    id: 'trip-1',
+    name: 'Red Sea Explorer',
+    startDate: DateTime(2025, 6, 1),
+    endDate: DateTime(2025, 6, 8),
+    tripType: TripType.liveaboard,
+    createdAt: DateTime(2025, 6, 1),
+    updatedAt: DateTime(2025, 6, 1),
+  ),
+  diveCount: 123,
+  totalRuntime: 7 * 24 * 3600,
+);
+
+void main() {
+  // Selection mode puts the checkbox ahead of the trip avatar rather than in
+  // its place (issue #1717), so the subtitle loses 40px. The dive count and
+  // runtime line must still fit a phone-width tile.
+  for (final selecting in [false, true]) {
+    testWidgets('fits a phone-width tile '
+        '${selecting ? 'in' : 'outside'} selection mode', (tester) async {
+      tester.view.physicalSize = const Size(353, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        testApp(
+          locale: const Locale('en'),
+          overrides: [
+            settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+          ],
+          child: TripListTile(
+            tripWithStats: _trip,
+            isSelectionMode: selecting,
+            onCheckChanged: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(Checkbox), selecting ? findsOneWidget : findsNothing);
+    });
+  }
+}

--- a/test/shared/selection/selection_checkbox_slot_test.dart
+++ b/test/shared/selection/selection_checkbox_slot_test.dart
@@ -75,20 +75,51 @@ void main() {
       expect(received, isTrue);
     });
 
-    testWidgets('renders nothing for a non-selectable row', (tester) async {
+    testWidgets('keeps the column blank for a non-selectable row', (
+      tester,
+    ) async {
+      const selectable = ValueKey('selectable');
+      const locked = ValueKey('locked');
       await tester.pumpWidget(
-        host(
-          const SelectionCheckboxSlot(
-            isSelectionMode: true,
-            isChecked: false,
-            isSelectable: false,
+        const MaterialApp(
+          home: Scaffold(
+            body: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    SelectionCheckboxSlot(
+                      key: selectable,
+                      isSelectionMode: true,
+                      isChecked: false,
+                    ),
+                  ],
+                ),
+                Row(
+                  children: [
+                    SelectionCheckboxSlot(
+                      key: locked,
+                      isSelectionMode: true,
+                      isChecked: false,
+                      isSelectable: false,
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       );
       await tester.pumpAndSettle();
 
-      expect(find.byType(Checkbox), findsNothing);
-      expect(tester.getSize(find.byType(SelectionCheckboxSlot)).width, 0);
+      expect(find.byType(Checkbox), findsOneWidget);
+      expect(
+        tester.getSize(find.byKey(locked)).width,
+        tester.getSize(find.byKey(selectable)).width,
+        reason:
+            'a row without a checkbox keeps the column blank so its content '
+            'lines up with the rows that have one',
+      );
     });
   });
 }

--- a/test/shared/selection/selection_inset_test.dart
+++ b/test/shared/selection/selection_inset_test.dart
@@ -9,22 +9,29 @@ void main() {
 
   /// A first line led by a [SelectionLeading], and a later line indented to
   /// sit under that line's leading element.
-  Widget host({required bool isSelectionMode, double start = 0}) => MaterialApp(
+  Widget host({
+    required bool isSelectionMode,
+    double start = 0,
+    TextDirection textDirection = TextDirection.ltr,
+  }) => MaterialApp(
     home: Scaffold(
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SelectionLeading(
-            isSelectionMode: isSelectionMode,
-            isChecked: false,
-            child: const SizedBox(key: leadingChild, width: 40, height: 40),
-          ),
-          SelectionInset(
-            isSelectionMode: isSelectionMode,
-            start: start,
-            child: const SizedBox(key: insetChild, width: 10, height: 10),
-          ),
-        ],
+      body: Directionality(
+        textDirection: textDirection,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SelectionLeading(
+              isSelectionMode: isSelectionMode,
+              isChecked: false,
+              child: const SizedBox(key: leadingChild, width: 40, height: 40),
+            ),
+            SelectionInset(
+              isSelectionMode: isSelectionMode,
+              start: start,
+              child: const SizedBox(key: insetChild, width: 10, height: 10),
+            ),
+          ],
+        ),
       ),
     ),
   );
@@ -47,6 +54,24 @@ void main() {
         tester.getTopLeft(find.byKey(insetChild)).dx,
         tester.getTopLeft(find.byKey(leadingChild)).dx,
         reason: 'the inset grows by exactly the width the checkbox adds',
+      );
+    });
+
+    testWidgets('moves with the checkbox column in RTL', (tester) async {
+      await tester.pumpWidget(
+        host(
+          isSelectionMode: true,
+          start: 52,
+          textDirection: TextDirection.rtl,
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        tester.getTopRight(find.byKey(insetChild)).dx,
+        tester.getTopRight(find.byKey(leadingChild)).dx - 52,
+        reason:
+            'in RTL the leading element and the checkbox column sit on the '
+            'right, so the inset must grow from the right edge as well',
       );
     });
 

--- a/test/shared/selection/selection_inset_test.dart
+++ b/test/shared/selection/selection_inset_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/shared/selection/selection_inset.dart';
+import 'package:submersion/shared/selection/selection_leading.dart';
+
+void main() {
+  const leadingChild = ValueKey('leading_child');
+  const insetChild = ValueKey('inset_child');
+
+  /// A first line led by a [SelectionLeading], and a later line indented to
+  /// sit under that line's leading element.
+  Widget host({required bool isSelectionMode, double start = 0}) => MaterialApp(
+    home: Scaffold(
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SelectionLeading(
+            isSelectionMode: isSelectionMode,
+            isChecked: false,
+            child: const SizedBox(key: leadingChild, width: 40, height: 40),
+          ),
+          SelectionInset(
+            isSelectionMode: isSelectionMode,
+            start: start,
+            child: const SizedBox(key: insetChild, width: 10, height: 10),
+          ),
+        ],
+      ),
+    ),
+  );
+
+  group('SelectionInset', () {
+    testWidgets('indents by start alone outside selection mode', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host(isSelectionMode: false, start: 52));
+      await tester.pumpAndSettle();
+      expect(tester.getTopLeft(find.byKey(insetChild)).dx, 52);
+    });
+
+    testWidgets('moves with the checkbox column in selection mode', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host(isSelectionMode: true));
+      await tester.pumpAndSettle();
+      expect(
+        tester.getTopLeft(find.byKey(insetChild)).dx,
+        tester.getTopLeft(find.byKey(leadingChild)).dx,
+        reason: 'the inset grows by exactly the width the checkbox adds',
+      );
+    });
+
+    testWidgets('keeps start on top of the checkbox column', (tester) async {
+      await tester.pumpWidget(host(isSelectionMode: true, start: 52));
+      await tester.pumpAndSettle();
+      expect(
+        tester.getTopLeft(find.byKey(insetChild)).dx,
+        tester.getTopLeft(find.byKey(leadingChild)).dx + 52,
+      );
+    });
+  });
+}

--- a/test/shared/selection/selection_leading_test.dart
+++ b/test/shared/selection/selection_leading_test.dart
@@ -3,61 +3,150 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
 
 void main() {
-  Widget host({
+  const childKey = ValueKey('leading_child');
+
+  Widget leading({
     required bool isSelectionMode,
     bool isChecked = false,
     bool isSelectable = true,
     ValueChanged<bool>? onChanged,
   }) {
-    return MaterialApp(
-      home: Scaffold(
-        body: SelectionLeading(
-          isSelectionMode: isSelectionMode,
-          isChecked: isChecked,
-          isSelectable: isSelectable,
-          onChanged: onChanged ?? (_) {},
-          child: const Text('412'),
-        ),
+    return SelectionLeading(
+      isSelectionMode: isSelectionMode,
+      isChecked: isChecked,
+      isSelectable: isSelectable,
+      onChanged: onChanged ?? (_) {},
+      child: const SizedBox(
+        key: childKey,
+        width: 40,
+        height: 40,
+        child: Text('412'),
       ),
     );
   }
+
+  Widget host(Widget child) => MaterialApp(
+    home: Scaffold(
+      body: Align(alignment: Alignment.topLeft, child: child),
+    ),
+  );
 
   group('SelectionLeading', () {
     testWidgets('shows the child and no checkbox outside selection mode', (
       tester,
     ) async {
-      await tester.pumpWidget(host(isSelectionMode: false));
+      await tester.pumpWidget(host(leading(isSelectionMode: false)));
       await tester.pumpAndSettle();
       expect(find.text('412'), findsOneWidget);
       expect(find.byType(Checkbox), findsNothing);
     });
 
-    testWidgets('replaces the child with a checkbox in selection mode', (
+    testWidgets('reserves no width outside selection mode', (tester) async {
+      await tester.pumpWidget(host(leading(isSelectionMode: false)));
+      await tester.pumpAndSettle();
+      expect(
+        tester.getSize(find.byType(SelectionLeading)).width,
+        40,
+        reason: 'only the child is laid out when selection mode is off',
+      );
+    });
+
+    testWidgets('keeps the child beside the checkbox in selection mode', (
       tester,
     ) async {
-      await tester.pumpWidget(host(isSelectionMode: true));
+      await tester.pumpWidget(host(leading(isSelectionMode: true)));
       await tester.pumpAndSettle();
       expect(find.byType(Checkbox), findsOneWidget);
-      expect(find.text('412'), findsNothing);
+      expect(
+        find.text('412'),
+        findsOneWidget,
+        reason:
+            'the leading element carries identifying data such as the dive '
+            'number, so the checkbox must not replace it (issue #1717)',
+      );
+      expect(
+        tester.getTopRight(find.byType(Checkbox)).dx,
+        lessThanOrEqualTo(tester.getTopLeft(find.byKey(childKey)).dx),
+        reason: 'the checkbox sits ahead of the child, not on top of it',
+      );
+    });
+
+    testWidgets('leads with the checkbox on the start side in RTL', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host(
+          Directionality(
+            textDirection: TextDirection.rtl,
+            child: leading(isSelectionMode: true),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        tester.getTopLeft(find.byType(Checkbox)).dx,
+        greaterThanOrEqualTo(tester.getTopRight(find.byKey(childKey)).dx),
+        reason: 'the checkbox leads the row on its start side',
+      );
     });
 
     testWidgets('reflects the checked state', (tester) async {
-      await tester.pumpWidget(host(isSelectionMode: true, isChecked: true));
+      await tester.pumpWidget(
+        host(leading(isSelectionMode: true, isChecked: true)),
+      );
       await tester.pumpAndSettle();
       expect(tester.widget<Checkbox>(find.byType(Checkbox)).value, isTrue);
     });
 
-    testWidgets('keeps the child for non-selectable rows', (tester) async {
-      await tester.pumpWidget(host(isSelectionMode: true, isSelectable: false));
+    testWidgets('keeps the child and shows no checkbox for non-selectable '
+        'rows', (tester) async {
+      await tester.pumpWidget(
+        host(leading(isSelectionMode: true, isSelectable: false)),
+      );
       await tester.pumpAndSettle();
       expect(find.text('412'), findsOneWidget);
       expect(find.byType(Checkbox), findsNothing);
+    });
+
+    testWidgets('aligns a non-selectable row with its selectable neighbours', (
+      tester,
+    ) async {
+      const selectableChild = ValueKey('selectable_child');
+      const lockedChild = ValueKey('locked_child');
+      await tester.pumpWidget(
+        host(
+          const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SelectionLeading(
+                isSelectionMode: true,
+                isChecked: false,
+                child: SizedBox(key: selectableChild, width: 40, height: 40),
+              ),
+              SelectionLeading(
+                isSelectionMode: true,
+                isChecked: false,
+                isSelectable: false,
+                child: SizedBox(key: lockedChild, width: 40, height: 40),
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        tester.getTopLeft(find.byKey(lockedChild)).dx,
+        tester.getTopLeft(find.byKey(selectableChild)).dx,
+        reason:
+            'a row without a checkbox keeps the checkbox column blank, so '
+            'its leading element lines up with the rows that have one',
+      );
     });
 
     testWidgets('reports a change when tapped', (tester) async {
       bool? reported;
       await tester.pumpWidget(
-        host(isSelectionMode: true, onChanged: (v) => reported = v),
+        host(leading(isSelectionMode: true, onChanged: (v) => reported = v)),
       );
       await tester.pumpAndSettle();
       await tester.tap(find.byType(Checkbox));
@@ -68,13 +157,11 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: SelectionLeading(
-              isSelectionMode: true,
-              isChecked: false,
-              child: Text('412'),
-            ),
+        host(
+          const SelectionLeading(
+            isSelectionMode: true,
+            isChecked: false,
+            child: Text('412'),
           ),
         ),
       );

--- a/test/shared/widgets/card_icon_label_test.dart
+++ b/test/shared/widgets/card_icon_label_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/shared/widgets/card_icon_label.dart';
+
+void main() {
+  Widget host(double width, Widget child) => MaterialApp(
+    home: Scaffold(
+      body: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(width: width, child: child),
+      ),
+    ),
+  );
+
+  group('CardIconLabel', () {
+    testWidgets('renders its icon and label', (tester) async {
+      await tester.pumpWidget(
+        host(300, const CardIconLabel(icon: Icons.access_time, text: 'Today')),
+      );
+
+      expect(find.byIcon(Icons.access_time), findsOneWidget);
+      expect(find.text('Today'), findsOneWidget);
+    });
+
+    testWidgets('tints icon and label with a given color', (tester) async {
+      const tint = Color(0xFF00897B);
+      await tester.pumpWidget(
+        host(
+          300,
+          const CardIconLabel(icon: Icons.timer, text: '7d 0h', color: tint),
+        ),
+      );
+
+      expect(tester.widget<Icon>(find.byIcon(Icons.timer)).color, tint);
+      expect(tester.widget<Text>(find.text('7d 0h')).style?.color, tint);
+    });
+
+    testWidgets('defaults to the secondary text color', (tester) async {
+      await tester.pumpWidget(
+        host(300, const CardIconLabel(icon: Icons.timer, text: '7d 0h')),
+      );
+
+      final scheme = Theme.of(tester.element(find.text('7d 0h'))).colorScheme;
+      expect(
+        tester.widget<Icon>(find.byIcon(Icons.timer)).color,
+        scheme.onSurfaceVariant,
+      );
+    });
+
+    testWidgets('ellipsizes a label wider than its row instead of '
+        'overflowing', (tester) async {
+      await tester.pumpWidget(
+        host(
+          80,
+          const Wrap(
+            children: [
+              CardIconLabel(
+                icon: Icons.access_time,
+                text: 'Last downloaded a very long time ago',
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      final text = tester.widget<Text>(find.byType(Text));
+      expect(text.maxLines, 1);
+      expect(text.overflow, TextOverflow.ellipsis);
+      expect(
+        tester.getSize(find.byType(CardIconLabel)).width,
+        lessThanOrEqualTo(80),
+      );
+    });
+
+    testWidgets('moves to its own line in a Wrap that cannot fit both', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host(
+          120,
+          const Wrap(
+            spacing: 16,
+            children: [
+              CardIconLabel(icon: Icons.scuba_diving, text: '1234 dives'),
+              CardIconLabel(icon: Icons.access_time, text: 'Dec 28, 2025'),
+            ],
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(
+        tester.getTopLeft(find.text('Dec 28, 2025')).dy,
+        greaterThan(tester.getTopLeft(find.text('1234 dives')).dy),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #1717. Entering selection mode on the dive list hid every dive number: the shared `SelectionLeading` widget swapped each row's leading element for the checkbox, and on dive rows that element is the `#N` badge. A diver picking dives for a bulk edit lost the one field they pick by.

The checkbox is now inserted ahead of the leading element instead of replacing it. Because the change is in the shared widget, every list that uses it (dives, sites, buddies, trips, equipment, courses, dive computers, dive centers, certifications, tags, species, service kinds, media transfers) now keeps its leading element visible while selecting.

## Changes

- `SelectionLeading` inserts an animated checkbox column ahead of its child rather than swapping it out. Rows that cannot be selected (built-in species, species with sightings, built-in service kinds) keep a blank column of the same width, width only, so their icons stay aligned with selectable neighbours without growing taller.
- `SelectionCheckboxSlot` now delegates to `SelectionLeading` with an empty child, so both share one checkbox column.
- New `SelectionInset`: card tiles indent their lower lines by a fixed amount to sit under the title. The inset grows by the checkbox column's width over the same slide, so stats, tags and extra fields stay under the title in selection mode instead of drifting 40px left of it. Its width and duration come from `SelectionLeading`, so the two cannot drift apart.
- Detailed and compact dive tiles, site tile and buddy tile: the fixed 40px (36px compact) box used to wrap `SelectionLeading`, which would now overflow; it wraps only the badge or avatar, and the lower lines use `SelectionInset`.
- The detailed dive card's extra-fields row used `EdgeInsets.only(left:)` while its sibling rows used `EdgeInsetsDirectional`; it now matches them (RTL layouts indent from the start side).

Trade-off: in selection mode the row's content shifts 40px along, so long titles ellipsize sooner on narrow phones. Outside selection mode the layout is unchanged.

## Test Plan

- [x] `flutter test` passes (27,411 passed, 21 pre-existing skips)
- [x] `flutter analyze` passes
- [x] New `dive_tile_selection_number_test.dart`: on both dive tiles, the number stays visible checked and unchecked, the checkbox sits ahead of it, the stat line stays under the title in and out of selection mode, and a 353px phone-width row does not overflow
- [x] `SelectionLeading`, `SelectionCheckboxSlot` and `SelectionInset` unit tests, including RTL and non-selectable alignment
- [x] Site and buddy tile tests: avatar stays beside the checkbox; lower lines stay under the title
- [x] Manual testing on: widget renders captured at 353px (the issue's screen width); not yet exercised in the running app

## Screenshots

Rendered at 353px wide, the width in the issue's screenshots:

- Before: in selection mode no `#N` appears on any detailed or compact row; the checkbox occupies the badge's slot.
- After: selection mode shows `[checkbox] #125 Centeen SCUBA park` on both tiles; the badge moves exactly 40px along (x 34.4 to 74.4 on the detailed tile) and the stat line moves with the title.
