### PR TITLE
fix(statistics): count each dive once in the Solo vs Buddy statistic

### DIFF
--- a/lib/features/statistics/data/repositories/statistics_repository.dart
+++ b/lib/features/statistics/data/repositories/statistics_repository.dart
@@ -1586,7 +1586,12 @@ class StatisticsRepository {
     }
   }
 
-  /// Get solo vs buddy dive percentage
+  /// Get solo vs buddy dive percentage.
+  ///
+  /// Each dive counts exactly once: a dive is a buddy dive when it has at
+  /// least one linked buddy or a non-empty free-text buddy. The linked
+  /// buddies are tested with EXISTS rather than a join, because a join yields
+  /// one row per linked buddy and would count a group dive several times.
   Future<({int solo, int buddy})> getSoloVsBuddyCount({
     String? diverId,
     DiveFilterState filter = const DiveFilterState(),
@@ -1598,11 +1603,15 @@ class StatisticsRepository {
 
       final results = await _db.customSelect('''
         SELECT
-          SUM(CASE WHEN db.buddy_id IS NULL AND (d.buddy IS NULL OR d.buddy = '') THEN 1 ELSE 0 END) AS solo,
-          SUM(CASE WHEN db.buddy_id IS NOT NULL OR (d.buddy IS NOT NULL AND d.buddy != '') THEN 1 ELSE 0 END) AS buddy
-        FROM dives d
-        LEFT JOIN dive_buddies db ON db.dive_id = d.id
-        WHERE 1=1 $diverFilter ${df.clause}
+          SUM(CASE WHEN has_buddy THEN 0 ELSE 1 END) AS solo,
+          SUM(CASE WHEN has_buddy THEN 1 ELSE 0 END) AS buddy
+        FROM (
+          SELECT
+            EXISTS (SELECT 1 FROM dive_buddies db WHERE db.dive_id = d.id)
+              OR (d.buddy IS NOT NULL AND d.buddy != '') AS has_buddy
+          FROM dives d
+          WHERE 1=1 $diverFilter ${df.clause}
+        )
         ''', variables: params.map((p) => Variable(p)).toList()).get();
 
       if (results.isEmpty) return (solo: 0, buddy: 0);

--- a/test/features/statistics/data/repositories/solo_vs_buddy_count_test.dart
+++ b/test/features/statistics/data/repositories/solo_vs_buddy_count_test.dart
@@ -1,0 +1,199 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Regression coverage for issue #1822: a dive with several linked buddies
+/// must count once in the Solo vs Buddy statistic, not once per buddy.
+void main() {
+  late StatisticsRepository repository;
+  late AppDatabase db;
+  final now = DateTime(2026, 1, 1).millisecondsSinceEpoch;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = StatisticsRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<void> insertDiver(String id) async {
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion(
+            id: Value(id),
+            name: Value('Diver $id'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> insertDive(
+    String id, {
+    String? diverId,
+    String? freeTextBuddy,
+  }) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diverId: Value(diverId),
+            buddy: Value(freeTextBuddy),
+            diveDateTime: Value(now),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> insertBuddy(String id) async {
+    await db
+        .into(db.buddies)
+        .insert(
+          BuddiesCompanion(
+            id: Value(id),
+            name: Value('Buddy $id'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> linkBuddy(String diveId, String buddyId) async {
+    await db
+        .into(db.diveBuddies)
+        .insert(
+          DiveBuddiesCompanion(
+            id: Value('$diveId-$buddyId'),
+            diveId: Value(diveId),
+            buddyId: Value(buddyId),
+            createdAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> insertBuddies(List<String> ids) async {
+    for (final id in ids) {
+      await insertBuddy(id);
+    }
+  }
+
+  group('getSoloVsBuddyCount', () {
+    test('counts a dive with three linked buddies once', () async {
+      await insertBuddies(['b1', 'b2', 'b3']);
+      await insertDive('solo');
+      await insertDive('group');
+      for (final buddyId in ['b1', 'b2', 'b3']) {
+        await linkBuddy('group', buddyId);
+      }
+
+      final result = await repository.getSoloVsBuddyCount();
+
+      expect(result.solo, 1);
+      expect(result.buddy, 1);
+    });
+
+    test('counts a dive with only a free-text buddy as a buddy dive', () async {
+      await insertDive('solo');
+      await insertDive('text-only', freeTextBuddy: 'Alex');
+
+      final result = await repository.getSoloVsBuddyCount();
+
+      expect(result.solo, 1);
+      expect(result.buddy, 1);
+    });
+
+    test('treats an empty free-text buddy as solo', () async {
+      await insertDive('empty-text', freeTextBuddy: '');
+
+      final result = await repository.getSoloVsBuddyCount();
+
+      expect(result.solo, 1);
+      expect(result.buddy, 0);
+    });
+
+    test(
+      'counts a dive with a free-text buddy and linked buddies once',
+      () async {
+        await insertBuddies(['b1', 'b2']);
+        await insertDive('both', freeTextBuddy: 'Alex');
+        await linkBuddy('both', 'b1');
+        await linkBuddy('both', 'b2');
+
+        final result = await repository.getSoloVsBuddyCount();
+
+        expect(result.solo, 0);
+        expect(result.buddy, 1);
+      },
+    );
+
+    test('scopes the count to the requested diver', () async {
+      await insertDiver('me');
+      await insertDiver('other');
+      await insertBuddies(['b1', 'b2']);
+      await insertDive('my-solo', diverId: 'me');
+      await insertDive('my-group', diverId: 'me');
+      await linkBuddy('my-group', 'b1');
+      await linkBuddy('my-group', 'b2');
+      await insertDive('their-group', diverId: 'other');
+      await linkBuddy('their-group', 'b1');
+
+      final result = await repository.getSoloVsBuddyCount(diverId: 'me');
+
+      expect(result.solo, 1);
+      expect(result.buddy, 1);
+    });
+
+    test('respects a tag filter', () async {
+      await insertBuddies(['b1', 'b2']);
+      await insertDive('tagged-group');
+      await linkBuddy('tagged-group', 'b1');
+      await linkBuddy('tagged-group', 'b2');
+      await insertDive('untagged-solo');
+      await insertDive('untagged-group');
+      await linkBuddy('untagged-group', 'b1');
+      await db
+          .into(db.tags)
+          .insert(
+            TagsCompanion(
+              id: const Value('dry'),
+              name: const Value('dry'),
+              createdAt: Value(now),
+              updatedAt: Value(now),
+            ),
+          );
+      await db
+          .into(db.diveTags)
+          .insert(
+            DiveTagsCompanion(
+              id: const Value('tagged-group-dry'),
+              diveId: const Value('tagged-group'),
+              tagId: const Value('dry'),
+              createdAt: Value(now),
+            ),
+          );
+
+      final result = await repository.getSoloVsBuddyCount(
+        filter: const DiveFilterState(tagIds: ['dry']),
+      );
+
+      expect(result.solo, 0);
+      expect(result.buddy, 1);
+    });
+
+    test('returns zeros when there are no dives', () async {
+      final result = await repository.getSoloVsBuddyCount();
+
+      expect(result.solo, 0);
+      expect(result.buddy, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The Solo vs Buddy statistic counted a dive once per linked buddy. `getSoloVsBuddyCount` summed over `dives d LEFT JOIN dive_buddies db`, and the join yields one row per linked buddy, so a dive with three linked buddies added 3 to the buddy count and a dive with both a free-text buddy and linked buddies was counted once per link. Solo dives joined a single NULL row, so the buddy share was inflated for anyone who logs group dives. Each dive now counts exactly once.

Closes #1822

## Changes

- `getSoloVsBuddyCount` classifies each dive once in a derived table: a dive is a buddy dive when `EXISTS (SELECT 1 FROM dive_buddies WHERE dive_id = d.id)` or the free-text `dives.buddy` is non-empty. The solo count is the exact complement, so `solo + buddy` always equals the number of dives in scope.
- The diver filter, `DiveStatsScope` and the view filter clause still apply to the outer `dives` scan. `EXISTS` adds no bind parameters, so the positional parameter order is unchanged.
- New regression test file `test/features/statistics/data/repositories/solo_vs_buddy_count_test.dart`.

Judgment calls, kept conservative:

- The change is confined to `getSoloVsBuddyCount`. `getDivesBySuitThickness` in the same file is being edited separately (#1824) and is left alone to avoid conflicts.
- The existing free-text rule is kept exactly: `NULL` or `''` means no buddy, anything else means a buddy. Whitespace-only free text is still treated as a buddy, as before, since changing that is outside this issue.

## Test Plan

- [x] New tests written first and confirmed failing against the old query (buddy 3 instead of 1 for the three-buddy dive, 2 instead of 1 for the mixed dive), then passing with the fix:
  - one solo dive plus one dive with three linked buddies gives solo 1, buddy 1
  - a dive with only a free-text buddy counts as a buddy dive
  - an empty free-text buddy counts as solo
  - a dive with a free-text buddy and two linked buddies counts once
  - `diverId` scoping still excludes another diver's dives
  - a tag filter still narrows the count
  - no dives returns zeros
- [x] Related statistics repository suites (error, filter, stats scope behaviour) pass locally; the pre-push hook's affected-test selection (188 tests) passed. The full `flutter test` suite is left to CI.
- [x] `dart format .` and `flutter analyze` over the whole project report no issues
- [ ] Manual testing: not performed; the change is a repository query with no UI change, covered by the repository tests above
