### PR TITLE
fix(list): wrap long dive and site card titles instead of truncating

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -967,13 +967,15 @@ class DiveListTile extends ConsumerWidget {
                                   // value (so the date line below doesn't
                                   // shift up) while textHeightBehavior only
                                   // repositions the ink within that space.
+                                  // No ellipsis: a long title wraps, like the
+                                  // trip and equipment cards, so the full
+                                  // name is always visible.
                                   style: titleStyle
                                       ?.copyWith(
                                         fontWeight: FontWeight.w600,
                                         color: primaryTextColor,
                                       )
                                       .inkCentered,
-                                  overflow: TextOverflow.ellipsis,
                                   textHeightBehavior:
                                       inkCenteredTextHeightBehavior,
                                   strutStyle: titleStyle?.preservingStrut,

--- a/lib/features/dive_sites/presentation/widgets/site_list_tile.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_tile.dart
@@ -192,6 +192,9 @@ class _SiteListTileState extends ConsumerState<SiteListTile> {
                     children: [
                       Row(
                         children: [
+                          // No ellipsis: a long title wraps, like the trip
+                          // and equipment cards, so the full name is always
+                          // visible.
                           Expanded(
                             child: Text(
                               title,
@@ -200,8 +203,6 @@ class _SiteListTileState extends ConsumerState<SiteListTile> {
                                     fontWeight: FontWeight.w600,
                                     color: primaryTextColor,
                                   ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
                             ),
                           ),
                           if (site.rating != null) ...[

--- a/test/features/dive_log/presentation/widgets/dive_tile_title_wrap_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_tile_title_wrap_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_list_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// The detailed dive card's title wraps instead of ellipsizing, matching the
+/// trip and equipment cards, so a long site name is always fully visible.
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// The detailed tile reads its slot config through a provider chain that
+/// reaches SharedPreferences, so the config is pinned to the default here.
+class _TestCardConfigNotifier extends CardViewConfigNotifier {
+  _TestCardConfigNotifier() : super.withMode(ListViewMode.detailed);
+}
+
+const _longSiteName =
+    'Centeen SCUBA park and quarry training platform on the north shore';
+
+void main() {
+  testWidgets('wraps a long title onto more lines instead of ellipsizing', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(353, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+          detailedCardConfigProvider.overrideWith(
+            (ref) => _TestCardConfigNotifier(),
+          ),
+        ],
+        child: DiveListTile(
+          diveId: 'd1',
+          diveNumber: 125,
+          dateTime: DateTime(2025, 7, 19, 12, 24),
+          siteName: _longSiteName,
+          siteLocation: 'Ontario, Canada',
+          maxDepth: 10.6,
+          duration: const Duration(minutes: 28),
+          isFavorite: true,
+          onTap: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    final title = tester.renderObject<RenderParagraph>(
+      find.text(_longSiteName),
+    );
+    final lineHeight = title.text.style!.fontSize!;
+    expect(
+      title.didExceedMaxLines,
+      isFalse,
+      reason: 'an ellipsized title hides the rest of the site name',
+    );
+    expect(
+      title.size.height,
+      greaterThan(lineHeight * 2),
+      reason: 'the full name only fits on a narrow card by wrapping',
+    );
+  });
+}

--- a/test/features/dive_sites/presentation/widgets/site_list_tile_test.dart
+++ b/test/features/dive_sites/presentation/widgets/site_list_tile_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
@@ -129,6 +130,43 @@ void main() {
     expect(find.text('Egypt'), findsOneWidget);
     expect(find.text('32m'), findsOneWidget);
     expect(find.text('5-50m'), findsNothing);
+  });
+
+  testWidgets('wraps a long title onto more lines instead of ellipsizing', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(353, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    const longName =
+        'Blue Hole Arch and Canyon drift along the northern reef wall';
+    final entry = SiteWithDiveCount(
+      site: _richEntry.site.copyWith(name: longName),
+      diveCount: _richEntry.diveCount,
+    );
+
+    await tester.pumpWidget(
+      testApp(
+        overrides: await _overrides(),
+        locale: const Locale('en'),
+        child: SiteListTile(entry: entry, onTap: () {}),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    final title = tester.renderObject<RenderParagraph>(find.text(longName));
+    final lineHeight = title.text.style!.fontSize!;
+    expect(
+      title.didExceedMaxLines,
+      isFalse,
+      reason: 'an ellipsized title hides the rest of the site name',
+    );
+    expect(
+      title.size.height,
+      greaterThan(lineHeight * 2),
+      reason: 'the full name only fits on a narrow card by wrapping',
+    );
   });
 
   testWidgets('shows a checkbox in selection mode', (tester) async {


### PR DESCRIPTION
## Summary

On a narrow window, the detailed Dives and Sites cards cut a long title off with an ellipsis, while the Trips and Equipment cards wrapped it onto more lines. This PR makes the Dives and Sites cards wrap too, so the full title is always visible and all four lists behave the same way.

## Changes

- `DiveListTile` (detailed dive card): removed `overflow: TextOverflow.ellipsis` from the title. The title had no `maxLines`, but `TextPainter` still ellipsizes the first overflowing line when `maxLines` is null, so that setting alone kept the title to one line. The forced strut it already uses keeps wrapped lines at the normal titleMedium line height.
- `SiteListTile` (detailed site card): removed `maxLines: 1` and the ellipsis from the title.
- The trailing title-row icons (favorite, rating, shared badge, and so on) stay vertically centered beside the title, the same as the trip card's shared badge.
- Compact and dense list modes are unchanged. All four features truncate the same way in those modes.
- Map-background card variants grow with their content (the map is a `Positioned.fill` behind it), so a taller title cannot overflow.

## Test Plan

- [x] New widget tests: at a 353px phone width, a long dive title and a long site title each lay out on more than one line with `didExceedMaxLines == false`. Both failed before the fix.
- [x] Existing Dive and Site card, list content, and dive_log page tests pass (573 tests)
- [x] `flutter analyze` passes
- [ ] Manual testing on: checked with a throwaway golden render at 380px width (before: both titles ellipsized; after: both wrap onto three lines)
