### PR TITLE
fix(import): stop batch import merging same-name records within one file

### DIFF
--- a/lib/features/universal_import/data/services/payload_merger.dart
+++ b/lib/features/universal_import/data/services/payload_merger.dart
@@ -15,6 +15,17 @@ class FilePayload {
   });
 }
 
+/// A reference record that survived folding, known by the source id of
+/// every record folded into it (issue #1807).
+class _Survivor {
+  _Survivor(this.item, String? sourceId) {
+    if (sourceId != null) sourceIds.add(sourceId);
+  }
+
+  final Map<String, dynamic> item;
+  final Set<String> sourceIds = {};
+}
+
 /// Merges N per-file [ImportPayload]s into one batch payload.
 ///
 /// - Every `uddfId` (and dive-side reference to one) is prefixed with the
@@ -25,6 +36,11 @@ class FilePayload {
 ///   the first occurrence survives, enriched with later files' non-null
 ///   fields, and dive-side references to folded entities are rewritten to
 ///   the survivor's id.
+/// - Records within one file are already distinct by id, so they never fold
+///   into each other; only repeats of one id do (issue #1807). Across files,
+///   a name held by one record on each side folds; when either side holds
+///   several, records pair only by a shared source id and the rest stay
+///   apart rather than merging two namesakes on a guess.
 /// - Dives are NEVER folded; cross-file dive duplicates are left for the
 ///   duplicate checker so the user decides.
 class PayloadMerger {
@@ -95,8 +111,9 @@ class PayloadMerger {
     final warnings = <ImportWarning>[];
     // prefixed folded id -> prefixed survivor id
     final aliases = <String, String>{};
-    // entity type -> fold key -> surviving map (already in `entities`)
-    final survivors = <ImportEntityType, Map<String, Map<String, dynamic>>>{};
+    // entity type -> fold key -> surviving records (already in `entities`),
+    // in first-seen order
+    final survivors = <ImportEntityType, Map<String, List<_Survivor>>>{};
     // Custom dive role definitions by id (issue #1737). Ids are device-minted
     // UUIDs referenced verbatim by dive links, so they are never namespaced,
     // and the same id in two files is the same role.
@@ -120,6 +137,7 @@ class PayloadMerger {
         final items = input.payload.entitiesOf(type);
         if (items.isEmpty) continue;
 
+        final references = <Map<String, dynamic>>[];
         for (final original in items) {
           final item = _namespaced(original, input.fileId, type);
           item['_sourceFile'] = input.fileName;
@@ -141,37 +159,18 @@ class PayloadMerger {
             continue;
           }
 
-          final key = _foldKey(type, item);
-          if (key == null) {
-            (entities[type] ??= []).add(item);
-            continue;
-          }
+          references.add(item);
+        }
 
-          final byKey = survivors[type] ??= {};
-          final survivor = byKey[key];
-          if (survivor == null) {
-            byKey[key] = item;
-            (entities[type] ??= []).add(item);
-          } else {
-            // Enrich the survivor with fields it is missing.
-            for (final entry in item.entries) {
-              if (entry.key == 'uddfId' ||
-                  entry.key == '_sourceFile' ||
-                  entry.key == '_sourceFileId') {
-                continue;
-              }
-              final existing = survivor[entry.key];
-              if (existing == null ||
-                  (existing is String && existing.isEmpty)) {
-                if (entry.value != null) survivor[entry.key] = entry.value;
-              }
-            }
-            final foldedId = item['uddfId'] as String?;
-            final survivorId = survivor['uddfId'] as String?;
-            if (foldedId != null && survivorId != null) {
-              aliases[foldedId] = survivorId;
-            }
-          }
+        if (references.isNotEmpty) {
+          _foldFileReferences(
+            type: type,
+            fileId: input.fileId,
+            items: references,
+            survivors: survivors[type] ??= {},
+            out: entities[type] ??= [],
+            aliases: aliases,
+          );
         }
       }
     }
@@ -265,6 +264,120 @@ class PayloadMerger {
     }
 
     return item;
+  }
+
+  /// Folds one file's reference records of one [type] into the batch.
+  ///
+  /// A named record the file repeats under one id is one record, so the
+  /// repeats fold into its first occurrence. Records with different ids stay
+  /// distinct (issue #1807), and each earlier-file [survivors] entry takes
+  /// at most one of them: by name when the name is held by exactly one
+  /// record on each side, otherwise only by a shared source id. A record
+  /// with no match is added to [out] and, if named, becomes a survivor for
+  /// later files.
+  void _foldFileReferences({
+    required ImportEntityType type,
+    required String fileId,
+    required List<Map<String, dynamic>> items,
+    required Map<String, List<_Survivor>> survivors,
+    required List<Map<String, dynamic>> out,
+    required Map<String, String> aliases,
+  }) {
+    final records = <({Map<String, dynamic> item, String? key})>[];
+    final firstById = <String, Map<String, dynamic>>{};
+    for (final item in items) {
+      final key = _foldKey(type, item);
+      final id = _recordId(type, item);
+      if (key != null && id != null) {
+        final first = firstById[id];
+        if (first != null) {
+          _enrich(first, item);
+          continue;
+        }
+        firstById[id] = item;
+      }
+      records.add((item: item, key: key));
+    }
+
+    final byKey = <String, List<Map<String, dynamic>>>{};
+    for (final (:item, :key) in records) {
+      if (key != null) (byKey[key] ??= []).add(item);
+    }
+
+    final matches = Map<Map<String, dynamic>, _Survivor>.identity();
+    for (final MapEntry(:key, value: group) in byKey.entries) {
+      final candidates = [...?survivors[key]];
+      if (group.length == 1 && candidates.length == 1) {
+        matches[group.single] = candidates.single;
+        continue;
+      }
+      for (final item in group) {
+        final sourceId = _sourceId(type, item, fileId);
+        if (sourceId == null) continue;
+        final index = candidates.indexWhere(
+          (s) => s.sourceIds.contains(sourceId),
+        );
+        if (index >= 0) matches[item] = candidates.removeAt(index);
+      }
+    }
+
+    for (final (:item, :key) in records) {
+      final sourceId = _sourceId(type, item, fileId);
+      final survivor = matches[item];
+      if (survivor == null) {
+        out.add(item);
+        if (key != null) (survivors[key] ??= []).add(_Survivor(item, sourceId));
+        continue;
+      }
+      _enrich(survivor.item, item);
+      if (sourceId != null) survivor.sourceIds.add(sourceId);
+      final foldedId = item['uddfId'];
+      final survivorId = survivor.item['uddfId'];
+      if (foldedId is String && survivorId is String) {
+        aliases[foldedId] = survivorId;
+      }
+    }
+  }
+
+  /// Fills [survivor]'s missing or empty fields from [item], leaving its
+  /// identity and file attribution alone.
+  static void _enrich(
+    Map<String, dynamic> survivor,
+    Map<String, dynamic> item,
+  ) {
+    for (final entry in item.entries) {
+      if (entry.key == 'uddfId' ||
+          entry.key == '_sourceFile' ||
+          entry.key == '_sourceFileId') {
+        continue;
+      }
+      final existing = survivor[entry.key];
+      if (existing == null || (existing is String && existing.isEmpty)) {
+        if (entry.value != null) survivor[entry.key] = entry.value;
+      }
+    }
+  }
+
+  /// [item]'s id within the batch. Dive types without a `uddfId` are
+  /// identified by the slug in `id`, which is shared across files.
+  static String? _recordId(ImportEntityType type, Map<String, dynamic> item) {
+    final id =
+        item['uddfId'] ??
+        (type == ImportEntityType.diveTypes ? item['id'] : null);
+    return id is String && id.isNotEmpty ? id : null;
+  }
+
+  /// [item]'s id as its source file wrote it, without the batch prefix.
+  /// Dive types are never prefixed, so theirs comes back unchanged.
+  static String? _sourceId(
+    ImportEntityType type,
+    Map<String, dynamic> item,
+    String fileId,
+  ) {
+    final id = _recordId(type, item);
+    if (id == null) return null;
+    final prefix = '$fileId:';
+    return id.startsWith(prefix) ? id.substring(prefix.length) : id;
   }
 
   /// Cross-file fold key for reference entities; null means "never fold".

--- a/lib/features/universal_import/data/services/payload_merger.dart
+++ b/lib/features/universal_import/data/services/payload_merger.dart
@@ -268,8 +268,8 @@ class PayloadMerger {
 
   /// Folds one file's reference records of one [type] into the batch.
   ///
-  /// A named record the file repeats under one id is one record, so the
-  /// repeats fold into its first occurrence. Records with different ids stay
+  /// A record the file repeats under one id is one record, so the repeats
+  /// fold into its first occurrence, named or not. Records with different ids stay
   /// distinct (issue #1807), and each earlier-file [survivors] entry takes
   /// at most one of them: by name when the name is held by exactly one
   /// record on each side, otherwise only by a shared source id. A record
@@ -283,12 +283,11 @@ class PayloadMerger {
     required List<Map<String, dynamic>> out,
     required Map<String, String> aliases,
   }) {
-    final records = <({Map<String, dynamic> item, String? key})>[];
+    final distinct = <Map<String, dynamic>>[];
     final firstById = <String, Map<String, dynamic>>{};
     for (final item in items) {
-      final key = _foldKey(type, item);
       final id = _recordId(type, item);
-      if (key != null && id != null) {
+      if (id != null) {
         final first = firstById[id];
         if (first != null) {
           _enrich(first, item);
@@ -296,8 +295,13 @@ class PayloadMerger {
         }
         firstById[id] = item;
       }
-      records.add((item: item, key: key));
+      distinct.add(item);
     }
+    // Keyed only once repeats are merged, so a name that only a repeat
+    // carries still counts.
+    final records = [
+      for (final item in distinct) (item: item, key: _foldKey(type, item)),
+    ];
 
     final byKey = <String, List<Map<String, dynamic>>>{};
     for (final (:item, :key) in records) {
@@ -358,12 +362,12 @@ class PayloadMerger {
     }
   }
 
-  /// [item]'s id within the batch. Dive types without a `uddfId` are
-  /// identified by the slug in `id`, which is shared across files.
+  /// [item]'s id within the batch. A dive type is identified by the slug in
+  /// `id`, which is shared across files and is what the importer creates it
+  /// under; `uddfId` stands in only when the slug is missing.
   static String? _recordId(ImportEntityType type, Map<String, dynamic> item) {
-    final id =
-        item['uddfId'] ??
-        (type == ImportEntityType.diveTypes ? item['id'] : null);
+    final slug = type == ImportEntityType.diveTypes ? item['id'] : null;
+    final id = slug is String && slug.isNotEmpty ? slug : item['uddfId'];
     return id is String && id.isNotEmpty ? id : null;
   }
 

--- a/test/features/universal_import/data/services/payload_merger_test.dart
+++ b/test/features/universal_import/data/services/payload_merger_test.dart
@@ -544,6 +544,54 @@ void main() {
       expect((dive['site'] as Map<String, dynamic>)['uddfId'], 'f0:s0');
     });
 
+    test('a repeated id is one record even when only a repeat is named', () {
+      final a = payloadWith(
+        sites: [
+          {'uddfId': 's0', 'name': 'Blue Hole'},
+        ],
+      );
+      final b = payloadWith(
+        sites: [
+          {'uddfId': 's1'},
+          {'uddfId': 's1', 'name': 'Blue Hole'},
+        ],
+        dives: [
+          {
+            'dateTime': DateTime(2026, 2, 1, 9),
+            'site': {'uddfId': 's1'},
+          },
+        ],
+      );
+
+      final merged = merger.merge([
+        FilePayload(fileId: 'f0', fileName: 'a.uddf', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.uddf', payload: b),
+      ]);
+
+      // The name arrives on the repeat, and still folds the one record.
+      expect(idsOf(merged, ImportEntityType.sites), ['f0:s0']);
+      final dive = merged.entitiesOf(ImportEntityType.dives).single;
+      expect((dive['site'] as Map<String, dynamic>)['uddfId'], 'f0:s0');
+    });
+
+    test('a dive type is identified by its slug over any uddfId', () {
+      const a = ImportPayload(
+        entities: {
+          ImportEntityType.diveTypes: [
+            {'id': 'wreck', 'uddfId': 'w1', 'name': 'Wreck'},
+            {'id': 'wreck', 'uddfId': 'w2', 'name': 'Wreck'},
+          ],
+        },
+      );
+
+      final merged = merger.merge([
+        const FilePayload(fileId: 'f0', fileName: 'a.uddf', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.fit', payload: unrelated),
+      ]);
+
+      expect(merged.entitiesOf(ImportEntityType.diveTypes), hasLength(1));
+    });
+
     test('folds dive types sharing a slug, which is their id', () {
       const a = ImportPayload(
         entities: {

--- a/test/features/universal_import/data/services/payload_merger_test.dart
+++ b/test/features/universal_import/data/services/payload_merger_test.dart
@@ -407,6 +407,313 @@ void main() {
     });
   });
 
+  group('same-name records within one file (issue #1807)', () {
+    // A file that holds nothing foldable, so the batch path runs without
+    // giving the namesakes anything to fold into.
+    final unrelated = payloadWith(
+      dives: [
+        {'dateTime': DateTime(2026, 3, 1, 9)},
+      ],
+    );
+
+    List<Object?> idsOf(ImportPayload merged, ImportEntityType type) => [
+      for (final e in merged.entitiesOf(type)) e['uddfId'],
+    ];
+
+    test('keeps two people with the same name apart, with their roles', () {
+      final a = payloadWith(
+        buddies: [
+          {'uddfId': 'b1', 'name': 'Chris Diver'},
+          {'uddfId': 'b2', 'name': 'Chris Diver'},
+        ],
+        dives: [
+          {
+            'dateTime': DateTime(2026, 1, 1, 9),
+            'buddyRefs': ['b1'],
+            'diveGuideRefs': ['b2'],
+            'buddyRoleRefs': [
+              {'buddyRef': 'b1', 'roleId': 'buddy'},
+              {'buddyRef': 'b2', 'roleId': 'diveGuide'},
+            ],
+          },
+        ],
+      );
+
+      final merged = merger.merge([
+        FilePayload(fileId: 'f0', fileName: 'a.uddf', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.fit', payload: unrelated),
+      ]);
+
+      expect(idsOf(merged, ImportEntityType.buddies), ['f0:b1', 'f0:b2']);
+      final dive = merged.entitiesOf(ImportEntityType.dives).first;
+      expect(dive['buddyRefs'], ['f0:b1']);
+      expect(dive['diveGuideRefs'], ['f0:b2']);
+      expect(dive['buddyRoleRefs'], [
+        {'buddyRef': 'f0:b1', 'roleId': 'buddy'},
+        {'buddyRef': 'f0:b2', 'roleId': 'diveGuide'},
+      ]);
+    });
+
+    test('keeps same-name records apart for every name-folded type', () {
+      List<Map<String, dynamic>> pair(
+        String prefix, [
+        Map<String, dynamic> extra = const {},
+      ]) => [
+        {'uddfId': '${prefix}1', 'name': 'Same', ...extra},
+        {'uddfId': '${prefix}2', 'name': 'Same', ...extra},
+      ];
+
+      final a = ImportPayload(
+        entities: {
+          ImportEntityType.sites: pair('s'),
+          ImportEntityType.trips: pair('t'),
+          ImportEntityType.diveCenters: pair('d'),
+          ImportEntityType.tags: pair('g'),
+          ImportEntityType.courses: pair('k'),
+          ImportEntityType.equipmentSets: pair('q'),
+          ImportEntityType.equipment: pair('e', {'type': 'computer'}),
+          ImportEntityType.certifications: pair('c', {'agency': 'PADI'}),
+        },
+      );
+
+      final merged = merger.merge([
+        FilePayload(fileId: 'f0', fileName: 'a.uddf', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.fit', payload: unrelated),
+      ]);
+
+      for (final type in a.entities.keys) {
+        expect(merged.entitiesOf(type), hasLength(2), reason: type.name);
+      }
+    });
+
+    test('folds repeats of one id, which are the same record', () {
+      // MacDive keys sites by name, so two same-name rows share an id.
+      final a = payloadWith(
+        sites: [
+          {'uddfId': 'Blue Hole', 'name': 'Blue Hole'},
+          {'uddfId': 'Blue Hole', 'name': 'Blue Hole', 'latitude': 12.2},
+        ],
+        dives: [
+          {
+            'dateTime': DateTime(2026, 1, 1, 9),
+            'site': {'uddfId': 'Blue Hole', 'name': 'Blue Hole'},
+          },
+        ],
+      );
+
+      final merged = merger.merge([
+        FilePayload(fileId: 'f0', fileName: 'a.sqlite', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.fit', payload: unrelated),
+      ]);
+
+      final sites = merged.entitiesOf(ImportEntityType.sites);
+      expect(sites, hasLength(1));
+      expect(sites.single['uddfId'], 'f0:Blue Hole');
+      expect(sites.single['latitude'], 12.2);
+    });
+
+    test('a repeated id folds with its record into an earlier file', () {
+      final a = payloadWith(
+        sites: [
+          {'uddfId': 's0', 'name': 'Blue Hole'},
+        ],
+      );
+      final b = payloadWith(
+        sites: [
+          {'uddfId': 'Blue Hole', 'name': 'Blue Hole'},
+          {'uddfId': 'Blue Hole', 'name': 'Blue Hole', 'latitude': 12.2},
+        ],
+        dives: [
+          {
+            'dateTime': DateTime(2026, 2, 1, 9),
+            'site': {'uddfId': 'Blue Hole', 'name': 'Blue Hole'},
+          },
+        ],
+      );
+
+      final merged = merger.merge([
+        FilePayload(fileId: 'f0', fileName: 'a.uddf', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.sqlite', payload: b),
+      ]);
+
+      final sites = merged.entitiesOf(ImportEntityType.sites);
+      expect(sites, hasLength(1));
+      expect(sites.single['uddfId'], 'f0:s0');
+      expect(sites.single['latitude'], 12.2);
+      final dive = merged.entitiesOf(ImportEntityType.dives).single;
+      expect((dive['site'] as Map<String, dynamic>)['uddfId'], 'f0:s0');
+    });
+
+    test('folds dive types sharing a slug, which is their id', () {
+      const a = ImportPayload(
+        entities: {
+          ImportEntityType.diveTypes: [
+            {'id': 'wreck', 'name': 'Wreck'},
+            {'id': 'wreck', 'name': 'Wreck', 'sortOrder': 7},
+          ],
+        },
+      );
+
+      final merged = merger.merge([
+        const FilePayload(fileId: 'f0', fileName: 'a.uddf', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.fit', payload: unrelated),
+      ]);
+
+      final types = merged.entitiesOf(ImportEntityType.diveTypes);
+      expect(types, hasLength(1));
+      expect(types.single['sortOrder'], 7);
+    });
+
+    test('pairs namesakes in two files by their source id', () {
+      // Two backups of one logbook: the same pair of namesakes, listed in
+      // a different order.
+      final a = payloadWith(
+        buddies: [
+          {'uddfId': 'b1', 'name': 'Chris Diver'},
+          {'uddfId': 'b2', 'name': 'Chris Diver'},
+        ],
+      );
+      final b = payloadWith(
+        buddies: [
+          {'uddfId': 'b2', 'name': 'Chris Diver'},
+          {'uddfId': 'b1', 'name': 'Chris Diver'},
+        ],
+        dives: [
+          {
+            'dateTime': DateTime(2026, 2, 1, 9),
+            'buddyRefs': ['b1'],
+            'diveGuideRefs': ['b2'],
+          },
+        ],
+      );
+
+      final merged = merger.merge([
+        FilePayload(fileId: 'f0', fileName: 'a.uddf', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.uddf', payload: b),
+      ]);
+
+      expect(idsOf(merged, ImportEntityType.buddies), ['f0:b1', 'f0:b2']);
+      final dive = merged.entitiesOf(ImportEntityType.dives).single;
+      expect(dive['buddyRefs'], ['f0:b1']);
+      expect(dive['diveGuideRefs'], ['f0:b2']);
+    });
+
+    test('keeps a later record apart when earlier namesakes are ambiguous', () {
+      final a = payloadWith(
+        buddies: [
+          {'uddfId': 'b1', 'name': 'Chris Diver'},
+          {'uddfId': 'b2', 'name': 'Chris Diver'},
+        ],
+      );
+      final b = payloadWith(
+        buddies: [
+          {'uddfId': 'x9', 'name': 'Chris Diver'},
+        ],
+        dives: [
+          {
+            'dateTime': DateTime(2026, 2, 1, 9),
+            'buddyRefs': ['x9'],
+          },
+        ],
+      );
+
+      final merged = merger.merge([
+        FilePayload(fileId: 'f0', fileName: 'a.uddf', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.uddf', payload: b),
+      ]);
+
+      expect(idsOf(merged, ImportEntityType.buddies), [
+        'f0:b1',
+        'f0:b2',
+        'f1:x9',
+      ]);
+      final dive = merged.entitiesOf(ImportEntityType.dives).single;
+      expect(dive['buddyRefs'], ['f1:x9']);
+    });
+
+    test('keeps later namesakes apart unless one shares the source id', () {
+      final a = payloadWith(
+        buddies: [
+          {'uddfId': 'b1', 'name': 'Chris Diver'},
+        ],
+      );
+      ImportPayload later(String first) => payloadWith(
+        buddies: [
+          {'uddfId': first, 'name': 'Chris Diver'},
+          {'uddfId': 'c2', 'name': 'Chris Diver'},
+        ],
+      );
+
+      final noMatch = merger.merge([
+        FilePayload(fileId: 'f0', fileName: 'a.uddf', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.uddf', payload: later('c1')),
+      ]);
+      expect(idsOf(noMatch, ImportEntityType.buddies), [
+        'f0:b1',
+        'f1:c1',
+        'f1:c2',
+      ]);
+
+      final idMatch = merger.merge([
+        FilePayload(fileId: 'f0', fileName: 'a.uddf', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.uddf', payload: later('b1')),
+      ]);
+      expect(idsOf(idMatch, ImportEntityType.buddies), ['f0:b1', 'f1:c2']);
+    });
+
+    test('keeps a leftover namesake apart after a partial id match', () {
+      final a = payloadWith(
+        buddies: [
+          {'uddfId': 'b1', 'name': 'Chris Diver'},
+          {'uddfId': 'b2', 'name': 'Chris Diver'},
+        ],
+      );
+      final b = payloadWith(
+        buddies: [
+          {'uddfId': 'b1', 'name': 'Chris Diver'},
+          {'uddfId': 'x9', 'name': 'Chris Diver'},
+        ],
+      );
+
+      final merged = merger.merge([
+        FilePayload(fileId: 'f0', fileName: 'a.uddf', payload: a),
+        FilePayload(fileId: 'f1', fileName: 'b.uddf', payload: b),
+      ]);
+
+      // b1 pairs by id. x9 and f0:b2 are then the only records left on
+      // each side, but after an ambiguous start that is no evidence they
+      // are the same person, so x9 stays its own record.
+      expect(idsOf(merged, ImportEntityType.buddies), [
+        'f0:b1',
+        'f0:b2',
+        'f1:x9',
+      ]);
+    });
+
+    test('a fold carries its source ids forward to later files', () {
+      ImportPayload chrises(List<String> ids) => payloadWith(
+        buddies: [
+          for (final id in ids) {'uddfId': id, 'name': 'Chris Diver'},
+        ],
+        dives: [
+          {'dateTime': DateTime(2026, 2, 1, 9), 'buddyRefs': ids},
+        ],
+      );
+
+      final merged = merger.merge([
+        FilePayload(fileId: 'f0', fileName: 'a', payload: chrises(['x'])),
+        // One on each side: y folds into f0:x as today.
+        FilePayload(fileId: 'f1', fileName: 'b', payload: chrises(['y'])),
+        // y is known as f0:x now, so it pairs there; z stays apart.
+        FilePayload(fileId: 'f2', fileName: 'c', payload: chrises(['y', 'z'])),
+      ]);
+
+      expect(idsOf(merged, ImportEntityType.buddies), ['f0:x', 'f2:z']);
+      final dives = merged.entitiesOf(ImportEntityType.dives);
+      expect(dives[2]['buddyRefs'], ['f0:x', 'f2:z']);
+    });
+  });
+
   group('media', () {
     ImportPayload mediaPayload({
       required int diveCount,


### PR DESCRIPTION
## Summary

Closes #1807.

In a multi-file batch, `PayloadMerger` folded reference entities by normalized name across the whole batch, including records within a single file. Two different people named "Chris Diver" in one UDDF backup became one person, and every buddy, guide and exact-role link to either was rewritten to the survivor. The same file imported on its own kept them apart, because the single-file path never runs the merger. Trips, sites, dive centers, courses, tags, equipment, equipment sets and certifications had the same problem.

Folding is still how the same entity arriving from different files gets merged. It now respects which file a record came from.

## Changes

- **Within one file:** records with different ids never fold into each other. Repeats of one id are one record and still fold. This matters for MacDive SQLite, which uses the name as the id for sites, buddies and tags. Dive types are identified by their slug.
- **Across files, unambiguous:** a name held by exactly one record in the incoming file and one earlier record folds as before.
- **Across files, ambiguous:** when either side holds several records with a name, they pair only by a shared source id. Submersion's own backups write `buddy_<uuid>`, so two backups of one logbook pair the same person exactly. A survivor remembers every source id folded into it, so the identity carries forward to later files. Anything left unpaired is imported as its own record rather than merged on a guess, and each earlier record takes at most one record per file.
- The fold logic moved into `_foldFileReferences`, with `_enrich`, `_recordId` and `_sourceId` extracted as helpers. Namespacing and alias rewriting are unchanged.

### Known trade-off

A 1:1 name fold is never revisited. Say file 1 has "Chris" (id `a`) and file 2 has "Chris" (id `b`): they fold on name. If file 3 then lists `a` and `b` as two separate people, the earlier record can take only one of them, so `b` becomes a second record. File 2's dives stay on the first. This follows from pairing only on evidence. The duplicate checker still offers every new record against existing data, as it does for single-file imports.

## Test Plan

- [x] `flutter test test/features/universal_import` passes (1837 tests)
- [x] `flutter analyze` passes
- [x] New `payload_merger_test.dart` group covers:
  - same-name people kept apart with their buddy, guide and role links
  - every name-folded type kept apart
  - repeated ids folding, including into an earlier file
  - dive types sharing a slug
  - pairing by source id in reverse order
  - ambiguous leftovers kept apart
  - source ids carried forward across three files
- [x] Mutation check: disabling the same-id fold fails the MacDive guard test
- [ ] Manual testing on: not run; the change is confined to the merger, which the tests exercise directly
