### PR TITLE
fix(planner): show the RMV slider in the diver's volume unit

### DIFF
--- a/lib/features/data_quality/presentation/widgets/quality_unit_formatters.dart
+++ b/lib/features/data_quality/presentation/widgets/quality_unit_formatters.dart
@@ -6,16 +6,15 @@ import 'package:submersion/features/data_quality/presentation/widgets/quality_fi
 /// Takes an already-built [UnitFormatter] rather than a `WidgetRef` so any
 /// caller that has one can reuse it, instead of watching the settings provider
 /// a second time just to reach these five closures.
-QualityUnitFormatters qualityUnitFormattersFor(
-  UnitFormatter units,
-) => QualityUnitFormatters(
-  depth: (m) => units.formatDepth(m),
-  pressure: (bar) => units.formatPressure(bar),
-  temperature: (c) => units.formatTemperature(c),
-  // Surface air consumption is a volume rate; honor the volume unit
-  // preference (L/min vs cuft/min); this is an RMV, never a pressure rate.
-  sac: (lpm) =>
-      '${units.convertVolume(lpm).toStringAsFixed(1)} ${units.volumeSymbol}/min',
-  date: (d) => units.formatDate(d),
-  dateTime: (d) => '${units.formatDate(d)} ${units.formatTime(d)}',
-);
+QualityUnitFormatters qualityUnitFormattersFor(UnitFormatter units) =>
+    QualityUnitFormatters(
+      depth: (m) => units.formatDepth(m),
+      pressure: (bar) => units.formatPressure(bar),
+      temperature: (c) => units.formatTemperature(c),
+      // Surface air consumption is a volume rate; honor the volume unit
+      // preference (L/min vs cuft/min); this is an RMV, never a pressure rate.
+      // formatRmv keeps 2 decimals for cuft/min, where values sit below 1.
+      sac: (lpm) => units.formatRmv(lpm),
+      date: (d) => units.formatDate(d),
+      dateTime: (d) => '${units.formatDate(d)} ${units.formatTime(d)}',
+    );

--- a/lib/features/dive_planner/presentation/widgets/setup/plan_gas_section.dart
+++ b/lib/features/dive_planner/presentation/widgets/setup/plan_gas_section.dart
@@ -3,7 +3,9 @@ import 'package:flutter/services.dart';
 
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/number_display.dart';
 import 'package:submersion/core/utils/number_input.dart';
+import 'package:submersion/core/utils/unit_axis.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_planner/domain/entities/plan_result.dart';
 import 'package:submersion/features/dive_planner/presentation/providers/dive_planner_providers.dart';
@@ -22,6 +24,10 @@ class PlanGasSection extends ConsumerWidget {
     final planState = ref.watch(divePlanNotifierProvider);
     final settings = ref.watch(settingsProvider);
     final units = UnitFormatter(settings);
+    // The plan keeps its RMV in L/min; the axis carries the slider range in
+    // the diver's volume unit and converts both ways (#1823).
+    final rmvAxis = UnitAxis.normalRmv(units);
+    final rmvText = units.formatRmv(planState.sacRate);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -36,26 +42,36 @@ class PlanGasSection extends ConsumerWidget {
             Expanded(
               child: Semantics(
                 label: context.l10n.divePlanner_semantics_sacRate(
-                  planState.sacRate.toStringAsFixed(0),
+                  formatFixedForDisplay(
+                    units.convertRmv(planState.sacRate),
+                    units.rmvDecimals,
+                  ),
                   units.volumeSymbol,
                 ),
                 child: Slider(
-                  value: planState.sacRate,
-                  min: 8,
-                  max: 30,
-                  divisions: 22,
-                  label:
-                      '${planState.sacRate.toStringAsFixed(0)} ${units.volumeSymbol}/min',
+                  // Only the thumb is clamped: a plan RMV inside 8-30 L/min
+                  // can still fall outside the snapped imperial range (8 L/min
+                  // is 0.28 cuft/min, below its 0.30 floor), and Slider
+                  // asserts outside its bounds. The readout keeps the value.
+                  value: rmvAxis
+                      .toDisplay(planState.sacRate)
+                      .clamp(rmvAxis.min, rmvAxis.max)
+                      .toDouble(),
+                  min: rmvAxis.min,
+                  max: rmvAxis.max,
+                  divisions: rmvAxis.divisions,
+                  label: rmvText,
                   onChanged: (value) => ref
                       .read(divePlanNotifierProvider.notifier)
-                      .updateSacRate(value),
+                      .updateSacRate(rmvAxis.toCanonical(value)),
                 ),
               ),
             ),
             SizedBox(
-              width: 70,
+              // Wide enough for "0.53 cuft/min" on one line.
+              width: 96,
               child: Text(
-                '${planState.sacRate.toStringAsFixed(0)} ${units.volumeSymbol}/min',
+                rmvText,
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
             ),
@@ -97,16 +113,17 @@ class _LoggedRmvButton extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    final display =
-        '${units.convertVolume(loggedRmv).toStringAsFixed(1)} '
-        '${units.volumeSymbol}/min';
     return Align(
       alignment: Alignment.centerLeft,
       child: TextButton.icon(
         icon: const Icon(Icons.history, size: 18),
-        label: Text(context.l10n.plannerCanvas_sac_useLogged(display)),
+        label: Text(
+          context.l10n.plannerCanvas_sac_useLogged(units.formatRmv(loggedRmv)),
+        ),
         onPressed: () => ref
             .read(divePlanNotifierProvider.notifier)
+            // The planner's L/min range, not the snapped imperial one, so
+            // the plan gets the same RMV whichever unit the diver reads.
             .updateSacRate(loggedRmv.clamp(8.0, 30.0)),
       ),
     );

--- a/test/features/data_quality/presentation/quality_unit_formatters_test.dart
+++ b/test/features/data_quality/presentation/quality_unit_formatters_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/data_quality/presentation/widgets/quality_unit_formatters.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+void main() {
+  group('qualityUnitFormattersFor sac (#1823)', () {
+    test('metric renders an RMV in L/min at 1 decimal', () {
+      final fmt = qualityUnitFormattersFor(const UnitFormatter(AppSettings()));
+
+      expect(fmt.sac(16.84), '16.8 L/min');
+    });
+
+    test('imperial renders an RMV in cuft/min at 2 decimals', () {
+      final fmt = qualityUnitFormattersFor(
+        const UnitFormatter(AppSettings(volumeUnit: VolumeUnit.cubicFeet)),
+      );
+
+      // 16.84 L/min is 0.5947 cuft/min; at 1 decimal it read "0.6", which
+      // hides most of the spread between typical imperial RMVs.
+      expect(fmt.sac(16.84), '0.59 cuft/min');
+    });
+  });
+}

--- a/test/features/data_quality/presentation/quality_unit_formatters_test.dart
+++ b/test/features/data_quality/presentation/quality_unit_formatters_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -6,6 +7,19 @@ import 'package:submersion/features/data_quality/presentation/widgets/quality_un
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 void main() {
+  // formatRmv localises the decimal separator from the process-global
+  // Intl.defaultLocale, so pin English for the dot-separated expectations.
+  late String? previousLocale;
+
+  setUp(() {
+    previousLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en';
+  });
+
+  tearDown(() {
+    Intl.defaultLocale = previousLocale;
+  });
+
   group('qualityUnitFormattersFor sac (#1823)', () {
     test('metric renders an RMV in L/min at 1 decimal', () {
       final fmt = qualityUnitFormattersFor(const UnitFormatter(AppSettings()));

--- a/test/features/dive_planner/presentation/widgets/setup/plan_setup_sections_test.dart
+++ b/test/features/dive_planner/presentation/widgets/setup/plan_setup_sections_test.dart
@@ -2,18 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_planner/presentation/providers/dive_planner_providers.dart';
 import 'package:submersion/features/dive_planner/presentation/widgets/setup/plan_deco_section.dart';
 import 'package:submersion/features/dive_planner/presentation/widgets/setup/plan_environment_section.dart';
 import 'package:submersion/features/dive_planner/presentation/widgets/setup/plan_gas_section.dart';
+import 'package:submersion/features/planner/presentation/providers/plan_canvas_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 import '../../../../../helpers/test_app.dart';
 
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
-  _TestSettingsNotifier() : super(const AppSettings());
+  _TestSettingsNotifier([super.state = const AppSettings()]);
 
   @override
   Future<void> setMapStyle(MapStyle style) async =>
@@ -23,13 +25,34 @@ class _TestSettingsNotifier extends StateNotifier<AppSettings>
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-Widget _harness(Widget child) => testApp(
+const _imperialVolume = AppSettings(volumeUnit: VolumeUnit.cubicFeet);
+
+/// cuft per liter, as [VolumeUnit.convert] applies it.
+const _cuftPerLiter = 0.0353147;
+
+Widget _harness(
+  Widget child, {
+  AppSettings settings = const AppSettings(),
+  double? loggedRmv,
+}) => testApp(
   // Pin English so finders on localized labels ("Must be greater than 0",
   // "Group 2", etc.) stay deterministic regardless of the platform locale.
   locale: const Locale('en'),
-  overrides: [settingsProvider.overrideWith((ref) => _TestSettingsNotifier())],
+  overrides: [
+    settingsProvider.overrideWith((ref) => _TestSettingsNotifier(settings)),
+    if (loggedRmv != null)
+      loggedAverageSacProvider.overrideWith((ref) async => loggedRmv),
+  ],
   child: SingleChildScrollView(child: child),
 );
+
+/// The Semantics label wrapping the RMV slider.
+String? _rmvSemanticsLabel(WidgetTester tester) => tester
+    .widgetList<Semantics>(
+      find.ancestor(of: find.byType(Slider), matching: find.byType(Semantics)),
+    )
+    .map((s) => s.properties.label)
+    .firstWhere((label) => label?.startsWith('RMV') ?? false);
 
 void main() {
   group('planWaterOptionFor', () {
@@ -156,6 +179,195 @@ void main() {
       tester.element(find.byType(PlanGasSection)),
     );
     expect(container.read(divePlanNotifierProvider).reservePressure, 60);
+  });
+
+  group('RMV slider units (#1823)', () {
+    testWidgets('metric runs 8-30 L/min in 1 L/min steps', (tester) async {
+      await tester.pumpWidget(_harness(const PlanGasSection()));
+      await tester.pumpAndSettle();
+
+      final slider = tester.widget<Slider>(find.byType(Slider));
+      expect(slider.min, 8);
+      expect(slider.max, 30);
+      expect(slider.divisions, 22);
+      expect(slider.value, 15);
+      expect(slider.label, '15.0 L/min');
+      expect(find.text('15.0 L/min'), findsOneWidget);
+      expect(_rmvSemanticsLabel(tester), 'RMV: 15.0 L per minute');
+    });
+
+    testWidgets('metric drag stores the dragged L/min value', (tester) async {
+      await tester.pumpWidget(_harness(const PlanGasSection()));
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(PlanGasSection)),
+      );
+
+      tester.widget<Slider>(find.byType(Slider)).onChanged!(20);
+      await tester.pumpAndSettle();
+
+      expect(container.read(divePlanNotifierProvider).sacRate, 20);
+      expect(find.text('20.0 L/min'), findsOneWidget);
+    });
+
+    testWidgets('imperial shows the plan RMV converted to cuft/min', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(const PlanGasSection(), settings: _imperialVolume),
+      );
+      await tester.pumpAndSettle();
+
+      // The default 15 L/min is 0.5297 cuft/min, not "15 cuft/min".
+      final slider = tester.widget<Slider>(find.byType(Slider));
+      expect(slider.value, closeTo(15 * _cuftPerLiter, 1e-9));
+      expect(slider.label, '0.53 cuft/min');
+      expect(find.text('0.53 cuft/min'), findsOneWidget);
+      expect(find.textContaining('15 cuft'), findsNothing);
+      expect(_rmvSemanticsLabel(tester), 'RMV: 0.53 cuft per minute');
+    });
+
+    testWidgets('imperial runs 0.30-1.05 cuft/min in 0.05 steps', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(const PlanGasSection(), settings: _imperialVolume),
+      );
+      await tester.pumpAndSettle();
+
+      final slider = tester.widget<Slider>(find.byType(Slider));
+      expect(slider.min, closeTo(0.30, 1e-9));
+      expect(slider.max, closeTo(1.05, 1e-9));
+      expect(slider.divisions, 15);
+    });
+
+    testWidgets('imperial drag stores the plan RMV in L/min', (tester) async {
+      await tester.pumpWidget(
+        _harness(const PlanGasSection(), settings: _imperialVolume),
+      );
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(PlanGasSection)),
+      );
+
+      tester.widget<Slider>(find.byType(Slider)).onChanged!(0.55);
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(divePlanNotifierProvider).sacRate,
+        closeTo(0.55 / _cuftPerLiter, 1e-6),
+      );
+      expect(find.text('0.55 cuft/min'), findsOneWidget);
+    });
+
+    testWidgets('imperial keeps a plan RMV below the slider floor visible', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(const PlanGasSection(), settings: _imperialVolume),
+      );
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(PlanGasSection)),
+      );
+
+      // 8 L/min is a valid plan RMV, but it is 0.2825 cuft/min, below the
+      // 0.30 cuft/min imperial floor. A saved plan can carry it.
+      final current = container.read(divePlanNotifierProvider);
+      container
+          .read(divePlanNotifierProvider.notifier)
+          .loadPlan(current.copyWith(sacRate: 8));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      final slider = tester.widget<Slider>(find.byType(Slider));
+      expect(slider.value, slider.min);
+      expect(find.text('0.28 cuft/min'), findsOneWidget);
+      expect(container.read(divePlanNotifierProvider).sacRate, 8);
+    });
+  });
+
+  group('logged RMV hint (#1823)', () {
+    testWidgets('metric shows the logged average at 1 decimal', (tester) async {
+      await tester.pumpWidget(
+        _harness(const PlanGasSection(), loggedRmv: 16.84),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Use logged average (16.8 L/min)'), findsOneWidget);
+    });
+
+    testWidgets('imperial shows the logged average at 2 decimals', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          const PlanGasSection(),
+          settings: _imperialVolume,
+          loggedRmv: 16.84,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 16.84 L/min is 0.5947 cuft/min; 1 decimal read "0.6".
+      expect(find.text('Use logged average (0.59 cuft/min)'), findsOneWidget);
+    });
+
+    testWidgets('imperial tap keeps a logged average below the slider floor', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          const PlanGasSection(),
+          settings: _imperialVolume,
+          loggedRmv: 8.2,
+        ),
+      );
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(PlanGasSection)),
+      );
+
+      await tester.tap(find.text('Use logged average (0.29 cuft/min)'));
+      await tester.pumpAndSettle();
+
+      // 8.2 L/min is inside the planner's 8-30 L/min range but below the
+      // 0.30 cuft/min imperial floor. The plan takes the value the button
+      // named, as it would for a metric diver; only the thumb pins to the
+      // floor.
+      expect(tester.takeException(), isNull);
+      expect(container.read(divePlanNotifierProvider).sacRate, 8.2);
+      final slider = tester.widget<Slider>(find.byType(Slider));
+      expect(slider.value, slider.min);
+      expect(find.text('0.29 cuft/min'), findsOneWidget);
+      expect(find.byIcon(Icons.history), findsNothing);
+    });
+
+    testWidgets('imperial tap on a logged average above 30 L/min hides it', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          const PlanGasSection(),
+          settings: _imperialVolume,
+          loggedRmv: 30.3,
+        ),
+      );
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(PlanGasSection)),
+      );
+
+      await tester.tap(find.byIcon(Icons.history));
+      await tester.pumpAndSettle();
+
+      // The plan clamps to the planner's 30 L/min ceiling, close enough to
+      // the logged average that the button hides. Clamping to the snapped
+      // 1.05 cuft/min (29.73 L/min) instead left a button that stayed on
+      // screen and did nothing when tapped again.
+      expect(container.read(divePlanNotifierProvider).sacRate, 30);
+      expect(find.byIcon(Icons.history), findsNothing);
+    });
   });
 
   testWidgets('environment section shows altitude group chip at 1000m', (

--- a/test/features/dive_planner/presentation/widgets/setup/plan_setup_sections_test.dart
+++ b/test/features/dive_planner/presentation/widgets/setup/plan_setup_sections_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/units.dart';
@@ -55,6 +56,20 @@ String? _rmvSemanticsLabel(WidgetTester tester) => tester
     .firstWhere((label) => label?.startsWith('RMV') ?? false);
 
 void main() {
+  // MaterialApp's locale does not reach the number formatting: formatRmv
+  // localises its decimal separator from the process-global
+  // Intl.defaultLocale. Pin English so "0.53 cuft/min" stays dot-separated.
+  late String? previousLocale;
+
+  setUp(() {
+    previousLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en';
+  });
+
+  tearDown(() {
+    Intl.defaultLocale = previousLocale;
+  });
+
   group('planWaterOptionFor', () {
     test('maps salt, fresh, custom salinity, leftover brackish, and null', () {
       expect(

--- a/test/features/planner/follow_dive_test.dart
+++ b/test/features/planner/follow_dive_test.dart
@@ -87,6 +87,7 @@ void main() {
 
     final button = find.textContaining('17.6');
     expect(button, findsOneWidget);
+    expect(find.byIcon(Icons.history), findsOneWidget);
 
     await tester.tap(button);
     await tester.pumpAndSettle();
@@ -98,8 +99,10 @@ void main() {
       container.read(divePlanNotifierProvider).sacRate,
       closeTo(17.6, 0.01),
     );
-    // Button hides once the plan matches the logged average.
-    expect(find.textContaining('17.6 '), findsNothing);
+    // Button hides once the plan matches the logged average. The readout
+    // beside the slider now shows the plan's 17.6 L/min itself, so look for
+    // the button's icon rather than the number.
+    expect(find.byIcon(Icons.history), findsNothing);
   });
 
   testWidgets('FollowDiveSheet lists dives and follows the tapped one', (


### PR DESCRIPTION
## Summary

The dive planner's RMV slider edits `planState.sacRate`, which is stored in L/min, but the slider label, the readout beside it and the Semantics label printed that raw number followed by the diver's volume symbol. An imperial diver saw the default 15 L/min as "15 cuft/min", about 28 times the real 0.53 cuft/min.

This PR converts the slider for display and input so an imperial diver works in cuft/min, while the plan state stays in L/min. It also fixes two related precision gaps where cuft/min RMVs were rendered at 1 decimal.

Closes #1823

## Changes

- `plan_gas_section.dart`: the slider takes its range, step and conversion from `UnitAxis.normalRmv`, the axis the gas consumption calculator already uses for the same 8-30 L/min range. Metric stays 8-30 L/min in 1 L/min steps. Imperial is 0.30-1.05 cuft/min in 0.05 steps (the axis snaps inward, so both bounds stay inside 8-30 L/min). Drag values are converted back to L/min before they reach the plan.
- The slider label, readout and Semantics label all go through `UnitFormatter.formatRmv` (1 decimal for L/min, 2 for cuft/min) instead of `toStringAsFixed(0)`, so they respect the active diver's volume unit and locale decimal separator.
- Only the slider thumb is clamped to the axis range. A plan RMV inside 8-30 L/min can still fall outside the snapped imperial range (8 L/min is 0.28 cuft/min, below the 0.30 floor), and `Slider` asserts on out-of-range values. The readout keeps showing the real value the calculator uses.
- The "Use logged average" hint uses `formatRmv` instead of 1 decimal, so 16.84 L/min reads "0.59 cuft/min" rather than "0.6 cuft/min".
- `quality_unit_formatters.dart`: the data-quality SAC formatter uses `formatRmv` for the same reason.

### Judgment calls

- **Imperial range and step.** I reused `UnitAxis.normalRmv` rather than inventing a planner-specific cuft/min range, so the planner and the gas consumption calculator agree. 0.05 cuft/min is about 1.4 L/min, close to the metric 1 L/min step.
- **Logged-average tap.** A tapped logged average still clamps to the planner's 8-30 L/min range, as before, and not to the snapped imperial range. Clamping to the imperial range would make the stored plan depend on the unit setting (8.2 L/min would become 8.495 L/min for an imperial diver only). It would also leave a button that stays visible and does nothing: a logged 30.3 L/min would clamp to 29.73 L/min, which never comes within the 0.5 L/min "already matches" threshold.
- **Metric readout precision.** Metric now reads "15.0 L/min" instead of "15 L/min". That is the 1 decimal `formatRmv` uses everywhere else in the app (stats, dive details), and it lets a logged average such as 16.8 L/min show as itself once applied.
- **Readout width.** The fixed readout box went from 70 to 96 logical pixels so "0.53 cuft/min" fits on one line. A narrower box only wraps the text; it cannot overflow.
- No new user-facing strings: the existing `divePlanner_semantics_sacRate` and `plannerCanvas_sac_useLogged` keys already take the value and unit as parameters, so no ARB files changed.

## Test Plan

- [x] New widget tests in `plan_setup_sections_test.dart` for metric and imperial: slider min, max, divisions and value; label, readout and Semantics text; drag stores L/min; a below-floor plan RMV renders without an assertion; logged-average hint precision; logged-average tap below the imperial floor and above 30 L/min. All written first and seen failing for the expected reason.
- [x] New unit tests in `quality_unit_formatters_test.dart` for the data-quality SAC formatter in L/min and cuft/min.
- [x] `follow_dive_test.dart`: the "button hides" check now looks for the button's icon. It used to look for any text containing "17.6", which only passed because the old readout rounded 17.6 L/min to "18".
- [x] Targeted runs pass locally: the three files above plus `plan_setup_accordion_test.dart`, `plan_panes_test.dart`, `plan_canvas_page_test.dart`, the `data_quality/presentation` tests, `rmv_relabel_test.dart`, `unit_axis_test.dart` and `unit_formatter_sac_test.dart`. The full suite is left to CI.
- [x] `dart format .` and `flutter analyze` over the whole project are clean.
- [ ] Manual testing: not done on a device; covered by the widget tests above.
