### PR TITLE
fix(uddf): define a dive's custom diver role in the dives-only export

### DIFF
--- a/lib/core/services/export/uddf/uddf_dives_extras.dart
+++ b/lib/core/services/export/uddf/uddf_dives_extras.dart
@@ -4,14 +4,18 @@ import 'package:submersion/core/services/export/models/uddf_export_options.dart'
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
+import 'package:submersion/features/dive_roles/data/repositories/dive_role_repository.dart';
+import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
+import 'package:submersion/features/dive_roles/presentation/providers/dive_role_providers.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_component_repository.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_component.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_component_providers.dart';
 
 /// What a dives only UDDF export needs beyond the dives themselves.
 ///
-/// The dives already carry their gear; participants and assembly rows are
-/// not hydrated on them, so they travel here.
+/// The dives already carry their gear; participants, assembly rows and role
+/// definitions are not hydrated on them, so they travel here.
 class UddfDivesExtras {
   /// Each exported dive's participants with their roles, by dive id.
   final Map<String, List<BuddyWithRole>> diveBuddies;
@@ -20,9 +24,16 @@ class UddfDivesExtras {
   /// filters them again against the items it declares.
   final List<EquipmentComponent> components;
 
+  /// The exporting diver's own roles, built-ins included. The export
+  /// declares a custom role only when this list holds it, so a role
+  /// resolved as synthetic (an id with no row, or another diver's role) is
+  /// never written out as a definition.
+  final List<DiveRole> diveRoles;
+
   const UddfDivesExtras({
     this.diveBuddies = const {},
     this.components = const [],
+    this.diveRoles = const [],
   });
 
   const UddfDivesExtras.empty() : this();
@@ -41,9 +52,12 @@ typedef UddfDivesExtrasFetch =
 /// actions live in widgets whose tests have no database, and overriding
 /// this is how such a test opts out.
 final uddfDivesExtrasFetchProvider = Provider<UddfDivesExtrasFetch>((ref) {
-  return (diveIds, options) => resolveDivesExtras(
+  return (diveIds, options) async => resolveDivesExtras(
     ref.read(buddyRepositoryProvider),
     ref.read(equipmentComponentRepositoryProvider),
+    ref.read(diveRoleRepositoryProvider),
+    // The same diver `allDiveRolesProvider` scopes the role list to.
+    await ref.read(validatedCurrentDiverIdProvider.future),
     diveIds,
     options,
   );
@@ -52,9 +66,15 @@ final uddfDivesExtrasFetchProvider = Provider<UddfDivesExtrasFetch>((ref) {
 /// Loads the extras for [diveIds], skipping any query whose checkbox in
 /// [options] is off: a share without participants or gear must not pay for
 /// reads it will not use.
+///
+/// [diverId]'s roles are read whatever the checkboxes: every dive writes
+/// its diver's own role, which is not a participant, so leaving
+/// participants out must not leave a custom one undefined.
 Future<UddfDivesExtras> resolveDivesExtras(
   BuddyRepository buddies,
   EquipmentComponentRepository components,
+  DiveRoleRepository roles,
+  String? diverId,
   List<String> diveIds,
   UddfExportOptions options,
 ) async => UddfDivesExtras(
@@ -66,4 +86,5 @@ Future<UddfDivesExtras> resolveDivesExtras(
   components: options.includeGear
       ? await components.getComponentsForDives(diveIds)
       : const [],
+  diveRoles: await roles.getAllDiveRoles(diverId: diverId),
 );

--- a/lib/core/services/export/uddf/uddf_export_service.dart
+++ b/lib/core/services/export/uddf/uddf_export_service.dart
@@ -60,12 +60,22 @@ class UddfExportService {
       for (final rows in diveBuddies.values)
         for (final row in rows) row.buddy.id: row.buddy,
     }.values.toList(growable: false);
-    // A <buddyroles> row naming a custom role is dropped on import unless
-    // the file also defines that role.
+    // A <buddyroles> row or a dive's <diverrole> naming a custom role is
+    // dropped on import unless the file also defines that role. Only the
+    // diver's own roles are defined: a synthetic role (an id with no row, or
+    // another diver's role) has nothing but its raw id for a name. The
+    // diver's own role is not a participant, so, like <diverrole> itself, it
+    // is defined whether or not participants are included.
+    final ownRoles = {for (final role in extras.diveRoles) role.id: role};
     final customRoles = <String, DiveRole>{
-      for (final rows in diveBuddies.values)
-        for (final row in rows)
-          if (!DiveRole.builtInIds.contains(row.role.id)) row.role.id: row.role,
+      for (final id in [
+        for (final rows in diveBuddies.values)
+          for (final row in rows) row.role.id,
+        for (final dive in dives) ?dive.diverRoleId,
+      ])
+        if (ownRoles[id] case final role?
+            when !DiveRole.builtInIds.contains(id))
+          id: role,
     }.values.toList(growable: false);
 
     // Gear (issue #1718): each distinct item on the exported dives, the

--- a/test/core/services/export/uddf/uddf_diver_role_round_trip_test.dart
+++ b/test/core/services/export/uddf/uddf_diver_role_round_trip_test.dart
@@ -3,8 +3,10 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/export/export_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_dives_extras.dart';
 import 'package:submersion/core/services/export/uddf/uddf_export_service.dart';
 import 'package:submersion/core/services/export/uddf/uddf_full_export_service.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 import 'package:submersion/features/dive_import/data/services/uddf_entity_importer.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
@@ -13,6 +15,7 @@ import 'package:submersion/features/dive_roles/data/repositories/dive_role_repos
 import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
 import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_component_repository.dart';
 import 'package:submersion/features/universal_import/data/models/import_enums.dart';
 import 'package:submersion/features/universal_import/data/models/import_payload.dart';
 import 'package:submersion/features/universal_import/data/parsers/uddf_import_parser.dart';
@@ -142,8 +145,9 @@ void main() {
   test(
     'a custom role the diver already has is kept without its definition',
     () async {
-      // A dives-only file declares no <diveroles>, yet may name a custom role
-      // this diver already holds; the database, not the file, vouches for it.
+      // A file may declare no <diveroles> (a dives-only export from before
+      // it wrote them), yet name a custom role this diver already holds; the
+      // database, not the file, vouches for it.
       final diverId = await createTestDiver();
       final custom = await DiveRoleRepository().createDiveRole(
         name: 'Photographer',
@@ -225,5 +229,116 @@ void main() {
     ))['dives']!.single;
 
     expect(dive['diverRoleId'], DiveRole.diveGuideId);
+  });
+
+  test(
+    'a custom diver role survives a dives-only export with no buddies',
+    () async {
+      // No participant holds the role, so only the dive itself can bring
+      // its definition along; without it a new device drops the role.
+      final diverId = await createTestDiver();
+      final custom = await DiveRoleRepository().createDiveRole(
+        name: 'Photographer',
+        diverId: diverId,
+      );
+      final dives = DiveRepository();
+      await dives.createDive(
+        domain.Dive(
+          id: 'd1',
+          diverId: diverId,
+          dateTime: DateTime(2026, 3, 1, 9),
+          diverRoleId: custom.id,
+        ),
+      );
+
+      final xml = await UddfExportService().generateDivesUddfContent(
+        await dives.getAllDives(),
+        extras: await resolveDivesExtras(
+          BuddyRepository(),
+          EquipmentComponentRepository(),
+          DiveRoleRepository(),
+          diverId,
+          ['d1'],
+          const UddfExportOptions(),
+        ),
+      );
+
+      await tearDownTestDatabase();
+      await setUpTestDatabase();
+      await restoreThroughWizard(xml);
+
+      expect(await diverRoles(), [custom.id]);
+      final restored = await DiveRoleRepository().getAllDiveRoles(
+        diverId: diverId,
+      );
+      expect(restored.where((r) => r.id == custom.id).map((r) => r.name), [
+        'Photographer',
+      ], reason: 'the role is restored into the importing diver\'s own list');
+    },
+  );
+
+  test(
+    'a dives-only export defines the diver role without participants',
+    () async {
+      // The diver's own role is not a participant: leaving participants out
+      // still writes <diverrole>, so it must still write the definition.
+      final epoch = DateTime(2024, 1, 1);
+      final photographer = DiveRole(
+        id: 'role-photo',
+        diverId: 'diver-1',
+        name: 'Photographer',
+        sortOrder: 12,
+        createdAt: epoch,
+        updatedAt: epoch,
+      );
+
+      final xml = await UddfExportService().generateDivesUddfContent(
+        [
+          domain.Dive(
+            id: 'd1',
+            dateTime: DateTime(2026, 3, 1, 9),
+            diverRoleId: photographer.id,
+          ),
+          domain.Dive(
+            id: 'd2',
+            dateTime: DateTime(2026, 3, 1, 14),
+            diverRoleId: photographer.id,
+          ),
+        ],
+        extras: UddfDivesExtras(
+          diveRoles: [DiveRole.builtInBuddy(), photographer],
+        ),
+        options: const UddfExportOptions(includeParticipants: false),
+      );
+
+      final parsed = await ExportService().importAllDataFromUddf(xml);
+
+      expect(parsed.customDiveRoles, [
+        {
+          'id': 'role-photo',
+          'name': 'Photographer',
+          'sortOrder': 12,
+          'isBuiltIn': false,
+        },
+      ]);
+    },
+  );
+
+  test('a dives-only export defines no role the diver does not own', () async {
+    // A role outside the diver's own list (another diver's, or an id with
+    // no row) would be written under a name the exporter cannot vouch
+    // for; the importer already drops such a role on its own.
+    final xml = await UddfExportService().generateDivesUddfContent([
+      domain.Dive(
+        id: 'd1',
+        dateTime: DateTime(2026, 3, 1, 9),
+        diverRoleId: 'role-foreign',
+      ),
+    ], extras: UddfDivesExtras(diveRoles: [DiveRole.builtInBuddy()]));
+
+    final parsed = await ExportService().importAllDataFromUddf(xml);
+
+    expect(parsed.dives.single['diverRoleId'], 'role-foreign');
+    expect(parsed.customDiveRoles, isEmpty);
   });
 }

--- a/test/core/services/export/uddf/uddf_dives_export_participants_test.dart
+++ b/test/core/services/export/uddf/uddf_dives_export_participants_test.dart
@@ -69,6 +69,7 @@ final _extras = UddfDivesExtras(
       BuddyWithRole(buddy: _stranger, role: _builtIn(DiveRole.buddyId)),
     ],
   },
+  diveRoles: [_builtIn(DiveRole.buddyId), _photographer],
 );
 
 Future<XmlDocument> _export({
@@ -170,6 +171,39 @@ void main() {
       ]);
     },
   );
+
+  test('links a synthetic role but never defines it', () async {
+    // A link to an id with no row, or to another diver's role, resolves as
+    // DiveRole.synthetic, whose name is only the raw id: declaring it would
+    // give the importing diver a role named after a UUID.
+    final doc = XmlDocument.parse(
+      await UddfExportService().generateDivesUddfContent(
+        [_d1],
+        extras: UddfDivesExtras(
+          diveBuddies: {
+            'd1': [
+              BuddyWithRole(
+                buddy: _photo,
+                role: DiveRole.synthetic('role-foreign'),
+              ),
+            ],
+          },
+          diveRoles: [_builtIn(DiveRole.buddyId), _photographer],
+        ),
+      ),
+    );
+
+    expect(
+      doc
+          .findAllElements('buddyroles')
+          .single
+          .findAllElements('buddy')
+          .single
+          .getAttribute('role'),
+      'role-foreign',
+    );
+    expect(doc.findAllElements('diveroles'), isEmpty);
+  });
 
   test(
     'leaving participants out writes none of it, legacy text included',

--- a/test/core/services/export/uddf/uddf_dives_export_round_trip_test.dart
+++ b/test/core/services/export/uddf/uddf_dives_export_round_trip_test.dart
@@ -125,6 +125,8 @@ void main() {
       extras: await resolveDivesExtras(
         buddies,
         EquipmentComponentRepository(),
+        DiveRoleRepository(),
+        diverId,
         ['d1'],
         options,
       ),

--- a/test/core/services/export/uddf/uddf_dives_extras_test.dart
+++ b/test/core/services/export/uddf/uddf_dives_extras_test.dart
@@ -5,7 +5,10 @@ import 'package:submersion/core/services/export/uddf/uddf_dives_extras.dart';
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
+import 'package:submersion/features/dive_roles/data/repositories/dive_role_repository.dart';
 import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
+import 'package:submersion/features/dive_roles/presentation/providers/dive_role_providers.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_component_repository.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_component.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_component_providers.dart';
@@ -19,6 +22,13 @@ final _row = BuddyWithRole(
     createdAt: _epoch,
     updatedAt: _epoch,
   ),
+);
+final _role = DiveRole(
+  id: 'role-photo',
+  diverId: 'diver-1',
+  name: 'Photographer',
+  createdAt: _epoch,
+  updatedAt: _epoch,
 );
 final _component = EquipmentComponent(
   id: 'c1',
@@ -54,13 +64,28 @@ class _Components extends Fake implements EquipmentComponentRepository {
   }
 }
 
+class _Roles extends Fake implements DiveRoleRepository {
+  final calls = <String?>[];
+
+  @override
+  Future<List<DiveRole>> getAllDiveRoles({String? diverId}) async {
+    calls.add(diverId);
+    return [_role];
+  }
+}
+
 void main() {
   test('fetches participants and components by default', () async {
     final buddies = _Buddies();
     final components = _Components();
-    final extras = await resolveDivesExtras(buddies, components, [
-      'd1',
-    ], const UddfExportOptions());
+    final extras = await resolveDivesExtras(
+      buddies,
+      components,
+      _Roles(),
+      'diver-1',
+      ['d1'],
+      const UddfExportOptions(),
+    );
     expect(buddies.calls, [
       ['d1'],
     ]);
@@ -74,20 +99,44 @@ void main() {
   test('queries nothing a checkbox left out', () async {
     final buddies = _Buddies();
     final components = _Components();
-    final extras = await resolveDivesExtras(buddies, components, [
-      'd1',
-    ], const UddfExportOptions(includeParticipants: false, includeGear: false));
+    final extras = await resolveDivesExtras(
+      buddies,
+      components,
+      _Roles(),
+      'diver-1',
+      ['d1'],
+      const UddfExportOptions(includeParticipants: false, includeGear: false),
+    );
     expect(buddies.calls, isEmpty);
     expect(components.calls, isEmpty);
     expect(extras.diveBuddies, isEmpty);
     expect(extras.components, isEmpty);
   });
 
-  test('the provider reads both repositories', () async {
+  test('fetches the diver\'s own roles whatever the checkboxes', () async {
+    // Every dive writes its diver's role, participants or not, so the file
+    // must be able to define a custom one either way.
+    final roles = _Roles();
+    final extras = await resolveDivesExtras(
+      _Buddies(),
+      _Components(),
+      roles,
+      'diver-1',
+      ['d1'],
+      const UddfExportOptions(includeParticipants: false, includeGear: false),
+    );
+    expect(roles.calls, ['diver-1']);
+    expect(extras.diveRoles, [_role]);
+  });
+
+  test('the provider reads every repository for the active diver', () async {
+    final roles = _Roles();
     final container = ProviderContainer(
       overrides: [
         buddyRepositoryProvider.overrideWithValue(_Buddies()),
         equipmentComponentRepositoryProvider.overrideWithValue(_Components()),
+        diveRoleRepositoryProvider.overrideWithValue(roles),
+        validatedCurrentDiverIdProvider.overrideWith((ref) async => 'diver-1'),
       ],
     );
     addTearDown(container.dispose);
@@ -96,11 +145,14 @@ void main() {
     ], const UddfExportOptions());
     expect(extras.diveBuddies['d1'], [_row]);
     expect(extras.components, [_component]);
+    expect(roles.calls, ['diver-1']);
+    expect(extras.diveRoles, [_role]);
   });
 
   test('empty holds nothing', () {
     const extras = UddfDivesExtras.empty();
     expect(extras.diveBuddies, isEmpty);
     expect(extras.components, isEmpty);
+    expect(extras.diveRoles, isEmpty);
   });
 }


### PR DESCRIPTION
## Summary

Since #1790 both UDDF writers write each dive's own role (`Dive.diverRoleId`) as `<diverrole>`, but the dives-only export built its `<diveroles>` definitions from the buddy rows alone. A dive whose own role was custom, with no participant holding that role, reached the file as a bare id. On import, `UddfEntityImporter._localRoleId` resolves such an id only if the importing diver already owns it, so on a new device or in another profile the dive silently came back with no role.

The export now defines every custom role the file names, whether it comes from a buddy row or from a dive's `diverRoleId`, and only when the exporting diver's own role list holds it.

## Changes

- `UddfDivesExtras` gains `diveRoles`: the active diver's roles, read through `DiveRoleRepository.getAllDiveRoles(diverId:)` in `resolveDivesExtras`. The fetch provider takes the diver from `validatedCurrentDiverIdProvider`, the same diver `allDiveRolesProvider` scopes to. All three dives-only entry points (dive list, dive detail, buddy detail) already go through this provider, so no call sites change.
- `UddfExportService.generateDivesUddfContent` collects role ids from the buddy rows and from each dive's `diverRoleId`, then declares a custom one only if the diver's own list holds it. A synthetic role (an id with no row, or another diver's role once #1806 scopes `resolveDiveRole`) stays linked but is never defined, because its only name is the raw id and declaring it would give the importing diver a role named after a UUID.
- **Participants option:** the role list is read and the diver's role is defined whatever the checkboxes. The diver's own role is not a participant, and `<diverrole>` is already written with participants left out; gating its definition on `includeParticipants` would bring this bug back for anyone who shares without participants. Buddy-row roles stay gated as before, since those rows are only written with participants on.

## Test Plan

- [x] New round trip in `uddf_diver_role_round_trip_test.dart`: a dive with a custom `diverRoleId` and no buddies, exported through `resolveDivesExtras` + `generateDivesUddfContent`, restored onto a clean database; the dive keeps the role and the role lands in the importing diver's list (failed before the fix with the role restored as `null`)
- [x] The diver role is defined with participants left out (failed before the fix)
- [x] A synthetic buddy role is linked but not defined (failed before the fix), and a dive role outside the diver's list is not defined; both also fail against a mutant that falls back to `DiveRole.synthetic` for missing roles
- [x] `resolveDivesExtras` reads the diver's roles whatever the checkboxes, and the provider passes the active diver (mutation-checked against dropping the diver id and against gating on participants)
- [x] `dart format .`, `dart analyze` (no issues)
- [x] `flutter test test/core/services/export/uddf/` plus the four dives-only export widget tests: 372 passed
- [x] Pre-push hook (format, analyze, affected tests: 83 passed)
- [x] Trial merge with #1815 (which scopes `resolveDiveRole` and edits the same test file): auto-merges cleanly, and `test/core/services/export/uddf/` passes on the merged tree (344 passed)

Note for #1815: its new test "another diver's custom role without its definition falls back to none" says "A dives-only file declares no <diveroles>". After this PR a dives-only file does declare the diver's own custom roles, so that comment would read better as "a file that declares no <diveroles>". The test's behaviour is unaffected.
