### PR TITLE
fix(import): import MySSI sites and buddies as linked records

### DIFF
--- a/lib/features/universal_import/data/csv/presets/built_in_presets.dart
+++ b/lib/features/universal_import/data/csv/presets/built_in_presets.dart
@@ -57,7 +57,11 @@ const _myssi = CsvPreset(
       ],
     ),
   },
-  supportedEntities: {ImportEntityType.dives},
+  supportedEntities: {
+    ImportEntityType.dives,
+    ImportEntityType.sites,
+    ImportEntityType.buddies,
+  },
 );
 
 // ======================== 1. Subsurface (multi-file) ========================

--- a/lib/features/universal_import/data/parsers/csv_import_parser.dart
+++ b/lib/features/universal_import/data/parsers/csv_import_parser.dart
@@ -101,12 +101,42 @@ class CsvImportParser implements ImportParser {
   // Private helpers
   // ---------------------------------------------------------------------------
 
+  /// Entity types imported when neither a preset nor the mapping asks for more.
+  static const _defaultEntityTypes = {
+    ImportEntityType.dives,
+    ImportEntityType.sites,
+  };
+
+  /// Target fields whose values only become linked records when the
+  /// correlator extracts the matching entity type. Without it a mapped site
+  /// column is dropped and a mapped buddy column stays free text (#1830).
+  /// 'site' is the legacy alias the correlator normalizes to 'siteName'.
+  static const _entityTypeForTargetField = {
+    'siteName': ImportEntityType.sites,
+    'site': ImportEntityType.sites,
+    'buddy': ImportEntityType.buddies,
+  };
+
+  /// [entityTypes] plus every type a column in [mappings] needs, so a
+  /// preset's or saved mapping's entity set cannot drift from its columns.
+  static Set<ImportEntityType> _withMappedEntityTypes(
+    Set<ImportEntityType> entityTypes,
+    Iterable<FieldMapping> mappings,
+  ) => {
+    ...entityTypes,
+    for (final mapping in mappings)
+      for (final column in mapping.columns)
+        ?_entityTypeForTargetField[column.targetField],
+  };
+
   /// Build an [ImportConfiguration] from the resolved mapping source.
   ///
   /// Priority order:
   /// 1. Explicit custom mapping (user-provided).
   /// 2. Detected preset from pipeline Detect stage.
   /// 3. Auto-mapped from CSV headers using keyword matching.
+  ///
+  /// In every case the entity types are widened by [_withMappedEntityTypes].
   ImportConfiguration _buildConfiguration({
     required ParsedCsv parsedCsv,
     required DetectionResult detection,
@@ -121,9 +151,10 @@ class CsvImportParser implements ImportParser {
     if (resolvedMapping != null) {
       return ImportConfiguration(
         mappings: {'primary': resolvedMapping},
-        entityTypesToImport:
-            detection.matchedPreset?.supportedEntities ??
-            const {ImportEntityType.dives, ImportEntityType.sites},
+        entityTypesToImport: _withMappedEntityTypes(
+          detection.matchedPreset?.supportedEntities ?? _defaultEntityTypes,
+          [resolvedMapping],
+        ),
         timeInterpretation: timeInterpretation,
         specificUtcOffset: specificUtcOffset,
         sourceApp: options?.sourceApp,
@@ -135,7 +166,10 @@ class CsvImportParser implements ImportParser {
       final preset = detection.matchedPreset!;
       return ImportConfiguration(
         mappings: preset.mappings,
-        entityTypesToImport: preset.supportedEntities,
+        entityTypesToImport: _withMappedEntityTypes(
+          preset.supportedEntities,
+          preset.mappings.values,
+        ),
         sourceApp: preset.sourceApp ?? options?.sourceApp,
         preset: preset,
         timeInterpretation: timeInterpretation,
@@ -147,6 +181,9 @@ class CsvImportParser implements ImportParser {
     final autoMapping = _autoMapFromHeaders(parsedCsv.headers);
     return ImportConfiguration(
       mappings: {'primary': autoMapping},
+      entityTypesToImport: _withMappedEntityTypes(_defaultEntityTypes, [
+        autoMapping,
+      ]),
       timeInterpretation: timeInterpretation,
       specificUtcOffset: specificUtcOffset,
       sourceApp: options?.sourceApp,

--- a/test/features/universal_import/data/csv/presets/built_in_presets_test.dart
+++ b/test/features/universal_import/data/csv/presets/built_in_presets_test.dart
@@ -82,6 +82,44 @@ void main() {
       }
     });
 
+    // A mapped site or buddy column only becomes a linked record when the
+    // correlator extracts that entity type; otherwise every dive imports
+    // with no site, and buddies stay free text (#1830). This table is kept
+    // separate from the parser's own rule so a preset cannot silently drift.
+    const entityTypeForTargetField = {
+      'siteName': ImportEntityType.sites,
+      'site': ImportEntityType.sites,
+      'buddy': ImportEntityType.buddies,
+    };
+
+    test('every preset imports the entity types its mapped columns need', () {
+      for (final preset in builtInCsvPresets) {
+        for (final mapping in preset.mappings.values) {
+          for (final column in mapping.columns) {
+            final required = entityTypeForTargetField[column.targetField];
+            if (required == null) continue;
+            expect(
+              preset.supportedEntities,
+              contains(required),
+              reason:
+                  '${preset.name} maps "${column.sourceColumn}" to '
+                  '${column.targetField} but does not import '
+                  '${required.name}',
+            );
+          }
+        }
+      }
+    });
+
+    test('MySSI imports dives, sites and buddies (#1830)', () {
+      final myssi = builtInCsvPresets.firstWhere((p) => p.id == 'myssi');
+      expect(myssi.supportedEntities, {
+        ImportEntityType.dives,
+        ImportEntityType.sites,
+        ImportEntityType.buddies,
+      });
+    });
+
     test('all presets are builtIn source', () {
       for (final preset in builtInCsvPresets) {
         expect(

--- a/test/features/universal_import/data/parsers/csv_import_parser_test.dart
+++ b/test/features/universal_import/data/parsers/csv_import_parser_test.dart
@@ -3,9 +3,14 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/universal_import/data/csv/models/import_configuration.dart';
+import 'package:submersion/features/universal_import/data/csv/pipeline/csv_pipeline.dart';
+import 'package:submersion/features/universal_import/data/csv/presets/built_in_presets.dart';
+import 'package:submersion/features/universal_import/data/csv/presets/csv_preset.dart';
+import 'package:submersion/features/universal_import/data/csv/presets/preset_registry.dart';
 import 'package:submersion/features/universal_import/data/models/field_mapping.dart';
 import 'package:submersion/features/universal_import/data/models/import_enums.dart';
 import 'package:submersion/features/universal_import/data/models/import_options.dart';
+import 'package:submersion/features/universal_import/data/models/import_payload.dart';
 import 'package:submersion/features/universal_import/data/models/import_warning.dart';
 import 'package:submersion/features/universal_import/data/parsers/csv_import_parser.dart';
 
@@ -603,9 +608,12 @@ void main() {
 
       final result = await parser.parse(csvBytes(csv));
 
+      // A mapped buddy column imports as a linked buddy record (#1830).
+      final buddies = result.entitiesOf(ImportEntityType.buddies);
+      expect(buddies.map((b) => b['name']), ['Alice']);
       final dives = result.entitiesOf(ImportEntityType.dives);
       expect(dives, isNotEmpty);
-      expect(dives.first['buddy'], 'Alice');
+      expect(dives.first['buddyRefs'], [buddies.single['id']]);
     });
 
     test('maps visibility header to visibility field', () async {
@@ -1003,22 +1011,113 @@ void main() {
       },
     );
 
+    test('custom mapping without detected preset adds mapped buddies to the '
+        'default entity types', () async {
+      // Headers that do not match any known preset.
+      const csv =
+          'my_date,my_time,my_depth,my_buddy,my_tags\n'
+          '2024-01-15,10:00,25.5,Alice,reef\n';
+
+      const customMapping = FieldMapping(
+        name: 'Unknown Source',
+        columns: [
+          ColumnMapping(sourceColumn: 'my_date', targetField: 'date'),
+          ColumnMapping(sourceColumn: 'my_time', targetField: 'time'),
+          ColumnMapping(sourceColumn: 'my_depth', targetField: 'maxDepth'),
+          ColumnMapping(sourceColumn: 'my_buddy', targetField: 'buddy'),
+          ColumnMapping(sourceColumn: 'my_tags', targetField: 'tags'),
+        ],
+      );
+
+      final result = await parser.parse(
+        csvBytes(csv),
+        customMappingOverride: customMapping,
+      );
+
+      // Without a detected preset the default entity types are
+      // {dives, sites}. A mapped buddy column still adds buddies (#1830),
+      // but tags are not part of that rule and stay unextracted.
+      final buddies = result.entitiesOf(ImportEntityType.buddies);
+      final tags = result.entitiesOf(ImportEntityType.tags);
+      expect(buddies.map((b) => b['name']), ['Alice']);
+      expect(
+        tags,
+        isEmpty,
+        reason:
+            'Without detected preset, default entity types should not '
+            'include tags',
+      );
+    });
+  });
+
+  group('entity types follow the mapped site and buddy columns (#1830)', () {
+    const myssiCsv =
+        'dive #,Dive Site,Country,Date / Time,Dive Activity,'
+        'Specialty Dive,Dive type,Duration,Depth,'
+        'Dive Buddy / Instructor / Center\n'
+        '1,Coral Garden,Egypt,2026-01-15 09:00,Fun Dive,,Open Water,45,'
+        '18.5,Alice\n'
+        '2,Coral Garden,Egypt,2026-01-15 14:00,Fun Dive,,Open Water,50,'
+        '16.0,Alice\n';
+
+    void expectLinkedSiteAndBuddy(ImportPayload result) {
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.map((s) => s['name']), ['Coral Garden']);
+
+      final buddies = result.entitiesOf(ImportEntityType.buddies);
+      expect(buddies.map((b) => b['name']), ['Alice']);
+
+      final dives = result.entitiesOf(ImportEntityType.dives);
+      expect(dives, hasLength(2));
+      for (final dive in dives) {
+        expect(dive['siteId'], sites.single['id']);
+        expect(dive['buddyRefs'], [buddies.single['id']]);
+        expect(
+          dive.containsKey('buddy'),
+          isFalse,
+          reason: 'the buddy column must not also be kept as free text',
+        );
+      }
+    }
+
+    test('a detected MySSI export imports linked sites and buddies', () async {
+      final result = await parser.parse(csvBytes(myssiCsv));
+
+      expectLinkedSiteAndBuddy(result);
+    });
+
+    test('a MySSI export imported through the mapping step keeps its sites and '
+        'buddies', () async {
+      // The wizard always hands its Map Fields mapping back as an override,
+      // so this is the path a real MySSI import takes.
+      final myssi = builtInCsvPresets.firstWhere((p) => p.id == 'myssi');
+
+      final result = await parser.parse(
+        csvBytes(myssiCsv),
+        customMappingOverride: myssi.primaryMapping,
+      );
+
+      expectLinkedSiteAndBuddy(result);
+    });
+
     test(
-      'custom mapping without detected preset falls back to default entity types',
+      'a custom mapping adds sites and buddies to a dives-only preset',
       () async {
-        // Headers that do not match any known preset.
+        // Garmin Connect is detected and imports dives only, but the user
+        // mapped the two extra columns by hand.
         const csv =
-            'my_date,my_time,my_depth,my_buddy,my_tags\n'
-            '2024-01-15,10:00,25.5,Alice,reef\n';
+            'Date,Activity Type,Max Depth,Avg Depth,Bottom Time,'
+            'Water Temperature,Location,Buddy\n'
+            '2024-01-15,Single-Gas Dive,25.5,18.0,00:45:00,27,Blue Hole,'
+            'Alice\n';
 
         const customMapping = FieldMapping(
-          name: 'Unknown Source',
+          name: 'Garmin plus people',
           columns: [
-            ColumnMapping(sourceColumn: 'my_date', targetField: 'date'),
-            ColumnMapping(sourceColumn: 'my_time', targetField: 'time'),
-            ColumnMapping(sourceColumn: 'my_depth', targetField: 'maxDepth'),
-            ColumnMapping(sourceColumn: 'my_buddy', targetField: 'buddy'),
-            ColumnMapping(sourceColumn: 'my_tags', targetField: 'tags'),
+            ColumnMapping(sourceColumn: 'Date', targetField: 'date'),
+            ColumnMapping(sourceColumn: 'Max Depth', targetField: 'maxDepth'),
+            ColumnMapping(sourceColumn: 'Location', targetField: 'siteName'),
+            ColumnMapping(sourceColumn: 'Buddy', targetField: 'buddy'),
           ],
         );
 
@@ -1027,25 +1126,70 @@ void main() {
           customMappingOverride: customMapping,
         );
 
-        // Without a detected preset, the default entity types are
-        // {dives, sites} only. Buddies and tags should not be extracted.
+        final sites = result.entitiesOf(ImportEntityType.sites);
+        expect(sites.map((s) => s['name']), ['Blue Hole']);
         final buddies = result.entitiesOf(ImportEntityType.buddies);
-        final tags = result.entitiesOf(ImportEntityType.tags);
-        expect(
-          buddies,
-          isEmpty,
-          reason:
-              'Without detected preset, default entity types should not '
-              'include buddies',
-        );
-        expect(
-          tags,
-          isEmpty,
-          reason:
-              'Without detected preset, default entity types should not '
-              'include tags',
-        );
+        expect(buddies.map((b) => b['name']), ['Alice']);
+        final dive = result.entitiesOf(ImportEntityType.dives).single;
+        expect(dive['siteId'], sites.single['id']);
+        expect(dive['buddyRefs'], [buddies.single['id']]);
       },
     );
+
+    test('a saved preset that maps sites and buddies imports them even when '
+        'its entity set omits them', () async {
+      // A preset saved from an earlier MySSI detection inherited
+      // {dives} only.
+      final registry = PresetRegistry(builtInPresets: builtInCsvPresets)
+        ..addUserPreset(
+          const CsvPreset(
+            id: 'user-spots',
+            name: 'My Spots',
+            source: PresetSource.userSaved,
+            signatureHeaders: ['Day', 'Spot', 'Deepest', 'Mate'],
+            mappings: {
+              'primary': FieldMapping(
+                name: 'My Spots',
+                columns: [
+                  ColumnMapping(sourceColumn: 'Day', targetField: 'date'),
+                  ColumnMapping(sourceColumn: 'Spot', targetField: 'site'),
+                  ColumnMapping(
+                    sourceColumn: 'Deepest',
+                    targetField: 'maxDepth',
+                  ),
+                  ColumnMapping(sourceColumn: 'Mate', targetField: 'buddy'),
+                ],
+              ),
+            },
+            supportedEntities: {ImportEntityType.dives},
+          ),
+        );
+      final savedPresetParser = CsvImportParser(
+        pipeline: CsvPipeline(registry: registry),
+      );
+
+      final result = await savedPresetParser.parse(
+        csvBytes('Day,Spot,Deepest,Mate\n2024-01-15,Blue Hole,25.5,Alice\n'),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.map((s) => s['name']), ['Blue Hole']);
+      final buddies = result.entitiesOf(ImportEntityType.buddies);
+      expect(buddies.map((b) => b['name']), ['Alice']);
+    });
+
+    test('an auto-mapped buddy column imports buddies', () async {
+      // No preset matches these headers, so they are keyword-mapped.
+      const csv =
+          'Date,Max Depth,Site,Buddy\n'
+          '2024-01-15,25.5,Blue Hole,Alice\n';
+
+      final result = await parser.parse(csvBytes(csv));
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.map((s) => s['name']), ['Blue Hole']);
+      final buddies = result.entitiesOf(ImportEntityType.buddies);
+      expect(buddies.map((b) => b['name']), ['Alice']);
+    });
   });
 }


### PR DESCRIPTION
## Summary

The built-in MySSI CSV preset maps `Dive Site` to `siteName` and `Dive Buddy / Instructor / Center` to `buddy`, but declared `supportedEntities: {dives}`. `CsvCorrelator` only extracts sites (and sets each dive's `siteId`) and builds buddy records when those entity types are enabled. So the review step listed site names, yet every MySSI dive imported with no site, and its buddies were saved to the free-text `dives.buddy` field.

Changes:

- **MySSI preset** (`built_in_presets.dart`) now declares `{dives, sites, buddies}`, matching MacDive, Diving Log and DiveMate.
- **Guard against drift** (`csv_import_parser.dart`): `_buildConfiguration` now widens the entity set with every type the mapping's columns need. `siteName` (and its legacy `site` alias, which `CsvCorrelator._normalizeRows` rewrites to `siteName`) enables `sites`; `buddy` enables `buddies`. It applies to all three configuration paths: custom mapping (Case 1, the path the wizard's Map Fields step always takes), detected preset (Case 2), and keyword auto-mapping (Case 3).
- **Invariant test over all built-in presets** (`built_in_presets_test.dart`): any preset that maps a site or buddy column must enable the matching entity type. The test keeps its own copy of the field-to-entity table rather than importing the parser's, so a bad rule can't make the test agree with the bug.

## Judgment calls

This ran without a maintainer in the loop, so where a choice was needed I took the most conservative option consistent with the issue:

- **Additive only.** The guard only adds entity types and never removes one, so an import that works today can't lose anything.
- **Scope kept to `siteName` and `buddy`,** as the issue asks. `diveMaster`, `tags` and `suit` are deliberately not in the rule. While tracing the correlator I found that Subsurface and Submersion Native map a `suit` column without enabling `equipment`, so that column is dropped on import. Fixing it would start creating gear records, which is a bigger product decision, so it is left for a follow-up.
- **Saved user presets are widened at import time.** The Save Preset dialog seeds its entity chips from the detected preset, so a preset saved from a MySSI detection stored `{dives}` without the user choosing it. Applying the guard to detected presets repairs those. A saved preset that maps a site column now always imports sites, even if the user unticked Sites when saving it. Without sites, the site name is not stored anywhere, so honouring that choice would silently lose data.
- **No UI or l10n changes.** The Save Preset dialog is unchanged.

## Behavior change to note

Two existing tests pinned the old behavior and were updated:

- `custom mapping without detected preset ...` asserted that a mapped `buddy` column produced **no** buddy records when no preset was detected. That is the drift the issue asks to remove, so it now asserts the buddy is imported. Its assertion that `tags` are not extracted is kept, to pin the scope.
- `auto-mapping from headers maps buddy header to buddy field` read the raw `buddy` string off the dive. It now asserts the buddy arrives as a linked record through `buddyRefs`.

## Testing

TDD: the new tests were written first, and all 8 failed for the expected reason (the sites and buddies lists came back empty) before the fix.

New tests:

- A detected MySSI export imports a deduplicated site and buddy, and every dive gets `siteId` and `buddyRefs` with no leftover free-text `buddy`.
- The same MySSI export imported through the mapping-step override (the real wizard path).
- A custom mapping adds sites and buddies to a detected dives-only preset (Garmin Connect).
- A saved user preset with `supportedEntities: {dives}` that maps `site` and `buddy` still imports both.
- A keyword auto-mapped `Buddy` column imports buddies.
- Every built-in preset enables the entity types its mapped site and buddy columns need, plus a MySSI entity-set pin.

Local runs:

- `flutter test test/features/universal_import`: 1846 passed (6 skips were already there)
- `flutter test test/features/import_wizard/data/adapters/universal_adapter_test.dart test/features/dive_import/data/services/uddf_entity_importer_test.dart`: 224 passed
- `dart format .` and `flutter analyze` over the whole project: clean
- Pre-push hook: passed

Closes #1830
