### PR TITLE
fix(sites): geocode Android place names through Nominatim (#1762)

### DIFF
--- a/lib/core/services/location_service.dart
+++ b/lib/core/services/location_service.dart
@@ -2,7 +2,8 @@ import 'dart:convert';
 import 'dart:io' show Platform, HttpClient, SocketException;
 import 'dart:ui' show Locale;
 
-import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb, visibleForTesting;
 import 'package:geolocator/geolocator.dart';
 import 'package:geocoding/geocoding.dart';
 
@@ -153,16 +154,20 @@ class LocationService {
     '&accept-language=$defaultLanguageCode',
   );
 
-  /// Routes reverse geocoding through the platform geocoder.
+  /// Routes reverse geocoding through the platform geocoder: iOS only.
   ///
-  /// True on mobile in production. `Platform.isIOS`/`isAndroid` are
-  /// natively-resolved statics with no override hook, so the mobile branch
-  /// is otherwise unreachable on a desktop test host -- including the
-  /// English-locale contract below, the part of #214 most worth asserting.
-  @visibleForTesting
-  static bool debugForceNativeGeocoder = false;
-
-  static bool get _useNativeGeocoder => debugForceNativeGeocoder || _isMobile;
+  /// Apple's geocoder answers every field in the requested language. The
+  /// Android one (Play services) translates only the country name and
+  /// returns the region in the local language, and not even consistently:
+  /// one Attersee lookup in English mixed 'Oberösterreich' and 'Upper
+  /// Austria' across its results. A place name language refresh on Android
+  /// therefore wrote local region names back (#1762), so Android shares the
+  /// Nominatim path the desktops use.
+  ///
+  /// Keyed on [defaultTargetPlatform] rather than `Platform.isIOS` so tests
+  /// can reach both branches through `debugDefaultTargetPlatformOverride`.
+  static bool get _useNativeGeocoder =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
 
   /// Process-wide spacing for every Nominatim request. Tests replace it with
   /// a zero-gap instance so lookups do not wait a real second each.
@@ -319,9 +324,9 @@ class LocationService {
   /// Reverse geocode a coordinate into country, region and locality, in the
   /// language named by [languageCode] (an ISO 639-1 code such as 'en').
   ///
-  /// Uses the platform geocoder on mobile and falls back to OpenStreetMap
-  /// Nominatim everywhere else. Never throws: a geocoder that cannot be
-  /// reached yields [PlaceLookup.unavailable].
+  /// Uses the platform geocoder on iOS, and OpenStreetMap Nominatim
+  /// everywhere else and whenever the iOS geocoder fails. Never throws: a
+  /// geocoder that cannot be reached yields [PlaceLookup.unavailable].
   Future<PlaceLookup> reverseGeocode(
     double latitude,
     double longitude, {
@@ -330,7 +335,7 @@ class LocationService {
     try {
       _log.info('Reverse geocoding: $latitude, $longitude ($languageCode)');
 
-      // Try native geocoding first (works on iOS/Android)
+      // Try native geocoding first (iOS only, see _useNativeGeocoder)
       if (_useNativeGeocoder) {
         try {
           // Built per call rather than cached in a static: construction only

--- a/test/core/services/location_service_test.dart
+++ b/test/core/services/location_service_test.dart
@@ -5,6 +5,8 @@ import 'dart:ui' show Locale;
 
 import 'package:clock/clock.dart';
 import 'package:fake_async/fake_async.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, debugDefaultTargetPlatformOverride;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geocoding/geocoding.dart';
 // `geocoding` declares its own app-facing `Geocoding`, which shadows the
@@ -539,11 +541,11 @@ void main() {
 
   group('native geocoder locale (#214)', () {
     setUp(() {
-      LocationService.debugForceNativeGeocoder = true;
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     });
 
     tearDown(() {
-      LocationService.debugForceNativeGeocoder = false;
+      debugDefaultTargetPlatformOverride = null;
     });
 
     test('asks the geocoder for the requested language', () async {
@@ -625,6 +627,80 @@ void main() {
       );
       expect(geocoding.locales, [const Locale('en'), const Locale('en')]);
     });
+  });
+
+  group('Android geocodes through Nominatim (#1762)', () {
+    setUp(() {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    });
+
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    test('the region follows the requested language', () async {
+      // What the Play services geocoder really answers for Attersee when
+      // asked in English: only the country name is translated, and the
+      // administrative area stays in the local language.
+      final geocoding = _FakeGeocoding(
+        placemarks: const [
+          Placemark(country: 'Austria', administrativeArea: 'Oberösterreich'),
+        ],
+      );
+      GeocodingPlatformFactory.instance = _FakeGeocodingFactory(geocoding);
+      final server = FakeNominatim(
+        body: jsonEncode(<String, dynamic>{
+          'address': <String, dynamic>{
+            'country': 'Austria',
+            'state': 'Upper Austria',
+            'village': 'Nußdorf am Attersee',
+          },
+        }),
+      );
+
+      final result = await server.run(
+        () => service.reverseGeocode(47.88, 13.545, languageCode: 'en'),
+      );
+
+      expect(
+        geocoding.locales,
+        isEmpty,
+        reason:
+            'the Android geocoder ignores the locale for everything but the '
+            'country, so a refresh would write local region names back',
+      );
+      expect(result.country, 'Austria');
+      expect(result.region, 'Upper Austria');
+      expect(result.locality, 'Nußdorf am Attersee');
+      expect(
+        server.requestedUris.first.queryParameters['accept-language'],
+        'en',
+      );
+    });
+
+    test(
+      'an unreachable Nominatim is reported, not answered natively',
+      () async {
+        final geocoding = _FakeGeocoding(
+          placemarks: const [
+            Placemark(country: 'Spain', administrativeArea: 'Canarias'),
+          ],
+        );
+        GeocodingPlatformFactory.instance = _FakeGeocodingFactory(geocoding);
+
+        final result = await HttpOverrides.runZoned(
+          () => service.reverseGeocode(28.047, -16.72, languageCode: 'en'),
+          createHttpClient: (_) => ThrowingHttpClient(),
+        );
+
+        expect(result.networkFailed, isTrue);
+        expect(
+          geocoding.locales,
+          isEmpty,
+          reason: 'a native answer would carry the local region name',
+        );
+      },
+    );
   });
 
   group('LocationResult.place', () {


### PR DESCRIPTION
## Summary

Fixes #1762: on Android, the dive sites menu option that rewrites location details in the selected place name language still stored local region names.

The cause is the Android (Play services) geocoder itself. It receives the requested locale but translates only the country name. The administrative area comes back in the local language regardless of the locale asked for, and it is not even consistent within one lookup. Measured on an API 36 Play Store emulator through the app's own geocoding plugin:

| Site | Requested `en` | Requested `de` |
| --- | --- | --- |
| Attersee | Austria / Oberösterreich (some results of the same call: Upper Austria) | Österreich / Oberösterreich |
| Tenerife | Spain / Canarias | Spanien / Canarias |
| Cozumel | Mexico / Quintana Roo | Mexiko / Quintana Roo |
| Roatán | Honduras / Bay Islands Department | Honduras / Bay Islands Department |

The app was passing the language correctly the whole way (`placeNameLanguageProvider` to `reverseGeocode` to `Geocoder(context, Locale)`); the refresh simply received local region names and overwrote each site with them. Apple's geocoder and Nominatim both translate the region, which is why only Android was affected.

## Changes

- Reverse geocoding uses the platform geocoder on iOS only. Android now shares the Nominatim path the desktop platforms already use, with no native fallback, so an unreachable Nominatim is reported as an outage instead of being answered with local names. This covers every caller of `reverseGeocode` (the site refresh, GPS capture on the site form, region downloads, UDDF import).
- The switch is keyed on `defaultTargetPlatform`, which tests can override through `debugDefaultTargetPlatformOverride`, replacing the `debugForceNativeGeocoder` flag. The existing native-locale tests now run under an iOS override.
- New tests pin the Android behavior: the region follows the requested language (the fake native geocoder returns the real `Oberösterreich` answer and must not be consulted), and an unreachable Nominatim is reported rather than answered natively.

Trade-off: Android lookups now go through the shared Nominatim throttle (one request per second), so refreshing a large site list takes longer than it did with the native geocoder.

Sites already rewritten with local names on Android are repaired by running the same refresh again once this ships.

## Test Plan

- [x] `flutter test` passes (all 31 test files touching geocoding plus `test/features/dive_sites`: 949 tests; pre-push hook suite)
- [x] `flutter analyze` passes
- [x] Mutation check: adding Android back to the native-geocoder rule turns both new Android tests red
- [x] Manual testing on: Android emulator (API 36, Play Store image). A probe confirmed the geocoder behavior in the table above, and the fixed `reverseGeocode` routed to Nominatim. Nominatim's translated answer could not be observed end to end from the test network, which receives HTTP 429 from the public instance.
