### PR TITLE
fix(dive-computer): don't wipe tank pressure on an empty reparse

### DIFF
--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -179,6 +179,25 @@ class ReparseService {
       // one original had one, so the ownership guard applies here too --
       // otherwise the merge's own surface-gap markers are deleted (#1164).
       final rewritesEvents = !isMultiSource && ownsStrand;
+
+      // Whether this parse actually reports any tank/gas-mix/pressure
+      // information to carry over. A re-parse reads the exact same raw bytes
+      // as the original download, so both empty here means the parser or
+      // resolver produced less than a previous parse of those same bytes did
+      // -- never a genuine "the diver's tank is gone", which the raw bytes
+      // cannot express. Gating the tank/gas-switch/pressure rewrite on it
+      // stops such a parse from permanently deleting tank pressure history
+      // it has nothing to replace (issue #1853).
+      final parsedHasTankData =
+          parsed.tanks.isNotEmpty ||
+          parsed.gasMixes.isNotEmpty ||
+          parsed.samples.any(
+            (s) =>
+                s.pressureBar != null ||
+                (s.tankPressuresBar?.isNotEmpty ?? false),
+          );
+      final rewritesTanks = rewritesEvents && parsedHasTankData;
+
       if (rewritesEvents) {
         // Tombstoned: a peer's import only upserts these, so a row removed
         // here without one would linger there beside its re-inserted copy.
@@ -186,11 +205,13 @@ class ReparseService {
           'diveProfileEvents',
           await _idsOf(db.diveProfileEvents, diveId),
         );
-        await _deleteAndTombstone(
-          'gasSwitches',
-          await _idsOf(db.gasSwitches, diveId),
-        );
-        await _tankSeries.deleteForDive(diveId);
+        if (rewritesTanks) {
+          await _deleteAndTombstone(
+            'gasSwitches',
+            await _idsOf(db.gasSwitches, diveId),
+          );
+          await _tankSeries.deleteForDive(diveId);
+        }
 
         // Re-insert events from parsed data
         await _insertEvents(
@@ -204,9 +225,9 @@ class ReparseService {
       // ------------------------------------------------------------------
       // 6. DiveTanks carry-over (primary + single-source only)
       //    Skip for non-primary or multi-source dives to avoid overwriting
-      //    tank data owned by other sources.
+      //    tank data owned by other sources, and for a parse reporting no
+      //    tank data at all (see [parsedHasTankData] above).
       // ------------------------------------------------------------------
-      final rewritesTanks = sourceRow.isPrimary && !isMultiSource;
       if (rewritesTanks) {
         final tankIdsByIndex = await _carryOverTanks(
           diveId: diveId,
@@ -255,8 +276,8 @@ class ReparseService {
       }
       if (rewritesTanks) {
         await stage('diveTanks', await _idsOf(db.diveTanks, diveId));
-      }
-      if (rewritesEvents || rewritesTanks) {
+        // gasSwitches is only touched (deleted + re-inserted) alongside
+        // tanks; see the guard above.
         await stage('gasSwitches', await _idsOf(db.gasSwitches, diveId));
       }
       if (sourceRow.isPrimary) await stage('dives', [diveId]);

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -2073,6 +2073,81 @@ void main() {
       expect(tank.endPressure, 90.0);
     });
 
+    test('a parse reporting no tank or gas-mix data at all preserves the '
+        'existing tank and its pressure history (issue #1853)', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      // Existing tank with a real pressure history, exactly as an earlier
+      // parse of these same raw bytes recorded it.
+      await db
+          .into(db.diveTanks)
+          .insert(
+            const DiveTanksCompanion(
+              id: Value('tank-0'),
+              diveId: Value('dive-1'),
+              volume: Value(12.0),
+              startPressure: Value(220.0),
+              endPressure: Value(90.0),
+              o2Percent: Value(32.0),
+              hePercent: Value(0.0),
+              tankOrder: Value(0),
+              tankRole: Value('backGas'),
+            ),
+          );
+      await insertTankPressureSeries(
+        id: 'pp-0',
+        diveId: 'dive-1',
+        tankId: 'tank-0',
+        computerId: 'comp-1',
+        timestamp: 0,
+        pressure: 220.0,
+      );
+
+      // This re-parse reports neither tank records nor gas mixes -- the raw
+      // bytes did not change, so this can only be the parser/resolver
+      // missing what it found before, never a genuine "tank removed".
+      final parsed = makeParsedDive(tanks: [], gasMixes: []);
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final tanks = await (db.select(
+        db.diveTanks,
+      )..where((t) => t.diveId.equals('dive-1'))).get();
+      expect(
+        tanks,
+        hasLength(1),
+        reason:
+            'the existing tank must survive a parse with nothing to '
+            'replace it with',
+      );
+      expect(tanks.single.id, 'tank-0');
+
+      final pressureSeries = await tankSeries.getSeriesForDive('dive-1');
+      expect(
+        pressureSeries,
+        hasLength(1),
+        reason:
+            'existing tank-pressure history must not be wiped when '
+            'the fresh parse has no pressure data of its own',
+      );
+      expect(pressureSeries.single.samples.single.pressure, 220.0);
+    });
+
     test('keeps both transmitters when a sample reports two tank pressures '
         '(issue #1223)', () async {
       // A CCR dive with an O2 and a diluent transmitter: libdivecomputer


### PR DESCRIPTION
## Summary

Fixes #1853.

- Re-parsing a dive whose raw bytes, when re-parsed, come back with no tank
  or gas-mix data at all (`ParsedDive.tanks` and `ParsedDive.gasMixes` both
  empty, and no per-sample pressure either) deleted that dive's existing
  `DiveTanks` rows and its entire tank-pressure history, with nothing to
  replace them and no way to get it back short of a full-app backup restore.
- Re-parsing reads the exact same raw bytes as the original download, so an
  empty result can only mean the parser/resolver produced less this time
  than a previous parse of those same bytes did -- never a genuine change in
  what the dive computer measured. `applyParsedUpdate` treats every other
  field this way already (water temp, GPS, ...): absent means "nothing new
  to say," not "the diver removed this."
- Introduces `parsedHasTankData` and gates the tank/gas-switch/tank-pressure
  delete-and-rewrite on it, leaving `DiveProfileEvents` handling unaffected.

## Test plan

- Added a regression test reproducing the report: an existing tank with a
  real pressure history survives a re-parse whose fresh `ParsedDive` reports
  no tanks and no gas mixes.
- `flutter test test/features/dive_computer/data/services/reparse_service_test.dart` -- 84 passed.
- `flutter test test/features/dive_computer/data/services/reparse_service_sync_test.dart test/features/dive_computer/data/services/reparse_service_series_test.dart test/features/dive_computer/data/services/reparse_service_surfacing_test.dart test/features/dive_log/presentation/pages/dive_detail_reparse_menu_test.dart` -- all passed.
- `dart analyze` on the changed files -- no issues.