### PR TITLE
fix(media): stop Linux and Windows reopening a file dialog on dive details

### DIFF
--- a/lib/features/media/data/resolvers/platform_gallery_resolver.dart
+++ b/lib/features/media/data/resolvers/platform_gallery_resolver.dart
@@ -30,17 +30,35 @@ class PlatformGalleryResolver implements MediaSourceResolver {
   /// production injects the singleton from [galleryThumbnailCacheProvider].
   final GalleryThumbnailCache _thumbnailCache;
 
+  /// False on Windows and Linux, which have no photo library for
+  /// photo_manager to read (it has no backend there). Every gallery row on
+  /// such a device was linked on another one, so this resolver answers
+  /// [UnavailableKind.fromOtherDevice] for all of them without consulting
+  /// [AssetResolutionService], whose gallery search is an interactive file
+  /// dialog on those platforms.
+  ///
+  /// Never [UnavailableKind.notFound]: that is the one verdict that orphans a
+  /// row, and the write syncs, so a Linux device would mark photos that are
+  /// still safe in a Mac's or phone's library missing everywhere.
+  final bool _hasPhotoLibrary;
+
+  static const _elsewhere = UnavailableData(
+    kind: UnavailableKind.fromOtherDevice,
+  );
+
   PlatformGalleryResolver({
     required AssetResolutionService resolutionService,
     GalleryThumbnailCache? thumbnailCache,
+    bool hasPhotoLibrary = true,
   }) : _resolutionService = resolutionService,
-       _thumbnailCache = thumbnailCache ?? GalleryThumbnailCache();
+       _thumbnailCache = thumbnailCache ?? GalleryThumbnailCache(),
+       _hasPhotoLibrary = hasPhotoLibrary;
 
   @override
   MediaSourceType get sourceType => MediaSourceType.platformGallery;
 
   @override
-  bool canResolveOnThisDevice(MediaItem item) => true;
+  bool canResolveOnThisDevice(MediaItem item) => _hasPhotoLibrary;
 
   @override
   Future<MediaSourceData> resolve(MediaItem item) async {
@@ -48,6 +66,7 @@ class PlatformGalleryResolver implements MediaSourceResolver {
     if (assetId == null || assetId.isEmpty) {
       return const UnavailableData(kind: UnavailableKind.notFound);
     }
+    if (!_hasPhotoLibrary) return _elsewhere;
     final resolution = await _resolutionService.resolveAssetId(item);
     // Checked before the id, because accessDenied always carries a null id
     // and collapsing the two would report "your photo is gone" for what is
@@ -83,6 +102,7 @@ class PlatformGalleryResolver implements MediaSourceResolver {
     if (assetId == null || assetId.isEmpty) {
       return const UnavailableData(kind: UnavailableKind.notFound);
     }
+    if (!_hasPhotoLibrary) return _elsewhere;
     final width = target.width.toInt();
     final height = target.height.toInt();
     // Keyed by size as well as item: the grid and the viewer ask for different
@@ -147,7 +167,7 @@ class PlatformGalleryResolver implements MediaSourceResolver {
   @override
   Future<MediaSourceMetadata?> extractMetadata(MediaItem item) async {
     final assetId = item.platformAssetId;
-    if (assetId == null || assetId.isEmpty) return null;
+    if (assetId == null || assetId.isEmpty || !_hasPhotoLibrary) return null;
     final resolvedId = await _resolveId(item);
     if (resolvedId == null) return null;
     // coverage:ignore-start
@@ -170,6 +190,7 @@ class PlatformGalleryResolver implements MediaSourceResolver {
   Future<VerifyResult> verify(MediaItem item) async {
     final assetId = item.platformAssetId;
     if (assetId == null || assetId.isEmpty) return VerifyResult.notFound;
+    if (!_hasPhotoLibrary) return VerifyResult.fromOtherDevice;
     final resolution = await _resolutionService.resolveAssetId(item);
     // Before the id check: accessDenied always carries a null id, and
     // returning notFound here is what used to let a revoked permission mark

--- a/lib/features/media/data/services/asset_resolution_service.dart
+++ b/lib/features/media/data/services/asset_resolution_service.dart
@@ -131,6 +131,11 @@ class AssetResolutionService {
   /// Self-limiting: a genuinely dead item ends up cached as `unresolved`, and
   /// the backoff branch in [resolveAssetId] then short-circuits later renders
   /// before any caller can reach this method again.
+  ///
+  /// Where there is no photo library to search (Windows and Linux),
+  /// [_resolveFromGallery] returns the stored id without searching, so
+  /// nothing is cached and no backoff applies; the answer is the one
+  /// [resolveAssetId] gives there.
   Future<ResolutionResult> reresolve(MediaItem item) async {
     if (item.platformAssetId == null) {
       return const ResolutionResult(status: ResolutionStatus.unavailable);

--- a/lib/features/media/data/services/asset_resolution_service.dart
+++ b/lib/features/media/data/services/asset_resolution_service.dart
@@ -74,10 +74,7 @@ class AssetResolutionService {
   Future<ResolutionResult> resolveAssetId(MediaItem item) async {
     // Desktop platforms don't use gallery asset IDs
     if (!_photoPickerService.supportsGalleryBrowsing) {
-      return ResolutionResult(
-        localAssetId: item.platformAssetId,
-        status: ResolutionStatus.resolved,
-      );
+      return _withoutGallery(item);
     }
 
     if (item.platformAssetId == null) {
@@ -145,6 +142,15 @@ class AssetResolutionService {
 
   /// Attempt to resolve by trying the original ID, then metadata matching.
   Future<ResolutionResult> _resolveFromGallery(MediaItem item) async {
+    // Every path into the gallery search funnels through here, so this is
+    // where the no-gallery guard has to live. On Windows and Linux the
+    // picker's getAssetsInDateRange is not a query but an interactive file
+    // dialog; reaching it from a thumbnail fetch opened one dialog per photo
+    // and time reading, and reopened it on every cancel.
+    if (!_photoPickerService.supportsGalleryBrowsing) {
+      return _withoutGallery(item);
+    }
+
     _log.info('Resolving asset for media ${item.id}');
 
     // Step 2: Try original platformAssetId
@@ -283,6 +289,15 @@ class AssetResolutionService {
     _log.info('Could not resolve media ${item.id} -- marked unresolved');
     return const ResolutionResult(status: ResolutionStatus.unavailable);
   }
+
+  /// The answer on a platform with no photo library to search: the stored id,
+  /// passed through unchanged. Deliberately not [ResolutionStatus.unavailable],
+  /// which is a positive "gone" finding a caller may orphan the row on, when
+  /// nothing was actually consulted.
+  ResolutionResult _withoutGallery(MediaItem item) => ResolutionResult(
+    localAssetId: item.platformAssetId,
+    status: ResolutionStatus.resolved,
+  );
 
   /// Verify that a platformAssetId actually loads on this device.
   ///

--- a/lib/features/media/presentation/pages/media_repair_wizard_page.dart
+++ b/lib/features/media/presentation/pages/media_repair_wizard_page.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/data/services/repair/media_repair_service.dart';
 import 'package:submersion/features/media/domain/services/media_repair_types.dart';
 import 'package:submersion/features/media/presentation/providers/media_repair_providers.dart';
+import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// The 3-step repair wizard (design spec section 6): scope and sources,
@@ -66,6 +67,12 @@ class _MediaRepairWizardPageState extends ConsumerState<MediaRepairWizardPage> {
   }
 
   Widget _scopePane(BuildContext context) {
+    // Windows and Linux have no photo library: there the photo library
+    // source's per-row date query is an interactive file dialog, so offering
+    // it would open one dialog per broken row.
+    final hasPhotoLibrary = ref
+        .watch(photoPickerServiceProvider)
+        .supportsGalleryBrowsing;
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -83,11 +90,12 @@ class _MediaRepairWizardPageState extends ConsumerState<MediaRepairWizardPage> {
           label: Text(context.l10n.media_repair_addFolder),
           onPressed: _addFolder,
         ),
-        SwitchListTile(
-          title: Text(context.l10n.media_repair_usePhotoLibrary),
-          value: _usePhotoLibrary,
-          onChanged: (v) => setState(() => _usePhotoLibrary = v),
-        ),
+        if (hasPhotoLibrary)
+          SwitchListTile(
+            title: Text(context.l10n.media_repair_usePhotoLibrary),
+            value: _usePhotoLibrary,
+            onChanged: (v) => setState(() => _usePhotoLibrary = v),
+          ),
         SwitchListTile(
           title: Text(context.l10n.media_repair_useStore),
           value: _useStore,
@@ -100,7 +108,7 @@ class _MediaRepairWizardPageState extends ConsumerState<MediaRepairWizardPage> {
               .harvest(
                 RepairWizardConfig(
                   folderRoots: List.of(_folderRoots),
-                  usePhotoLibrary: _usePhotoLibrary,
+                  usePhotoLibrary: hasPhotoLibrary && _usePhotoLibrary,
                   useStore: _useStore,
                 ),
               ),

--- a/lib/features/media/presentation/providers/media_resolver_providers.dart
+++ b/lib/features/media/presentation/providers/media_resolver_providers.dart
@@ -31,6 +31,7 @@ import 'package:submersion/features/media/domain/entities/media_source_type.dart
 import 'package:submersion/features/media/data/resolvers/media_store_source_resolver.dart';
 import 'package:submersion/features/media/presentation/providers/lightroom_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
+import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media/presentation/providers/url_tab_providers.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
@@ -45,6 +46,9 @@ final platformGalleryResolverProvider = Provider<PlatformGalleryResolver>(
   (ref) => PlatformGalleryResolver(
     resolutionService: ref.watch(assetResolutionServiceProvider),
     thumbnailCache: ref.watch(galleryThumbnailCacheProvider),
+    hasPhotoLibrary: ref
+        .watch(photoPickerServiceProvider)
+        .supportsGalleryBrowsing,
   ),
 );
 

--- a/test/features/media/data/resolvers/platform_gallery_resolver_test.dart
+++ b/test/features/media/data/resolvers/platform_gallery_resolver_test.dart
@@ -80,6 +80,25 @@ AssetResolutionService _accessDeniedService() => _FakeAssetResolutionService(
   const ResolutionResult(status: ResolutionStatus.accessDenied),
 );
 
+/// Fails the test if consulted: on a platform with no photo library there is
+/// nothing for the resolution service to search, and on Windows and Linux
+/// its gallery search is an interactive file dialog.
+class _UnconsultedResolutionService extends AssetResolutionService {
+  _UnconsultedResolutionService()
+    : super(
+        cacheRepository: LocalAssetCacheRepository(),
+        photoPickerService: _StubPhotoPickerService(),
+      );
+
+  @override
+  Future<ResolutionResult> resolveAssetId(MediaItem item) =>
+      throw StateError('resolveAssetId consulted without a photo library');
+
+  @override
+  Future<ResolutionResult> reresolve(MediaItem item) =>
+      throw StateError('reresolve consulted without a photo library');
+}
+
 MediaItem _gallery({String? assetId, String? originDeviceId}) => MediaItem(
   id: 'x',
   mediaType: MediaType.photo,
@@ -96,10 +115,52 @@ MediaItem _gallery({String? assetId, String? originDeviceId}) => MediaItem(
 // ---------------------------------------------------------------------------
 
 void main() {
-  test('canResolveOnThisDevice is always true for gallery items', () {
+  test('canResolveOnThisDevice is true wherever there is a photo library', () {
     final r = PlatformGalleryResolver(resolutionService: _unavailableService());
     expect(r.canResolveOnThisDevice(_gallery(assetId: 'A')), isTrue);
     expect(r.canResolveOnThisDevice(_gallery(originDeviceId: 'other')), isTrue);
+  });
+
+  // Windows and Linux have no photo library, so every gallery row there was
+  // linked on another device. notFound is the one verdict that orphans a row,
+  // and that write syncs, so reporting it here would mark photos that are
+  // still safe in a Mac's or phone's library missing on every device.
+  group('a platform with no photo library', () {
+    PlatformGalleryResolver resolver() => PlatformGalleryResolver(
+      resolutionService: _UnconsultedResolutionService(),
+      hasPhotoLibrary: false,
+    );
+
+    test('cannot resolve gallery rows on this device', () {
+      expect(
+        resolver().canResolveOnThisDevice(_gallery(assetId: 'A')),
+        isFalse,
+      );
+    });
+
+    test('resolve reports fromOtherDevice', () async {
+      final data = await resolver().resolve(_gallery(assetId: 'A'));
+      expect((data as UnavailableData).kind, UnavailableKind.fromOtherDevice);
+    });
+
+    test('resolveThumbnail reports fromOtherDevice', () async {
+      final data = await resolver().resolveThumbnail(
+        _gallery(assetId: 'A'),
+        target: const Size(200, 200),
+      );
+      expect((data as UnavailableData).kind, UnavailableKind.fromOtherDevice);
+    });
+
+    test('verify reports fromOtherDevice', () async {
+      expect(
+        await resolver().verify(_gallery(assetId: 'A')),
+        VerifyResult.fromOtherDevice,
+      );
+    });
+
+    test('extractMetadata returns null', () async {
+      expect(await resolver().extractMetadata(_gallery(assetId: 'A')), isNull);
+    });
   });
 
   test('resolve returns Unavailable.notFound when assetId missing', () async {

--- a/test/features/media/data/services/asset_resolution_service_test.dart
+++ b/test/features/media/data/services/asset_resolution_service_test.dart
@@ -164,6 +164,44 @@ void main() {
       expect(result.localAssetId, equals('original-asset-id'));
       expect(result.status, equals(ResolutionStatus.resolved));
     });
+
+    test('reresolve never searches the gallery on desktop platforms', () async {
+      // Windows and Linux have no photo library, so the desktop picker's
+      // getAssetsInDateRange opens an interactive file dialog instead of
+      // running a query. A synced gallery photo's thumbnail fetch always comes
+      // back empty there (photo_manager has no backend), and the resolver's
+      // stale-mapping retry used to reach that dialog once per photo and time
+      // reading, reopening it on every cancel.
+      when(mockPicker.supportsGalleryBrowsing).thenReturn(false);
+      when(
+        mockPicker.checkPermission(),
+      ).thenAnswer((_) async => PhotoPermissionStatus.authorized);
+      when(
+        mockPicker.getThumbnail(any, size: anyNamed('size')),
+      ).thenAnswer((_) async => null);
+      // What a cancelled dialog returns.
+      when(
+        mockPicker.getAssetsInDateRange(any, any),
+      ).thenAnswer((_) async => []);
+      when(mockCache.clearEntry(any)).thenAnswer((_) async {});
+      when(mockCache.getCacheEntry(any)).thenAnswer((_) async => null);
+      when(
+        mockCache.cacheResolution(
+          mediaId: anyNamed('mediaId'),
+          localAssetId: anyNamed('localAssetId'),
+          method: anyNamed('method'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final result = await service.reresolve(createTestItem());
+
+      verifyNever(mockPicker.getAssetsInDateRange(any, any));
+      // Same answer resolveAssetId gives on desktop: with no gallery to search
+      // again the answer cannot change, and it must not read as a positive
+      // "gone" finding that a caller could orphan the row on.
+      expect(result.localAssetId, equals('original-asset-id'));
+      expect(result.status, equals(ResolutionStatus.resolved));
+    });
   });
 
   // A gallery query against a library the app cannot access yet returns

--- a/test/features/media/presentation/media_repair_wizard_test.dart
+++ b/test/features/media/presentation/media_repair_wizard_test.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/data/services/repair/media_repair_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media/domain/services/media_repair_types.dart';
 import 'package:submersion/features/media/presentation/pages/media_repair_wizard_page.dart';
 import 'package:submersion/features/media/presentation/providers/media_repair_providers.dart';
+import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 MediaItem broken(String id) => MediaItem(
@@ -51,10 +53,22 @@ class _SeededWizardNotifier extends RepairWizardNotifier {
   }
 }
 
+class _StubPicker extends Fake implements PhotoPickerService {
+  _StubPicker({required this.supportsGalleryBrowsing});
+
+  @override
+  final bool supportsGalleryBrowsing;
+}
+
 void main() {
-  Widget host(_SeededWizardNotifier notifier) {
+  Widget host(_SeededWizardNotifier notifier, {bool galleryBrowsing = true}) {
     return ProviderScope(
-      overrides: [repairWizardProvider.overrideWith((ref) => notifier)],
+      overrides: [
+        repairWizardProvider.overrideWith((ref) => notifier),
+        photoPickerServiceProvider.overrideWithValue(
+          _StubPicker(supportsGalleryBrowsing: galleryBrowsing),
+        ),
+      ],
       child: const MaterialApp(
         locale: Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -76,6 +90,24 @@ void main() {
     expect(find.text('Search photo library'), findsOneWidget);
     expect(find.text('Use cloud media store'), findsOneWidget);
     expect(find.text('Scan'), findsOneWidget);
+  });
+
+  testWidgets('hides the photo library toggle where there is no library', (
+    tester,
+  ) async {
+    // On Windows and Linux the photo library source's per-row date query is
+    // an interactive file dialog, so enabling it would open one dialog per
+    // broken row.
+    await tester.pumpWidget(
+      host(
+        _SeededWizardNotifier(const RepairWizardIdle()),
+        galleryBrowsing: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Search photo library'), findsNothing);
+    expect(find.text('Use cloud media store'), findsOneWidget);
   });
 
   testWidgets('review groups by confidence, pre-checks per ladder, and '

--- a/test/features/media/presentation/media_repair_wizard_test.dart
+++ b/test/features/media/presentation/media_repair_wizard_test.dart
@@ -46,10 +46,16 @@ class _SeededWizardNotifier extends RepairWizardNotifier {
   }
 
   int applyCalls = 0;
+  RepairWizardConfig? harvestedWith;
 
   @override
   Future<void> applyChecked() async {
     applyCalls++;
+  }
+
+  @override
+  Future<void> harvest(RepairWizardConfig config) async {
+    harvestedWith = config;
   }
 }
 
@@ -108,6 +114,35 @@ void main() {
 
     expect(find.text('Search photo library'), findsNothing);
     expect(find.text('Use cloud media store'), findsOneWidget);
+  });
+
+  testWidgets('scanning with the photo library toggled on searches it', (
+    tester,
+  ) async {
+    final notifier = _SeededWizardNotifier(const RepairWizardIdle());
+    await tester.pumpWidget(host(notifier));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Search photo library'));
+    await tester.pump();
+    await tester.tap(find.text('Scan'));
+    await tester.pump();
+
+    expect(notifier.harvestedWith?.usePhotoLibrary, isTrue);
+  });
+
+  testWidgets('scanning without a photo library never searches one', (
+    tester,
+  ) async {
+    final notifier = _SeededWizardNotifier(const RepairWizardIdle());
+    await tester.pumpWidget(host(notifier, galleryBrowsing: false));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Scan'));
+    await tester.pump();
+
+    expect(notifier.harvestedWith, isNotNull);
+    expect(notifier.harvestedWith!.usePhotoLibrary, isFalse);
   });
 
   testWidgets('review groups by confidence, pre-checks per ladder, and '

--- a/test/features/media/presentation/providers/media_resolver_providers_test.dart
+++ b/test/features/media/presentation/providers/media_resolver_providers_test.dart
@@ -3,10 +3,12 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/media/data/services/local_files_diagnostics_service.dart';
+import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 
 /// Stub diagnostics service used to drive the FutureProvider tests in this
 /// file. We override `localFilesDiagnosticsServiceProvider` so the providers
@@ -50,6 +52,13 @@ void Function() _disposeOnce(ProviderContainer container) {
 
   addTearDown(dispose);
   return dispose;
+}
+
+class _StubPicker extends Fake implements PhotoPickerService {
+  _StubPicker({required this.supportsGalleryBrowsing});
+
+  @override
+  final bool supportsGalleryBrowsing;
 }
 
 void main() {
@@ -180,5 +189,40 @@ void main() {
     // What unmounting a ProviderScope does, and what the binding does for
     // every widget test before it checks for stray timers.
     disposeContainer();
+  });
+
+  // The resolver's only production construction site. Windows and Linux have
+  // no photo library, and a resolver that thinks otherwise reports a synced
+  // gallery photo as notFound, which orphans the row on every device.
+  group('platformGalleryResolverProvider photo library wiring', () {
+    for (final hasLibrary in [true, false]) {
+      test('follows supportsGalleryBrowsing=$hasLibrary', () {
+        final container = ProviderContainer(
+          overrides: [
+            photoPickerServiceProvider.overrideWithValue(
+              _StubPicker(supportsGalleryBrowsing: hasLibrary),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final resolver = container.read(platformGalleryResolverProvider);
+
+        expect(
+          resolver.canResolveOnThisDevice(
+            MediaItem(
+              id: 'g1',
+              mediaType: MediaType.photo,
+              sourceType: MediaSourceType.platformGallery,
+              platformAssetId: 'A',
+              takenAt: DateTime(2026),
+              createdAt: DateTime(2026),
+              updatedAt: DateTime(2026),
+            ),
+          ),
+          hasLibrary,
+        );
+      });
+    }
   });
 }


### PR DESCRIPTION
## Summary

On Debian with a Dropbox-synced library, opening dive details popped up an "Open File" dialog (filter: "Images and videos"). Cancelling it just opened it again.

Windows and Linux have no photo library, so there `PhotoPickerServiceDesktop.getAssetsInDateRange` opens an interactive file dialog instead of running a query. Here's the chain that reached it:

1. A dive's photos were linked on a Mac or phone, so they are `platformGallery` rows holding an Apple Photos or Android asset id.
2. `PlatformGalleryResolver._fetchThumbnail` asks `photo_manager` for the thumbnail. `photo_manager` has no Linux or Windows backend, and `AssetEntity.fromId` swallows the `MissingPluginException` and returns `null`.
3. The resolver treats an empty fetch as a stale mapping and calls `AssetResolutionService.reresolve`.
4. `resolveAssetId` has a `supportsGalleryBrowsing` guard, but `reresolve` did not. It went straight into the gallery search, which opened the dialog once per photo and time reading (UTC and local). Failed thumbnails are never cached, so every rebuild started it again.

This regressed in a49907efe9e, which added `reresolve`, and has shipped since v1.7.5.

## Changes

- Move the no-gallery guard into `_resolveFromGallery`, the single path every gallery search takes, so no background resolution can reach the dialog. Without a gallery, `reresolve` now returns what `resolveAssetId` already did (the stored id, `resolved`). It does not return `unavailable`, because the enum defines that as a positive "gone" finding that a caller may orphan the row on.
- On a platform with no photo library, `PlatformGalleryResolver` now answers `fromOtherDevice` from `resolve`, `resolveThumbnail` and `verify`, and reports `canResolveOnThisDevice` false, all without consulting the resolution service. Before this, those rows came back `notFound`, the one verdict the orphan reconciler and the verifier treat as proof of absence. That write syncs, so a Linux device could mark photos that are still safe in a Mac's or phone's library as missing on every device. The tile now reads "From another device" instead of "File not found". The resolver gets the fact through a `hasPhotoLibrary` flag, wired from `supportsGalleryBrowsing` in `platformGalleryResolverProvider`.
- Hide the Media Repair wizard's "Search photo library" toggle where there is no photo library. That source runs one date query per broken row, so on desktop it would have opened one dialog per row.

## Test Plan

- [x] `flutter test`: the affected tests pass locally (pre-push hook). The full suite runs in CI.
- [x] `flutter analyze` passes
- [x] New regression test `reresolve never searches the gallery on desktop platforms`. Before the fix it failed on the unexpected `getAssetsInDateRange` call.
- [x] New widget test `hides the photo library toggle where there is no library`. Before the fix it failed with the toggle present.
- [x] New resolver tests (`a platform with no photo library`) and a provider wiring test (`platformGalleryResolverProvider photo library wiring`). Before the change they failed on the assertions, not just to compile.
- [ ] Manual testing on: Linux (Debian) with a synced library containing gallery-linked photos. Not run: no Linux host here.
