### PR TITLE
fix(backup): make restore's temp-file cleanup resilient to locked files

### DIFF
--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -141,6 +141,7 @@ class DatabaseService {
     // The service is a singleton, so a restore seam set by one test would
     // otherwise leak into the next and fire unexpectedly.
     debugOnRestoreWindowOpen = null;
+    debugFailDeleteFor = null;
   }
 
   /// Registers [locationService] without opening anything.
@@ -933,10 +934,17 @@ class DatabaseService {
     // with no database and no data. Renaming into a non-existent destination
     // works identically on POSIX and Windows, so no per-platform branching.
     final asidePath = '$destinationPath.pre-restore';
-    await _deleteIfExists(asidePath);
     final destFile = File(destinationPath);
     final hadDest = await destFile.exists();
     try {
+      // Inside the try: a stray `.pre-restore` left by an earlier failed
+      // restore can be locked by exactly the kind of transient condition
+      // (a cloud-sync daemon materializing/evicting it, an AV scan, ...)
+      // that also causes the swap below to fail. Before this was inside the
+      // guarded block, a delete failure here escaped uncaught AFTER close()
+      // had already run, leaving the app with no open database until restart
+      // and masking itself as a bare "cannot delete file" error.
+      await _deleteIfExists(asidePath);
       if (hadDest) await destFile.rename(asidePath);
       // The old WAL/SHM sidecars belong to the pre-restore database and must
       // not be next to the swapped-in file: SQLite would replay them into it
@@ -960,7 +968,11 @@ class DatabaseService {
         await _moveIfExists('$asidePath-wal', '$destinationPath-wal');
         await _moveIfExists('$asidePath-shm', '$destinationPath-shm');
       }
-      await _deleteIfExists(stagingPath);
+      // Best-effort: this is cleanup of an orphaned copy we no longer need,
+      // not a step the rollback depends on. A transient failure to remove it
+      // (the same lock that likely broke the swap above) must not skip the
+      // reopen below and leave the app with no database until restart.
+      await _bestEffortDelete(stagingPath);
       await initialize();
       rethrow;
     }
@@ -991,9 +1003,15 @@ class DatabaseService {
       // (corruption, a locked file) is the restored file's own problem and
       // keeps its existing handling, which may legitimately want the
       // swapped-in file left in place for recovery.
-      await _deleteIfExists(destinationPath);
-      await _deleteIfExists('$destinationPath-wal');
-      await _deleteIfExists('$destinationPath-shm');
+      //
+      // Best-effort: the rollback below only needs asidePath, not the
+      // removal of the too-new file it is about to overwrite anyway (rename
+      // replaces its destination). A transient failure to delete it must not
+      // skip the rollback and leave the too-new file live with no database
+      // open.
+      await _bestEffortDelete(destinationPath);
+      await _bestEffortDelete('$destinationPath-wal');
+      await _bestEffortDelete('$destinationPath-shm');
       if (hadDest && await File(asidePath).exists()) {
         await File(asidePath).rename(destinationPath);
         await _moveIfExists('$asidePath-wal', '$destinationPath-wal');
@@ -1022,7 +1040,18 @@ class DatabaseService {
     await source.rename(to);
   }
 
+  /// Test seam: paths on which the next [_deleteIfExists] call raises instead
+  /// of deleting, simulating a transient locked-file condition (e.g. a
+  /// cloud-sync provider materializing/evicting the file) that real
+  /// permission errors on desktop otherwise need flaky OS-level setup to
+  /// reproduce. [resetForTesting] also clears it.
+  @visibleForTesting
+  Set<String>? debugFailDeleteFor;
+
   Future<void> _deleteIfExists(String path) async {
+    if (debugFailDeleteFor?.contains(path) ?? false) {
+      throw FileSystemException('debug: simulated delete failure', path);
+    }
     final file = File(path);
     if (await file.exists()) {
       await file.delete();

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -326,6 +326,86 @@ void main() {
     },
   );
 
+  test(
+    'a cleanup failure during swap rollback still reopens the database',
+    () async {
+      // Regression guard: the rollback catch block used to delete the
+      // orphaned staging file with a call that could itself throw (e.g. a
+      // cloud-sync provider transiently locking it) and skip initialize(),
+      // leaving the app with no open database until restart. That cleanup
+      // must be best-effort.
+      final defaultPath = p.join(tempDir.path, 'Submersion', 'submersion.db');
+      await DatabaseService.instance.initialize(
+        locationService: _FakeLocation(defaultPath),
+      );
+      await DatabaseService.instance.database
+          .customSelect('SELECT 1')
+          .getSingle();
+      final backupPath = p.join(tempDir.path, 'backup.db');
+      await DatabaseService.instance.backup(backupPath);
+
+      final now = DateTime.now();
+      await DiverRepository().createDiver(
+        domain.Diver(id: '', name: 'Keep Me', createdAt: now, updatedAt: now),
+      );
+
+      // Sabotage the swap (as in the sibling test above), and also make the
+      // rollback's own staging-file cleanup fail.
+      DatabaseService.instance.debugOnRestoreWindowOpen = (stagingPath) {
+        File(stagingPath).deleteSync();
+        DatabaseService.instance.debugFailDeleteFor = {stagingPath};
+      };
+
+      await expectLater(
+        DatabaseService.instance.restore(backupPath),
+        throwsA(anything),
+      );
+
+      // The database must still be open and usable, with the original data
+      // intact, despite the cleanup failure.
+      final divers = await DiverRepository().getAllDivers();
+      expect(divers.map((d) => d.name), contains('Keep Me'));
+    },
+  );
+
+  test('a locked stale .pre-restore file fails the restore without leaving '
+      'the database closed', () async {
+    // Regression guard: this delete used to run AFTER close() but OUTSIDE
+    // any try/catch, so a transient failure to remove a leftover
+    // .pre-restore file (a prior restore's own best-effort cleanup can
+    // fail the same way) propagated out of restore() with the live
+    // database already closed and no reopen ever attempted.
+    final defaultPath = p.join(tempDir.path, 'Submersion', 'submersion.db');
+    await DatabaseService.instance.initialize(
+      locationService: _FakeLocation(defaultPath),
+    );
+    await DatabaseService.instance.database
+        .customSelect('SELECT 1')
+        .getSingle();
+    final backupPath = p.join(tempDir.path, 'backup.db');
+    await DatabaseService.instance.backup(backupPath);
+
+    final now = DateTime.now();
+    await DiverRepository().createDiver(
+      domain.Diver(id: '', name: 'Keep Me', createdAt: now, updatedAt: now),
+    );
+
+    // A stale .pre-restore left by some earlier run, and locked.
+    final asidePath = '$defaultPath.pre-restore';
+    File(asidePath).writeAsStringSync('stale');
+    DatabaseService.instance.debugFailDeleteFor = {asidePath};
+
+    await expectLater(
+      DatabaseService.instance.restore(backupPath),
+      throwsA(anything),
+    );
+
+    // The original database must still be open and usable, not left
+    // closed by a delete failure that occurred after close().
+    final divers = await DiverRepository().getAllDivers();
+    expect(divers.map((d) => d.name), contains('Keep Me'));
+  });
+
   test('a newer-schema file rejected at the post-swap reopen rolls back '
       '(no data loss)', () async {
     // The sibling test above covers a failed SWAP, which the rename's own


### PR DESCRIPTION
## Summary

Fixes #1855.

- `DatabaseService.restore` deleted a stale `.pre-restore` leftover from an
  earlier failed restore *after* closing the live database but *outside*
  the try/catch that guards the swap. A transient failure there (e.g. a
  cloud-sync provider such as iCloud Drive briefly locking the file while
  materializing/evicting it) propagated straight out of `restore()` with
  `initialize()` never called again, leaving the app with no open database
  until it was force-quit and reopened.
- The swap-failure `catch` block and the `DatabaseVersionMismatchException`
  handler had the same class of gap: their own cleanup deletes (an orphaned
  staging copy; a too-new file the rollback rename is about to overwrite
  anyway) used `_deleteIfExists` instead of the already-existing
  `_bestEffortDelete` helper, so a failure there could also skip the
  `initialize()` call right after it.
- Moves the `.pre-restore` cleanup inside the swap's try/catch (so a
  failure there gets the same rollback+reopen treatment as a swap failure)
  and swaps the three cleanup-only deletes to `_bestEffortDelete`.

## Test plan

- Added `DatabaseService.debugFailDeleteFor`, a test seam that makes
  `_deleteIfExists` raise for a chosen path, to simulate a locked delete
  deterministically (a real OS-level permission race isn't reproducible on
  demand in CI).
- Two new regression tests in `database_service_isolate_test.dart`:
  - a cleanup failure during swap rollback still reopens the database
  - a locked stale `.pre-restore` file fails the restore without leaving
    the database closed
- `flutter test test/core/services/database_service_isolate_test.dart` -- 18 passed.
- `flutter test test/core/services/` (full directory) -- 2841 passed.
- `dart analyze` on the changed files -- no issues.