### PR TITLE
fix(dive-log): the dive table shows diver names for custom dive types

### DIFF
--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -1658,6 +1658,9 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
   /// Build the DiveTableView widget from the full-Dive provider.
   Widget _buildTableView(BuildContext context, DiveFilterState filter) {
     final divesAsync = ref.watch(allDivesForTableProvider);
+    // Built once above the table, as for the list tiles, so the Dive Type
+    // column shows the diver's names and localized built-ins.
+    final diveTypeLabelResolver = watchDiveTypeLabelResolver(ref, context.l10n);
 
     return divesAsync.when(
       loading: () => const Center(child: CircularProgressIndicator()),
@@ -1672,6 +1675,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
             Expanded(
               child: DiveTableView(
                 dives: dives,
+                diveTypeLabelResolver: diveTypeLabelResolver,
                 onDiveTapDown: (id) {
                   // Rows carry a double-tap, so onDiveTap only resolves after
                   // the double-tap timer -- long after this fires. A modified

--- a/lib/features/dive_log/presentation/widgets/dive_table_view.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_table_view.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/constants/dive_field.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/formatters/dive_type_label_resolver.dart';
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/table_header_cell.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -32,10 +33,21 @@ class DiveTableView extends ConsumerStatefulWidget {
   final bool isSelectionMode;
   final String? highlightedId;
 
+  /// Resolves a dive-type slug to its on-screen label for the Dive Type
+  /// column and its sort.
+  ///
+  /// Required rather than optional, like `DiveListItem.diveTypeLabelResolver`:
+  /// without one, [DiveField.extractFromDive] falls back to the slug
+  /// capitalization, so a custom type shows its id instead of the diver's
+  /// name and a built-in type stays English. Build it once, above the table,
+  /// via [watchDiveTypeLabelResolver].
+  final DiveTypeLabelResolver diveTypeLabelResolver;
+
   const DiveTableView({
     super.key,
     required this.dives,
     required this.onDiveTap,
+    required this.diveTypeLabelResolver,
     this.onDiveTapDown,
     this.onDiveDoubleTap,
     this.selectedIds = const {},
@@ -136,8 +148,16 @@ class _DiveTableViewState extends ConsumerState<DiveTableView> {
 
     final sorted = List<Dive>.from(widget.dives);
     sorted.sort((a, b) {
-      final va = field.extractFromDive(a, gasModel: units.settings.gasModel);
-      final vb = field.extractFromDive(b, gasModel: units.settings.gasModel);
+      final va = field.extractFromDive(
+        a,
+        gasModel: units.settings.gasModel,
+        diveTypeLabel: widget.diveTypeLabelResolver,
+      );
+      final vb = field.extractFromDive(
+        b,
+        gasModel: units.settings.gasModel,
+        diveTypeLabel: widget.diveTypeLabelResolver,
+      );
 
       // Nulls always sort to the end
       if (va == null && vb == null) return 0;
@@ -240,6 +260,7 @@ class _DiveTableViewState extends ConsumerState<DiveTableView> {
     final value = column.field.extractFromDive(
       dive,
       gasModel: units.settings.gasModel,
+      diveTypeLabel: widget.diveTypeLabelResolver,
     );
     final text = column.field.formatValue(value, units);
     final rightAligned = _isRightAligned(column.field);

--- a/test/features/dive_log/presentation/widgets/dive_list_content_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_content_test.dart
@@ -116,6 +116,7 @@ Widget _buildTableModeLayout({
         Expanded(
           child: DiveTableView(
             dives: dives,
+            diveTypeLabelResolver: Dive.diveTypeDisplayName,
             onDiveTap: onDiveTap ?? (_) {},
             onDiveDoubleTap: onDiveDoubleTap,
             selectedIds: selectedIds,

--- a/test/features/dive_log/presentation/widgets/dive_table_view_dive_type_label_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_table_view_dive_type_label_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/formatters/dive_type_label_resolver.dart';
+import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_table_view.dart';
+import 'package:submersion/features/dive_types/domain/entities/dive_type_entity.dart';
+import 'package:submersion/features/dive_types/presentation/providers/dive_type_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// The desktop table's Dive Type column used to call
+/// `DiveField.extractFromDive` without a `diveTypeLabel`, so it fell back to
+/// `Dive.diveTypeNames`: a custom type showed its slug capitalized
+/// (`search_recovery` -> `Search recovery`) instead of the diver's own name,
+/// and a built-in type stayed English under every locale. The table now takes
+/// the same resolver the list tiles use, for both its cells and its sort.
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestTableConfigNotifier extends TableViewConfigNotifier {
+  _TestTableConfigNotifier(TableViewConfig config) {
+    state = config;
+  }
+}
+
+void main() {
+  DiveTypeEntity builtIn(String id, String name) => DiveTypeEntity(
+    id: id,
+    name: name,
+    isBuiltIn: true,
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+  );
+
+  DiveTypeEntity custom(String id, String name) => DiveTypeEntity(
+    id: id,
+    name: name,
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+  );
+
+  Dive diveWith(String id, int number, List<String> typeIds) => Dive(
+    id: id,
+    dateTime: DateTime(2026, 3, 15),
+    diveNumber: number,
+    diveTypeIds: typeIds,
+  );
+
+  Widget table({
+    required List<Dive> dives,
+    required List<DiveTypeEntity> types,
+    Locale locale = const Locale('en'),
+    DiveField? sortField,
+  }) {
+    return testApp(
+      locale: locale,
+      overrides: [
+        settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+        diveTypesProvider.overrideWith((ref) async => types),
+        tableViewConfigProvider.overrideWith(
+          (ref) => _TestTableConfigNotifier(
+            TableViewConfig(
+              columns: [
+                TableColumnConfig(field: DiveField.diveNumber, isPinned: true),
+                TableColumnConfig(field: DiveField.diveTypeName, width: 200),
+              ],
+              sortField: sortField,
+            ),
+          ),
+        ),
+      ],
+      // Built through the production helper, as dive_list_content does, so
+      // these cases cover the provider -> label seam too.
+      child: Consumer(
+        builder: (context, ref, _) => DiveTableView(
+          dives: dives,
+          onDiveTap: (_) {},
+          diveTypeLabelResolver: watchDiveTypeLabelResolver(ref, context.l10n),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('a custom type renders under the name the diver gave it', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      table(
+        dives: [
+          diveWith('d1', 1, ['search_recovery']),
+        ],
+        types: [custom('search_recovery', 'Search & Recovery')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Search & Recovery'), findsOneWidget);
+    expect(find.text('Search recovery'), findsNothing);
+  });
+
+  testWidgets('a collision-suffixed custom id renders the diver name', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      table(
+        dives: [
+          diveWith('d1', 1, ['search_recovery_1a2b3c4d']),
+        ],
+        types: [custom('search_recovery_1a2b3c4d', 'Search & Recovery')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Search & Recovery'), findsOneWidget);
+    expect(find.textContaining('1a2b3c4d'), findsNothing);
+  });
+
+  testWidgets('a built-in type is localized', (tester) async {
+    await tester.pumpWidget(
+      table(
+        locale: const Locale('de'),
+        dives: [
+          diveWith('d1', 1, ['wreck']),
+        ],
+        types: [builtIn('wreck', 'Wreck')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Wracktauchen'), findsOneWidget);
+    expect(find.text('Wreck'), findsNothing);
+  });
+
+  testWidgets('sorting by dive type orders rows by the resolved label', (
+    tester,
+  ) async {
+    // Slug order is the reverse of label order, and the dives arrive in slug
+    // order, so a comparator still reading slug capitalizations would leave
+    // "Zulu" on top.
+    await tester.pumpWidget(
+      table(
+        sortField: DiveField.diveTypeName,
+        dives: [
+          diveWith('d1', 1, ['alpha_x']),
+          diveWith('d2', 2, ['zulu_x']),
+        ],
+        types: [custom('alpha_x', 'Zulu'), custom('zulu_x', 'Alpha')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getTopLeft(find.text('Alpha')).dy,
+      lessThan(tester.getTopLeft(find.text('Zulu')).dy),
+    );
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_table_view_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_table_view_test.dart
@@ -115,6 +115,7 @@ Widget _buildTable({
     ],
     child: DiveTableView(
       dives: dives,
+      diveTypeLabelResolver: Dive.diveTypeDisplayName,
       onDiveTap: onDiveTap ?? (_) {},
       onDiveDoubleTap: onDiveDoubleTap,
       selectedIds: selectedIds ?? const {},
@@ -325,6 +326,7 @@ void main() {
           ],
           child: DiveTableView(
             dives: dives,
+            diveTypeLabelResolver: Dive.diveTypeDisplayName,
             onDiveTap: (_) {},
             highlightedId: 'hl-1',
           ),
@@ -480,6 +482,7 @@ void main() {
           ],
           child: DiveTableView(
             dives: dives,
+            diveTypeLabelResolver: Dive.diveTypeDisplayName,
             onDiveTap: (_) {},
             highlightedId: 'h1',
           ),
@@ -638,6 +641,7 @@ void main() {
           ],
           child: DiveTableView(
             dives: dives,
+            diveTypeLabelResolver: Dive.diveTypeDisplayName,
             onDiveTap: (_) {},
             highlightedId: 'du1',
           ),
@@ -656,6 +660,7 @@ void main() {
           ],
           child: DiveTableView(
             dives: dives,
+            diveTypeLabelResolver: Dive.diveTypeDisplayName,
             onDiveTap: (_) {},
             highlightedId: 'du2',
           ),


### PR DESCRIPTION
## Summary

The desktop dive table view showed custom dive types under a name rebuilt from their id instead of the name the diver gave them, and showed built-in types untranslated. `DiveTableView` called `DiveField.extractFromDive` without a `diveTypeLabel`, so the Dive Type column fell back to `Dive.diveTypeNames`, which capitalizes the slug:

- `search_recovery` rendered as "Search recovery" instead of "Search & Recovery"
- a collision-suffixed id `search_recovery_1a2b3c4d` rendered as "Search recovery 1a2b3c4d"
- `wreck` stayed "Wreck" under German instead of "Wracktauchen"

The column's sort read the same fallback, so it ordered rows by slug rather than by the label on screen.

The list tiles already get this right by taking a `DiveTypeLabelResolver` built once per list; the table now does the same.

Refs #1834, which is the same bug in the CSV, Excel and PDF exports.

## Changes

- `DiveTableView` takes a required `diveTypeLabelResolver` and passes it to both `extractFromDive` calls: the sort comparator and the cell builder.
- `DiveListContent._buildTableView` builds the resolver once above the table with `watchDiveTypeLabelResolver`, as `_buildDiveList` already does for the tiles.
- The parameter is required rather than optional, matching `DiveListItem`, so a future caller cannot silently regress to slug names. Existing table tests that do not exercise dive types pass `Dive.diveTypeDisplayName` (the old fallback).
- New `dive_table_view_dive_type_label_test.dart` covers a custom name, a collision-suffixed custom id, a localized built-in, and sorting by the resolved label. The sort case uses ids whose slug order is the reverse of their label order, and was confirmed to fail with only the cell builder fixed, so it pins the comparator on its own.

## Test Plan

- [x] `flutter test` passes for the new test and the neighbouring suites (table view, list content, list tile dive-type localization, dive list page, dive list detail callbacks)
- [x] `flutter analyze` passes
- [x] `dart format .` reports no changes
- [ ] Manual testing on: not run; covered by widget tests
