### PR TITLE
feat(equipment): show hose and SMB length in cm or inches

### DIFF
--- a/lib/core/utils/unit_formatter.dart
+++ b/lib/core/utils/unit_formatter.dart
@@ -351,6 +351,23 @@ class UnitFormatter {
       (feet * 12 + inches) * _cmPerInch;
 
   // ============================================================================
+  // Short length
+  // ============================================================================
+
+  /// Convert a short length stored in meters (a regulator hose, an SMB) to
+  /// the unit it is sold in: centimeters for a metric diver, inches for an
+  /// imperial one. Keyed off the depth unit, like [heightIsMetric] (#1804).
+  double convertShortLength(double meters) =>
+      heightIsMetric ? meters * 100 : meters * 100 / _cmPerInch;
+
+  /// Convert a short length in the diver's unit back to meters for storage.
+  double shortLengthToMeters(double value) =>
+      heightIsMetric ? value / 100 : value * _cmPerInch / 100;
+
+  /// Symbol for [convertShortLength]'s output.
+  String get shortLengthSymbol => heightIsMetric ? 'cm' : 'in';
+
+  // ============================================================================
   // Altitude
   // ============================================================================
 

--- a/lib/features/equipment/domain/constants/equipment_attribute_catalog.dart
+++ b/lib/features/equipment/domain/constants/equipment_attribute_catalog.dart
@@ -38,6 +38,8 @@ enum AttributeGroup {
 ///   displays as m/min or ft/min, the way a DPV's rated speed is quoted.
 /// - [durationH] stores hours and displays as minutes, the way a scooter's
 ///   rated run time is quoted.
+/// - [shortLengthM] stores metres and displays as cm or inches, the way a
+///   hose or an SMB is sold (issue #1804): a 15" hose, not a 1.25 ft one.
 enum AttributeDimension {
   none,
   thicknessMm,
@@ -45,6 +47,7 @@ enum AttributeDimension {
   pressureBar,
   massKg,
   lengthM,
+  shortLengthM,
   depthM,
   speedMps,
   durationH,
@@ -331,12 +334,12 @@ abstract final class EquipmentAttributeCatalog {
     EquipmentType.firstStage: [_connection, _coldWaterRated],
     EquipmentType.secondStage: [_coldWaterRated],
     EquipmentType.hose: [
-      // Stored in metres and shown in the diver's length unit through the
-      // existing lengthM dimension, like an SMB or a reel line.
+      // Stored in metres, shown in cm or inches: hoses are sold as 22" or
+      // 56 cm, never as 1.8 ft or 0.56 m (issue #1804).
       EquipmentAttributeDef(
         key: 'hose_length_m',
         kind: AttributeKind.number,
-        dimension: AttributeDimension.lengthM,
+        dimension: AttributeDimension.shortLengthM,
       ),
     ],
     EquipmentType.bcd: [
@@ -520,10 +523,12 @@ abstract final class EquipmentAttributeCatalog {
         kind: AttributeKind.choice,
         choiceKeys: ['open', 'closed'],
       ),
+      // Shown in cm or inches like a hose (issue #1804). A reel's line below
+      // stays in m / ft: 45 m of line is not read as 4500 cm.
       EquipmentAttributeDef(
         key: 'length_m',
         kind: AttributeKind.number,
-        dimension: AttributeDimension.lengthM,
+        dimension: AttributeDimension.shortLengthM,
       ),
     ],
     EquipmentType.reel: [

--- a/lib/features/equipment/domain/constants/equipment_attribute_catalog.dart
+++ b/lib/features/equipment/domain/constants/equipment_attribute_catalog.dart
@@ -32,8 +32,8 @@ enum AttributeGroup {
 /// Unit dimension for number attributes; drives UnitFormatter conversion.
 /// thicknessMm always displays in mm (industry convention in every market).
 ///
-/// Every dimension stores its canonical metric value, which for all of them
-/// except the two per-time ones is also what a metric diver reads:
+/// Every dimension stores its canonical metric value, which is also what a
+/// metric diver reads for all of them except these three:
 /// - [speedMps] stores m/s (matching wind speed and GPS track speed) and
 ///   displays as m/min or ft/min, the way a DPV's rated speed is quoted.
 /// - [durationH] stores hours and displays as minutes, the way a scooter's

--- a/lib/features/equipment/presentation/utils/equipment_attribute_units.dart
+++ b/lib/features/equipment/presentation/utils/equipment_attribute_units.dart
@@ -81,7 +81,9 @@ String formatAttributeNumberForEditing(
   return formatRoundedForInput(display, 1);
 }
 
-/// Display string for a stored attribute value (detail page, CSV).
+/// Display string for a stored attribute value on the detail page. The
+/// equipment CSV does not use it: that export writes each attribute's raw
+/// canonical metric value, as its `_m` / `_kg` key names promise.
 String formatAttributeValue(
   EquipmentAttribute attr,
   EquipmentAttributeDef? def,

--- a/lib/features/equipment/presentation/utils/equipment_attribute_units.dart
+++ b/lib/features/equipment/presentation/utils/equipment_attribute_units.dart
@@ -6,7 +6,8 @@ import 'package:submersion/features/equipment/presentation/utils/equipment_attri
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 /// Canonical metric -> diver's display units. thicknessMm and none are
-/// identity (mm is the industry convention in every market).
+/// identity (mm is the industry convention in every market); shortLengthM
+/// reads metres as cm or inches.
 double attributeDisplayFromMetric(
   AttributeDimension d,
   UnitFormatter units,
@@ -17,6 +18,7 @@ double attributeDisplayFromMetric(
   AttributeDimension.pressureBar => units.convertPressure(metric),
   AttributeDimension.lengthM ||
   AttributeDimension.depthM => units.convertDepth(metric),
+  AttributeDimension.shortLengthM => units.convertShortLength(metric),
   // Stored in m/s (see AttributeDimension.speedMps), read as distance per
   // minute: m/s -> m/min is x60, then the depth conversion carries it to
   // ft/min for an imperial diver. Same shape as the ascent-rate axis, which
@@ -38,6 +40,7 @@ double attributeMetricFromDisplay(
   AttributeDimension.pressureBar => units.pressureToBar(display),
   AttributeDimension.lengthM ||
   AttributeDimension.depthM => units.depthToMeters(display),
+  AttributeDimension.shortLengthM => units.shortLengthToMeters(display),
   AttributeDimension.speedMps => units.depthToMeters(display) / 60,
   AttributeDimension.durationH => display / 60,
   AttributeDimension.thicknessMm || AttributeDimension.none => display,
@@ -50,6 +53,7 @@ String attributeUnitSymbol(AttributeDimension d, UnitFormatter units) =>
       AttributeDimension.pressureBar => units.pressureSymbol,
       AttributeDimension.lengthM ||
       AttributeDimension.depthM => units.depthSymbol,
+      AttributeDimension.shortLengthM => units.shortLengthSymbol,
       AttributeDimension.speedMps => '${units.depthSymbol}/min',
       AttributeDimension.durationH => 'min',
       AttributeDimension.thicknessMm => 'mm',

--- a/test/core/services/export/equipment_csv_export_test.dart
+++ b/test/core/services/export/equipment_csv_export_test.dart
@@ -47,6 +47,28 @@ void main() {
     expect(lines[1], contains('2.5'));
   });
 
+  test('a hose length exports in canonical metres, as its key says', () {
+    // The app shows a hose in cm or inches (issue #1804), but the CSV is a
+    // raw data export: "hose_length_m=15" would claim metres for an inch
+    // value, so the stored metres go out unconverted.
+    final csv = CsvExportService().generateEquipmentCsvContent([
+      EquipmentItem(
+        id: 'h1',
+        name: 'Long hose',
+        type: EquipmentType.hose,
+        attributes: [
+          EquipmentAttribute.curated(
+            equipmentId: 'h1',
+            key: 'hose_length_m',
+            valueNum: 0.381,
+          ),
+        ],
+      ),
+    ]);
+
+    expect(csv.split('\n')[1], contains('hose_length_m=0.381'));
+  });
+
   test('custom field colliding with a curated key is not dropped', () {
     final csv = CsvExportService().generateEquipmentCsvContent([
       const EquipmentItem(

--- a/test/core/utils/unit_formatter_short_length_test.dart
+++ b/test/core/utils/unit_formatter_short_length_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+void main() {
+  const metric = UnitFormatter(AppSettings(depthUnit: DepthUnit.meters));
+  const imperial = UnitFormatter(AppSettings(depthUnit: DepthUnit.feet));
+
+  group('short length (issue #1804)', () {
+    test('metric reads stored metres as centimetres', () {
+      expect(metric.convertShortLength(0.56), closeTo(56, 1e-9));
+      expect(metric.shortLengthSymbol, 'cm');
+    });
+
+    test('imperial reads stored metres as inches', () {
+      // A 22" hose is 55.88 cm.
+      expect(imperial.convertShortLength(0.5588), closeTo(22, 1e-9));
+      expect(imperial.shortLengthSymbol, 'in');
+    });
+
+    test('display converts back to metres for storage', () {
+      expect(metric.shortLengthToMeters(56), closeTo(0.56, 1e-12));
+      expect(imperial.shortLengthToMeters(15), closeTo(0.381, 1e-12));
+    });
+
+    test('follows the depth unit, like body height', () {
+      expect(metric.heightIsMetric, isTrue);
+      expect(metric.shortLengthSymbol, 'cm');
+      expect(imperial.heightIsMetric, isFalse);
+      expect(imperial.shortLengthSymbol, 'in');
+    });
+  });
+}

--- a/test/features/equipment/domain/equipment_attribute_catalog_test.dart
+++ b/test/features/equipment/domain/equipment_attribute_catalog_test.dart
@@ -96,7 +96,10 @@ void main() {
       'lift_capacity_kg': AttributeDimension.massKg,
       'buoyancy_kg': AttributeDimension.massKg,
       'dry_weight_kg': AttributeDimension.massKg,
-      'length_m': AttributeDimension.lengthM,
+      // Hose and SMB lengths are read in cm / in; a reel's line stays in
+      // m / ft (issue #1804).
+      'hose_length_m': AttributeDimension.shortLengthM,
+      'length_m': AttributeDimension.shortLengthM,
       'line_length_m': AttributeDimension.lengthM,
       'depth_rating_m': AttributeDimension.depthM,
       'thickness_mm': AttributeDimension.thicknessMm,

--- a/test/features/equipment/domain/equipment_type_assembly_parts_test.dart
+++ b/test/features/equipment/domain/equipment_type_assembly_parts_test.dart
@@ -83,6 +83,6 @@ void main() {
     expect(keysFor(EquipmentType.housing), contains('depth_rating_m'));
     expect(keysFor(EquipmentType.strobe), contains('depth_rating_m'));
     final hose = EquipmentAttributeCatalog.defFor('hose_length_m')!;
-    expect(hose.dimension, AttributeDimension.lengthM);
+    expect(hose.dimension, AttributeDimension.shortLengthM);
   });
 }

--- a/test/features/equipment/presentation/equipment_attribute_units_test.dart
+++ b/test/features/equipment/presentation/equipment_attribute_units_test.dart
@@ -69,15 +69,17 @@ void main() {
   group('attributeDisplayFromMetric', () {
     test('metric formatter is identity for every same-unit dimension', () {
       // Every dimension whose canonical storage unit is also its metric
-      // display unit: kg, L, bar, m, mm. speedMps (stored m/s, shown m/min)
-      // and durationH (stored hours, shown minutes) are the deliberate
-      // per-time exceptions and are asserted on their own below.
-      const perTime = {
+      // display unit: kg, L, bar, m, mm. speedMps (stored m/s, shown m/min),
+      // durationH (stored hours, shown minutes) and shortLengthM (stored m,
+      // shown cm) are the deliberate exceptions and are asserted on their
+      // own below.
+      const rescaled = {
         AttributeDimension.speedMps,
         AttributeDimension.durationH,
+        AttributeDimension.shortLengthM,
       };
       for (final d in AttributeDimension.values) {
-        if (perTime.contains(d)) continue;
+        if (rescaled.contains(d)) continue;
         expect(
           attributeDisplayFromMetric(d, units, 10),
           closeTo(10, 1e-9),
@@ -108,6 +110,21 @@ void main() {
       expect(
         attributeDisplayFromMetric(AttributeDimension.durationH, imperial, 1.5),
         closeTo(90, 1e-9),
+      );
+    });
+
+    test('short length converts metres to cm or inches (issue #1804)', () {
+      expect(
+        attributeDisplayFromMetric(AttributeDimension.shortLengthM, units, 1),
+        closeTo(100, 1e-9),
+      );
+      expect(
+        attributeDisplayFromMetric(
+          AttributeDimension.shortLengthM,
+          imperial,
+          0.0254,
+        ),
+        closeTo(1, 1e-9),
       );
     });
 
@@ -172,6 +189,11 @@ void main() {
     expect(attributeUnitSymbol(AttributeDimension.speedMps, units), 'm/min');
     expect(attributeUnitSymbol(AttributeDimension.durationH, imperial), 'min');
     expect(attributeUnitSymbol(AttributeDimension.durationH, units), 'min');
+    expect(
+      attributeUnitSymbol(AttributeDimension.shortLengthM, imperial),
+      'in',
+    );
+    expect(attributeUnitSymbol(AttributeDimension.shortLengthM, units), 'cm');
     expect(attributeUnitSymbol(AttributeDimension.none, imperial), '');
   });
 
@@ -286,6 +308,48 @@ void main() {
         expect(
           formatAttributeValue(attr(num: metricValue), def, imperial, l10n),
           '180.4 ft/min',
+        );
+      });
+    });
+
+    group('hose and SMB length (issue #1804)', () {
+      test('a hose typed in inches reads back in inches, not feet', () {
+        final def = EquipmentAttributeCatalog.defFor('hose_length_m')!;
+        // Hoses are sold by the inch: a 15" hose must not read as 1.3 ft.
+        final stored = attributeMetricFromDisplay(def.dimension, imperial, 15);
+        expect(
+          formatAttributeValue(attr(num: stored), def, imperial, l10n),
+          '15 in',
+        );
+        // Re-seeding the edit field must give back exactly what was typed.
+        expect(
+          formatAttributeNumberForEditing(def.dimension, imperial, stored),
+          '15',
+        );
+      });
+
+      test('a metric diver reads the same hose in centimetres', () {
+        final def = EquipmentAttributeCatalog.defFor('hose_length_m')!;
+        // 22" is 55.88 cm; one decimal place keeps the fraction visible.
+        expect(
+          formatAttributeValue(attr(num: 0.5588), def, units, l10n),
+          '55.9 cm',
+        );
+        expect(
+          formatAttributeValue(attr(num: 0.56), def, units, l10n),
+          '56 cm',
+        );
+      });
+
+      test('an SMB length shares the cm / in display', () {
+        final def = EquipmentAttributeCatalog.defFor('length_m')!;
+        expect(
+          formatAttributeValue(attr(num: 1.4), def, units, l10n),
+          '140 cm',
+        );
+        expect(
+          formatAttributeValue(attr(num: 1.4), def, imperial, l10n),
+          '55.1 in',
         );
       });
     });


### PR DESCRIPTION
## Summary

Closes #1804.

Hoses are sold by the inch (15", 22", 30") or the centimetre, but hose length borrowed the diver's depth unit. A 15" hose had to be entered as 1.25 ft and read back as `1.3 ft`, and a metric diver saw `0.6 m` for a 56 cm hose. Hose length (and SMB length) now read in the unit they are sold in: inches for an imperial diver, centimetres for a metric one.

## Changes

- New `AttributeDimension.shortLengthM`: stored in metres like before, displayed in cm or inches. It follows the diver's depth unit, the same way body height chooses cm or feet/inches.
- `UnitFormatter` gains `convertShortLength`, `shortLengthToMeters` and `shortLengthSymbol`, beside the height helpers that share `_cmPerInch`.
- `hose_length_m` and the SMB's `length_m` move to the new dimension. A reel's `line_length_m` stays in m / ft (45 m of line should not read as 4500 cm).
- The three exhaustive dimension switches in `equipment_attribute_units.dart` gain one arm each. The edit field and detail page route through them.
- The equipment CSV is deliberately unchanged: it writes each attribute's raw canonical metric value (`hose_length_m=0.381`), as its `_m` / `_kg` key names promise, so converting there would put inches under a metres key. A new test pins that. Unit-aware CSV export, with a metric option, is tracked in #1813.
- No migration: stored values keep their keys and remain in metres, so existing hoses and SMBs simply display in the new unit. Sync and UDDF export are unaffected. Labels carry no unit in any locale, so no l10n changes.

| Value stored | Imperial, before | Imperial, after | Metric, before | Metric, after |
| --- | --- | --- | --- | --- |
| 15" hose (0.381 m) | 1.3 ft | 15 in | 0.4 m | 38.1 cm |
| 22" hose (0.5588 m) | 1.8 ft | 22 in | 0.6 m | 55.9 cm |
| 1.4 m SMB | 4.6 ft | 55.1 in | 1.4 m | 140 cm |

## Test Plan

- [x] New tests went red on behaviour before the catalog change (`'15 ft'` vs `'15 in'`, `'0.6 m'` vs `'55.9 cm'`), green after
- [x] A 15 in hose re-seeds the edit field as exactly `15`
- [x] Short-length helpers mutation-tested: breaking the inch factor fails both imperial tests
- [x] `flutter test test/features/equipment/ test/core/utils/unit_formatter_*` passes (1352 tests)
- [x] `flutter analyze` passes
- [x] `dart format .` clean
- [ ] Manual testing on: not run in the app; covered by the formatter and attribute-unit tests


