### PR TITLE
fix(import): link CSV tags to their dives and keep the suit in notes

### DIFF
--- a/lib/features/universal_import/data/csv/extractors/dive_extractor.dart
+++ b/lib/features/universal_import/data/csv/extractors/dive_extractor.dart
@@ -48,7 +48,8 @@ class DiveExtractor {
 
   /// Extract a single dive map from [row].
   ///
-  /// Only known dive fields are copied. A new UUID is generated for 'id'.
+  /// Only known dive fields are copied, plus a 'suit' line appended to the
+  /// notes. A new UUID is generated for 'id'.
   Map<String, dynamic> extract(Map<String, dynamic> row) {
     final dive = <String, dynamic>{'id': _uuid.v4()};
 
@@ -56,6 +57,16 @@ class DiveExtractor {
       if (row.containsKey(field)) {
         dive[field] = row[field];
       }
+    }
+
+    // A dive has no suit field and the presets create no gear from it, so
+    // the suit is kept in the notes, as the Subsurface XML import keeps it.
+    final suit = row['suit']?.toString().trim() ?? '';
+    if (suit.isNotEmpty) {
+      final notes = dive['notes']?.toString() ?? '';
+      dive['notes'] = notes.trim().isEmpty
+          ? 'Suit: $suit'
+          : '$notes\nSuit: $suit';
     }
 
     return dive;

--- a/lib/features/universal_import/data/csv/extractors/tag_extractor.dart
+++ b/lib/features/universal_import/data/csv/extractors/tag_extractor.dart
@@ -39,6 +39,16 @@ class TagExtractor implements EntityExtractor<Map<String, dynamic>> {
   /// Returns the generated UUID for a tag name, or null if not seen.
   String? tagIdForName(String name) => _tagNameToId[name];
 
+  /// Returns the generated UUIDs of the tags named in [row]'s 'tags' field,
+  /// in order and without repeats, so the row's dive can link to them.
+  List<String> tagIdsForRow(Map<String, dynamic> row) {
+    final raw = row['tags'];
+    if (raw == null) return const [];
+    return {
+      for (final name in _splitNames(raw.toString())) ?_tagNameToId[name],
+    }.toList();
+  }
+
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------

--- a/lib/features/universal_import/data/csv/pipeline/csv_correlator.dart
+++ b/lib/features/universal_import/data/csv/pipeline/csv_correlator.dart
@@ -31,7 +31,7 @@ class CsvCorrelator {
   /// 4. Extract sites via [SiteExtractor] (deduplicated).
   /// 5. Link each dive to its site using [SiteExtractor.siteIdForName].
   /// 6. Conditionally extract buddies, tags, and gear.
-  /// 7. Attach tanks list to each dive map.
+  /// 7. Attach tanks list to each dive map, and link buddies and tags.
   /// 8. If [profileRows] provided, run [ProfileExtractor] and attach profiles.
   /// 9. Build metadata and return [CorrelatedPayload].
   CorrelatedPayload correlate({
@@ -88,9 +88,11 @@ class CsvCorrelator {
     }
 
     // Step 6b: Extract tags if requested.
+    TagExtractor? tagExtractor;
     final tags = <Map<String, dynamic>>[];
     if (entityTypes.contains(ImportEntityType.tags)) {
-      tags.addAll(TagExtractor().extractFromRows(rows));
+      tagExtractor = TagExtractor();
+      tags.addAll(tagExtractor.extractFromRows(rows));
     }
 
     // Step 6c: Extract gear/equipment if requested.
@@ -113,10 +115,16 @@ class CsvCorrelator {
         ? _attachBuddyRefs(divesWithTanks, buddyExtractor)
         : divesWithTanks;
 
+    // Step 7c: Link tags to dives so the importer's _linkTagsToDive method
+    // attaches them; without tagRefs the tags import linked to no dive.
+    final divesWithTagRefs = tagExtractor != null
+        ? _attachTagRefs(divesWithBuddyRefs, rows, tagExtractor)
+        : divesWithBuddyRefs;
+
     // Step 8: Attach profile data if provided.
     final finalDives = profileRows != null
-        ? _attachProfiles(divesWithBuddyRefs, profileRows.rows)
-        : divesWithBuddyRefs;
+        ? _attachProfiles(divesWithTagRefs, profileRows.rows)
+        : divesWithTagRefs;
 
     // Step 9: Build metadata and entities map.
     final metadata = <String, dynamic>{
@@ -195,6 +203,24 @@ class CsvCorrelator {
 
       return updated;
     }).toList();
+  }
+
+  /// Set each dive's tagRefs to the ids of the tags in its source row, as
+  /// [UddfEntityImporter._linkTagsToDive] expects. [dives] and [rows] are
+  /// index-aligned: every dive was extracted from the row at its index.
+  List<Map<String, dynamic>> _attachTagRefs(
+    List<Map<String, dynamic>> dives,
+    List<Map<String, dynamic>> rows,
+    TagExtractor extractor,
+  ) {
+    return [
+      for (var i = 0; i < dives.length; i++)
+        if (extractor.tagIdsForRow(rows[i]) case final refs
+            when refs.isNotEmpty)
+          Map<String, dynamic>.from(dives[i])..['tagRefs'] = refs
+        else
+          dives[i],
+    ];
   }
 
   /// Normalize field name aliases to canonical names for extractors.

--- a/lib/features/universal_import/data/csv/presets/built_in_presets.dart
+++ b/lib/features/universal_import/data/csv/presets/built_in_presets.dart
@@ -57,7 +57,11 @@ const _myssi = CsvPreset(
       ],
     ),
   },
-  supportedEntities: {ImportEntityType.dives},
+  supportedEntities: {
+    ImportEntityType.dives,
+    ImportEntityType.sites,
+    ImportEntityType.buddies,
+  },
 );
 
 // ======================== 1. Subsurface (multi-file) ========================

--- a/lib/features/universal_import/data/parsers/csv_import_parser.dart
+++ b/lib/features/universal_import/data/parsers/csv_import_parser.dart
@@ -109,12 +109,14 @@ class CsvImportParser implements ImportParser {
 
   /// Target fields whose values only become linked records when the
   /// correlator extracts the matching entity type. Without it a mapped site
-  /// column is dropped and a mapped buddy column stays free text (#1830).
-  /// 'site' is the legacy alias the correlator normalizes to 'siteName'.
+  /// column is dropped, a mapped buddy column stays free text (#1830), and a
+  /// mapped tags column is dropped. 'site' is the legacy alias the
+  /// correlator normalizes to 'siteName'.
   static const _entityTypeForTargetField = {
     'siteName': ImportEntityType.sites,
     'site': ImportEntityType.sites,
     'buddy': ImportEntityType.buddies,
+    'tags': ImportEntityType.tags,
   };
 
   /// [entityTypes] plus every type a column in [mappings] needs, so a

--- a/lib/features/universal_import/data/parsers/csv_import_parser.dart
+++ b/lib/features/universal_import/data/parsers/csv_import_parser.dart
@@ -101,12 +101,42 @@ class CsvImportParser implements ImportParser {
   // Private helpers
   // ---------------------------------------------------------------------------
 
+  /// Entity types imported when neither a preset nor the mapping asks for more.
+  static const _defaultEntityTypes = {
+    ImportEntityType.dives,
+    ImportEntityType.sites,
+  };
+
+  /// Target fields whose values only become linked records when the
+  /// correlator extracts the matching entity type. Without it a mapped site
+  /// column is dropped and a mapped buddy column stays free text (#1830).
+  /// 'site' is the legacy alias the correlator normalizes to 'siteName'.
+  static const _entityTypeForTargetField = {
+    'siteName': ImportEntityType.sites,
+    'site': ImportEntityType.sites,
+    'buddy': ImportEntityType.buddies,
+  };
+
+  /// [entityTypes] plus every type a column in [mappings] needs, so a
+  /// preset's or saved mapping's entity set cannot drift from its columns.
+  static Set<ImportEntityType> _withMappedEntityTypes(
+    Set<ImportEntityType> entityTypes,
+    Iterable<FieldMapping> mappings,
+  ) => {
+    ...entityTypes,
+    for (final mapping in mappings)
+      for (final column in mapping.columns)
+        ?_entityTypeForTargetField[column.targetField],
+  };
+
   /// Build an [ImportConfiguration] from the resolved mapping source.
   ///
   /// Priority order:
   /// 1. Explicit custom mapping (user-provided).
   /// 2. Detected preset from pipeline Detect stage.
   /// 3. Auto-mapped from CSV headers using keyword matching.
+  ///
+  /// In every case the entity types are widened by [_withMappedEntityTypes].
   ImportConfiguration _buildConfiguration({
     required ParsedCsv parsedCsv,
     required DetectionResult detection,
@@ -121,9 +151,10 @@ class CsvImportParser implements ImportParser {
     if (resolvedMapping != null) {
       return ImportConfiguration(
         mappings: {'primary': resolvedMapping},
-        entityTypesToImport:
-            detection.matchedPreset?.supportedEntities ??
-            const {ImportEntityType.dives, ImportEntityType.sites},
+        entityTypesToImport: _withMappedEntityTypes(
+          detection.matchedPreset?.supportedEntities ?? _defaultEntityTypes,
+          [resolvedMapping],
+        ),
         timeInterpretation: timeInterpretation,
         specificUtcOffset: specificUtcOffset,
         sourceApp: options?.sourceApp,
@@ -135,7 +166,10 @@ class CsvImportParser implements ImportParser {
       final preset = detection.matchedPreset!;
       return ImportConfiguration(
         mappings: preset.mappings,
-        entityTypesToImport: preset.supportedEntities,
+        entityTypesToImport: _withMappedEntityTypes(
+          preset.supportedEntities,
+          preset.mappings.values,
+        ),
         sourceApp: preset.sourceApp ?? options?.sourceApp,
         preset: preset,
         timeInterpretation: timeInterpretation,
@@ -147,6 +181,9 @@ class CsvImportParser implements ImportParser {
     final autoMapping = _autoMapFromHeaders(parsedCsv.headers);
     return ImportConfiguration(
       mappings: {'primary': autoMapping},
+      entityTypesToImport: _withMappedEntityTypes(_defaultEntityTypes, [
+        autoMapping,
+      ]),
       timeInterpretation: timeInterpretation,
       specificUtcOffset: specificUtcOffset,
       sourceApp: options?.sourceApp,

--- a/test/features/universal_import/data/csv/integration/csv_tags_and_suit_import_test.dart
+++ b/test/features/universal_import/data/csv/integration/csv_tags_and_suit_import_test.dart
@@ -1,0 +1,121 @@
+// End-to-end check that a CSV's tags and suit columns reach the database:
+// real CsvImportParser output, converted the way the import wizard converts
+// it, imported by the real UddfEntityImporter into an in-memory AppDatabase.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/export/models/uddf_import_result.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/certifications/data/repositories/certification_repository.dart';
+import 'package:submersion/features/courses/data/repositories/course_repository.dart';
+import 'package:submersion/features/dive_centers/data/repositories/dive_center_repository.dart';
+import 'package:submersion/features/dive_import/data/services/uddf_entity_importer.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/dive_types/data/repositories/dive_type_repository.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart'
+    as domain;
+import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_set_repository_impl.dart';
+import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
+import 'package:submersion/features/trips/data/repositories/trip_repository.dart';
+import 'package:submersion/features/universal_import/data/models/import_enums.dart';
+import 'package:submersion/features/universal_import/data/parsers/csv_import_parser.dart';
+
+import '../../../../../helpers/test_database.dart';
+
+/// A Subsurface dive list: dive 1 is tagged "reef, night" and worn with a
+/// suit, dive 2 is tagged "reef" only.
+const _csv =
+    'dive number,date,time,duration [min],maxdepth [m],'
+    'avgdepth [m],mode,airtemp [C],watertemp [C],'
+    'cylinder size (1) [l],startpressure (1) [bar],'
+    'endpressure (1) [bar],o2 (1) [%],he (1) [%],'
+    'location,gps,divemaster,buddy,suit,rating,'
+    'visibility,notes,weight [kg],tags,sac [l/min]\n'
+    '1,2024-06-15,09:00,45,25.0,18.0,OC,28.0,27.0,'
+    '12.0,200,50,21,0,Blue Hole,,,,7mm Wetsuit,5,good,'
+    'Saw a turtle,2.0,"reef, night",14.5\n'
+    '2,2024-06-16,10:00,50,30.0,22.0,OC,28.0,26.5,'
+    '12.0,200,60,21,0,The Wall,,,,,4,good,'
+    ',2.0,reef,15.0\n';
+
+ImportRepositories _buildRepositories() {
+  return ImportRepositories(
+    tripRepository: TripRepository(),
+    equipmentRepository: EquipmentRepository(),
+    equipmentSetRepository: EquipmentSetRepository(),
+    buddyRepository: BuddyRepository(),
+    diveCenterRepository: DiveCenterRepository(),
+    certificationRepository: CertificationRepository(),
+    tagRepository: TagRepository(),
+    diveTypeRepository: DiveTypeRepository(),
+    siteRepository: SiteRepository(),
+    diveRepository: DiveRepository(),
+    tankPressureRepository: TankPressureRepository(),
+    courseRepository: CourseRepository(),
+  );
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+  });
+
+  tearDown(tearDownTestDatabase);
+
+  test('a Subsurface CSV import tags each dive and keeps its suit', () async {
+    const diverId = 'diver-csv-tags';
+    final now = DateTime.now();
+    await DiverRepository().createDiver(
+      domain.Diver(
+        id: diverId,
+        name: 'Test Diver',
+        isDefault: true,
+        createdAt: now,
+        updatedAt: now,
+      ),
+    );
+
+    final payload = await CsvImportParser().parse(
+      Uint8List.fromList(utf8.encode(_csv)),
+    );
+    final data = UddfImportResult(
+      dives: payload.entitiesOf(ImportEntityType.dives),
+      sites: payload.entitiesOf(ImportEntityType.sites),
+      buddies: payload.entitiesOf(ImportEntityType.buddies),
+      tags: payload.entitiesOf(ImportEntityType.tags),
+    );
+
+    final result = await UddfEntityImporter().import(
+      data: data,
+      selections: UddfImportSelections.selectAll(data),
+      repositories: _buildRepositories(),
+      diverId: diverId,
+    );
+    expect(result.dives, 2);
+    expect(result.tags, 2, reason: '"reef" is shared, not created twice');
+
+    final dives = {
+      for (final row in await db.select(db.dives).get()) row.diveNumber: row,
+    };
+    final tagRepository = TagRepository();
+    Future<Set<String>> tagNamesOf(int diveNumber) async => {
+      for (final tag in await tagRepository.getTagsForDive(
+        dives[diveNumber]!.id,
+      ))
+        tag.name,
+    };
+
+    expect(await tagNamesOf(1), {'reef', 'night'});
+    expect(await tagNamesOf(2), {'reef'});
+    expect(dives[1]!.notes, 'Saw a turtle\nSuit: 7mm Wetsuit');
+  });
+}

--- a/test/features/universal_import/data/csv/integration/subsurface_csv_integration_test.dart
+++ b/test/features/universal_import/data/csv/integration/subsurface_csv_integration_test.dart
@@ -158,6 +158,47 @@ void main() {
       expect(tagNames, contains('student'));
     });
 
+    test('links each tagged dive to its tags', () {
+      final bytes = diveListFile.readAsBytesSync();
+      final parsed = pipeline.parse(bytes);
+      final detected = pipeline.detect(parsed);
+      final config = _configFromPreset(detected.matchedPreset!);
+      final payload = pipeline.execute(primaryCsv: parsed, config: config);
+
+      final tagIdByName = {
+        for (final tag in payload.entitiesOf(ImportEntityType.tags))
+          tag['name'] as String: tag['id'] as String,
+      };
+      final divesByNumber = {
+        for (final dive in payload.entitiesOf(ImportEntityType.dives))
+          if (dive['diveNumber'] != null) dive['diveNumber'].toString(): dive,
+      };
+
+      // Dives 1-5 are tagged "shore, student"; dive 6 has no tags. Without
+      // tagRefs the importer creates the tags but links them to no dive.
+      expect(divesByNumber['1']?['tagRefs'], [
+        tagIdByName['shore'],
+        tagIdByName['student'],
+      ]);
+      expect(divesByNumber['6']?.containsKey('tagRefs'), isFalse);
+    });
+
+    test('keeps the suit in the dive notes', () {
+      final bytes = diveListFile.readAsBytesSync();
+      final parsed = pipeline.parse(bytes);
+      final detected = pipeline.detect(parsed);
+      final config = _configFromPreset(detected.matchedPreset!);
+      final payload = pipeline.execute(primaryCsv: parsed, config: config);
+
+      final dive = payload
+          .entitiesOf(ImportEntityType.dives)
+          .firstWhere((d) => d['diveNumber']?.toString() == '1');
+
+      // The preset maps the suit column but creates no gear, so the suit
+      // is kept the way the Subsurface XML import keeps it.
+      expect(dive['notes'], 'Summary:\nSuit: 3mm Bare wetsuit');
+    });
+
     test('all dive times are UTC wall-clock and not shifted '
         '(first numbered dive at 07:44 remains 07:44)', () {
       final bytes = diveListFile.readAsBytesSync();

--- a/test/features/universal_import/data/csv/pipeline/csv_correlator_test.dart
+++ b/test/features/universal_import/data/csv/pipeline/csv_correlator_test.dart
@@ -285,6 +285,118 @@ void main() {
       expect(tags, isNotEmpty);
     });
 
+    group('tagRefs', () {
+      const tagTypes = {ImportEntityType.dives, ImportEntityType.tags};
+
+      test('links each dive to the ids of its tags', () {
+        final rows = makeRows([
+          {'dateTime': DateTime(2024, 6, 15, 9, 0), 'tags': 'reef, training'},
+          {'dateTime': DateTime(2024, 6, 16, 9, 0), 'tags': 'reef'},
+          {'dateTime': DateTime(2024, 6, 17, 9, 0)},
+        ]);
+
+        final result = correlator.correlate(
+          diveListRows: rows,
+          config: makeConfig(entityTypes: tagTypes),
+        );
+
+        final tagIdByName = {
+          for (final tag in result.entitiesOf(ImportEntityType.tags))
+            tag['name'] as String: tag['id'] as String,
+        };
+        final dives = result.entitiesOf(ImportEntityType.dives);
+        expect(dives[0]['tagRefs'], [
+          tagIdByName['reef'],
+          tagIdByName['training'],
+        ]);
+        expect(dives[1]['tagRefs'], [tagIdByName['reef']]);
+        expect(dives[2].containsKey('tagRefs'), isFalse);
+      });
+
+      test('links a tag repeated within one dive once', () {
+        final rows = makeRows([
+          {'dateTime': DateTime(2024, 6, 15, 9, 0), 'tags': 'reef, reef'},
+        ]);
+
+        final result = correlator.correlate(
+          diveListRows: rows,
+          config: makeConfig(entityTypes: tagTypes),
+        );
+
+        final tag = result.entitiesOf(ImportEntityType.tags).single;
+        final dive = result.entitiesOf(ImportEntityType.dives).single;
+        expect(dive['tagRefs'], [tag['id']]);
+      });
+
+      test('are not attached when tags are not imported', () {
+        final rows = makeRows([
+          {'dateTime': DateTime(2024, 6, 15, 9, 0), 'tags': 'reef'},
+        ]);
+
+        final result = correlator.correlate(
+          diveListRows: rows,
+          config: makeConfig(),
+        );
+
+        final dive = result.entitiesOf(ImportEntityType.dives).single;
+        expect(dive.containsKey('tagRefs'), isFalse);
+      });
+    });
+
+    group('suit', () {
+      test('is appended to the dive notes', () {
+        final rows = makeRows([
+          {
+            'dateTime': DateTime(2024, 6, 15, 9, 0),
+            'notes': 'Saw a turtle',
+            'suit': '7mm Wetsuit',
+          },
+        ]);
+
+        final result = correlator.correlate(
+          diveListRows: rows,
+          config: makeConfig(),
+        );
+
+        final dive = result.entitiesOf(ImportEntityType.dives).single;
+        expect(dive['notes'], 'Saw a turtle\nSuit: 7mm Wetsuit');
+      });
+
+      test('becomes the notes of a dive with none', () {
+        final rows = makeRows([
+          {'dateTime': DateTime(2024, 6, 15, 9, 0), 'suit': ' Drysuit '},
+        ]);
+
+        final result = correlator.correlate(
+          diveListRows: rows,
+          config: makeConfig(),
+        );
+
+        final dive = result.entitiesOf(ImportEntityType.dives).single;
+        expect(dive['notes'], 'Suit: Drysuit');
+      });
+
+      test('leaves the notes alone when blank', () {
+        final rows = makeRows([
+          {
+            'dateTime': DateTime(2024, 6, 15, 9, 0),
+            'notes': 'Saw a turtle',
+            'suit': '  ',
+          },
+          {'dateTime': DateTime(2024, 6, 16, 9, 0), 'suit': ''},
+        ]);
+
+        final result = correlator.correlate(
+          diveListRows: rows,
+          config: makeConfig(),
+        );
+
+        final dives = result.entitiesOf(ImportEntityType.dives);
+        expect(dives[0]['notes'], 'Saw a turtle');
+        expect(dives[1].containsKey('notes'), isFalse);
+      });
+    });
+
     test('extracts gear when in entityTypesToImport', () {
       final rows = makeRows([
         {'dateTime': DateTime(2024, 6, 15, 9, 0), 'suit': '7mm Wetsuit'},

--- a/test/features/universal_import/data/csv/presets/built_in_presets_test.dart
+++ b/test/features/universal_import/data/csv/presets/built_in_presets_test.dart
@@ -82,14 +82,16 @@ void main() {
       }
     });
 
-    // A mapped site or buddy column only becomes a linked record when the
-    // correlator extracts that entity type; otherwise every dive imports
-    // with no site, and buddies stay free text (#1830). This table is kept
-    // separate from the parser's own rule so a preset cannot silently drift.
+    // A mapped site, buddy or tags column only becomes a linked record when
+    // the correlator extracts that entity type; otherwise every dive imports
+    // with no site, buddies stay free text (#1830), and tags are dropped.
+    // This table is kept separate from the parser's own rule so a preset
+    // cannot silently drift.
     const entityTypeForTargetField = {
       'siteName': ImportEntityType.sites,
       'site': ImportEntityType.sites,
       'buddy': ImportEntityType.buddies,
+      'tags': ImportEntityType.tags,
     };
 
     test('every preset imports the entity types its mapped columns need', () {

--- a/test/features/universal_import/data/csv/presets/built_in_presets_test.dart
+++ b/test/features/universal_import/data/csv/presets/built_in_presets_test.dart
@@ -82,6 +82,44 @@ void main() {
       }
     });
 
+    // A mapped site or buddy column only becomes a linked record when the
+    // correlator extracts that entity type; otherwise every dive imports
+    // with no site, and buddies stay free text (#1830). This table is kept
+    // separate from the parser's own rule so a preset cannot silently drift.
+    const entityTypeForTargetField = {
+      'siteName': ImportEntityType.sites,
+      'site': ImportEntityType.sites,
+      'buddy': ImportEntityType.buddies,
+    };
+
+    test('every preset imports the entity types its mapped columns need', () {
+      for (final preset in builtInCsvPresets) {
+        for (final mapping in preset.mappings.values) {
+          for (final column in mapping.columns) {
+            final required = entityTypeForTargetField[column.targetField];
+            if (required == null) continue;
+            expect(
+              preset.supportedEntities,
+              contains(required),
+              reason:
+                  '${preset.name} maps "${column.sourceColumn}" to '
+                  '${column.targetField} but does not import '
+                  '${required.name}',
+            );
+          }
+        }
+      }
+    });
+
+    test('MySSI imports dives, sites and buddies (#1830)', () {
+      final myssi = builtInCsvPresets.firstWhere((p) => p.id == 'myssi');
+      expect(myssi.supportedEntities, {
+        ImportEntityType.dives,
+        ImportEntityType.sites,
+        ImportEntityType.buddies,
+      });
+    });
+
     test('all presets are builtIn source', () {
       for (final preset in builtInCsvPresets) {
         expect(

--- a/test/features/universal_import/data/parsers/csv_import_parser_test.dart
+++ b/test/features/universal_import/data/parsers/csv_import_parser_test.dart
@@ -1011,8 +1011,8 @@ void main() {
       },
     );
 
-    test('custom mapping without detected preset adds mapped buddies to the '
-        'default entity types', () async {
+    test('custom mapping without detected preset adds mapped buddies and '
+        'tags to the default entity types', () async {
       // Headers that do not match any known preset.
       const csv =
           'my_date,my_time,my_depth,my_buddy,my_tags\n'
@@ -1035,18 +1035,14 @@ void main() {
       );
 
       // Without a detected preset the default entity types are
-      // {dives, sites}. A mapped buddy column still adds buddies (#1830),
-      // but tags are not part of that rule and stay unextracted.
+      // {dives, sites}. Mapped buddy (#1830) and tags columns add their
+      // entity types, so neither column is dropped.
       final buddies = result.entitiesOf(ImportEntityType.buddies);
       final tags = result.entitiesOf(ImportEntityType.tags);
       expect(buddies.map((b) => b['name']), ['Alice']);
-      expect(
-        tags,
-        isEmpty,
-        reason:
-            'Without detected preset, default entity types should not '
-            'include tags',
-      );
+      expect(tags.map((t) => t['name']), ['reef']);
+      final dive = result.entitiesOf(ImportEntityType.dives).single;
+      expect(dive['tagRefs'], [tags.single['id']]);
     });
   });
 
@@ -1190,6 +1186,50 @@ void main() {
       expect(sites.map((s) => s['name']), ['Blue Hole']);
       final buddies = result.entitiesOf(ImportEntityType.buddies);
       expect(buddies.map((b) => b['name']), ['Alice']);
+    });
+  });
+
+  group('a mapped tags column imports linked tags', () {
+    test('a custom mapping adds tags to a preset without them', () async {
+      // Garmin Connect is detected and imports dives only, but the user
+      // mapped a tags column by hand.
+      const csv =
+          'Date,Activity Type,Max Depth,Avg Depth,Bottom Time,'
+          'Water Temperature,Labels\n'
+          '2024-01-15,Single-Gas Dive,25.5,18.0,00:45:00,27,"night, wreck"\n';
+
+      const customMapping = FieldMapping(
+        name: 'Garmin plus tags',
+        columns: [
+          ColumnMapping(sourceColumn: 'Date', targetField: 'date'),
+          ColumnMapping(sourceColumn: 'Max Depth', targetField: 'maxDepth'),
+          ColumnMapping(sourceColumn: 'Labels', targetField: 'tags'),
+        ],
+      );
+
+      final result = await parser.parse(
+        csvBytes(csv),
+        customMappingOverride: customMapping,
+      );
+
+      final tags = result.entitiesOf(ImportEntityType.tags);
+      expect(tags.map((t) => t['name']), ['night', 'wreck']);
+      final dive = result.entitiesOf(ImportEntityType.dives).single;
+      expect(dive['tagRefs'], [for (final tag in tags) tag['id']]);
+    });
+
+    test('an auto-mapped tags column imports tags', () async {
+      // No preset matches these headers, so they are keyword-mapped.
+      const csv =
+          'Date,Max Depth,Tags\n'
+          '2024-01-15,25.5,reef\n';
+
+      final result = await parser.parse(csvBytes(csv));
+
+      final tags = result.entitiesOf(ImportEntityType.tags);
+      expect(tags.map((t) => t['name']), ['reef']);
+      final dive = result.entitiesOf(ImportEntityType.dives).single;
+      expect(dive['tagRefs'], [tags.single['id']]);
     });
   });
 }

--- a/test/features/universal_import/data/parsers/csv_import_parser_test.dart
+++ b/test/features/universal_import/data/parsers/csv_import_parser_test.dart
@@ -3,9 +3,14 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/universal_import/data/csv/models/import_configuration.dart';
+import 'package:submersion/features/universal_import/data/csv/pipeline/csv_pipeline.dart';
+import 'package:submersion/features/universal_import/data/csv/presets/built_in_presets.dart';
+import 'package:submersion/features/universal_import/data/csv/presets/csv_preset.dart';
+import 'package:submersion/features/universal_import/data/csv/presets/preset_registry.dart';
 import 'package:submersion/features/universal_import/data/models/field_mapping.dart';
 import 'package:submersion/features/universal_import/data/models/import_enums.dart';
 import 'package:submersion/features/universal_import/data/models/import_options.dart';
+import 'package:submersion/features/universal_import/data/models/import_payload.dart';
 import 'package:submersion/features/universal_import/data/models/import_warning.dart';
 import 'package:submersion/features/universal_import/data/parsers/csv_import_parser.dart';
 
@@ -603,9 +608,12 @@ void main() {
 
       final result = await parser.parse(csvBytes(csv));
 
+      // A mapped buddy column imports as a linked buddy record (#1830).
+      final buddies = result.entitiesOf(ImportEntityType.buddies);
+      expect(buddies.map((b) => b['name']), ['Alice']);
       final dives = result.entitiesOf(ImportEntityType.dives);
       expect(dives, isNotEmpty);
-      expect(dives.first['buddy'], 'Alice');
+      expect(dives.first['buddyRefs'], [buddies.single['id']]);
     });
 
     test('maps visibility header to visibility field', () async {
@@ -1003,22 +1011,113 @@ void main() {
       },
     );
 
+    test('custom mapping without detected preset adds mapped buddies to the '
+        'default entity types', () async {
+      // Headers that do not match any known preset.
+      const csv =
+          'my_date,my_time,my_depth,my_buddy,my_tags\n'
+          '2024-01-15,10:00,25.5,Alice,reef\n';
+
+      const customMapping = FieldMapping(
+        name: 'Unknown Source',
+        columns: [
+          ColumnMapping(sourceColumn: 'my_date', targetField: 'date'),
+          ColumnMapping(sourceColumn: 'my_time', targetField: 'time'),
+          ColumnMapping(sourceColumn: 'my_depth', targetField: 'maxDepth'),
+          ColumnMapping(sourceColumn: 'my_buddy', targetField: 'buddy'),
+          ColumnMapping(sourceColumn: 'my_tags', targetField: 'tags'),
+        ],
+      );
+
+      final result = await parser.parse(
+        csvBytes(csv),
+        customMappingOverride: customMapping,
+      );
+
+      // Without a detected preset the default entity types are
+      // {dives, sites}. A mapped buddy column still adds buddies (#1830),
+      // but tags are not part of that rule and stay unextracted.
+      final buddies = result.entitiesOf(ImportEntityType.buddies);
+      final tags = result.entitiesOf(ImportEntityType.tags);
+      expect(buddies.map((b) => b['name']), ['Alice']);
+      expect(
+        tags,
+        isEmpty,
+        reason:
+            'Without detected preset, default entity types should not '
+            'include tags',
+      );
+    });
+  });
+
+  group('entity types follow the mapped site and buddy columns (#1830)', () {
+    const myssiCsv =
+        'dive #,Dive Site,Country,Date / Time,Dive Activity,'
+        'Specialty Dive,Dive type,Duration,Depth,'
+        'Dive Buddy / Instructor / Center\n'
+        '1,Coral Garden,Egypt,2026-01-15 09:00,Fun Dive,,Open Water,45,'
+        '18.5,Alice\n'
+        '2,Coral Garden,Egypt,2026-01-15 14:00,Fun Dive,,Open Water,50,'
+        '16.0,Alice\n';
+
+    void expectLinkedSiteAndBuddy(ImportPayload result) {
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.map((s) => s['name']), ['Coral Garden']);
+
+      final buddies = result.entitiesOf(ImportEntityType.buddies);
+      expect(buddies.map((b) => b['name']), ['Alice']);
+
+      final dives = result.entitiesOf(ImportEntityType.dives);
+      expect(dives, hasLength(2));
+      for (final dive in dives) {
+        expect(dive['siteId'], sites.single['id']);
+        expect(dive['buddyRefs'], [buddies.single['id']]);
+        expect(
+          dive.containsKey('buddy'),
+          isFalse,
+          reason: 'the buddy column must not also be kept as free text',
+        );
+      }
+    }
+
+    test('a detected MySSI export imports linked sites and buddies', () async {
+      final result = await parser.parse(csvBytes(myssiCsv));
+
+      expectLinkedSiteAndBuddy(result);
+    });
+
+    test('a MySSI export imported through the mapping step keeps its sites and '
+        'buddies', () async {
+      // The wizard always hands its Map Fields mapping back as an override,
+      // so this is the path a real MySSI import takes.
+      final myssi = builtInCsvPresets.firstWhere((p) => p.id == 'myssi');
+
+      final result = await parser.parse(
+        csvBytes(myssiCsv),
+        customMappingOverride: myssi.primaryMapping,
+      );
+
+      expectLinkedSiteAndBuddy(result);
+    });
+
     test(
-      'custom mapping without detected preset falls back to default entity types',
+      'a custom mapping adds sites and buddies to a dives-only preset',
       () async {
-        // Headers that do not match any known preset.
+        // Garmin Connect is detected and imports dives only, but the user
+        // mapped the two extra columns by hand.
         const csv =
-            'my_date,my_time,my_depth,my_buddy,my_tags\n'
-            '2024-01-15,10:00,25.5,Alice,reef\n';
+            'Date,Activity Type,Max Depth,Avg Depth,Bottom Time,'
+            'Water Temperature,Location,Buddy\n'
+            '2024-01-15,Single-Gas Dive,25.5,18.0,00:45:00,27,Blue Hole,'
+            'Alice\n';
 
         const customMapping = FieldMapping(
-          name: 'Unknown Source',
+          name: 'Garmin plus people',
           columns: [
-            ColumnMapping(sourceColumn: 'my_date', targetField: 'date'),
-            ColumnMapping(sourceColumn: 'my_time', targetField: 'time'),
-            ColumnMapping(sourceColumn: 'my_depth', targetField: 'maxDepth'),
-            ColumnMapping(sourceColumn: 'my_buddy', targetField: 'buddy'),
-            ColumnMapping(sourceColumn: 'my_tags', targetField: 'tags'),
+            ColumnMapping(sourceColumn: 'Date', targetField: 'date'),
+            ColumnMapping(sourceColumn: 'Max Depth', targetField: 'maxDepth'),
+            ColumnMapping(sourceColumn: 'Location', targetField: 'siteName'),
+            ColumnMapping(sourceColumn: 'Buddy', targetField: 'buddy'),
           ],
         );
 
@@ -1027,25 +1126,70 @@ void main() {
           customMappingOverride: customMapping,
         );
 
-        // Without a detected preset, the default entity types are
-        // {dives, sites} only. Buddies and tags should not be extracted.
+        final sites = result.entitiesOf(ImportEntityType.sites);
+        expect(sites.map((s) => s['name']), ['Blue Hole']);
         final buddies = result.entitiesOf(ImportEntityType.buddies);
-        final tags = result.entitiesOf(ImportEntityType.tags);
-        expect(
-          buddies,
-          isEmpty,
-          reason:
-              'Without detected preset, default entity types should not '
-              'include buddies',
-        );
-        expect(
-          tags,
-          isEmpty,
-          reason:
-              'Without detected preset, default entity types should not '
-              'include tags',
-        );
+        expect(buddies.map((b) => b['name']), ['Alice']);
+        final dive = result.entitiesOf(ImportEntityType.dives).single;
+        expect(dive['siteId'], sites.single['id']);
+        expect(dive['buddyRefs'], [buddies.single['id']]);
       },
     );
+
+    test('a saved preset that maps sites and buddies imports them even when '
+        'its entity set omits them', () async {
+      // A preset saved from an earlier MySSI detection inherited
+      // {dives} only.
+      final registry = PresetRegistry(builtInPresets: builtInCsvPresets)
+        ..addUserPreset(
+          const CsvPreset(
+            id: 'user-spots',
+            name: 'My Spots',
+            source: PresetSource.userSaved,
+            signatureHeaders: ['Day', 'Spot', 'Deepest', 'Mate'],
+            mappings: {
+              'primary': FieldMapping(
+                name: 'My Spots',
+                columns: [
+                  ColumnMapping(sourceColumn: 'Day', targetField: 'date'),
+                  ColumnMapping(sourceColumn: 'Spot', targetField: 'site'),
+                  ColumnMapping(
+                    sourceColumn: 'Deepest',
+                    targetField: 'maxDepth',
+                  ),
+                  ColumnMapping(sourceColumn: 'Mate', targetField: 'buddy'),
+                ],
+              ),
+            },
+            supportedEntities: {ImportEntityType.dives},
+          ),
+        );
+      final savedPresetParser = CsvImportParser(
+        pipeline: CsvPipeline(registry: registry),
+      );
+
+      final result = await savedPresetParser.parse(
+        csvBytes('Day,Spot,Deepest,Mate\n2024-01-15,Blue Hole,25.5,Alice\n'),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.map((s) => s['name']), ['Blue Hole']);
+      final buddies = result.entitiesOf(ImportEntityType.buddies);
+      expect(buddies.map((b) => b['name']), ['Alice']);
+    });
+
+    test('an auto-mapped buddy column imports buddies', () async {
+      // No preset matches these headers, so they are keyword-mapped.
+      const csv =
+          'Date,Max Depth,Site,Buddy\n'
+          '2024-01-15,25.5,Blue Hole,Alice\n';
+
+      final result = await parser.parse(csvBytes(csv));
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.map((s) => s['name']), ['Blue Hole']);
+      final buddies = result.entitiesOf(ImportEntityType.buddies);
+      expect(buddies.map((b) => b['name']), ['Alice']);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to #1838 (merged, for issue #1830), which widened a CSV import's entity types to cover mapped site and buddy columns and deliberately left `suit` and `tags` out. This PR covers those two columns.

- **Tags were extracted but never linked to a dive.** `CsvCorrelator` sets `buddyRefs` on each dive but never set `tagRefs`, so `UddfEntityImporter._linkTagsToDive` found nothing and every tag was created attached to no dive. The Subsurface preset already imports tags, so its CSV imports lose every dive's tags on main today. Each dive now links to the tags in its own row.
- **A mapped tags column now enables tag import.** `'tags'` joins #1838's `_entityTypeForTargetField` rule, so a custom mapping on a preset without tags (MacDive, Garmin, no preset) or an auto-mapped `Tags` header no longer drops the column.
- **The suit is kept in the dive notes.** No dive field holds a suit, and no built-in preset imports equipment, so the Subsurface preset's mapped suit column (and any custom-mapped one) was discarded. It is now appended to the notes as `Suit: <value>`, matching the Subsurface XML import. Submersion's own CSV export writes no suit column, so an export and re-import cannot stack `Suit:` lines.

### Why the suit does not become gear

Enabling equipment for a mapped suit column was considered and rejected, because the gear path is not safe to turn on yet:

- `GearExtractor` types every suit as `'exposure_suit'`, which is not an `EquipmentType`, so the importer stores it as `other`.
- `ImportDuplicateChecker` matches equipment on name plus type, so a CSV suit never matches an existing row. Every re-import would add another suit.
- The correlator sets no `equipmentRefs`, and there is no `preResolvedEquipmentIds` seed, so the gear would not be linked to any dive either.

## Changes

- `csv_correlator.dart`: new step 7c, `_attachTagRefs`, sets each dive's `tagRefs` from its source row. Dives and rows are index-aligned.
- `tag_extractor.dart`: `tagIdsForRow` returns a row's tag ids in order, with repeats removed.
- `dive_extractor.dart`: appends `Suit: <value>` to the notes when the suit is non-blank.
- `csv_import_parser.dart`: `'tags': ImportEntityType.tags` in `_entityTypeForTargetField`.

### Reviewer notes

- Tag duplicates already work at import time. `_importTags` reuses an existing tag by case-insensitive name, and a tag skipped as a duplicate still links through `preResolvedTagIds`, which is keyed by the tag's `uddfId`, the same UUID the new `tagRefs` carry.
- For a custom-mapped CSV that newly imports tags, re-importing the same file flags each repeated tag as a pending duplicate in the review step. This is the same behavior Subsurface CSV imports already have.
- #1838's test asserting that a custom mapping without a preset leaves tags unextracted now asserts the opposite.

## Test Plan

- [x] `flutter test` passes for `test/features/universal_import`, `import_wizard` and `dive_import` (3,197 tests after merging main, including the Submersion CSV round-trip test) and the pre-push hook's affected-test run (5,656 tests).
- [x] `flutter analyze --fatal-infos` passes
- [x] `dart format .` leaves no changes
- [x] New real-database test (`csv_tags_and_suit_import_test.dart`): Subsurface CSV bytes, through `CsvImportParser`, into `UddfEntityImporter` with real repositories. Asserts each dive's tags from `TagRepository.getTagsForDive`, a shared tag created once, and the suit line in the stored notes.
- [x] Mutation checks: with step 7c removed, the database test finds no tags on the dive; with the suit block disabled, the notes assertion fails; with the tag-id set changed to a list, the repeated-tag test fails.
- [x] Real Subsurface fixture: dives 1-5 link to `shore` and `student`, dive 6 has no `tagRefs`, and dive 1's notes read `Summary:\nSuit: 3mm Bare wetsuit`.
- [ ] Manual testing: not done

Refs #1830
