### PR TITLE
fix(dive-log): show a text-only buddy instead of "Solo dive"

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -4605,6 +4605,11 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
 
     return buddiesAsync.when(
       data: (buddies) {
+        // The dive_buddies junction is authoritative once it holds anyone.
+        // The legacy free-text dives.buddy column is only a fallback for a
+        // dive whose buddy was never linked, such as a CSV import that did
+        // not bring in buddy records, so it is not called solo (#1831).
+        final textBuddy = buddies.isEmpty ? dive.buddy?.trim() ?? '' : '';
         return Card(
           child: Padding(
             padding: const EdgeInsets.all(16),
@@ -4630,7 +4635,9 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                 const Divider(),
                 if (dive.diverRoleId != null)
                   _buildMyRoleTile(context, ref, dive),
-                if (buddies.isEmpty && dive.diverRoleId == null)
+                if (textBuddy.isNotEmpty)
+                  _buildTextBuddyTile(context, textBuddy)
+                else if (buddies.isEmpty && dive.diverRoleId == null)
                   Padding(
                     padding: const EdgeInsets.symmetric(vertical: 8),
                     child: Text(
@@ -4670,6 +4677,23 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
       subtitle: Text(bwr.role.localizedName(context.l10n)),
       trailing: const Icon(Icons.chevron_right, size: 20),
       onTap: () => context.push('/buddies/${bwr.buddy.id}'),
+    );
+  }
+
+  /// A buddy stored only as free text on the dive (#1831). There is no buddy
+  /// record behind it, so the tile has no role and nothing to open.
+  Widget _buildTextBuddyTile(BuildContext context, String name) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: CircleAvatar(
+        backgroundColor: colorScheme.primaryContainer,
+        child: Icon(
+          Icons.person_outline,
+          color: colorScheme.onPrimaryContainer,
+        ),
+      ),
+      title: Text(name),
     );
   }
 

--- a/test/features/dive_log/presentation/pages/dive_detail_text_buddy_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_text_buddy_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
-import 'package:riverpod/src/framework.dart' as riverpod show Override;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/constants/dive_detail_sections.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -18,8 +18,6 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 import 'package:submersion/features/signatures/domain/entities/signature.dart';
 import 'package:submersion/features/signatures/presentation/providers/signature_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
-
-typedef Override = riverpod.Override;
 
 /// Mock SettingsNotifier that does not access the database.
 class _MockSettingsNotifier extends StateNotifier<AppSettings>
@@ -43,11 +41,15 @@ AppSettings _buddiesOnly() => AppSettings(
       .toList(),
 );
 
-/// The Buddies card's solo copy, read from the generated English strings so
-/// a wording change does not silently turn these into always-green tests.
-final String _soloDive = lookupAppLocalizations(
-  const Locale('en'),
-).diveLog_detail_soloDive;
+/// The generated English strings, read so a wording change cannot break
+/// these tests or silently turn a "findsNothing" into an always-green check.
+final AppLocalizations _en = lookupAppLocalizations(const Locale('en'));
+
+/// The Buddies card's solo copy.
+final String _soloDive = _en.diveLog_detail_soloDive;
+
+/// The label on the diver's own role tile.
+final String _me = _en.buddies_picker_me;
 
 BuddyWithRole _linkedBuddy() => BuddyWithRole(
   buddy: Buddy(
@@ -155,7 +157,7 @@ void main() {
       );
     });
 
-    testWidgets('a text-only buddy is shown below the diver own role', (
+    testWidgets("a text-only buddy is shown below the diver's own role", (
       tester,
     ) async {
       await _pump(
@@ -165,9 +167,9 @@ void main() {
         diverRoleId: 'mysterySlug',
       );
 
-      expect(find.text('Me'), findsOneWidget);
+      expect(find.text(_me), findsOneWidget);
       expect(find.text('Bob Brown'), findsOneWidget);
-      final meY = tester.getCenter(find.text('Me')).dy;
+      final meY = tester.getCenter(find.text(_me)).dy;
       final bobY = tester.getCenter(find.text('Bob Brown')).dy;
       expect(meY, lessThan(bobY));
     });

--- a/test/features/dive_log/presentation/pages/dive_detail_text_buddy_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_text_buddy_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod/src/framework.dart' as riverpod show Override;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/dive_detail_sections.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
+import 'package:submersion/features/dive_roles/presentation/providers/dive_role_providers.dart';
+import 'package:submersion/features/marine_life/domain/entities/species.dart';
+import 'package:submersion/features/marine_life/presentation/providers/species_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/signatures/domain/entities/signature.dart';
+import 'package:submersion/features/signatures/presentation/providers/signature_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+typedef Override = riverpod.Override;
+
+/// Mock SettingsNotifier that does not access the database.
+class _MockSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _MockSettingsNotifier(super.initial);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Only the Buddies section visible, so the Details section's own "Buddy"
+/// row cannot satisfy a text assertion meant for the Buddies card.
+AppSettings _buddiesOnly() => AppSettings(
+  diveDetailSections: DiveDetailSectionId.values
+      .map(
+        (id) => DiveDetailSectionConfig(
+          id: id,
+          visible: id == DiveDetailSectionId.buddies,
+        ),
+      )
+      .toList(),
+);
+
+/// The Buddies card's solo copy, read from the generated English strings so
+/// a wording change does not silently turn these into always-green tests.
+final String _soloDive = lookupAppLocalizations(
+  const Locale('en'),
+).diveLog_detail_soloDive;
+
+BuddyWithRole _linkedBuddy() => BuddyWithRole(
+  buddy: Buddy(
+    id: 'b1',
+    name: 'Alice Adams',
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  ),
+  role: DiveRole.builtInBuddy(),
+);
+
+Future<void> _pump(
+  WidgetTester tester,
+  SharedPreferences prefs, {
+  String? textBuddy,
+  String? diverRoleId,
+  List<BuddyWithRole> linked = const [],
+}) async {
+  final dive = Dive(
+    id: 'd1',
+    dateTime: DateTime(2026, 3, 15, 10, 0),
+    buddy: textBuddy,
+    diverRoleId: diverRoleId,
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        diveProvider(dive.id).overrideWith((ref) async => dive),
+        diveDataSourcesProvider(
+          dive.id,
+        ).overrideWith((ref) async => <DiveDataSource>[]),
+        settingsProvider.overrideWith(
+          (ref) => _MockSettingsNotifier(_buddiesOnly()),
+        ),
+        buddiesForDiveProvider(dive.id).overrideWith((ref) async => linked),
+        diveSightingsProvider(
+          dive.id,
+        ).overrideWith((ref) async => <Sighting>[]),
+        buddySignaturesForDiveProvider(
+          dive.id,
+        ).overrideWith((ref) async => <Signature>[]),
+        allDiveRolesProvider.overrideWith((ref) async => <DiveRole>[]),
+      ],
+      child: MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: DiveDetailPage(diveId: dive.id),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  group('Buddies card with a free-text buddy (#1831)', () {
+    testWidgets('linked buddy records are listed and the dive is not solo', (
+      tester,
+    ) async {
+      await _pump(tester, prefs, linked: [_linkedBuddy()]);
+
+      expect(find.text('Alice Adams'), findsOneWidget);
+      expect(find.text(_soloDive), findsNothing);
+    });
+
+    testWidgets('linked buddy records win over stale free-text buddy', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        prefs,
+        textBuddy: 'Legacy Text',
+        linked: [_linkedBuddy()],
+      );
+
+      expect(find.text('Alice Adams'), findsOneWidget);
+      expect(
+        find.text('Legacy Text'),
+        findsNothing,
+        reason:
+            'the dive_buddies junction is authoritative once it holds anyone; '
+            'the frozen free-text column must not duplicate it',
+      );
+    });
+
+    testWidgets('a text-only buddy is shown instead of "Solo dive"', (
+      tester,
+    ) async {
+      await _pump(tester, prefs, textBuddy: 'Bob Brown');
+
+      expect(find.text('Bob Brown'), findsOneWidget);
+      expect(
+        find.text(_soloDive),
+        findsNothing,
+        reason: 'a dive with a buddy stored as text is not a solo dive',
+      );
+    });
+
+    testWidgets('a text-only buddy is shown below the diver own role', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        prefs,
+        textBuddy: 'Bob Brown',
+        diverRoleId: 'mysterySlug',
+      );
+
+      expect(find.text('Me'), findsOneWidget);
+      expect(find.text('Bob Brown'), findsOneWidget);
+      final meY = tester.getCenter(find.text('Me')).dy;
+      final bobY = tester.getCenter(find.text('Bob Brown')).dy;
+      expect(meY, lessThan(bobY));
+    });
+
+    testWidgets('no linked and no text buddy still reads "Solo dive"', (
+      tester,
+    ) async {
+      await _pump(tester, prefs);
+
+      expect(find.text(_soloDive), findsOneWidget);
+    });
+
+    testWidgets('a whitespace-only text buddy still reads "Solo dive"', (
+      tester,
+    ) async {
+      await _pump(tester, prefs, textBuddy: '   ');
+
+      expect(find.text(_soloDive), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The dive detail Buddies card decided "Solo dive" from the linked `dive_buddies` records alone. A dive whose buddy was only ever stored in the free-text `dives.buddy` column (a CSV import that did not bring in buddy records, such as the MySSI preset, or an older dive) showed "Buddy: <name>" under Details and "Solo dive" in the Buddies card at the same time.

The card now falls back to the free-text buddy when no buddy records are linked, so it no longer calls such a dive solo.

Closes #1831

## Changes

- `dive_detail_page.dart`, Buddies card only: when the dive has no linked buddies and a non-blank `dives.buddy`, the card shows that text as a buddy tile instead of the solo text.
- The rule matches what the export field extractor (`_buddyColumnValue`), the detailed PDF template and the no-buddy filter already do: the junction is authoritative once it holds anyone, and the free text is only a fallback. A dive with linked buddies never also shows stale free text.
- A whitespace-only `dives.buddy` still counts as no buddy.
- The text tile has a plain person icon, no role subtitle, no chevron and no tap target, because there is no buddy record behind it to open. It sits below the diver's own role tile when one is set.
- No new user-facing strings, so no ARB or l10n changes.

### Judgment calls

- The Details section's existing "Buddy" row is left unchanged, so this PR only touches the Buddies card.
- The optional "convert to buddy records" action is not included. Doing it properly means splitting a free-text value that can hold several names, matching them against existing buddy records to avoid duplicates, choosing a role, and writing through the sync-aware repository. That is bigger than this fix, so it is left as a follow-up.

## Test Plan

- [x] New `test/features/dive_log/presentation/pages/dive_detail_text_buddy_test.dart` (TDD: written first). With only the Buddies section visible, so the Details row cannot satisfy an assertion:
  - linked buddy records are listed and the dive is not solo
  - linked buddy records win over a stale free-text buddy
  - a text-only buddy is shown instead of the solo text (failed before the fix)
  - a text-only buddy is shown below the diver's own role (failed before the fix)
  - no linked and no text buddy still reads as solo
  - a whitespace-only text buddy still reads as solo
- [x] Mutation-checked the two guard cases: removing the "junction wins" check fails the stale-text test, and removing the trim fails the whitespace test.
- [x] Neighbouring dive detail tests pass: `dive_detail_buddy_photo_test.dart`, `dive_detail_page_section_config_test.dart`, `dive_detail_page_paired_sections_test.dart`, `dive_detail_course_row_test.dart` (81 tests including the new file).
- [x] `dart format .` made no changes, and `flutter analyze` over the whole project reports no issues.
- [x] Pre-push hook passed.
