### PR TITLE
ci: require every PR description to link its issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,19 @@
+## Related Issue
+
+<!--
+Required: every PR must relate to an issue. The "PR Issue Link" check fails
+until this description links one. Write one line per issue:
+
+  Closes #123        this PR fully resolves the issue (Fixes/Resolves also work)
+  Refs #123          related, but the issue stays open
+  Part of #123       one step of a larger issue that stays open
+  Related to #123    same as Refs
+
+Only a closing keyword directly before the number closes the issue on merge,
+and each issue needs its own keyword ("Closes #1, closes #2", not
+"Closes #1, #2"). A number in the title does nothing.
+-->
+
 ## Summary
 
 <!-- What does this PR do and why? -->

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -521,7 +521,7 @@ jobs:
       - name: Run Python guard tests with coverage
         run: |
           mkdir -p coverage
-          guards='scripts/check_proguard_serial_keep.py,scripts/check_apk_signing_cert.py,scripts/check_native_libs_present.py,scripts/check_bundled_native_assets.py,scripts/check_jni_local_refs.py,scripts/check_dc_process_isolation.py,scripts/check_ci_success_gate.py,scripts/fix_macho_symbol_order.py,scripts/release/sanitize_apple_store_notes.py'
+          guards='scripts/check_proguard_serial_keep.py,scripts/check_apk_signing_cert.py,scripts/check_native_libs_present.py,scripts/check_bundled_native_assets.py,scripts/check_jni_local_refs.py,scripts/check_dc_process_isolation.py,scripts/check_ci_success_gate.py,scripts/check_pr_issue_link.py,scripts/fix_macho_symbol_order.py,scripts/release/sanitize_apple_store_notes.py'
           python3 -m coverage run --include="$guards" \
             scripts/check_proguard_serial_keep_test.py
           python3 -m coverage run --append --include="$guards" \
@@ -536,6 +536,8 @@ jobs:
             scripts/check_dc_process_isolation_test.py
           python3 -m coverage run --append --include="$guards" \
             scripts/check_ci_success_gate_test.py
+          python3 -m coverage run --append --include="$guards" \
+            scripts/check_pr_issue_link_test.py
           python3 -m coverage run --append --include="$guards" \
             scripts/fix_macho_symbol_order_test.py
           python3 -m coverage run --append --include="$guards" \

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -1,0 +1,63 @@
+name: PR Issue Link
+
+# Every pull request must link the issue it relates to (issue #1800): a
+# closing keyword (`Closes #N`) when it resolves the issue, or `Refs #N` /
+# `Part of #N` / `Related to #N` when it does not. Without the keyword GitHub
+# leaves a resolved issue open after the merge. The rule itself lives in
+# scripts/check_pr_issue_link.py, which Script Tests in ci.yaml unit-tests.
+#
+# Kept out of ci.yaml on purpose. The check has to re-run when the description
+# is edited, and adding `edited` to ci.yaml's triggers would restart the whole
+# pipeline on every description edit. It blocks a merge by being listed as a
+# required status check ("PR Issue Link") next to CI Success in main's branch
+# protection. No `paths` filter: a required check that never reports leaves
+# the PR waiting forever.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  issue-link:
+    name: PR Issue Link
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: scripts
+
+      - name: Fetch the current PR description
+        # Read live rather than from the event payload: re-running a failed
+        # job replays the original payload, which would still hold the
+        # description from before the author fixed it.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' \
+            > "${RUNNER_TEMP}/pr_body.md"
+
+      - name: Check the description links an issue
+        # Untrusted PR fields reach the script only through env vars, never
+        # through ${{ }} interpolation inside the shell text.
+        env:
+          REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+        run: |
+          python3 scripts/check_pr_issue_link.py \
+            --body-file "${RUNNER_TEMP}/pr_body.md" \
+            --branch "$HEAD_REF" \
+            --author-type "$AUTHOR_TYPE" \
+            --repo "$REPO"

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -12,9 +12,20 @@ name: PR Issue Link
 # required status check ("PR Issue Link") next to CI Success in main's branch
 # protection. No `paths` filter: a required check that never reports leaves
 # the PR waiting forever.
+#
+# pull_request_target, not pull_request: under pull_request the workflow and
+# the script come from the PR's merge ref, so a PR could edit either to report
+# green and walk through its own gate. pull_request_target runs both as they
+# exist on main, and its check run still lands on the PR's head commit, where
+# branch protection looks for it. That trigger is safe here only because this
+# job never checks out or executes PR code: the checkout below is main, and
+# the description is read through the API as data. Keep it that way. Two
+# consequences: a PR that changes the rule is judged by main's copy until it
+# merges (Script Tests still runs its own unit tests), and the PR that first
+# adds this file gets no run.
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, edited, reopened, synchronize]
 
@@ -32,9 +43,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # No `ref:`: under pull_request_target the default is main. Never point
+      # this at the PR head; that would run untrusted code with this token.
       - uses: actions/checkout@v7
         with:
           sparse-checkout: scripts
+          persist-credentials: false
 
       - name: Fetch the current PR description
         # Read live rather than from the event payload: re-running a failed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,27 @@ git at them.
 
 **Bypass (if needed):** `git push --no-verify`
 
+## Pull Requests
+
+Every PR must relate to an issue, and its description must say which one. The
+"PR Issue Link" check (`scripts/check_pr_issue_link.py`) blocks the merge until
+it does.
+
+- **Resolves the issue:** `Closes #123` (or `Fixes` / `Resolves`). GitHub
+  closes the issue on merge only when the keyword sits directly before the
+  number in the PR description. A number in the title, or a passing mention in
+  prose, closes nothing, which is how resolved issues were left open (#1800).
+- **Relates without resolving it** (one phase of a larger issue, a follow-up):
+  `Refs #123`, `Part of #123` or `Related to #123`. The issue stays open.
+- **Several issues:** one keyword per issue, `Closes #1, closes #2`.
+  `Closes #1, #2` closes only #1.
+- **Branch names an issue** (`github-issue-1800-...`, `feature-request-1803-...`):
+  the description must link that issue, with `Refs` if the PR does not resolve it.
+- **No issue yet:** open one first. Only bot-authored PRs are exempt.
+
+Links inside HTML comments, code spans or fenced code blocks are ignored, by
+GitHub and by the check. Editing the description re-runs the check.
+
 ## Gotchas
 
 - The `dives` table uses `diveDateTime` (not `dateTime`) as the column name to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,10 +81,20 @@ files you touched) before committing.
 
 1. Push your branch and open a pull request against `main`.
 2. Fill out the [pull request template](.github/PULL_REQUEST_TEMPLATE.md),
-   describing what changed and why, and link any related issues.
-3. Keep PRs focused and reasonably small — one logical change per PR is easier
+   describing what changed and why.
+3. **Link the issue the PR relates to.** Every PR must relate to an issue, and
+   the "PR Issue Link" check blocks the merge until the description links one:
+   - `Closes #123` (or `Fixes` / `Resolves`) when the PR fully resolves the
+     issue. GitHub closes the issue on merge only when the keyword sits
+     directly before the number in the description; a number in the title does
+     nothing. Give each issue its own keyword: `Closes #1, closes #2`.
+   - `Refs #123`, `Part of #123` or `Related to #123` when the PR relates to an
+     issue without resolving it, so the issue stays open.
+
+   If no issue exists yet, open one first.
+4. Keep PRs focused and reasonably small: one logical change per PR is easier
    to review and merge.
-4. Ensure CI passes. Maintainers may request changes; discussion is part of the
+5. Ensure CI passes. Maintainers may request changes; discussion is part of the
    process.
 
 For detailed conventions, see:

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -10,6 +10,9 @@ This guide explains how to submit effective pull requests.
 2. Check [open PRs](https://github.com/submersion-app/submersion/pulls)
 3. Review the [roadmap](contributing/roadmap.md)
 
+Every PR must relate to an issue (see [Linking Issues](#linking-issues)). If
+none exists for your change, open one before you open the PR.
+
 ### Discuss Large Changes
 
 For significant changes:
@@ -32,7 +35,8 @@ git remote add upstream https://github.com/submersion-app/submersion.git
 
 # Create branch
 git checkout -b feature/your-feature
-```text
+```
+
 ### 2. Make Changes
 
 - Follow [code style](contributing/code-style.md)
@@ -48,12 +52,14 @@ git commit -m "feat: add nitrox calculator"
 git commit -m "fix: correct MOD calculation for trimix"
 git commit -m "docs: add calculator documentation"
 git commit -m "test: add unit tests for gas calculations"
-```text
+```
+
 ### 4. Push
 
 ```bash
 git push origin feature/your-feature
-```text
+```
+
 ### 5. Open PR
 
 1. Go to your fork on GitHub
@@ -62,46 +68,64 @@ git push origin feature/your-feature
 
 ## PR Template
 
+GitHub pre-fills new PRs from
+[`.github/PULL_REQUEST_TEMPLATE.md`](https://github.com/submersion-app/submersion/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
+A filled-out description looks like this:
+
 ```markdown
-## Description
+## Related Issue
 
-Brief description of what this PR does.
+Closes #123
 
-## Type of Change
+## Summary
 
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change
-- [ ] Documentation
+Fixes the MOD calculation for trimix, which used the O2 fraction of air.
 
-## Changes Made
+## Changes
 
-- Added X
-- Modified Y
-- Removed Z
+- Pass the mix's own O2 fraction into `calculateMod`
+- Add unit tests for air, EAN32 and 18/45 trimix
 
-## Testing
+## Test Plan
 
-- [ ] Unit tests added/updated
-- [ ] Widget tests added/updated
-- [ ] Manual testing performed
-
-## Checklist
-
-- [ ] Code follows style guidelines
-- [ ] Tests pass locally
-- [ ] Documentation updated
-- [ ] No new warnings from `flutter analyze`
+- [x] `flutter test` passes
+- [x] `flutter analyze` passes
+- [x] Manual testing on: macOS
 
 ## Screenshots
 
-(If applicable)
+(Delete this section if not applicable.)
+```
 
-## Related Issues
+## Linking Issues
 
-Fixes #123
-Related to #456
-```text
+Every PR must relate to an issue. The **PR Issue Link** check blocks the merge
+until the description links one, and re-runs whenever the description is
+edited.
+
+| The PR... | Write | On merge |
+| --- | --- | --- |
+| fully resolves the issue | `Closes #123` (or `Fixes` / `Resolves`) | the issue closes |
+| is one step of a larger issue | `Part of #123` | the issue stays open |
+| is related work or a follow-up | `Refs #123` or `Related to #123` | the issue stays open |
+
+Things that trip people up:
+
+- **Only the description counts.** GitHub closes an issue only when a closing
+  keyword sits directly before the number in the PR description. A number in
+  the PR title, or a passing mention like "builds on #123", links nothing.
+- **One keyword per issue.** `Closes #1, closes #2` closes both;
+  `Closes #1, #2` closes only #1.
+- **Comments and code do not count.** A link inside an HTML comment
+  (`<!-- -->`) or a code span is ignored, by GitHub and by the check. The
+  template's examples live in a comment for that reason, so an unedited
+  template fails.
+- **Branch names are checked.** If the branch name contains an issue number
+  (`issue-123-...`, `github-issue-123-...`, `feature-request-123-...`), the
+  description must link that issue, with `Refs` if the PR does not resolve it.
+- **No issue yet?** Open one first. Only bot-authored PRs (version bumps,
+  Dependabot) are exempt.
+
 ## PR Best Practices
 
 ### Keep PRs Small
@@ -114,7 +138,7 @@ Related to #456
 
 - Explain what and why
 - Include context
-- Link related issues
+- Link the issue with `Closes #N` or `Refs #N` (see [Linking Issues](#linking-issues))
 
 ### Add Screenshots
 
@@ -155,7 +179,8 @@ For UI changes:
 git add .
 git commit -m "fix: address review feedback"
 git push origin feature/your-feature
-```text
+```
+
 ## After Merge
 
 ### Clean Up
@@ -169,7 +194,8 @@ git branch -d feature/your-feature
 
 # Update from upstream
 git pull upstream main
-```text
+```
+
 ### Celebrate
 
 Your contribution is now part of Submersion!
@@ -179,6 +205,9 @@ Your contribution is now part of Submersion!
 ### Bug Fixes
 
 ```markdown
+## Related Issue
+Closes #123
+
 ## Description
 Fixes incorrect depth unit conversion when switching between metric and imperial.
 
@@ -191,10 +220,14 @@ Corrected the conversion factor from 3.28084 to 0.3048 for feet to meters.
 ## Testing
 - Added unit tests for both conversion directions
 - Manually verified in settings page
-```text
+```
+
 ### New Features
 
 ```markdown
+## Related Issue
+Closes #456
+
 ## Description
 Adds a nitrox calculator to the tools section.
 
@@ -209,10 +242,14 @@ Adds a nitrox calculator to the tools section.
 
 ## Documentation
 - Updated tools section in user guide
-```text
+```
+
 ### Refactoring
 
 ```markdown
+## Related Issue
+Refs #789
+
 ## Description
 Refactors dive repository to use a base repository class.
 
@@ -226,7 +263,8 @@ Reduces code duplication across repositories.
 
 ## Testing
 All existing tests pass without modification.
-```text
+```
+
 ## Common Issues
 
 ### Merge Conflicts

--- a/scripts/check_pr_issue_link.py
+++ b/scripts/check_pr_issue_link.py
@@ -95,8 +95,9 @@ def _strip_blocks(text):
 
     Block structure is decided before inline markup, so a `<!--` inside a
     fence is content. A comment block starts with `<!--` at the start of a
-    line (it may interrupt a paragraph) and ends on the line holding `-->`.
-    An unclosed fence or comment block runs to the end of the text.
+    line (it may interrupt a paragraph) and ends at the `-->`; any text after
+    the closer stays. An unclosed fence or comment block runs to the end of
+    the text.
     """
     kept, fence, in_comment = [], None, False
     for line in text.splitlines():
@@ -105,7 +106,11 @@ def _strip_blocks(text):
                 fence = None
             continue
         if in_comment:
-            in_comment = "-->" not in line
+            end = line.find("-->")
+            if end >= 0:
+                in_comment = False
+                # Text after the closer is visible, so it can hold a link.
+                kept.append(line[end + 3:])
             continue
         opening = _FENCE_OPEN.match(line)
         # A backtick fence's info string cannot contain a backtick, so a line
@@ -115,9 +120,13 @@ def _strip_blocks(text):
         ):
             fence = opening.group(1)
             continue
-        if _COMMENT_BLOCK_OPEN.match(line):
-            in_comment = "-->" not in line[line.index("<!--") + 4:]
+        if _COMMENT_BLOCK_OPEN.match(line) and (
+            "-->" not in line[line.index("<!--") + 4:]
+        ):
+            in_comment = True
             continue
+        # A comment that also closes on this line is left to _strip_inline,
+        # which removes only the comment and keeps the text after it.
         kept.append(line)
     return "\n".join(kept)
 

--- a/scripts/check_pr_issue_link.py
+++ b/scripts/check_pr_issue_link.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Require every pull request description to link the issue it relates to.
+
+GitHub closes an issue on merge only when a closing keyword sits directly in
+front of the issue number in the PR description (or in a commit message that
+reaches the default branch). A number in the title, or a passing mention in
+prose, links nothing. Issue #1800 found issues left open after the PR that
+resolved them had merged, because the description never said `Closes #N`.
+
+This guard makes the link a deliberate, checked part of every PR. It passes
+when the description contains at least one of:
+
+  * a closing link:     Close[sd] / Fix(e[sd]) / Resolve[sd] #N
+  * a non-closing link: Refs / Part of / Related to #N
+
+The non-closing forms exist for phased work and follow-ups that relate to an
+issue without resolving it, so the issue is not closed early. When the branch
+name encodes an issue number (`github-issue-1800-...`, `feature-request-1803-
+...`, `fix/issue-12`), that particular issue must be one of the links: the
+branch says which issue the work is for, so a description that forgets it is
+almost certainly the #1800 mistake.
+
+Bot-authored PRs (the version bump promote.yml opens, Dependabot) pass
+unconditionally: they have no issue, and blocking them would stall the bump
+PR's auto-merge and with it the beta train.
+
+Text GitHub does not parse for links is ignored: HTML comments (where the PR
+template keeps its examples, so an untouched template fails), fenced code
+blocks and inline code spans. Indented code blocks are not stripped, because
+telling them apart from nested list content needs a full Markdown parser.
+
+Pure stdlib, so the workflow needs no dependency install.
+
+Usage: check_pr_issue_link.py --body-file PATH [--branch NAME]
+                              [--author-type User|Bot] [--repo OWNER/NAME]
+"""
+
+import argparse
+import re
+import sys
+
+CLOSING_KEYWORD = r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)"
+LINKING_KEYWORD = r"(?:refs|part[ \t]+of|related[ \t]+to)"
+
+# GitHub accepts an optional colon after the keyword, but the keyword and the
+# reference must still be separated by it or by whitespace.
+_SEPARATOR = r"(?::[ \t]*|[ \t]+)"
+_REFERENCE = r"(?:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(?P<num>\d+)\b"
+
+# re.ASCII: without it `\d` also matches digits such as Arabic-Indic ones,
+# which GitHub does not treat as an issue number.
+_CLOSING = re.compile(
+    r"\b" + CLOSING_KEYWORD + r"\b" + _SEPARATOR + _REFERENCE,
+    re.IGNORECASE | re.ASCII,
+)
+_LINKING = re.compile(
+    r"\b" + LINKING_KEYWORD + r"\b" + _SEPARATOR + _REFERENCE,
+    re.IGNORECASE | re.ASCII,
+)
+
+# `issue-N` must start a path segment or follow a hyphen/underscore, so
+# `tissue-5` is not an issue branch.
+_BRANCH_ISSUE = re.compile(
+    r"(?:^|[/_-])(?:issue|feature-request)-(\d+)(?=$|[/_-])",
+    re.IGNORECASE | re.ASCII,
+)
+
+_FENCE_OPEN = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
+_COMMENT_BLOCK_OPEN = re.compile(r"^ {0,3}<!--")
+_PARAGRAPH_BREAK = re.compile(r"\n[ \t]*\n")
+_INLINE_OPEN = re.compile(r"<!--|`+")
+
+HOW_TO_FIX = (
+    "Every PR must relate to an issue. Add `Closes #N` (or Fixes/Resolves) to "
+    "the description if this PR resolves the issue, or `Refs #N`, `Part of "
+    "#N` or `Related to #N` if it does not. A number in the title or in "
+    "passing prose links nothing. Editing the description re-runs this check."
+)
+
+
+def _closes_fence(line, fence):
+    """A closing fence repeats the opening character, at least as many times,
+    with nothing after it: a line such as ```text inside a block is content."""
+    stripped = line.strip()
+    return (
+        bool(stripped)
+        and set(stripped) == {fence[0]}
+        and len(stripped) >= len(fence)
+        and len(line) - len(line.lstrip(" ")) <= 3
+    )
+
+
+def _strip_blocks(text):
+    """Drop fenced code blocks and HTML comment blocks, line by line.
+
+    Block structure is decided before inline markup, so a `<!--` inside a
+    fence is content. A comment block starts with `<!--` at the start of a
+    line (it may interrupt a paragraph) and ends on the line holding `-->`.
+    An unclosed fence or comment block runs to the end of the text.
+    """
+    kept, fence, in_comment = [], None, False
+    for line in text.splitlines():
+        if fence is not None:
+            if _closes_fence(line, fence):
+                fence = None
+            continue
+        if in_comment:
+            in_comment = "-->" not in line
+            continue
+        opening = _FENCE_OPEN.match(line)
+        # A backtick fence's info string cannot contain a backtick, so a line
+        # like ```x``` is an inline code span, not a fence.
+        if opening and not (
+            opening.group(1)[0] == "`" and "`" in opening.group(2)
+        ):
+            fence = opening.group(1)
+            continue
+        if _COMMENT_BLOCK_OPEN.match(line):
+            in_comment = "-->" not in line[line.index("<!--") + 4:]
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def _strip_inline(paragraph):
+    """Drop code spans and inline HTML comments, in document order.
+
+    Whichever construct opens first wins, so a `<!--` inside a code span is
+    code and a backtick inside a comment is comment. An opener with no closer
+    in the same paragraph is literal text.
+    """
+    out, pos = [], 0
+    while True:
+        opening = _INLINE_OPEN.search(paragraph, pos)
+        if not opening:
+            out.append(paragraph[pos:])
+            return "".join(out)
+        out.append(paragraph[pos:opening.start()])
+        token = opening.group()
+        if token == "<!--":
+            end = paragraph.find("-->", opening.end())
+            close_end = end + 3 if end >= 0 else None
+        else:
+            # A code span closes on a backtick run of exactly the same length.
+            closer = re.compile(r"(?<!`)" + token + r"(?!`)").search(
+                paragraph, opening.end()
+            )
+            close_end = closer.end() if closer else None
+        if close_end is None:
+            out.append(token)
+            pos = opening.end()
+        else:
+            pos = close_end
+
+
+def prose(body):
+    """Return only the text GitHub scans for issue links."""
+    paragraphs = _PARAGRAPH_BREAK.split(_strip_blocks(body or ""))
+    return "\n\n".join(_strip_inline(p) for p in paragraphs)
+
+
+def _refs(pattern, body, repo):
+    refs = set()
+    for match in pattern.finditer(prose(body)):
+        ref_repo, number = match.group("repo"), match.group("num")
+        if ref_repo and ref_repo.lower() != (repo or "").lower():
+            refs.add(f"{ref_repo}#{number}")
+        else:
+            refs.add(f"#{number}")
+    return refs
+
+
+def closing_refs(body, repo):
+    """Issues GitHub will close when this PR merges into the default branch."""
+    return _refs(_CLOSING, body, repo)
+
+
+def linking_refs(body, repo):
+    """Issues the description explicitly relates to without closing them."""
+    return _refs(_LINKING, body, repo)
+
+
+def branch_issue(branch):
+    """Return `#N` when the branch name encodes an issue number, else None."""
+    match = _BRANCH_ISSUE.search(branch or "")
+    return f"#{match.group(1)}" if match else None
+
+
+def evaluate(body, branch, author_type, repo):
+    """Return (ok, lines) for one pull request."""
+    if (author_type or "").lower() == "bot":
+        return True, ["  ok    bot-authored PR: exempt from the issue-link rule"]
+
+    closes = closing_refs(body, repo)
+    relates = linking_refs(body, repo)
+    lines = []
+    ok = True
+
+    if not closes and not relates:
+        ok = False
+        lines.append(f"  FAIL  the description links no issue. {HOW_TO_FIX}")
+
+    expected = branch_issue(branch)
+    if expected and expected not in closes | relates:
+        ok = False
+        lines.append(
+            f"  FAIL  branch '{branch}' is for issue {expected}, but the "
+            f"description neither closes nor references it. Add `Closes "
+            f"{expected}`, or `Refs {expected}` if this PR does not resolve it."
+        )
+
+    if ok:
+        if closes:
+            lines.append("  ok    closes " + ", ".join(sorted(closes)))
+        if relates:
+            lines.append("  ok    relates to " + ", ".join(sorted(relates)))
+    return ok, lines
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--body-file", required=True)
+    parser.add_argument("--branch", default="")
+    parser.add_argument("--author-type", default="User")
+    parser.add_argument("--repo", default="")
+    args = parser.parse_args(argv[1:])
+
+    print("Checking the PR description for an issue link")
+    try:
+        with open(args.body_file, encoding="utf-8", errors="replace") as fh:
+            body = fh.read()
+    except OSError as exc:
+        print(f"::error::could not read the PR description: {exc}")
+        return 1
+
+    ok, lines = evaluate(body, args.branch, args.author_type, args.repo)
+    for line in lines:
+        print(line)
+    if ok:
+        print("  -> PASS")
+        return 0
+    for line in lines:
+        if line.startswith("  FAIL"):
+            print("::error::" + line[len("  FAIL  "):])
+    print("  -> FAIL: link the issue this PR relates to")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main(sys.argv))

--- a/scripts/check_pr_issue_link_test.py
+++ b/scripts/check_pr_issue_link_test.py
@@ -77,6 +77,17 @@ class ClosingRefsTest(unittest.TestCase):
         self.assertEqual(closing("<!-- Closes #123 -->"), set())
         self.assertEqual(closing("<!--\nCloses #123\n-->\nFixes #4"), {"#4"})
 
+    def test_text_after_a_one_line_comment_is_kept(self):
+        self.assertEqual(closing("<!-- template note --> Closes #1800"), {"#1800"})
+        self.assertEqual(
+            closing("<!-- a --> Closes #1 <!-- Fixes #2 --> fixes #3"),
+            {"#1", "#3"},
+        )
+
+    def test_text_after_a_multi_line_comment_closes_is_kept(self):
+        body = "<!--\nCloses #5\n--> Closes #1800"
+        self.assertEqual(closing(body), {"#1800"})
+
     def test_an_unterminated_html_comment_hides_the_rest(self):
         self.assertEqual(closing("Fixes #4\n<!-- Closes #5"), {"#4"})
 

--- a/scripts/check_pr_issue_link_test.py
+++ b/scripts/check_pr_issue_link_test.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Unit tests for check_pr_issue_link.py."""
+
+import contextlib
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "check_pr_issue_link",
+    os.path.join(_HERE, "check_pr_issue_link.py"),
+)
+guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(guard)
+
+REPO = "submersion-app/submersion"
+TEMPLATE = os.path.join(_HERE, os.pardir, ".github", "PULL_REQUEST_TEMPLATE.md")
+
+
+def closing(body):
+    return guard.closing_refs(body, REPO)
+
+
+def linked(body):
+    return guard.linking_refs(body, REPO)
+
+
+class ClosingRefsTest(unittest.TestCase):
+    def test_every_github_closing_keyword_is_recognised(self):
+        for keyword in (
+            "close", "closes", "closed",
+            "fix", "fixes", "fixed",
+            "resolve", "resolves", "resolved",
+        ):
+            with self.subTest(keyword=keyword):
+                self.assertEqual(closing(f"{keyword} #10"), {"#10"})
+
+    def test_keywords_are_case_insensitive(self):
+        self.assertEqual(closing("CLOSES #10"), {"#10"})
+        self.assertEqual(closing("Fixes #10"), {"#10"})
+
+    def test_a_colon_after_the_keyword_is_allowed(self):
+        self.assertEqual(closing("Closes: #10"), {"#10"})
+        self.assertEqual(closing("Closes:#10"), {"#10"})
+
+    def test_keyword_must_be_separated_from_the_reference(self):
+        self.assertEqual(closing("Closes#10"), set())
+
+    def test_each_issue_needs_its_own_keyword(self):
+        # GitHub closes only #1 here; the check must not promise more.
+        self.assertEqual(closing("Fixes #1, #2"), {"#1"})
+        self.assertEqual(closing("Fixes #1, fixes #2"), {"#1", "#2"})
+
+    def test_keyword_must_be_a_whole_word(self):
+        self.assertEqual(closing("prefixes #3"), set())
+        self.assertEqual(closing("unresolved #3"), set())
+
+    def test_reference_must_end_at_a_word_boundary(self):
+        self.assertEqual(closing("Fixes #12abc"), set())
+        self.assertEqual(closing("Fixes #12."), {"#12"})
+
+    def test_cross_repository_reference_keeps_its_repository(self):
+        self.assertEqual(
+            closing("Fixes octo-org/octo-repo#100"), {"octo-org/octo-repo#100"}
+        )
+
+    def test_same_repository_long_form_normalises_to_short_form(self):
+        self.assertEqual(closing("Fixes Submersion-App/Submersion#7"), {"#7"})
+
+    def test_mentions_without_a_keyword_do_not_close(self):
+        self.assertEqual(closing("Follows up on #1790 and #1806."), set())
+
+    def test_keywords_inside_html_comments_are_ignored(self):
+        self.assertEqual(closing("<!-- Closes #123 -->"), set())
+        self.assertEqual(closing("<!--\nCloses #123\n-->\nFixes #4"), {"#4"})
+
+    def test_an_unterminated_html_comment_hides_the_rest(self):
+        self.assertEqual(closing("Fixes #4\n<!-- Closes #5"), {"#4"})
+
+    def test_keywords_inside_fenced_code_are_ignored(self):
+        body = "```markdown\nCloses #123\n```\nFixes #4\n~~~\nFixes #5\n~~~"
+        self.assertEqual(closing(body), {"#4"})
+
+    def test_an_unclosed_fence_hides_the_rest(self):
+        self.assertEqual(closing("Fixes #4\n```\nCloses #5"), {"#4"})
+
+    def test_a_fence_with_an_info_string_does_not_close_the_block(self):
+        body = "```\nCloses #1\n```text\nCloses #2\n```\nFixes #3"
+        self.assertEqual(closing(body), {"#3"})
+
+    def test_keywords_inside_inline_code_are_ignored(self):
+        self.assertEqual(closing("Write `Closes #123` in the body."), set())
+        self.assertEqual(closing("Use ``Closes #1`` then Fixes #2"), {"#2"})
+
+    def test_an_inline_html_comment_is_ignored(self):
+        self.assertEqual(closing("See <!-- Closes #5 --> Fixes #4"), {"#4"})
+
+    def test_a_comment_opener_inside_inline_code_is_literal(self):
+        # Whichever construct starts first wins: here the code span does, so
+        # the `<!--` inside it must not hide the rest of the description.
+        body = "Moves the examples into a `<!--` comment.\n\nCloses #1800"
+        self.assertEqual(closing(body), {"#1800"})
+
+    def test_a_comment_opener_inside_a_fence_is_literal(self):
+        body = "```\n<!-- start\n```\nCloses #1800"
+        self.assertEqual(closing(body), {"#1800"})
+
+    def test_an_unmatched_comment_opener_mid_line_is_literal(self):
+        self.assertEqual(closing("Use <!-- to start one.\nCloses #1800"), {"#1800"})
+
+    def test_an_unmatched_backtick_is_literal(self):
+        self.assertEqual(closing("A stray ` backtick. Closes #1800"), {"#1800"})
+
+    def test_a_backtick_run_with_backticks_after_it_is_inline_code(self):
+        # A backtick fence's info string cannot contain a backtick, so this
+        # line is an inline code span, not an unclosed fenced block.
+        self.assertEqual(closing("```x``` then Closes #1800"), {"#1800"})
+
+    def test_non_ascii_digits_are_not_references(self):
+        self.assertEqual(closing("Closes #١٢"), set())
+
+
+class LinkingRefsTest(unittest.TestCase):
+    def test_every_non_closing_form_is_recognised(self):
+        for phrase in ("Refs", "Part of", "Related to"):
+            with self.subTest(phrase=phrase):
+                self.assertEqual(linked(f"{phrase} #5"), {"#5"})
+
+    def test_non_closing_forms_are_case_insensitive_and_allow_a_colon(self):
+        self.assertEqual(linked("refs: #5"), {"#5"})
+        self.assertEqual(linked("PART OF #5"), {"#5"})
+        self.assertEqual(linked("related  to #5"), {"#5"})
+
+    def test_passing_prose_is_not_a_declaration(self):
+        self.assertEqual(linked("see #5, like #6 did"), set())
+
+    def test_closing_keywords_are_not_counted_as_non_closing(self):
+        self.assertEqual(linked("Closes #5"), set())
+
+    def test_non_closing_forms_inside_comments_are_ignored(self):
+        self.assertEqual(linked("<!-- Refs #5 -->"), set())
+
+
+class BranchIssueTest(unittest.TestCase):
+    def test_issue_worktree_branch(self):
+        self.assertEqual(
+            guard.branch_issue("ericgriffin/github-issue-1800-6a78c2"), "#1800"
+        )
+
+    def test_feature_request_worktree_branch(self):
+        self.assertEqual(
+            guard.branch_issue("ericgriffin/feature-request-1803-9f1671"), "#1803"
+        )
+
+    def test_conventional_issue_branch(self):
+        self.assertEqual(guard.branch_issue("fix/issue-12"), "#12")
+        self.assertEqual(guard.branch_issue("issue-12-short-name"), "#12")
+
+    def test_branches_without_an_issue_number(self):
+        for branch in ("ericgriffin/bulk-use-set-1754", "tissue-5", "main", ""):
+            with self.subTest(branch=branch):
+                self.assertIsNone(guard.branch_issue(branch))
+
+
+class EvaluateTest(unittest.TestCase):
+    def evaluate(self, body, branch="feature/x", author_type="User"):
+        return guard.evaluate(body, branch, author_type, REPO)
+
+    def test_bot_authored_prs_pass_without_a_link(self):
+        ok, lines = self.evaluate("", author_type="Bot")
+        self.assertTrue(ok)
+        self.assertIn("bot", " ".join(lines).lower())
+
+    def test_empty_description_fails(self):
+        ok, _ = self.evaluate("")
+        self.assertFalse(ok)
+
+    def test_missing_description_fails(self):
+        ok, _ = self.evaluate(None)
+        self.assertFalse(ok)
+
+    def test_prose_mention_alone_fails(self):
+        ok, lines = self.evaluate("Builds on #1790 to finish the export.")
+        self.assertFalse(ok)
+        self.assertTrue(any("Closes #N" in line for line in lines))
+
+    def test_closing_keyword_passes(self):
+        ok, lines = self.evaluate("Fixes #1800")
+        self.assertTrue(ok)
+        self.assertIn("#1800", " ".join(lines))
+
+    def test_non_closing_link_passes(self):
+        ok, _ = self.evaluate("Part of #1487")
+        self.assertTrue(ok)
+
+    def test_branch_issue_closed_by_the_description_passes(self):
+        ok, _ = self.evaluate(
+            "Closes #1800", branch="ericgriffin/github-issue-1800-6a78c2"
+        )
+        self.assertTrue(ok)
+
+    def test_branch_issue_referenced_without_closing_passes(self):
+        # A follow-up PR on the same branch, like #1742 after #1733.
+        ok, _ = self.evaluate(
+            "Refs #1729", branch="ericgriffin/github-issue-1729-55db0b"
+        )
+        self.assertTrue(ok)
+
+    def test_branch_issue_missing_from_the_description_fails(self):
+        ok, lines = self.evaluate(
+            "Closes #1801", branch="ericgriffin/github-issue-1800-6a78c2"
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any("#1800" in line for line in lines))
+
+    def test_untouched_pull_request_template_fails(self):
+        # The template's examples live in HTML comments, so a description left
+        # as the bare template must not satisfy the check by accident.
+        with open(TEMPLATE, encoding="utf-8") as fh:
+            ok, _ = self.evaluate(fh.read())
+        self.assertFalse(ok)
+
+
+class MainTest(unittest.TestCase):
+    def run_main(self, body, *extra):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "body.md")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(body)
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                code = guard.main(
+                    ["check_pr_issue_link.py", "--body-file", path,
+                     "--repo", REPO, *extra]
+                )
+        return code, out.getvalue()
+
+    def test_linked_description_exits_zero(self):
+        code, out = self.run_main("Closes #10", "--branch", "feature/x")
+        self.assertEqual(code, 0)
+        self.assertIn("PASS", out)
+
+    def test_unlinked_description_exits_one_with_an_error_annotation(self):
+        code, out = self.run_main("No issue here.", "--branch", "feature/x")
+        self.assertEqual(code, 1)
+        self.assertIn("::error::", out)
+
+    def test_bot_author_type_exits_zero(self):
+        code, _ = self.run_main("", "--author-type", "Bot")
+        self.assertEqual(code, 0)
+
+    def test_unreadable_body_file_exits_one(self):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            code = guard.main(
+                ["check_pr_issue_link.py", "--body-file", "/nonexistent/body.md"]
+            )
+        self.assertEqual(code, 1)
+        self.assertIn("::error::", out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Related Issue

Closes #1800

## Summary

GitHub closes an issue on merge only when a closing keyword sits directly before the issue number in the PR description. A number in the title, or a passing mention in prose, links nothing, so a resolved issue can stay open after its PR merges. This PR makes the link a required, checked part of every PR: its description must say which issue it relates to.

## Changes

- **New `PR Issue Link` workflow** (`.github/workflows/pr-issue-link.yml`) runs `scripts/check_pr_issue_link.py` on `pull_request_target` (`opened`, `edited`, `reopened`, `synchronize`). It fails unless the description contains:
  - a closing link, `Closes` / `Fixes` / `Resolves` #N (all nine GitHub keywords, case-insensitive, optional colon), or
  - a non-closing link, `Refs` / `Part of` / `Related to` #N, for phased work and follow-ups that must not close the issue early.
- **Branch names are checked.** When the branch encodes an issue (`github-issue-N`, `feature-request-N`, `issue-N`), that issue must be among the links.
- **Bot-authored PRs are exempt**, so the version-bump PR from `promote.yml` and Dependabot PRs still auto-merge.
- **Text GitHub does not parse for links is ignored:** HTML comments, code spans and fenced code, resolved in document order. The PR template keeps its examples in a comment, so a description left as the bare template fails.
- **Why a separate workflow:** the check has to re-run on `edited`. In ci.yaml that trigger would restart the whole pipeline on every description edit.
- **Why `pull_request_target`:** under `pull_request` the workflow and script come from the PR's merge ref, so a PR could edit either to report green and bypass its own gate. `pull_request_target` runs both as they exist on main. Its check run still lands on the PR head commit (verified on this repo: a `pull_request_target` run's `head_sha` is the PR head), which is where branch protection looks. The trigger is safe here because the job never checks out or runs PR code: it checks out main with credentials not persisted, reads the description through the API, and passes untrusted fields to the script only through env vars.
- **The body is fetched live** with `gh api`, so re-running a failed job sees the corrected description.
- **Tests:** unit tests run in ci.yaml's Script Tests coverage step. They cover 100% of the script.
- **Docs:**
  - CLAUDE.md, CONTRIBUTING.md and `.github/PULL_REQUEST_TEMPLATE.md` (new "Related Issue" section) document the rule.
  - `docs/contributing/pull-requests.md` gains a "Linking Issues" section.
  - Its broken closing fences are repaired: every block closed with ```` ```text ````, which is not a valid closing fence, so most of the page rendered as one code block.
  - Its stale template sample is replaced.

### The examples in #1800

None of the three examples is actually a missed auto-close, so this PR leaves them as they are:

- #1038 is already closed.
- #1020: a maintainer comment notes #1320 does not complete it (it asks for pre-loading a whole equipment set per dive computer).
- #1511 proposes a standalone pre-processed data repository. #1550 was linked to issue 1061 and added live swisstopo fetching, which is not that proposal.

### After merge

The check blocks merges only once it is a required status check. This adds it without touching `CI Success` or any other protection field:

```bash
gh api -X POST repos/submersion-app/submersion/branches/main/protection/required_status_checks/contexts -f 'contexts[]=PR Issue Link'
```

Once it is required, PRs that are already open show "Expected" until someone pushes to them or edits their description. Over the last 40 merged PRs, 26 linked no issue and would have been blocked, so expect most PRs to need an issue opened or referenced first.

## Test Plan

- [x] `python3 scripts/check_pr_issue_link_test.py`: 48 tests pass on Python 3.14 and 3.9, 100% line coverage of the script
- [x] Parity check against the last 40 merged PRs: the set of issues the script says will close matches GitHub's `closingIssuesReferences` for every PR (0 mismatches); both bot bump PRs pass
- [x] Dry run on the bare PR template fails, and flags the branch's own issue
- [x] Mutation check: breaking the closing-fence rule turns its test red
- [x] `python3 scripts/check_ci_success_gate.py` passes; actionlint reports nothing for the new workflow
- [x] Pre-push hook (format, analyze) passes
- [x] The first commit (then on `pull_request`) ran the check on this PR and passed: `ok closes #1800`. Since the switch to `pull_request_target`, the workflow runs as it exists on main, so this PR gets no further run; the first run on another PR happens after merge.
