### PR TITLE
fix(equipment): count battery cycles only on battery-powered gear

### DIFF
--- a/lib/features/equipment/domain/services/battery_cycles.dart
+++ b/lib/features/equipment/domain/services/battery_cycles.dart
@@ -1,0 +1,39 @@
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/equipment/domain/entities/exposure_unit.dart';
+import 'package:submersion/features/equipment/domain/entities/service_kind.dart';
+import 'package:submersion/features/equipment/domain/entities/service_schedule.dart';
+
+/// Gear that runs on a battery, and so is charged (or swapped) around each
+/// dive. Everything else counts no [ExposureUnit.cycles] unless the diver
+/// asks for a cycles clock on it (see [accruesBatteryCycles]).
+const Set<EquipmentType> kBatteryPoweredTypes = {
+  EquipmentType.battery,
+  EquipmentType.light,
+  EquipmentType.dpv,
+  EquipmentType.computer,
+  EquipmentType.transmitter,
+  EquipmentType.rebreather,
+  EquipmentType.camera,
+  EquipmentType.strobe,
+};
+
+/// Whether an item of [type] counts battery cycles: a powered type always
+/// does, and any other item does once it has a clock that counts cycles
+/// (a heated vest filed as `other`, say), or that clock could never come
+/// due. A clock counts only as the service engine would read it: enabled,
+/// with a known kind, and a cycles interval of its own or its kind's.
+bool accruesBatteryCycles({
+  required EquipmentType type,
+  required Iterable<ServiceSchedule> schedules,
+  required Map<String, ServiceKind> kindsById,
+}) {
+  if (kBatteryPoweredTypes.contains(type)) return true;
+  for (final schedule in schedules) {
+    if (!schedule.enabled) continue;
+    final kind = kindsById[schedule.serviceKindId];
+    if (kind == null) continue;
+    final interval = schedule.intervalFor(ExposureUnit.cycles, kind);
+    if (interval != null && interval > 0) return true;
+  }
+  return false;
+}

--- a/lib/features/equipment/domain/services/exposure_classifier.dart
+++ b/lib/features/equipment/domain/services/exposure_classifier.dart
@@ -7,21 +7,25 @@ import 'package:submersion/features/equipment/domain/entities/service_clock_stat
 /// so a changed setting changes every total on the next read with nothing
 /// to rebuild.
 ///
-/// Two item-level rules ride on the classifier because they depend on what
+/// Three item-level rules ride on the classifier because they depend on what
 /// the item is, not on the dive:
 /// - [loopTimeOnly]: rebreathers (and their children) accrue
 ///   [ExposureUnit.hours] on CCR and SCR mode dives only. Salt hours still
 ///   count every dive: the unit was wet whatever the loop did.
+/// - [countsCycles]: only an item that `accruesBatteryCycles` counts
+///   [ExposureUnit.cycles]; a BCD or a pair of fins has no battery to cycle.
 /// - [hasBatteryChild]: a parent whose battery is modelled as a child item
 ///   accrues no [ExposureUnit.cycles]; the child does.
 class ExposureClassifier {
   final ExposureThresholds thresholds;
   final bool loopTimeOnly;
+  final bool countsCycles;
   final bool hasBatteryChild;
 
   const ExposureClassifier({
     this.thresholds = ExposureThresholds.defaults,
     this.loopTimeOnly = false,
+    this.countsCycles = false,
     this.hasBatteryChild = false,
   });
 
@@ -55,7 +59,7 @@ class ExposureClassifier {
         final depth = s.maxDepth;
         return depth != null && depth >= thresholds.deepDiveM ? 1 : 0;
       case ExposureUnit.cycles:
-        return hasBatteryChild ? 0 : 1;
+        return countsCycles && !hasBatteryChild ? 1 : 0;
     }
   }
 

--- a/lib/features/equipment/presentation/providers/equipment_exposure_providers.dart
+++ b/lib/features/equipment/presentation/providers/equipment_exposure_providers.dart
@@ -5,6 +5,7 @@ import 'package:submersion/features/equipment/domain/entities/equipment_exposure
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 import 'package:submersion/features/equipment/domain/entities/exposure_unit.dart';
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
+import 'package:submersion/features/equipment/domain/services/battery_cycles.dart';
 import 'package:submersion/features/equipment/domain/services/exposure_classifier.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
 import 'package:submersion/features/equipment/presentation/providers/exposure_thresholds_provider.dart';
@@ -51,6 +52,7 @@ final equipmentExposureInputsProvider =
       final classifier = ExposureClassifier(
         thresholds: ref.watch(exposureThresholdsProvider),
         loopTimeOnly: exposure.isRebreather,
+        countsCycles: await _accruesBatteryCycles(ref, item),
         hasBatteryChild: children.any((c) => c.type == EquipmentType.battery),
       );
       return (
@@ -61,6 +63,25 @@ final equipmentExposureInputsProvider =
         classifier: classifier,
       );
     });
+
+/// The clocks' cycles rule, read the way the clocks read it. A powered type
+/// needs no lookup; any other item is opted in by a cycles clock, so its
+/// schedules (and the kinds they inherit from) are read and watched.
+Future<bool> _accruesBatteryCycles(Ref ref, EquipmentItem item) async {
+  if (kBatteryPoweredTypes.contains(item.type)) return true;
+  final scheduleRepository = ref.watch(serviceScheduleRepositoryProvider);
+  final kindRepository = ref.watch(serviceKindRepositoryProvider);
+  ref.invalidateSelfWhen(scheduleRepository.watchSchedulesChanges());
+  ref.invalidateSelfWhen(kindRepository.watchServiceKindsChanges());
+  final schedules = await scheduleRepository.getSchedulesForEquipment(item.id);
+  if (schedules.isEmpty) return false;
+  final kinds = await kindRepository.getAllKinds();
+  return accruesBatteryCycles(
+    type: item.type,
+    schedules: schedules,
+    kindsById: {for (final k in kinds) k.id: k},
+  );
+}
 
 /// Totals per unit for the exposure card. [EquipmentExposureTotals.empty]
 /// for an unknown item or one with no dives.

--- a/lib/features/equipment/presentation/providers/equipment_providers.dart
+++ b/lib/features/equipment/presentation/providers/equipment_providers.dart
@@ -20,6 +20,7 @@ import 'package:submersion/features/equipment/domain/entities/service_record.dar
 import 'package:submersion/features/equipment/domain/entities/service_schedule.dart';
 import 'package:submersion/features/equipment/domain/models/equipment_filter_state.dart';
 import 'package:submersion/features/equipment/domain/models/equipment_picker_filter.dart';
+import 'package:submersion/features/equipment/domain/services/battery_cycles.dart';
 import 'package:submersion/features/equipment/domain/services/exposure_classifier.dart';
 import 'package:submersion/features/equipment/domain/services/service_due_engine.dart';
 import 'package:submersion/features/equipment/presentation/providers/exposure_thresholds_provider.dart';
@@ -768,9 +769,15 @@ Future<List<ServiceClockStatus>> _evaluateClocksFor(
       .watch(equipmentRepositoryProvider)
       .getItemExposure(item, siblings: siblings);
   final usage = exposure.samples;
+  final kindsById = {for (final k in allKinds) k.id: k};
   final classifier = ExposureClassifier(
     thresholds: ref.watch(exposureThresholdsProvider),
     loopTimeOnly: exposure.isRebreather,
+    countsCycles: accruesBatteryCycles(
+      type: item.type,
+      schedules: schedules,
+      kindsById: kindsById,
+    ),
     hasBatteryChild: exposure.fittedChildren.any(
       (c) => c.type == EquipmentType.battery,
     ),
@@ -778,7 +785,7 @@ Future<List<ServiceClockStatus>> _evaluateClocksFor(
   final window = await ref.watch(serviceDueSoonWindowDaysProvider.future);
   return const ServiceDueEngine().evaluate(
     schedules: schedules,
-    kindsById: {for (final k in allKinds) k.id: k},
+    kindsById: kindsById,
     records: records,
     usage: usage,
     classifier: classifier,

--- a/lib/features/notifications/data/services/notification_scheduler.dart
+++ b/lib/features/notifications/data/services/notification_scheduler.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/equipment/domain/entities/equipment_item.dar
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
 import 'package:submersion/features/equipment/domain/entities/service_kind.dart';
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/equipment/domain/services/battery_cycles.dart';
 import 'package:submersion/features/equipment/domain/services/exposure_classifier.dart';
 import 'package:submersion/features/equipment/domain/services/service_due_engine.dart';
 import 'package:submersion/features/equipment/presentation/providers/exposure_thresholds_provider.dart';
@@ -118,6 +119,11 @@ class NotificationScheduler {
     final classifier = ExposureClassifier(
       thresholds: exposureThresholdsFromSettings(settings),
       loopTimeOnly: exposure.isRebreather,
+      countsCycles: accruesBatteryCycles(
+        type: item.type,
+        schedules: schedules,
+        kindsById: kindsById,
+      ),
       hasBatteryChild: exposure.fittedChildren.any(
         (c) => c.type == EquipmentType.battery,
       ),

--- a/test/features/equipment/domain/services/battery_cycles_test.dart
+++ b/test/features/equipment/domain/services/battery_cycles_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/equipment/domain/entities/exposure_unit.dart';
+import 'package:submersion/features/equipment/domain/entities/service_kind.dart';
+import 'package:submersion/features/equipment/domain/entities/service_schedule.dart';
+import 'package:submersion/features/equipment/domain/services/battery_cycles.dart';
+
+/// Only gear that runs on a battery counts battery cycles, unless the diver
+/// has asked for a cycles clock on it, which opts the item in.
+void main() {
+  final t = DateTime.utc(2026, 1, 1);
+  ServiceKind kind({Map<ExposureUnit, double> intervals = const {}}) =>
+      ServiceKind(
+        id: 'k',
+        name: 'Charge',
+        exposureIntervals: intervals,
+        createdAt: t,
+        updatedAt: t,
+      );
+  ServiceSchedule schedule({
+    Map<ExposureUnit, double> intervals = const {},
+    int? dives,
+    bool enabled = true,
+  }) => ServiceSchedule(
+    id: 's',
+    equipmentId: 'e',
+    serviceKindId: 'k',
+    intervalDives: dives,
+    exposureIntervals: intervals,
+    enabled: enabled,
+    createdAt: t,
+    updatedAt: t,
+  );
+
+  test('every battery-powered type accrues cycles with no schedule', () {
+    for (final type in const [
+      EquipmentType.battery,
+      EquipmentType.light,
+      EquipmentType.dpv,
+      EquipmentType.computer,
+      EquipmentType.transmitter,
+      EquipmentType.rebreather,
+      EquipmentType.camera,
+      EquipmentType.strobe,
+    ]) {
+      expect(
+        accruesBatteryCycles(type: type, schedules: const [], kindsById: {}),
+        isTrue,
+        reason: type.name,
+      );
+    }
+  });
+
+  test('unpowered gear accrues no cycles', () {
+    for (final type in const [
+      EquipmentType.bcd,
+      EquipmentType.fins,
+      EquipmentType.drysuit,
+      EquipmentType.regulator,
+      EquipmentType.other,
+    ]) {
+      expect(
+        accruesBatteryCycles(type: type, schedules: const [], kindsById: {}),
+        isFalse,
+        reason: type.name,
+      );
+    }
+  });
+
+  test('a cycles interval on the schedule opts unpowered gear in', () {
+    expect(
+      accruesBatteryCycles(
+        type: EquipmentType.other,
+        schedules: [
+          schedule(intervals: const {ExposureUnit.cycles: 50}),
+        ],
+        kindsById: {'k': kind()},
+      ),
+      isTrue,
+    );
+  });
+
+  test('a cycles interval inherited from the kind opts it in too', () {
+    expect(
+      accruesBatteryCycles(
+        type: EquipmentType.other,
+        schedules: [schedule()],
+        kindsById: {
+          'k': kind(intervals: const {ExposureUnit.cycles: 50}),
+        },
+      ),
+      isTrue,
+    );
+  });
+
+  test('a clock the engine would skip does not opt it in', () {
+    final cycles = {'k': kind()};
+    // Disabled.
+    expect(
+      accruesBatteryCycles(
+        type: EquipmentType.bcd,
+        schedules: [
+          schedule(intervals: const {ExposureUnit.cycles: 50}, enabled: false),
+        ],
+        kindsById: cycles,
+      ),
+      isFalse,
+    );
+    // Its kind is unknown.
+    expect(
+      accruesBatteryCycles(
+        type: EquipmentType.bcd,
+        schedules: [
+          schedule(intervals: const {ExposureUnit.cycles: 50}),
+        ],
+        kindsById: const {},
+      ),
+      isFalse,
+    );
+    // Counts dives, not cycles.
+    expect(
+      accruesBatteryCycles(
+        type: EquipmentType.bcd,
+        schedules: [schedule(dives: 100)],
+        kindsById: cycles,
+      ),
+      isFalse,
+    );
+  });
+}

--- a/test/features/equipment/domain/services/exposure_classifier_test.dart
+++ b/test/features/equipment/domain/services/exposure_classifier_test.dart
@@ -25,12 +25,17 @@ void main() {
   );
   const c = ExposureClassifier();
 
-  test('dives and cycles count one per sample; hours are duration', () {
+  test('dives count one per sample; hours are duration', () {
     final s = sample(seconds: 5400);
     expect(c.contribution(s, ExposureUnit.dives), 1);
-    expect(c.contribution(s, ExposureUnit.cycles), 1);
     expect(c.contribution(s, ExposureUnit.hours), closeTo(1.5, 1e-9));
     expect(c.contribution(s, ExposureUnit.days), 0);
+  });
+
+  test('cycles count one per sample only on gear that counts them', () {
+    expect(c.contribution(sample(), ExposureUnit.cycles), 0);
+    const powered = ExposureClassifier(countsCycles: true);
+    expect(powered.contribution(sample(), ExposureUnit.cycles), 1);
   });
 
   test('salt hours count salt and brackish, not fresh or unknown', () {
@@ -105,7 +110,10 @@ void main() {
   });
 
   test('a parent with a battery child accrues no cycles', () {
-    const parent = ExposureClassifier(hasBatteryChild: true);
+    const parent = ExposureClassifier(
+      countsCycles: true,
+      hasBatteryChild: true,
+    );
     expect(parent.contribution(sample(), ExposureUnit.cycles), 0);
     expect(parent.contribution(sample(), ExposureUnit.dives), 1);
   });
@@ -121,7 +129,7 @@ void main() {
     expect(totals[ExposureUnit.coldDives], 1);
     expect(totals[ExposureUnit.deepCycles], 1);
     expect(totals[ExposureUnit.o2Hours], closeTo(1.0, 1e-9));
-    expect(totals[ExposureUnit.cycles], 2);
+    expect(totals[ExposureUnit.cycles], 0);
     expect(totals[ExposureUnit.days], 0);
   });
 }

--- a/test/features/equipment/presentation/providers/equipment_exposure_providers_test.dart
+++ b/test/features/equipment/presentation/providers/equipment_exposure_providers_test.dart
@@ -4,10 +4,12 @@ import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/data/repositories/service_kind_repository.dart';
 import 'package:submersion/features/equipment/data/repositories/service_schedule_repository.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_exposure_totals.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 import 'package:submersion/features/equipment/domain/entities/exposure_unit.dart';
+import 'package:submersion/features/equipment/domain/entities/service_kind.dart';
 import 'package:submersion/features/equipment/domain/entities/service_schedule.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_exposure_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -136,6 +138,55 @@ void main() {
       equipmentExposureTotalsProvider(bcd.id).future,
     );
     expect(totals.byUnit[ExposureUnit.cycles], 2);
+  });
+
+  test('a kind or schedule edit reaches an open card', () async {
+    final bcd = await itemWithTwoDives(EquipmentType.bcd);
+    final t = DateTime(2025);
+    final kinds = ServiceKindRepository();
+    final kind = await kinds.createKind(
+      ServiceKind(id: 'charge', name: 'Charge', createdAt: t, updatedAt: t),
+    );
+    final schedules = ServiceScheduleRepository();
+    final schedule = await schedules.createSchedule(
+      ServiceSchedule(
+        id: '',
+        equipmentId: bcd.id,
+        serviceKindId: kind.id,
+        createdAt: t,
+        updatedAt: t,
+      ),
+    );
+    final sub = container.listen(
+      equipmentExposureTotalsProvider(bcd.id),
+      (_, _) {},
+    );
+    addTearDown(sub.close);
+    Future<double?> cycles() async => (await container.read(
+      equipmentExposureTotalsProvider(bcd.id).future,
+    )).byUnit[ExposureUnit.cycles];
+    // Writes go through drift, so the change streams tick as the app's own
+    // writes do; give the invalidation a moment to land.
+    Future<double?> settle(double? want) async {
+      var now = await cycles();
+      for (var i = 0; i < 50 && now != want; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        now = await cycles();
+      }
+      return now;
+    }
+
+    expect(await cycles(), isNull);
+
+    // The kind gains a cycles default, which the schedule inherits.
+    await kinds.updateKind(
+      kind.copyWith(exposureIntervals: const {ExposureUnit.cycles: 50}),
+    );
+    expect(await settle(2), 2);
+
+    // Disabling the clock withdraws the opt-in.
+    await schedules.updateSchedule(schedule.copyWith(enabled: false));
+    expect(await settle(null), isNull);
   });
 
   test('an unknown item yields the empty totals', () async {

--- a/test/features/equipment/presentation/providers/equipment_exposure_providers_test.dart
+++ b/test/features/equipment/presentation/providers/equipment_exposure_providers_test.dart
@@ -4,9 +4,11 @@ import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/data/repositories/service_schedule_repository.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_exposure_totals.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 import 'package:submersion/features/equipment/domain/entities/exposure_unit.dart';
+import 'package:submersion/features/equipment/domain/entities/service_schedule.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_exposure_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
@@ -88,6 +90,52 @@ void main() {
     expect(totals.diveCount, 3);
     expect(totals.firstDive, DateTime.utc(2026, 1, 10));
     expect(totals.lastDive, DateTime.utc(2026, 3, 10));
+  });
+
+  Future<EquipmentItem> itemWithTwoDives(EquipmentType type) async {
+    final item = await EquipmentRepository().createEquipment(
+      EquipmentItem(id: '', name: type.name, type: type),
+    );
+    await insertDive('a', dateMs: t1);
+    await insertDive('b', dateMs: t2);
+    await link('a', item.id);
+    await link('b', item.id);
+    return item;
+  }
+
+  test('a BCD accrues no battery cycles', () async {
+    final bcd = await itemWithTwoDives(EquipmentType.bcd);
+    final totals = await container.read(
+      equipmentExposureTotalsProvider(bcd.id).future,
+    );
+    expect(totals.byUnit[ExposureUnit.dives], 2);
+    expect(totals.byUnit.containsKey(ExposureUnit.cycles), isFalse);
+  });
+
+  test('a light accrues one battery cycle per dive', () async {
+    final light = await itemWithTwoDives(EquipmentType.light);
+    final totals = await container.read(
+      equipmentExposureTotalsProvider(light.id).future,
+    );
+    expect(totals.byUnit[ExposureUnit.cycles], 2);
+  });
+
+  test('a cycles clock opts unpowered gear in', () async {
+    final bcd = await itemWithTwoDives(EquipmentType.bcd);
+    await ServiceScheduleRepository().createSchedule(
+      ServiceSchedule(
+        id: '',
+        equipmentId: bcd.id,
+        serviceKindId: 'o2-cell-replacement',
+        exposureIntervals: const {ExposureUnit.cycles: 50},
+        createdAt: DateTime(2025),
+        updatedAt: DateTime(2025),
+      ),
+    );
+    final totals = await container.read(
+      equipmentExposureTotalsProvider(bcd.id).future,
+    );
+    expect(totals.byUnit[ExposureUnit.cycles], 2);
   });
 
   test('an unknown item yields the empty totals', () async {

--- a/test/features/equipment/presentation/providers/exposure_clock_providers_test.dart
+++ b/test/features/equipment/presentation/providers/exposure_clock_providers_test.dart
@@ -132,6 +132,37 @@ void main() {
     expect(status.usageByUnit[ExposureUnit.cycles]!.since, 1);
   });
 
+  test('a cycles clock counts on gear that is not battery powered', () async {
+    // Only powered types count cycles by default; a clock the diver set
+    // up in cycles opts the item in, or it could never come due.
+    final bcd = await EquipmentRepository().createEquipment(
+      EquipmentItem(
+        id: '',
+        name: 'BCD',
+        type: EquipmentType.bcd,
+        purchaseDate: DateTime(2025, 1, 1),
+      ),
+    );
+    final schedule = await ServiceScheduleRepository().createSchedule(
+      ServiceSchedule(
+        id: '',
+        equipmentId: bcd.id,
+        serviceKindId: 'o2-cell-replacement',
+        exposureIntervals: const {ExposureUnit.cycles: 5},
+        createdAt: DateTime(2025),
+        updatedAt: DateTime(2025),
+      ),
+    );
+    await coldDive('c1', bcd.id, 20);
+    await coldDive('c2', bcd.id, 20);
+
+    final statuses = await container.read(
+      serviceClockStatusesProvider(bcd.id).future,
+    );
+    final status = statuses.firstWhere((s) => s.schedule.id == schedule.id);
+    expect(status.usageByUnit[ExposureUnit.cycles]!.since, 2);
+  });
+
   test(
     'an open clock follows a new dive link and an install-date edit',
     () async {

--- a/test/features/notifications/usage_clock_reminder_test.dart
+++ b/test/features/notifications/usage_clock_reminder_test.dart
@@ -3,9 +3,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/data/repositories/service_kind_repository.dart';
 import 'package:submersion/features/equipment/data/repositories/service_record_repository.dart';
 import 'package:submersion/features/equipment/data/repositories/service_schedule_repository.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/equipment/domain/entities/exposure_unit.dart';
+import 'package:submersion/features/equipment/domain/entities/service_kind.dart';
+import 'package:submersion/features/equipment/domain/entities/service_schedule.dart';
 import 'package:submersion/features/equipment/domain/entities/service_record.dart'
     as domain;
 import 'package:submersion/features/notifications/data/repositories/scheduled_notification_repository.dart';
@@ -193,6 +197,53 @@ void main() {
       expect(rows.single.createdAt, now.millisecondsSinceEpoch);
     },
   );
+
+  test('a cycles clock on unpowered gear schedules its reminder', () async {
+    // A BCD counts no battery cycles by default; a cycles clock (inherited
+    // here from its kind) opts it in, or this reminder could never fire.
+    // Two cycles, not one: a count's due-soon band rounds up to a whole
+    // cycle, so a one-cycle clock is due at zero and would pass regardless.
+    final bcd = await EquipmentRepository().createEquipment(
+      EquipmentItem(
+        id: '',
+        name: 'BCD',
+        type: EquipmentType.bcd,
+        purchaseDate: DateTime(2025, 1, 1),
+      ),
+    );
+    final t = DateTime(2025);
+    final kind = await ServiceKindRepository().createKind(
+      ServiceKind(
+        id: 'charge',
+        name: 'Charge',
+        exposureIntervals: const {ExposureUnit.cycles: 2},
+        createdAt: t,
+        updatedAt: t,
+      ),
+    );
+    final schedule = await ServiceScheduleRepository().createSchedule(
+      ServiceSchedule(
+        id: '',
+        equipmentId: bcd.id,
+        serviceKindId: kind.id,
+        createdAt: t,
+        updatedAt: t,
+      ),
+    );
+    await linkDive('d1', bcd.id);
+    await linkDive('d2', bcd.id);
+
+    await NotificationScheduler().scheduleAll(settings: const AppSettings());
+    final rows = await db.select(db.scheduledNotifications).get();
+    expect(
+      rows.where(
+        (r) =>
+            r.reminderDaysBefore == kUsageReminderDaysBefore &&
+            r.scheduleId == schedule.id,
+      ),
+      hasLength(1),
+    );
+  });
 
   test('an ok usage clock schedules nothing', () async {
     final reg = await EquipmentRepository().createEquipment(


### PR DESCRIPTION
## Summary

A BCD's Exposure card showed "N battery cycles", always equal to its dive count. The exposure classifier counted one battery cycle per dive for every item unless the item had a battery child part, and the card shows every unit with a non-zero total. The same bug put unpowered gear (BCDs, fins, suits) in the "Battery cycles" ranking on Statistics > Equipment.

Battery cycles now accrue only on gear that has a battery, plus any item the diver has opted in by setting up a battery-cycles service clock on it.

## Changes

- **New rule `accruesBatteryCycles`** (`domain/services/battery_cycles.dart`): a powered type (battery, light, DPV, computer, transmitter, rebreather, camera, strobe) always counts cycles. Any other item counts them once it has a clock with a cycles interval, either its own or inherited from the service kind. Clocks are read the way `ServiceDueEngine` reads them: enabled, with a known kind. Without that opt-in, a cycles clock on a heated vest filed as `other` could never come due.
- **`ExposureClassifier.countsCycles`**: a new flag, off by default, so a classifier built without it shows no cycles instead of bogus ones. The existing `hasBatteryChild` rule still hands a parent's cycles to its battery part.
- **All three classifier sites set the flag**, so the card and the clocks cannot disagree:
  - `equipmentExposureInputsProvider` (Exposure card, trend chart, statistics ranking). For unpowered items it reads the schedules and kinds and refreshes when either changes; powered items need no lookup.
  - The in-app service clocks (`_evaluateClocksFor`).
  - The reminder scheduler (`NotificationScheduler._evaluateClocks`).
- **Tests**: unit tests for the rule; classifier tests updated on purpose (the phase 1 test pinned "cycles count one per sample" for any item); provider tests for a BCD (no cycles), a light (cycles) and a BCD with a cycles schedule (opted in); and a clock test showing a cycles clock on a BCD still counts.

No schema, sync or storage change: exposure is derived on read, so existing items show the corrected totals on the next build.

## Test Plan

- [x] `flutter test` passes: `test/features/equipment`, `test/features/statistics` and `test/features/notifications` (1,901 tests) locally, plus the pre-push hook's 52 affected test files; CI runs the full suite
- [x] `flutter analyze` passes (whole project)
- [x] The new BCD exposure test failed before the fix (cycles present) and passes after
- [x] Mutation-checked: 7 single-line breaks of the fix (classifier ignoring the flag or the battery child, a type dropped from the powered set, disabled or unknown-kind clocks opting in, a clock site dropping the flag, the provider ignoring schedules) are each caught by a test
- [ ] Manual testing on: macOS (open a BCD and a light; only the light shows a battery cycles chip)

## Notes

- Camera and strobe count cycles, but the equipment edit page still only allows a battery child part under a computer, transmitter, light, DPV or rebreather. Widening that is a separate change.
- The reminder scheduler's wiring has no direct test; it matches the tested in-app clock wiring line for line.
