### PR TITLE
feat(tags): open a tag's dives from Manage Tags and dive tag chips

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -128,6 +128,7 @@ import 'package:submersion/features/signatures/presentation/providers/signature_
 import 'package:submersion/features/signatures/presentation/widgets/buddy_signatures_section.dart';
 import 'package:submersion/features/signatures/presentation/widgets/signature_capture_widget.dart';
 import 'package:submersion/features/signatures/presentation/widgets/signature_display_widget.dart';
+import 'package:submersion/features/tags/presentation/tag_dives_navigation.dart';
 import 'package:submersion/features/tides/domain/entities/tide_record.dart';
 import 'package:submersion/features/reef/presentation/providers/reef_providers.dart';
 import 'package:submersion/features/reef/presentation/widgets/water_conditions_card.dart';
@@ -4245,12 +4246,14 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
               runSpacing: 8,
               children: dive.tags
                   .map(
-                    (tag) => Chip(
+                    (tag) => ActionChip(
                       label: Text(tag.name),
+                      tooltip: context.l10n.tags_action_showDives(tag.name),
                       backgroundColor: tag.color.withValues(alpha: 0.2),
                       side: BorderSide(color: tag.color),
                       labelStyle: TextStyle(color: tag.color),
                       visualDensity: VisualDensity.compact,
+                      onPressed: () => openDivesWithTag(context, ref, tag.id),
                     ),
                   )
                   .toList(),

--- a/lib/features/tags/presentation/pages/tag_manage_page.dart
+++ b/lib/features/tags/presentation/pages/tag_manage_page.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
 import 'package:submersion/features/tags/presentation/providers/tag_providers.dart';
+import 'package:submersion/features/tags/presentation/tag_dives_navigation.dart';
 import 'package:submersion/features/tags/presentation/widgets/tag_input_widget.dart';
 import 'package:submersion/features/tags/presentation/widgets/tag_merge_sheet.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -225,16 +226,35 @@ class _TagManagePageState extends ConsumerState<TagManagePage> {
         child: CircleAvatar(radius: 16, backgroundColor: tag.color),
       ),
       title: Text(tag.name),
-      trailing: Text(
-        context.l10n.tags_manage_diveCount(stat.diveCount),
-        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-          color: Theme.of(context).colorScheme.onSurfaceVariant,
-        ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            context.l10n.tags_manage_diveCount(stat.diveCount),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+          // Editing moved off the row tap when the row started opening the
+          // tag's dives (#1833). Hidden while selecting, where a row tap
+          // toggles the row and a second target inside it would be a trap.
+          if (!_isSelectionMode)
+            IconButton(
+              key: ValueKey('tag_edit_${tag.id}'),
+              icon: const Icon(Icons.edit_outlined),
+              tooltip: context.l10n.tags_manage_editTitle,
+              onPressed: () => _showEditDialog(tag),
+            ),
+        ],
       ),
       selected: isSelected,
       onTap: _isSelectionMode
           ? () => _toggleSelection(tag.id)
-          : () => _showEditDialog(tag),
+          : () => openDivesWithTag(context, ref, tag.id),
+      // Without a handler a long press falls through to onTap, which is how
+      // it used to open the editor. Keep that, but not while selecting, where
+      // the fall-through toggles the row like a tap.
+      onLongPress: _isSelectionMode ? null : () => _showEditDialog(tag),
     );
   }
 

--- a/lib/features/tags/presentation/tag_dives_navigation.dart
+++ b/lib/features/tags/presentation/tag_dives_navigation.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+
+/// Opens the dive list showing only the dives tagged [tagId] (#1833).
+///
+/// The one place a tap on a tag becomes "show me those dives", shared by the
+/// Manage Tags rows and the tag chips on a dive, so every tag surface behaves
+/// the same.
+///
+/// The filter is replaced rather than merged, like the site, buddy and dive
+/// computer "view dives" links: a leftover date, depth or site filter would
+/// hide some of the tag's dives, and the list would stop matching the dive
+/// count Manage Tags shows for the tag. The filter chip on the dive list
+/// clears it again.
+void openDivesWithTag(BuildContext context, WidgetRef ref, String tagId) {
+  ref.read(diveFilterProvider.notifier).state = DiveFilterState(
+    tagIds: [tagId],
+  );
+  context.go('/dives');
+}

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6084,6 +6084,7 @@
   "tags_picker_noMatches": "لا توجد وسوم تطابق بحثك.",
   "tags_picker_addCount": "{count, plural, =0{إضافة وسوم} =1{إضافة وسم واحد} other{إضافة {count} وسم}}",
   "tags_action_deleteTag": "حذف الوسم",
+  "tags_action_showDives": "عرض الغطسات الموسومة بـ \"{tagName}\"",
   "tags_dialog_deleteMessage": "هل أنت متأكد من حذف \"{tagName}\"؟ سيتم إزالته من جميع الغطسات.",
   "tags_dialog_deleteTitle": "حذف الوسم؟",
   "tags_empty": "لا توجد وسوم بعد. أنشئ وسوماً عند تعديل الغطسات.",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6084,6 +6084,7 @@
   "tags_picker_noMatches": "Keine Tags entsprechen deiner Suche.",
   "tags_picker_addCount": "{count, plural, =0{Tags hinzufügen} =1{1 Tag hinzufügen} other{{count} Tags hinzufügen}}",
   "tags_action_deleteTag": "Tag löschen",
+  "tags_action_showDives": "Tauchgänge mit Tag \"{tagName}\" anzeigen",
   "tags_dialog_deleteMessage": "Möchten Sie \"{tagName}\" wirklich löschen? Dies entfernt es von allen Tauchgängen.",
   "tags_dialog_deleteTitle": "Tag löschen?",
   "tags_empty": "Noch keine Tags. Erstellen Sie Tags beim Bearbeiten von Tauchgängen.",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -12322,6 +12322,15 @@
     }
   },
   "tags_action_deleteTag": "Delete tag",
+  "tags_action_showDives": "Show dives tagged \"{tagName}\"",
+  "@tags_action_showDives": {
+    "description": "Tooltip on a tag chip; tapping the chip opens the dive list filtered to that tag",
+    "placeholders": {
+      "tagName": {
+        "type": "String"
+      }
+    }
+  },
   "tags_dialog_deleteMessage": "Are you sure you want to delete \"{tagName}\"? This will remove it from all dives.",
   "tags_dialog_deleteTitle": "Delete Tag?",
   "tags_empty": "No tags yet. Create tags when editing dives.",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6084,6 +6084,7 @@
   "tags_picker_noMatches": "Ninguna etiqueta coincide con tu búsqueda.",
   "tags_picker_addCount": "{count, plural, =0{Añadir etiquetas} =1{Añadir 1 etiqueta} other{Añadir {count} etiquetas}}",
   "tags_action_deleteTag": "Eliminar etiqueta",
+  "tags_action_showDives": "Mostrar inmersiones con la etiqueta \"{tagName}\"",
   "tags_dialog_deleteMessage": "¿Estás seguro de que deseas eliminar \"{tagName}\"? Esto la eliminará de todas las inmersiones.",
   "tags_dialog_deleteTitle": "¿Eliminar Etiqueta?",
   "tags_empty": "Aún no hay etiquetas. Crea etiquetas al editar inmersiones.",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6000,6 +6000,7 @@
   "tags_picker_noMatches": "Aucun tag ne correspond à votre recherche.",
   "tags_picker_addCount": "{count, plural, =0{Ajouter des tags} =1{Ajouter 1 tag} other{Ajouter {count} tags}}",
   "tags_action_deleteTag": "Supprimer l'étiquette",
+  "tags_action_showDives": "Afficher les plongées avec l'étiquette « {tagName} »",
   "tags_dialog_deleteMessage": "Voulez-vous vraiment supprimer « {tagName} » ? Cela la supprimera de toutes les plongées.",
   "tags_dialog_deleteTitle": "Supprimer l'étiquette ?",
   "tags_empty": "Aucune étiquette pour le moment. Créez des étiquettes lors de la modification des plongées.",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6084,6 +6084,7 @@
   "tags_picker_noMatches": "אין תגיות התואמות לחיפוש שלך.",
   "tags_picker_addCount": "{count, plural, =0{הוספת תגיות} =1{הוספת תגית אחת} other{הוספת {count} תגיות}}",
   "tags_action_deleteTag": "מחק תגית",
+  "tags_action_showDives": "הצג צלילות עם התגית \"{tagName}\"",
   "tags_dialog_deleteMessage": "האם אתה בטוח שברצונך למחוק את \"{tagName}\"? פעולה זו תסיר אותה מכל הצלילות.",
   "tags_dialog_deleteTitle": "למחוק תגית?",
   "tags_empty": "עדיין אין תגיות. צור תגיות בעת עריכת צלילות.",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6000,6 +6000,7 @@
   "tags_picker_noMatches": "Nincs a keresésnek megfelelő címke.",
   "tags_picker_addCount": "{count, plural, =0{Címkék hozzáadása} =1{1 címke hozzáadása} other{{count} címke hozzáadása}}",
   "tags_action_deleteTag": "Címke törlése",
+  "tags_action_showDives": "\"{tagName}\" címkéjű merülések megjelenítése",
   "tags_dialog_deleteMessage": "Biztosan törölni szeretnéd: \"{tagName}\"? Ez eltávolítja az összes merülésről.",
   "tags_dialog_deleteTitle": "Címke törlése?",
   "tags_empty": "Még nincsenek címkék. Hozz létre címkéket a merülések szerkesztésekor.",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -5996,6 +5996,7 @@
   "tags_picker_noMatches": "Nessun tag corrisponde alla ricerca.",
   "tags_picker_addCount": "{count, plural, =0{Aggiungi tag} =1{Aggiungi 1 tag} other{Aggiungi {count} tag}}",
   "tags_action_deleteTag": "Elimina tag",
+  "tags_action_showDives": "Mostra immersioni con tag \"{tagName}\"",
   "tags_dialog_deleteMessage": "Sei sicuro di voler eliminare \"{tagName}\"? Questo lo rimuoverà da tutte le immersioni.",
   "tags_dialog_deleteTitle": "Eliminare Tag?",
   "tags_empty": "Nessun tag ancora. Crea tag quando modifichi le immersioni.",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -33438,6 +33438,12 @@ abstract class AppLocalizations {
   /// **'Delete tag'**
   String get tags_action_deleteTag;
 
+  /// Tooltip on a tag chip; tapping the chip opens the dive list filtered to that tag
+  ///
+  /// In en, this message translates to:
+  /// **'Show dives tagged \"{tagName}\"'**
+  String tags_action_showDives(String tagName);
+
   /// No description provided for @tags_dialog_deleteMessage.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -19929,6 +19929,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get tags_action_deleteTag => 'حذف الوسم';
 
   @override
+  String tags_action_showDives(String tagName) {
+    return 'عرض الغطسات الموسومة بـ \"$tagName\"';
+  }
+
+  @override
   String tags_dialog_deleteMessage(Object tagName) {
     return 'هل أنت متأكد من حذف \"$tagName\"؟ سيتم إزالته من جميع الغطسات.';
   }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -20257,6 +20257,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tags_action_deleteTag => 'Tag löschen';
 
   @override
+  String tags_action_showDives(String tagName) {
+    return 'Tauchgänge mit Tag \"$tagName\" anzeigen';
+  }
+
+  @override
   String tags_dialog_deleteMessage(Object tagName) {
     return 'Möchten Sie \"$tagName\" wirklich löschen? Dies entfernt es von allen Tauchgängen.';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -19951,6 +19951,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tags_action_deleteTag => 'Delete tag';
 
   @override
+  String tags_action_showDives(String tagName) {
+    return 'Show dives tagged \"$tagName\"';
+  }
+
+  @override
   String tags_dialog_deleteMessage(Object tagName) {
     return 'Are you sure you want to delete \"$tagName\"? This will remove it from all dives.';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -20319,6 +20319,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tags_action_deleteTag => 'Eliminar etiqueta';
 
   @override
+  String tags_action_showDives(String tagName) {
+    return 'Mostrar inmersiones con la etiqueta \"$tagName\"';
+  }
+
+  @override
   String tags_dialog_deleteMessage(Object tagName) {
     return '¿Estás seguro de que deseas eliminar \"$tagName\"? Esto la eliminará de todas las inmersiones.';
   }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -20392,6 +20392,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tags_action_deleteTag => 'Supprimer l\'étiquette';
 
   @override
+  String tags_action_showDives(String tagName) {
+    return 'Afficher les plongées avec l\'étiquette « $tagName »';
+  }
+
+  @override
   String tags_dialog_deleteMessage(Object tagName) {
     return 'Voulez-vous vraiment supprimer « $tagName » ? Cela la supprimera de toutes les plongées.';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -19778,6 +19778,11 @@ class AppLocalizationsHe extends AppLocalizations {
   String get tags_action_deleteTag => 'מחק תגית';
 
   @override
+  String tags_action_showDives(String tagName) {
+    return 'הצג צלילות עם התגית \"$tagName\"';
+  }
+
+  @override
   String tags_dialog_deleteMessage(Object tagName) {
     return 'האם אתה בטוח שברצונך למחוק את \"$tagName\"? פעולה זו תסיר אותה מכל הצלילות.';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -20248,6 +20248,11 @@ class AppLocalizationsHu extends AppLocalizations {
   String get tags_action_deleteTag => 'Címke törlése';
 
   @override
+  String tags_action_showDives(String tagName) {
+    return '\"$tagName\" címkéjű merülések megjelenítése';
+  }
+
+  @override
   String tags_dialog_deleteMessage(Object tagName) {
     return 'Biztosan törölni szeretnéd: \"$tagName\"? Ez eltávolítja az összes merülésről.';
   }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -20306,6 +20306,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get tags_action_deleteTag => 'Elimina tag';
 
   @override
+  String tags_action_showDives(String tagName) {
+    return 'Mostra immersioni con tag \"$tagName\"';
+  }
+
+  @override
   String tags_dialog_deleteMessage(Object tagName) {
     return 'Sei sicuro di voler eliminare \"$tagName\"? Questo lo rimuoverà da tutte le immersioni.';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -20132,6 +20132,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get tags_action_deleteTag => 'Tag verwijderen';
 
   @override
+  String tags_action_showDives(String tagName) {
+    return 'Duiken met tag \"$tagName\" tonen';
+  }
+
+  @override
   String tags_dialog_deleteMessage(Object tagName) {
     return 'Weet je zeker dat je \"$tagName\" wilt verwijderen? Dit verwijdert het van alle duiken.';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -20315,6 +20315,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get tags_action_deleteTag => 'Excluir tag';
 
   @override
+  String tags_action_showDives(String tagName) {
+    return 'Mostrar mergulhos com a tag \"$tagName\"';
+  }
+
+  @override
   String tags_dialog_deleteMessage(Object tagName) {
     return 'Tem certeza de que deseja excluir \"$tagName\"? Isso irá removê-la de todos os mergulhos.';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -19234,6 +19234,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get tags_action_deleteTag => '删除标签';
 
   @override
+  String tags_action_showDives(String tagName) {
+    return '显示带有「$tagName」标签的潜水';
+  }
+
+  @override
   String tags_dialog_deleteMessage(Object tagName) {
     return '确定要删除「$tagName」吗？这将从所有潜水中移除该标签。';
   }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6084,6 +6084,7 @@
   "tags_picker_noMatches": "Geen tags komen overeen met je zoekopdracht.",
   "tags_picker_addCount": "{count, plural, =0{Tags toevoegen} =1{1 tag toevoegen} other{{count} tags toevoegen}}",
   "tags_action_deleteTag": "Tag verwijderen",
+  "tags_action_showDives": "Duiken met tag \"{tagName}\" tonen",
   "tags_dialog_deleteMessage": "Weet je zeker dat je \"{tagName}\" wilt verwijderen? Dit verwijdert het van alle duiken.",
   "tags_dialog_deleteTitle": "Tag verwijderen?",
   "tags_empty": "Nog geen tags. Maak tags aan bij het bewerken van duiken.",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6084,6 +6084,7 @@
   "tags_picker_noMatches": "Nenhuma etiqueta corresponde à sua pesquisa.",
   "tags_picker_addCount": "{count, plural, =0{Adicionar etiquetas} =1{Adicionar 1 etiqueta} other{Adicionar {count} etiquetas}}",
   "tags_action_deleteTag": "Excluir tag",
+  "tags_action_showDives": "Mostrar mergulhos com a tag \"{tagName}\"",
   "tags_dialog_deleteMessage": "Tem certeza de que deseja excluir \"{tagName}\"? Isso irá removê-la de todos os mergulhos.",
   "tags_dialog_deleteTitle": "Excluir Tag?",
   "tags_empty": "Nenhuma tag ainda. Crie tags ao editar mergulhos.",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -6275,6 +6275,7 @@
   "tags_picker_noMatches": "没有标签与您的搜索匹配。",
   "tags_picker_addCount": "{count, plural, =0{添加标签} other{添加 {count} 个标签}}",
   "tags_action_deleteTag": "删除标签",
+  "tags_action_showDives": "显示带有「{tagName}」标签的潜水",
   "tags_dialog_deleteMessage": "确定要删除「{tagName}」吗？这将从所有潜水中移除该标签。",
   "tags_dialog_deleteTitle": "删除标签？",
   "tags_empty": "暂无标签。在编辑潜水时创建标签。",

--- a/test/features/dive_log/presentation/pages/dive_detail_tag_chip_tap_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_tag_chip_tap_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/tags/domain/entities/tag.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// A tag chip on the dive detail page opens the dive list filtered to that
+/// tag (#1833).
+void main() {
+  final nightDive = Tag(
+    id: 'tag-night',
+    name: 'Night Dive',
+    colorHex: '#EF4444',
+    createdAt: DateTime(2024),
+    updatedAt: DateTime(2024),
+  );
+  final wreck = Tag(
+    id: 'tag-wreck',
+    name: 'Wreck',
+    colorHex: '#3B82F6',
+    createdAt: DateTime(2024),
+    updatedAt: DateTime(2024),
+  );
+  final dive = Dive(
+    id: 'dive-1',
+    diveNumber: 1,
+    dateTime: DateTime(2023, 1, 1),
+    tags: [nightDive, wreck],
+  );
+
+  /// Pumps the detail page under a router with a stub dive list and returns
+  /// the router, so a test can read where a tap took it.
+  Future<GoRouter> pumpDetail(
+    WidgetTester tester, {
+    required bool embedded,
+    required Size size,
+    DiveFilterState initialFilter = const DiveFilterState(),
+  }) async {
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = size;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final overrides = await getBaseOverrides();
+    final router = GoRouter(
+      initialLocation: '/test',
+      routes: [
+        GoRoute(
+          path: '/test',
+          builder: (context, state) =>
+              DiveDetailPage(diveId: dive.id, embedded: embedded),
+        ),
+        GoRoute(
+          path: '/dives',
+          builder: (context, state) =>
+              const Scaffold(body: Text('DIVES_LIST_PAGE')),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          diveProvider(dive.id).overrideWith((ref) async => dive),
+          diveDataSourcesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <DiveDataSource>[]),
+          diveFilterProvider.overrideWith((ref) => initialFilter),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    return router;
+  }
+
+  Future<void> tapChip(WidgetTester tester, String name) async {
+    final chip = find.text(name);
+    await tester.scrollUntilVisible(
+      chip,
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(chip);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  DiveFilterState filterAt(WidgetTester tester) {
+    final container = ProviderScope.containerOf(
+      tester.element(find.text('DIVES_LIST_PAGE')),
+    );
+    return container.read(diveFilterProvider);
+  }
+
+  testWidgets('tapping a tag chip opens the dive list filtered to that tag', (
+    tester,
+  ) async {
+    final router = await pumpDetail(
+      tester,
+      embedded: false,
+      size: const Size(700, 1000),
+    );
+
+    await tapChip(tester, 'Wreck');
+
+    expect(find.text('DIVES_LIST_PAGE'), findsOneWidget);
+    expect(router.routeInformationProvider.value.uri.path, '/dives');
+    expect(filterAt(tester).tagIds, ['tag-wreck']);
+  });
+
+  testWidgets('the tag filter replaces the filter the diver had before', (
+    tester,
+  ) async {
+    await pumpDetail(
+      tester,
+      embedded: false,
+      size: const Size(700, 1000),
+      initialFilter: const DiveFilterState(
+        siteId: 'site-1',
+        tagIds: ['tag-other'],
+        minDepth: 30,
+      ),
+    );
+
+    await tapChip(tester, 'Night Dive');
+
+    final filter = filterAt(tester);
+    expect(filter.tagIds, ['tag-night']);
+    expect(filter.siteId, isNull);
+    expect(filter.minDepth, isNull);
+  });
+
+  testWidgets('a chip in the master-detail pane also opens the tag dives', (
+    tester,
+  ) async {
+    await pumpDetail(tester, embedded: true, size: const Size(1200, 900));
+
+    await tapChip(tester, 'Night Dive');
+
+    expect(find.text('DIVES_LIST_PAGE'), findsOneWidget);
+    expect(filterAt(tester).tagIds, ['tag-night']);
+  });
+
+  testWidgets('each chip says what tapping it does', (tester) async {
+    await pumpDetail(tester, embedded: false, size: const Size(700, 1000));
+    await tester.scrollUntilVisible(
+      find.text('Wreck'),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+
+    expect(find.byTooltip('Show dives tagged "Wreck"'), findsOneWidget);
+    expect(find.byTooltip('Show dives tagged "Night Dive"'), findsOneWidget);
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_detail_tag_chip_tap_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_tag_chip_tap_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
 import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/highlight_providers.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
@@ -156,6 +157,25 @@ void main() {
 
     expect(find.text('DIVES_LIST_PAGE'), findsOneWidget);
     expect(filterAt(tester).tagIds, ['tag-night']);
+  });
+
+  testWidgets('a chip in the master-detail pane keeps the dive highlighted', (
+    tester,
+  ) async {
+    await pumpDetail(tester, embedded: true, size: const Size(1200, 900));
+    // Opening a row in the list highlights it as well as selecting it.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(DiveDetailPage)),
+    );
+    container.read(highlightedDiveIdProvider.notifier).state = dive.id;
+
+    await tapChip(tester, 'Night Dive');
+
+    // Deliberate: the chip clears only the selection, exactly as the detail
+    // pane's own close button does, so the diver keeps their place. The dive
+    // carries the tag, so it is in the filtered list the chip opens.
+    expect(find.text('DIVES_LIST_PAGE'), findsOneWidget);
+    expect(container.read(highlightedDiveIdProvider), dive.id);
   });
 
   testWidgets('each chip says what tapping it does', (tester) async {

--- a/test/features/tags/presentation/pages/tag_manage_page_test.dart
+++ b/test/features/tags/presentation/pages/tag_manage_page_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
@@ -130,6 +132,46 @@ Widget _buildTestWidget({
   );
 }
 
+/// Like [_buildTestWidget], but under a GoRouter with a stub dive list, so a
+/// row tap can navigate. [initialFilter] seeds the dive filter the diver had
+/// before opening Manage Tags.
+Widget _buildRoutedTestWidget({
+  required List<TagStatistic> stats,
+  DiveFilterState initialFilter = const DiveFilterState(),
+}) {
+  final router = GoRouter(
+    initialLocation: '/tags',
+    routes: [
+      GoRoute(
+        path: '/tags',
+        builder: (context, state) => const TagManagePage(),
+      ),
+      GoRoute(
+        path: '/dives',
+        builder: (context, state) =>
+            const Scaffold(body: Text('DIVES_LIST_PAGE')),
+      ),
+    ],
+  );
+  return ProviderScope(
+    overrides: [
+      tagStatisticsProvider.overrideWith((ref) => Future.value(stats)),
+      tagListNotifierProvider.overrideWith(
+        (ref) => _MockTagListNotifier(_tagsFromStats(stats)),
+      ),
+      tagRepositoryProvider.overrideWithValue(_MockTagRepository()),
+      settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+      diveFilterProvider.overrideWith((ref) => initialFilter),
+    ],
+    child: MaterialApp.router(
+      routerConfig: router,
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+    ),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -246,18 +288,33 @@ void main() {
       expect(find.text('Photography'), findsNothing);
     });
 
-    testWidgets('tapping a tag opens edit dialog', (tester) async {
+    testWidgets('the edit button opens the edit dialog', (tester) async {
       await tester.pumpWidget(_buildTestWidget(stats: _testStats));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Night Dive'));
+      await tester.tap(find.byKey(const ValueKey('tag_edit_tag1')));
       await tester.pumpAndSettle();
 
-      // Edit dialog should appear
       expect(find.text('Edit Tag'), findsOneWidget);
       expect(find.text('Tag Name'), findsOneWidget);
       expect(find.text('Save'), findsOneWidget);
       expect(find.text('Cancel'), findsOneWidget);
+      // The dialog edits the tag whose button was tapped.
+      expect(find.widgetWithText(TextField, 'Night Dive'), findsOneWidget);
+    });
+
+    testWidgets('the edit button is hidden while selecting', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(stats: _testStats));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('tag_edit_tag1')), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+
+      // A row tap toggles the row during selection, so a second tap target
+      // inside the row that does something else would be a trap.
+      expect(find.byKey(const ValueKey('tag_edit_tag1')), findsNothing);
+      expect(find.text('12 dives'), findsOneWidget);
     });
 
     testWidgets('FAB opens create dialog', (tester) async {
@@ -290,7 +347,7 @@ void main() {
       expect(find.byType(FloatingActionButton), findsNothing);
     });
 
-    testWidgets('long-press on a tag does not enter selection mode', (
+    testWidgets('long-press on a tag edits it and does not enter selection', (
       tester,
     ) async {
       await tester.pumpWidget(_buildTestWidget(stats: _testStats));
@@ -299,9 +356,26 @@ void main() {
       await tester.longPress(find.text('Night Dive'));
       await tester.pumpAndSettle();
 
+      // A long press opened the editor before a row tap started opening the
+      // tag's dives (#1833), and still does.
+      expect(find.text('Edit Tag'), findsOneWidget);
+      expect(find.widgetWithText(TextField, 'Night Dive'), findsOneWidget);
       expect(find.text('1 selected'), findsNothing);
       expect(find.byType(Checkbox), findsNothing);
       expect(find.byKey(const ValueKey('enter_selection')), findsOneWidget);
+    });
+
+    testWidgets('long-press while selecting toggles the row', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(stats: _testStats));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.longPress(find.text('Night Dive'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsOneWidget);
+      expect(find.text('Edit Tag'), findsNothing);
     });
 
     testWidgets('delete button shows confirmation with dive count', (
@@ -372,6 +446,85 @@ void main() {
             .onPressed,
         isNotNull,
       );
+    });
+  });
+
+  group('tapping a tag opens its dives (#1833)', () {
+    testWidgets('a row tap opens the dive list filtered to that tag', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildRoutedTestWidget(stats: _testStats));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Night Dive'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('DIVES_LIST_PAGE'), findsOneWidget);
+      final container = ProviderScope.containerOf(
+        tester.element(find.text('DIVES_LIST_PAGE')),
+      );
+      expect(container.read(diveFilterProvider).tagIds, ['tag1']);
+    });
+
+    testWidgets('the tag filter replaces the filter the diver had before', (
+      tester,
+    ) async {
+      // A leftover filter would hide some of the tag's dives, so the list
+      // would no longer match the count shown on the row.
+      await tester.pumpWidget(
+        _buildRoutedTestWidget(
+          stats: _testStats,
+          initialFilter: const DiveFilterState(
+            siteId: 'site-1',
+            tagIds: ['tag2'],
+            favoritesOnly: true,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Night Dive'));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.text('DIVES_LIST_PAGE')),
+      );
+      final filter = container.read(diveFilterProvider);
+      expect(filter.tagIds, ['tag1']);
+      expect(filter.siteId, isNull);
+      expect(filter.favoritesOnly, isNull);
+    });
+
+    testWidgets('a row tap while selecting toggles it and stays put', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildRoutedTestWidget(stats: _testStats));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Night Dive'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsOneWidget);
+      expect(find.text('DIVES_LIST_PAGE'), findsNothing);
+      final container = ProviderScope.containerOf(
+        tester.element(find.text('Night Dive')),
+      );
+      expect(container.read(diveFilterProvider).tagIds, isEmpty);
+    });
+
+    testWidgets('the edit button edits without leaving the page', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildRoutedTestWidget(stats: _testStats));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('tag_edit_tag2')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit Tag'), findsOneWidget);
+      expect(find.text('DIVES_LIST_PAGE'), findsNothing);
     });
   });
 


### PR DESCRIPTION
## Summary

Tapping a tag now opens the dive list filtered to that tag, from both places tags appear:

- **Settings > Manage > Tags**: tapping a row (outside selection mode) opens that tag's dives. Editing is still one tap away through a new trailing edit button, and long press still opens the editor.
- **Dive detail**: the tag chips were plain `Chip`s with no action. They are now `ActionChip`s that open the tag's dives, with a tooltip ("Show dives tagged "Night Dive"") for hover and screen readers.

Both surfaces call one helper, `openDivesWithTag` (`lib/features/tags/presentation/tag_dives_navigation.dart`). The dive filter sheet already supports tags, so this only adds navigation plus a preset filter. When #1765 adds tags to dive sites, the site tag chips can use the same helper, so there is one tag interaction rather than two.

## Judgment calls

The issue left a few choices open. In each case I picked the most conservative option:

- **Replace the filter, do not merge it.** The helper sets the dive filter to just the tag, as the existing site, buddy and dive computer "View dives" links do. If a leftover date, depth or site filter stayed on, some of the tag's dives would be hidden and the list would no longer match the "12 dives" count on the Manage Tags row. The chip on the dive list clears the tag filter.
- **Editing in Manage Tags uses a trailing edit button (tooltip "Edit Tag"), plus long press.** The visible button is the discoverable, accessible path. Long press already opened the editor before this change: `ListTile` had no `onLongPress`, so a long press fell through to the old tap-to-edit. That behavior is now explicit and covered by a test instead of being an accident.
- **Selection mode is unchanged.** While selecting, the edit button is hidden, so every tap inside a row toggles it, and long press falls through to toggle as before. The shared selection contract test still passes.
- **A tag with 0 dives still opens the (empty) filtered list**, so every row responds the same way when tapped.
- **In the desktop master-detail layout, a chip tap shows the filtered list with no dive selected**, as the site and buddy "View dives" links do, rather than keeping the current dive open. The dive stays highlighted in the list, exactly as when the pane's own close button is used; it carries the tag, so it is in the filtered list. A test pins this.
- **The dive detail change is limited to the tag chips**, to stay clear of the concurrent Buddies card work in the same file.
- Out of scope, possible follow-up: for a single tag, the dive list's active-filter chip reads "1 tag" rather than the tag's name. This PR leaves that chip as it is.

## Localization

Adds `tags_action_showDives` with translations in all 11 locales (ar, de, en, es, fr, he, hu, it, nl, pt, zh), using each locale's existing quotation style (« » in French, 「」 in Chinese). Regenerated with `flutter gen-l10n`.

## How it was tested

Tests were written first and confirmed failing for the right reason before implementing.

- `test/features/tags/presentation/pages/tag_manage_page_test.dart`
  - a row tap opens `/dives` with `tagIds == ['tag1']`
  - the tag filter replaces an earlier filter (site, other tag, favorites)
  - a row tap while selecting toggles the row and does not navigate or touch the filter
  - the edit button opens the editor for that tag, stays on the page, and is hidden while selecting
  - long press opens the editor outside selection mode and toggles the row while selecting
- `test/features/dive_log/presentation/pages/dive_detail_tag_chip_tap_test.dart` (new)
  - a chip tap opens `/dives` filtered to that tag, both on the standalone page and in the embedded master-detail pane
  - the tag filter replaces an earlier filter
  - in the master-detail pane the dive stays highlighted after the tap (mutation-checked: fails if the helper clears the highlight)
  - each chip carries its "Show dives tagged ..." tooltip
- Also ran the existing dive detail page, section config, ARB parity, localization and repo-wide guard tests, all passing.
- `dart format .` and `flutter analyze` over the whole project: clean.
- Checked the new Manage Tags row layout visually with a throwaway golden render: the dive count and the edit button fit on each row with no overflow.

Closes #1833
